### PR TITLE
WEB-392 refactor behat tests for performance

### DIFF
--- a/src/Catrobat/AppBundle/Features/Web/Context/FeatureContext.php
+++ b/src/Catrobat/AppBundle/Features/Web/Context/FeatureContext.php
@@ -752,8 +752,7 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
   {
       if ($arg1 == 'in') {
           $this->assertPageNotContainsText('Your password or username was incorrect.');
-          $this->getSession()->wait(10000, 'window.location.href.search("login") == -1');
-          $this->getSession()->wait(1000);
+          $this->getSession()->wait(2000, 'window.location.href.search("login") == -1');
           $this->assertElementOnPage('#logo');
           $this->assertElementNotOnPage('#btn-login');
           $this->assertElementOnPage('#nav-dropdown');
@@ -761,8 +760,7 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
           $this->assertElementOnPage('#nav-dropdown');
       }
       if ($arg1 == 'out') {
-          $this->getSession()->wait(10000, 'window.location.href.search("profile") == -1');
-          $this->getSession()->wait(1000);
+          $this->getSession()->wait(2000, 'window.location.href.search("profile") == -1');
           $this->assertElementOnPage('#btn-login');
           $this->assertElementNotOnPage('#nav-dropdown');
       }
@@ -970,7 +968,6 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
     {
         if ($this->use_real_oauth_javascript_code) {
             $this->clickLink('btn-login_facebook');
-            $this->getSession()->wait(2000);
         } else {
             $this->setFacebookFakeData();
             $this->clickFacebookFakeButton();
@@ -1001,10 +998,8 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
     {
         if ($this->use_real_oauth_javascript_code) {
             $this->clickLink('btn-login_google');
-            $this->getSession()->wait(1500);
             if($arg1 == 'twice') {
                 $this->clickLink('btn-login_google');
-                $this->getSession()->wait(2500);
             }
         } else {
             $this->setGooglePlusFakeData();
@@ -1435,7 +1430,6 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
    */
   public function iSwitchToPopupWindow()
   {
-      $this->getSession()->wait(6000);
       $page = $this->getSession()->getPage();
       $window_names = $this->getSession()->getDriver()->getWindowNames();
       foreach ($window_names as $name) {
@@ -1446,7 +1440,6 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
           }
           $this->getSession()->switchToWindow($name);
       }
-      $this->getSession()->wait(1000);
   }
 
     /**
@@ -1458,7 +1451,6 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
             $mail = $this->getParameterValue('facebook_testuser_mail');
             $pw = $this->getParameterValue('facebook_testuser_pw');
             echo 'Login with mail address ' . $mail . ' and pw ' . $pw . "\n";
-            $this->getSession()->wait(1000);
             $page = $this->getSession()->getPage();
             if($page->find('css', '#facebook') && $page->find('css', '#login_form')) {
                 echo 'facebook login form appeared' . "\n";
@@ -1472,23 +1464,19 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
                 $page->fillField('pass',$pw);
                 $button = $page->findById('u_0_0');
                 assertTrue($button != null);
-                $this->getSession()->wait(500);
                 $button->press();
             } else {
                 assertTrue(false, 'No Facebook form appeared!' . "\n");
             }
             $this->getSession()->switchToWindow(null);
-            $this->getSession()->wait(1000);
 
             $this->iSwitchToPopupWindow();
             if($page->find('css', '#facebook') && $page->find('css', '._1a_q') ) {
                 echo 'facebook authentication login form appeared' . "\n";
                 $button = $page->findButton('__CONFIRM__');
                 assertTrue($button != null);
-                $this->getSession()->wait(500);
                 $button->press();
                 $this->getSession()->switchToWindow(null);
-                $this->getSession()->wait(1000);
             }
         } else {
             //simulate Facebook login by faking Javascript code and server responses from FakeOAuthService
@@ -1506,7 +1494,6 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
             $mail = $this->getParameterValue('google_testuser_mail');
             $pw = $this->getParameterValue('google_testuser_pw');
             echo 'Login with mail address ' . $mail . ' and pw ' . $pw . "\n";
-            $this->getSession()->wait(3000);
             $page = $this->getSession()->getPage();
             if($page->find('css', '#approval_container') &&
                 $page->find('css', '#submit_approve_access')) {
@@ -1523,7 +1510,6 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
             else {
                 assertTrue(false, 'No Google form appeared!' . "\n");
             }
-            $this->getSession()->wait(1000);
         } else {
             $this->setGooglePlusFakeData();
             $this->clickGooglePlusFakeButton();
@@ -1536,7 +1522,6 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
         $page = $this->getSession()->getPage();
         $button = $page->findById('submit_approve_access');
         assertTrue($button != null);
-        $this->getSession()->wait(1500);
         $button->press();
         $this->getSession()->switchToWindow(null);
     }
@@ -1550,7 +1535,6 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
         $button = $page->findById('signIn');
         assertTrue($button != null);
         $button->press();
-        $this->getSession()->wait(2000);
 
         $this->approveGoogleAccess();
     }
@@ -1563,7 +1547,6 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
         $button = $page->findById('next');
         assertTrue($button != null);
         $button->press();
-        $this->getSession()->wait(2000);
         if($page->find('css', '#gaia_firstform') &&
             $page->find('css', '#Email-hidden') &&
             $page->find('css', '#Passwd')
@@ -1580,7 +1563,6 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
         $button = $page->findById('signIn');
         assertTrue($button != null);
         $button->press();
-        $this->getSession()->wait(2000);
         if($page->find('css', '#approval_container') &&
             $page->find('css', '#submit_approve_access')) {
             $this->approveGoogleAccess();
@@ -1673,8 +1655,7 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
      */
     public function iShouldNotBeLoggedIn()
     {
-        $this->getSession()->wait(10000, 'window.location.href.search("profile") == -1');
-        $this->getSession()->wait(1000);
+        $this->getSession()->wait(1000, 'window.location.href.search("profile") == -1');
         $this->assertElementOnPage("#logo");
         $this->assertElementOnPage("#btn-login");
         $this->assertElementNotOnPage("#nav-dropdown");
@@ -1693,7 +1674,7 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
      */
     public function iChooseTheUsernameTestingButtonEnabled($arg1)
     {
-        $this->getSession()->wait(2500);
+        $this->getSession()->wait(300);
         $page = $this->getSession()->getPage();
 
         $button = $page->findById('btn_oauth_username');
@@ -1701,20 +1682,16 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
         assertTrue($button->hasAttribute('disabled'));
 
         $page->fillField('dialog_oauth_username_input',$arg1);
-        $this->getSession()->wait(400);
         assertFalse($button->hasAttribute('disabled'));
 
         $page->fillField('dialog_oauth_username_input','');
-        $this->getSession()->wait(400);
         assertTrue($button->hasAttribute('disabled'));
 
         $page->fillField('dialog_oauth_username_input',$arg1);
-        $this->getSession()->wait(400);
         $button->press();
         if (!$arg1 === self::ALREADY_IN_DB_USER) {
-            $this->getSession()->wait(10000, 'window.location.href.search("login") == -1');
+            $this->getSession()->wait(1000, 'window.location.href.search("login") == -1');
         }
-        $this->getSession()->wait(2500);
     }
 
     /**
@@ -1722,7 +1699,7 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
      */
     public function iChooseTheUsername($arg1)
     {
-        $this->getSession()->wait(2500);
+        $this->getSession()->wait(300);
         $page = $this->getSession()->getPage();
 
         $button = $page->findById('btn_oauth_username');
@@ -1730,14 +1707,13 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
         assertTrue($button->hasAttribute('disabled'));
 
         $page->fillField('dialog_oauth_username_input',$arg1);
-        $this->getSession()->wait(400);
         assertFalse($button->hasAttribute('disabled'));
 
         $button->press();
         if (!$arg1 === self::ALREADY_IN_DB_USER) {
-            $this->getSession()->wait(10000, 'window.location.href.search("login") == -1');
+            $this->getSession()->wait(1000, 'window.location.href.search("login") == -1');
         }
-        $this->getSession()->wait(2500);
+        $this->getSession()->wait(500);
     }
 
     private function getParameterValue($name) {
@@ -2102,7 +2078,7 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
      * @Given /^I wait for AJAX to finish$/
      */
     public function iWaitForAjaxToFinish() {
-        $this->getSession()->wait(10000, '(typeof(jQuery)=="undefined" || (0 === jQuery.active && 0 === jQuery(\':animated\').length))');
+        $this->getSession()->wait(5000, '(typeof(jQuery)=="undefined" || (0 === jQuery.active && 0 === jQuery(\':animated\').length))');
     }
 
     /**

--- a/src/Catrobat/AppBundle/Features/Web/comments.feature
+++ b/src/Catrobat/AppBundle/Features/Web/comments.feature
@@ -41,7 +41,7 @@ Feature: As a visitor I want to write, see and report comments.
     Given I am on "/pocketcode/program/1"
     And I write "hello" in textbox
     And I click the "send" button
-    And I wait for a second
+    And I wait 200 milliseconds
     Then I should be on "/pocketcode/login"
 
   Scenario: I should be able to write a comment when I am logged in
@@ -88,7 +88,7 @@ Feature: As a visitor I want to write, see and report comments.
   Scenario: When I click the report button, I should be redirected to the login page
     Given I am on "/pocketcode/program/2"
     When I click the "report-comment" button
-    And I wait for a second
+    And I wait 200 milliseconds
     Then I should be on "/pocketcode/login"
 
   Scenario: When I am logged in as an admin, I should see a delete button

--- a/src/Catrobat/AppBundle/Features/Web/login.feature
+++ b/src/Catrobat/AppBundle/Features/Web/login.feature
@@ -43,7 +43,6 @@
     When I go to "/pocketcode/resetting/request"
     And I fill in "username" with "Catrobat"
     And I press "recover"
-    And I wait for a second
     Then I should see "The password for this user has already been requested within the last 24 hours."
 
 Scenario: The referer should work even after one failed login

--- a/src/Catrobat/AppBundle/Features/Web/nolb.feature
+++ b/src/Catrobat/AppBundle/Features/Web/nolb.feature
@@ -24,13 +24,11 @@ Feature: Testcases for nolb user
   Scenario: Nolb user cannot edit their profile
     Given I log in as "nolbmuser" with the password "123456"
     And I am on "/pocketcode/profile"
-    And I wait for a second
     Then I should see 0 "#edit-icon"
 
   Scenario: Nolb teacher can only edit their password
     Given I log in as "nolbteacher" with the password "654321"
     And I am on "/pocketcode/profile"
-    And I wait for a second
     Then the element "#edit-icon" should be visible
     When I click the "edit" button
     Then the element "#password-information" should be visible

--- a/src/Catrobat/AppBundle/Features/Web/oauth.feature
+++ b/src/Catrobat/AppBundle/Features/Web/oauth.feature
@@ -25,7 +25,6 @@ Feature: Open Authentication
     Then I should not be logged in
     When I trigger Facebook login with auth_type ''
     And I click Facebook login link
-    And I wait for a second
     Then I should be logged in
 
   @javascript @insulated @RealOAuth
@@ -45,7 +44,6 @@ Feature: Open Authentication
     Then I should not be logged in
     When I trigger Google login with approval prompt "auto"
     And I click Google login link "once"
-    And I wait for a second
     Then I should be logged in
 
   @javascript
@@ -53,6 +51,7 @@ Feature: Open Authentication
     Given I am on "/pocketcode/login"
     When I log in to Facebook with valid credentials
     And I choose the username 'AlreadyinDB' and check button activations
+    And I wait 300 milliseconds
     Then I should see "Username already taken, please choose a different one."
 
   @javascript

--- a/src/Catrobat/AppBundle/Features/Web/program.feature
+++ b/src/Catrobat/AppBundle/Features/Web/program.feature
@@ -87,13 +87,13 @@ Feature: As a visitor I want to see a program page
       When I am on "/pocketcode/program/1"
       Then I should see "6 downloads"
 
-    Scenario:
+    Scenario: Clicking the download button should deactivate the download button for 5 seconds
       Given I am on "/pocketcode/program/1"
        When I click "#url-download"
        Then the href with id "url-download" should be void
 
-    Scenario:
+    Scenario: Clicking the download button again after 5 seconds should work
       Given I am on "/pocketcode/program/1"
-       When I click "#url-download"
-        And I wait 5000 milliseconds
+      When I click "#url-download"
+      And I wait 5000 milliseconds
       Then the href with id "url-download" should not be void

--- a/src/Catrobat/AppBundle/Features/Web/program_remixes.feature
+++ b/src/Catrobat/AppBundle/Features/Web/program_remixes.feature
@@ -94,7 +94,7 @@ Feature: As a visitor I want to see the full remix graph of a program on the pro
     Scenario: Viewing remix graph of program 8
       Given I am on "/pocketcode/program/8?show_graph=1"
       When I click "#remix-graph-modal-link"
-      When I wait 2000 milliseconds
+      When I wait 800 milliseconds
       And I should see a node with id "catrobat_8" having name "program 8" and username "Gangster"
       And I should see a node with id "catrobat_9" having name "program 9" and username "Superman"
       And I should see an edge from "catrobat_8" to "catrobat_9"
@@ -102,7 +102,7 @@ Feature: As a visitor I want to see the full remix graph of a program on the pro
     Scenario: Viewing remix graph of program 9
       Given I am on "/pocketcode/program/9?show_graph=1"
       When I click "#remix-graph-modal-link"
-      When I wait 2000 milliseconds
+      When I wait 800 milliseconds
       And I should see a node with id "catrobat_8" having name "program 8" and username "Gangster"
       And I should see a node with id "catrobat_9" having name "program 9" and username "Superman"
       And I should see an edge from "catrobat_8" to "catrobat_9"

--- a/src/Catrobat/AppBundle/Features/Web/share.feature
+++ b/src/Catrobat/AppBundle/Features/Web/share.feature
@@ -19,7 +19,7 @@ Feature: Sharing and Liking of programs
   Scenario: In a mobile browser the Facebook like button and the Google+ +1 button should be visible on the bottom of the program page
     Given I am browsing with my pocketcode app
     And I am on "/pocketcode/program/1"
-    And I wait for a second
+    And I wait 200 milliseconds
     Then I should see "program 1"
     And I should see the Facebook Like button on the bottom of the program page
 

--- a/src/Catrobat/AppBundle/Features/Web/visited_programs.feature
+++ b/src/Catrobat/AppBundle/Features/Web/visited_programs.feature
@@ -16,13 +16,11 @@ Feature: Pocketcode homepage visited programs
     And I should see 1 "#newest #program-1"
     When I click "#newest #program-1"
     And I am on homepage
-    And I wait for a second
     Then I should see marked "#newest #program-1"
 
   Scenario: Visited programs should be marked on the entire page.
     Given I am on "/pocketcode"
     And I should see 1 "#newest #program-1"
     When I click "#newest #program-1"
-    And I wait for a second
     And I am on "/pocketcode/profile/1"
     Then I should see marked "#program-1"


### PR DESCRIPTION
this removes any unneeded waits from behat tests and lowers the duration of needed waits to boost test execution

boost oauth.feature

remove unneeded waits and lower timing on needed ones which have a condition that wakes them up

increase waiting time for remix since passing propability was too low

lower waiting time of comment.feature

remove all unneeded occassions of waiting for 1 sec, lowered time to wait where waiting was needed