### PR TITLE
WEB-328 no mail for username

### DIFF
--- a/app/Resources/SonataUserBundle/views/Registration/register.html.twig
+++ b/app/Resources/SonataUserBundle/views/Registration/register.html.twig
@@ -20,9 +20,8 @@
 {% block body %}
 
   {% block fos_user_content %}
-    <form id="registration_form" action="{{ path('fos_user_registration_register') }}" {{ form_enctype(form) }} method="POST" class="fos_user_registration_register">
+    <form id="registration_form" action="{{ path('register_check') }}" {{ form_enctype(form) }} method="POST" class="fos_user_registration_register">
       {#{{ form_widget(form) }}#}
-
       {{ form_errors(form) }}
       <div id="sonata_user_registration_form">
 
@@ -48,9 +47,13 @@
 
         <input id="sonata_user_registration_form__token" type="hidden" name="sonata_user_registration_form[_token]" value="{{ csrf_token('authentication') }}" />
       </div>
-
+        {% for flash_message in app.session.flashBag.get('catroweb_error_message') %}
+        <div id="Error-Message" style="display:block">
+            <p>{{ flash_message|trans({}, "catroweb") }}</p>
+        </div>
+        {% endfor %}
       <div id="Error-Message" style="display:none">
-        <p>{{ 'registrationError'|trans({}, 'catroweb') }}</p>
+          <p>{{ 'registrationError'|trans({}, 'catroweb') }}</p>
       </div>
 
       <div>

--- a/app/Resources/SonataUserBundle/views/Security/login.html.twig
+++ b/app/Resources/SonataUserBundle/views/Security/login.html.twig
@@ -60,7 +60,7 @@
 
     <div id="login_links">
          <div>
-             <a id="create_account" href="{{ path('fos_user_registration_register') }}">{{ 'login.createAccount'|trans({}, 'catroweb') }}</a>
+             <a id="create_account" href="{{ path('register_form') }}">{{ 'login.createAccount'|trans({}, 'catroweb') }}</a>
          </div>
          <div>
              <a href="{{ path("sonata_user_resetting_request") }}" id="pw-request">{{ "login.forgotPass"|trans({}, "catroweb") }}</a>

--- a/app/Resources/translations/catroweb.en.yml
+++ b/app/Resources/translations/catroweb.en.yml
@@ -466,6 +466,7 @@ errors:
     invalid: Your username is invalid
     exists: This username already exists.
     not_exists: This username does not exist.
+    not_email: The username must not be an email address.
   password:
     blank: The password is missing.
     short: 'Your password must have at least {{ limit }} characters.'

--- a/app/config/routing_flavored.yml
+++ b/app/config/routing_flavored.yml
@@ -72,7 +72,7 @@ sonata_user_profile:
 
 sonata_user_register:
     resource: "@SonataUserBundle/Resources/config/routing/sonata_registration_1.xml"
-    prefix: /register
+    prefix: /middleware_register
 
 sonata_user_change_password:
     resource: "@SonataUserBundle/Resources/config/routing/sonata_change_password_1.xml"

--- a/src/Catrobat/AppBundle/Controller/Web/RegisterController.php
+++ b/src/Catrobat/AppBundle/Controller/Web/RegisterController.php
@@ -1,0 +1,59 @@
+<?php
+namespace Catrobat\AppBundle\Controller\Web;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Symfony\Component\HttpFoundation\Request;
+
+class RegisterController extends Controller
+{
+  /**
+   * @Route("/register", name="register_check")
+   * @Method({"POST"})
+   */
+  public function checkRegistration(Request $request)
+  {
+    $route = 'fos_user_registration_register';
+    $error = false;
+
+    $username = $request->request->get('sonata_user_registration_form')['username'];
+    if (strpos($username, "@") !== false)
+    {
+      $this->addFlash(
+        'catroweb_error_message',
+        "errors.username.not_email"
+      );
+      $error = true;
+    }
+
+    $password = $request->request->get('sonata_user_registration_form')['plainPassword'];
+    if ($password['first'] !== $password['second'])
+    {
+      $this->addFlash(
+        'catroweb_error_message',
+        "passwordsNoMatch"
+      );
+      $error = true;
+    }
+
+    if ($error)
+    {
+      return $this->redirectToRoute('register_form');
+    }
+
+    $response = $this->forward('SonataUserBundle:RegistrationFOSUser1:register');
+    return $response;
+  }
+
+  /**
+   * @Route("/register", name="register_form")
+   * @Method({"GET"})
+   */
+  public function showRegistrationForm(Request $request)
+  {
+    $response = $this->forward('SonataUserBundle:RegistrationFOSUser1:register');
+    return $response;
+  }
+}
+

--- a/src/Catrobat/AppBundle/Features/Web/register.feature
+++ b/src/Catrobat/AppBundle/Features/Web/register.feature
@@ -15,7 +15,7 @@
     Then I should be on "/pocketcode/login"
     And I should see an "#header-logo" element
     When I follow "Create an account"
-    Then I should be on "/pocketcode/register/"
+    Then I should be on "/pocketcode/register"
     And I should see an "#header-logo" element
     And I fill in "sonata_user_registration_form_username" with "CatrobatNew"
     And I fill in "sonata_user_registration_form[email]" with "CatrobatNew@gmail.com"
@@ -34,14 +34,14 @@
     Then I should be on "/pocketcode/login"
     And I should see an "#header-logo" element
     When I follow "Create an account"
-    Then I should be on "/pocketcode/register/"
+    Then I should be on "/pocketcode/register"
     And I should see an "#header-logo" element
     And I fill in "sonata_user_registration_form_username" with "CatrobatNew"
     And I fill in "sonata_user_registration_form[email]" with "CatrobatNew@gmail.com"
     And I fill in "sonata_user_registration_form_plainPassword_first" with "123456"
     And I fill in "sonata_user_registration_form_plainPassword_second" with "12345"
     Then I press "Create my Account"
-    Then I should be on "/pocketcode/register/"
+    Then I should be on "/pocketcode/register"
 
   Scenario: Trying to register with an existing username should fail
     Given I am on homepage
@@ -50,30 +50,46 @@
     Then I should be on "/pocketcode/login"
     And I should see an "#header-logo" element
     When I follow "Create an account"
-    Then I should be on "/pocketcode/register/"
+    Then I should be on "/pocketcode/register"
     And I should see an "#header-logo" element
     And I fill in "sonata_user_registration_form_username" with "Catrobat"
     And I fill in "sonata_user_registration_form[email]" with "Catrobat@gmail.com"
     And I fill in "sonata_user_registration_form_plainPassword_first" with "123456"
     And I fill in "sonata_user_registration_form_plainPassword_second" with "123456"
     Then I press "Create my Account"
-    Then I should be on "/pocketcode/register/"
+    Then I should be on "/pocketcode/register"
 
-    Scenario: Trying to register with an existing e-mail-address should fail
-      Given I am on homepage
-      Then I should see an "#btn-login" element
-      When I click "#btn-login"
-      Then I should be on "/pocketcode/login"
-      And I should see an "#header-logo" element
-      When I follow "Create an account"
-      Then I should be on "/pocketcode/register/"
-      And I should see an "#header-logo" element
-      And I fill in "sonata_user_registration_form_username" with "CatrobatNew"
-      And I fill in "sonata_user_registration_form[email]" with "dev1@pocketcode.org"
-      And I fill in "sonata_user_registration_form_plainPassword_first" with "123456"
-      And I fill in "sonata_user_registration_form_plainPassword_second" with "123456"
-      Then I press "Create my Account"
-      Then I should be on "/pocketcode/register/"
+  Scenario: Trying to register with an existing e-mail-address should fail
+    Given I am on homepage
+    Then I should see an "#btn-login" element
+    When I click "#btn-login"
+    Then I should be on "/pocketcode/login"
+    And I should see an "#header-logo" element
+    When I follow "Create an account"
+    Then I should be on "/pocketcode/register"
+    And I should see an "#header-logo" element
+    And I fill in "sonata_user_registration_form_username" with "CatrobatNew"
+    And I fill in "sonata_user_registration_form[email]" with "dev1@pocketcode.org"
+    And I fill in "sonata_user_registration_form_plainPassword_first" with "123456"
+    And I fill in "sonata_user_registration_form_plainPassword_second" with "123456"
+    Then I press "Create my Account"
+    Then I should be on "/pocketcode/register"
+
+  Scenario: Trying to register with an e-mail address as username should fail
+    Given I am on homepage
+    Then I should see an "#btn-login" element
+    When I click "#btn-login"
+    Then I should be on "/pocketcode/login"
+    And I should see an "#header-logo" element
+    When I follow "Create an account"
+    Then I should be on "/pocketcode/register"
+    And I should see an "#header-logo" element
+    And I fill in "sonata_user_registration_form_username" with "catro@bat.org"
+    And I fill in "sonata_user_registration_form[email]" with "dev1337@pocketcode.org"
+    And I fill in "sonata_user_registration_form_plainPassword_first" with "123456"
+    And I fill in "sonata_user_registration_form_plainPassword_second" with "123456"
+    Then I press "Create my Account"
+    Then I should be on "/pocketcode/register"
 
 
   Scenario: Registering and login with the registered user but wrong password should not work
@@ -83,7 +99,7 @@
     Then I should be on "/pocketcode/login"
     And I should see an "#header-logo" element
     When I follow "Create an account"
-    Then I should be on "/pocketcode/register/"
+    Then I should be on "/pocketcode/register"
     And I should see an "#header-logo" element
     And I fill in "sonata_user_registration_form_username" with "CatrobatNew"
     And I fill in "sonata_user_registration_form[email]" with "CatrobatNew@gmail.com"


### PR DESCRIPTION
This PR implements a check if the username contains a `@` symbol and tells the user what the reason is why the registration failed.

It also adds error messages to tell the user when his entered passwords didn't match.