### PR TITLE
WEB-375_PenalizeComments bann user for comments

### DIFF
--- a/app/DoctrineMigrations/Version20170221152814.php
+++ b/app/DoctrineMigrations/Version20170221152814.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170221152814 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE fos_user ADD times_banned SMALLINT DEFAULT 0 NOT NULL, ADD banned_until DATETIME DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE fos_user DROP times_banned, DROP banned_until');
+    }
+}

--- a/app/DoctrineMigrations/Version20170411154141.php
+++ b/app/DoctrineMigrations/Version20170411154141.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170411154141 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE fos_user ADD warned TINYINT(1) DEFAULT \'0\' NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE fos_user DROP warned');
+    }
+}

--- a/app/Resources/translations/catroweb.en.yml
+++ b/app/Resources/translations/catroweb.en.yml
@@ -623,3 +623,10 @@ pmd:
 
 codeview:
   showText: Show code
+
+mail_messages:
+  banned_user:
+    subject: Your PocketCode account has been banned.
+    text_1_day: We are sorry to tell you that your PocketCode account has been banned for 24 hours because you violated our terms of service. If you violate our terms of service again your next bann will last a whole week. The third bann will be permanent. The reason for your bann is:
+    text_1_week: We are sorry to tell you that your PocketCode account has been banned for 1 week because you violated our terms of service. If you violate our terms of service again your next bann will be permanent. The reason for your bann is:
+    text_perm: We are sorry to tell you that your PocketCode account has been permanently banned. The reason for your bann is:

--- a/app/Resources/views/CRUD/list__action_bann.html.twig
+++ b/app/Resources/views/CRUD/list__action_bann.html.twig
@@ -1,0 +1,38 @@
+<button type="button" class="btn btn-sm btn-danger" data-toggle="modal" data-target="#ban-user-{{ object.id }}-modal">
+    <i class="glyphicon glyphicon-alert"></i> Ban User
+</button>
+
+<!-- Modal -->
+<div class="modal fade" id="ban-user-{{ object.id }}-modal" tabindex="-1" role="dialog" aria-labelledby="ban-user-{{ object.id }}-modal">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="Ban user?">Confirm ban of user</h4>
+            </div>
+            <form action="{{ admin.generateObjectUrl('bann', object) }}">
+                <input type="hidden" name="id" value="{{ object.id }}">
+                <div class="modal-body">
+                    <div class="row">
+                        <div class="col-md-12">
+                            You are about to ban the user {{ object.getUsername() }}. Please confirm your decision.
+                        </div>
+                        {#
+                        <div class="col-md-12">
+                            <div class="form-group">
+                                <label class="control-label"> Reason for the ban:</label>
+                                <textarea name="reason" class="form-control" rows="5"></textarea>
+                            </div>
+                        </div>
+                        #}
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                    {#<button type="submit" class="btn btn-sm btn-danger"><i class="glyphicon glyphicon-alert"></i> Ban User</button>#}
+                    <a class="btn btn-sm btn-danger" href="{{ admin.generateObjectUrl('bann', object) }}"><i class="glyphicon glyphicon-alert"></i> Ban User</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/app/Resources/views/CRUD/list__action_warn.html.twig
+++ b/app/Resources/views/CRUD/list__action_warn.html.twig
@@ -1,0 +1,40 @@
+<button type="button" class="btn btn-sm btn-warning" data-toggle="modal" data-target="#warn-user-{{ object.id }}-modal">
+    <i class="glyphicon glyphicon-alert"></i> Warn User
+</button>
+
+<!-- Modal -->
+<div class="modal fade" id="warn-user-{{ object.id }}-modal" tabindex="-1" role="dialog" aria-labelledby="warn-user-{{ object.id }}-modal">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="Warn user?">Confirm warn of user</h4>
+            </div>
+            <form action="{{ admin.generateObjectUrl('warn', object) }}">
+                <input type="hidden" name="id" value="{{ object.id }}">
+                <div class="modal-body">
+                    <div class="row">
+                        <div class="col-md-12">
+                            You are about to warn the user {{ object.getUsername() }}. You can use the User admin view
+                            to check if the user has already been warned before. After continuous
+                            violations against our ToS you should ban the user. Please confirm your decision.
+                        </div>
+                        {#
+                        <div class="col-md-12">
+                            <div class="form-group">
+                                <label class="control-label"> Reason for the ban:</label>
+                                <textarea name="reason" class="form-control" rows="5"></textarea>
+                            </div>
+                        </div>
+                        #}
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                    {#<button type="submit" class="btn btn-sm btn-danger"><i class="glyphicon glyphicon-alert"></i> Ban User</button>#}
+                    <a class="btn btn-sm btn-warning" href="{{ admin.generateObjectUrl('warn', object) }}"><i class="glyphicon glyphicon-alert"></i> Warn User</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -29,7 +29,6 @@ parameters:
       
 services:
 
-
     apikey_authenticator:
         class:     Catrobat\AppBundle\Security\ApiKeyAuthenticator
         arguments: ["@translator"]
@@ -377,3 +376,7 @@ services:
         class: Catrobat\AppBundle\Services\AsyncHttpClient
         arguments:
           - { timeout: 8.0, max_number_of_total_requests: 12, max_number_of_concurrent_requests: 4 }
+
+    security.user_checker:
+        class: Catrobat\AppBundle\Security\UserChecker
+        arguments: ['@doctrine.orm.entity_manager']

--- a/src/Catrobat/AppBundle/Admin/ReportAdmin.php
+++ b/src/Catrobat/AppBundle/Admin/ReportAdmin.php
@@ -49,6 +49,8 @@ class ReportAdmin extends Admin
       ->add('_action', 'actions', array('actions' => array(
         'delete' => array('template' => ':CRUD:list__action_delete_comment.html.twig'),
         'unreport' => array('template' => ':CRUD:list__action_unreport.html.twig'),
+        'warn' => array('template' => ':CRUD:list__action_warn.html.twig'),
+        'bann' => array('template' => ':CRUD:list__action_bann.html.twig'),
       )))
     ;
   }
@@ -58,6 +60,8 @@ class ReportAdmin extends Admin
   {
     $collection->add('deleteComment');
     $collection->add('unreport');
+    $collection->add('bann');
+    $collection->add('warn');
   }
 
 

--- a/src/Catrobat/AppBundle/Controller/Admin/ReportController.php
+++ b/src/Catrobat/AppBundle/Controller/Admin/ReportController.php
@@ -5,43 +5,178 @@ namespace Catrobat\AppBundle\Controller\Admin;
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ReportController extends Controller
 {
-    public function unreportAction(Request $request = null) {
+  public function unreportAction(Request $request = null)
+  {
 
-        /* @var $object \Catrobat\AppBundle\Entity\UserComment */
-        $object = $this->admin->getSubject();
+    /* @var $object \Catrobat\AppBundle\Entity\UserComment */
+    $object = $this->admin->getSubject();
 
-        if (!$object) {
-            throw new NotFoundHttpException();
-        }
-
-        $object->setIsReported(false);
-        $this->admin->update($object);
-
-        $this->addFlash('sonata_flash_success', 'Report ' . $object->getId() . ' removed from list');
-
-        return new RedirectResponse($this->admin->generateUrl('list'));
+    if (!$object)
+    {
+      throw new NotFoundHttpException();
     }
 
-    public function deleteCommentAction(Request $request = null) {
-        /* @var $object \Catrobat\AppBundle\Entity\UserComment */
-        $object = $this->admin->getSubject();
+    $object->setIsReported(false);
+    $this->admin->update($object);
 
-        if (!$object) {
-            throw new NotFoundHttpException();
-        }
-        $em = $this->getDoctrine()->getManager();
-        $comment = $em->getRepository('AppBundle:UserComment')->find($object->getId());
+    $this->addFlash('sonata_flash_success', 'Report ' . $object->getId() . ' removed from list');
 
-        if (!$comment) {
-            throw $this->createNotFoundException(
-                'No comment found for this id ' . $object->getId());
-        }
-        $em->remove($comment);
-        $em->flush();
-        $this->addFlash('sonata_flash_success', 'Comment ' . $object->getId() . ' deleted');
-        return new RedirectResponse($this->admin->generateUrl('list'));
+    return new RedirectResponse($this->admin->generateUrl('list'));
+  }
+
+  public function deleteCommentAction(Request $request = null)
+  {
+    /* @var $object \Catrobat\AppBundle\Entity\UserComment */
+    $object = $this->admin->getSubject();
+
+    if (!$object)
+    {
+      throw new NotFoundHttpException();
     }
+    $em = $this->getDoctrine()->getManager();
+    $comment = $em->getRepository('AppBundle:UserComment')->find($object->getId());
+
+    if (!$comment)
+    {
+      throw $this->createNotFoundException(
+        'No comment found for this id ' . $object->getId());
+    }
+    $em->remove($comment);
+    $em->flush();
+    $this->addFlash('sonata_flash_success', 'Comment ' . $object->getId() . ' deleted');
+
+    return new RedirectResponse($this->admin->generateUrl('list'));
+  }
+
+  public function warnAction(Request $request = null)
+  {
+    /* @var $object \Catrobat\AppBundle\Entity\UserComment */
+    $object = $this->admin->getSubject();
+
+    if (!$object)
+    {
+      throw new NotFoundHttpException();
+    }
+    $em = $this->getDoctrine()->getManager();
+    $comment = $em->getRepository('AppBundle:UserComment')->find($object->getId());
+
+    if (!$comment)
+    {
+      throw $this->createNotFoundException(
+        'No comment found for this id ' . $object->getId());
+    }
+
+    $user = $em->getRepository('AppBundle:User')->find($comment->getUserId());
+
+    if (!$user)
+    {
+      throw $this->createNotFoundException(
+        'No user found for this id ' . $comment->getUserId());
+    }
+    $user->setWarned(true);
+    $admin_message = 'User ' . $user->getUsername() . ' successfully warned.';
+    $mail_message = 'Hi ' . $user->getUsername() . ".\n";
+    $mail_message .= 'This is a warning. It seems like you have violated our terms of service. 
+    If you violate our terms of service again your PocketCode account will be banned.' .
+      'The reason for warning ban is:';
+    $reason = "Violation of our Terms of service. You can find them here: https://share.catrob.at/pocketcode/termsOfUse";
+    $reason .= "\n\nText of the comment you have been warned for: \n";
+    $reason .= $comment->getText();
+    $mail_message .= "\n" . $reason;
+
+    $em->remove($comment);
+    $em->flush();
+
+    $mail_address = $user->getEmail();
+
+    $mail_content = wordwrap($mail_message, 70);
+    $headers = "From: webmaster@catrob.at" . "\r\n";
+    mail($mail_address, "Your PocketCode account has been banned", $mail_content, $headers);
+
+    $this->addFlash('sonata_flash_success', $admin_message);
+
+//        $this->addFlash('sonata_flash_success', 'Message is: ' . $mail_message);
+    return new RedirectResponse($this->admin->generateUrl('list'));
+  }
+
+  public function bannAction(Request $request = null)
+  {
+    /* @var $object \Catrobat\AppBundle\Entity\UserComment */
+    $object = $this->admin->getSubject();
+
+    if (!$object)
+    {
+      throw new NotFoundHttpException();
+    }
+    $em = $this->getDoctrine()->getManager();
+    $comment = $em->getRepository('AppBundle:UserComment')->find($object->getId());
+
+    if (!$comment)
+    {
+      throw $this->createNotFoundException(
+        'No comment found for this id ' . $object->getId());
+    }
+
+    $user = $em->getRepository('AppBundle:User')->find($comment->getUserId());
+
+    if (!$user)
+    {
+      throw $this->createNotFoundException(
+        'No user found for this id ' . $comment->getUserId());
+    }
+
+    $ban_duration = $user->ban();
+    $admin_message = 'User ' . $user->getUsername() . ' successfully banned for ';
+    $mail_message = 'Hi ' . $user->getUsername() . ".\n";
+
+    switch ($ban_duration)
+    {
+      case 1:
+        $admin_message .= "1 day.";
+        $mail_message .= 'We are sorry to tell you that your PocketCode account has been banned for 24 hours ' .
+          'because you violated our terms of service. If you violate our terms of service again your next ' .
+          'ban will last a whole week. The third ban will be permanent. The reason for your ban is:';
+        break;
+      case 7:
+        $admin_message .= "1 week.";
+        $mail_message .= 'We are sorry to tell you that your PocketCode account has been banned for 1 week ' .
+          'because you violated our terms of service. If you violate our terms of service again your next ' .
+          'ban will be permanent. The reason for your ban is:';
+        break;
+      case 99:
+        $admin_message = 'User ' . $user->getUsername() . ' was permanently banned.';
+        $mail_message .= 'We are sorry to tell you that your PocketCode account has been permanently banned. ' .
+          'The reason for your ban is:';
+        break;
+      default:
+        $admin_message = 'User ' . $user->getUsername() . ' was permanently banned.';
+        $mail_message .= 'We are sorry to tell you that your PocketCode account has been permanently banned. ' .
+          'The reason for your ban is:';
+        break;
+    }
+
+//        $reason = $request->query->get('reason');
+    $reason = "Violation of our Terms of service. You can find them here: https://share.catrob.at/pocketcode/termsOfUse";
+    $reason .= "\nText of the comment you have been banned for: \n";
+    $reason .= $comment->getText();
+    $mail_message .= "\n" . $reason;
+
+    $em->remove($comment);
+    $em->flush();
+
+    $mail_address = $user->getEmail();
+
+    $mail_content = wordwrap($mail_message, 70);
+    $headers = "From: webmaster@catrob.at" . "\r\n";
+    mail($mail_address, "Your PocketCode account has been banned", $mail_content, $headers);
+
+    $this->addFlash('sonata_flash_success', $admin_message);
+
+//        $this->addFlash('sonata_flash_success', 'Message is: ' . $mail_message);
+    return new RedirectResponse($this->admin->generateUrl('list'));
+  }
 }

--- a/src/Catrobat/AppBundle/Entity/User.php
+++ b/src/Catrobat/AppBundle/Entity/User.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Catrobat\AppBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -13,368 +14,471 @@ use Doctrine\ORM\Mapping as ORM;
 class User extends BaseUser implements LdapUserInterface
 {
 
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    protected $id;
+  /**
+   * @ORM\Id
+   * @ORM\Column(type="integer")
+   * @ORM\GeneratedValue(strategy="AUTO")
+   */
+  protected $id;
 
-    /**
-     * @ORM\Column(type="string", length=300, nullable=true)
-     */
-    protected $upload_token;
+  /**
+   * @ORM\Column(type="string", length=300, nullable=true)
+   */
+  protected $upload_token;
 
-    /**
-     * @ORM\Column(type="text", nullable=true)
-     */
-    protected $avatar;
+  /**
+   * @ORM\Column(type="text", nullable=true)
+   */
+  protected $avatar;
 
-    /**
-     * @ORM\Column(type="string", length=5, nullable=false, options={"default":""})
-     */
-    protected $country;
+  /**
+   * @ORM\Column(type="string", length=5, nullable=false, options={"default":""})
+   */
+  protected $country;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
-    protected $additional_email;
+  /**
+   * @ORM\Column(type="string", nullable=true)
+   */
+  protected $additional_email;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
-    protected $dn;
+  /**
+   * @ORM\Column(type="string", nullable=true)
+   */
+  protected $dn;
 
-    /**
-     * @ORM\OneToMany(targetEntity="Program", mappedBy="user", fetch="EXTRA_LAZY")
-     */
-    protected $programs;
+  /**
+   * @ORM\OneToMany(targetEntity="Program", mappedBy="user", fetch="EXTRA_LAZY")
+   */
+  protected $programs;
 
-    /**
-     * @ORM\OneToMany(
-     *     targetEntity="\Catrobat\AppBundle\Entity\ProgramLike",
-     *     mappedBy="user",
-     *     cascade={"persist", "remove"},
-     *     orphanRemoval=true
-     * )
-     * @var \Doctrine\Common\Collections\Collection|ProgramLike[]
-     */
-    protected $likes;
+  /**
+   * @ORM\OneToMany(
+   *     targetEntity="\Catrobat\AppBundle\Entity\ProgramLike",
+   *     mappedBy="user",
+   *     cascade={"persist", "remove"},
+   *     orphanRemoval=true
+   * )
+   * @var \Doctrine\Common\Collections\Collection|ProgramLike[]
+   */
+  protected $likes;
 
-    /**
-     * @ORM\OneToMany(
-     *     targetEntity="\Catrobat\AppBundle\Entity\UserLikeSimilarityRelation",
-     *     mappedBy="first_user",
-     *     cascade={"persist", "remove"},
-     *     orphanRemoval=true
-     * )
-     * @var \Doctrine\Common\Collections\Collection|UserLikeSimilarityRelation[]
-     */
-    protected $relations_of_similar_users_based_on_likes;
+  /**
+   * @ORM\OneToMany(
+   *     targetEntity="\Catrobat\AppBundle\Entity\UserLikeSimilarityRelation",
+   *     mappedBy="first_user",
+   *     cascade={"persist", "remove"},
+   *     orphanRemoval=true
+   * )
+   * @var \Doctrine\Common\Collections\Collection|UserLikeSimilarityRelation[]
+   */
+  protected $relations_of_similar_users_based_on_likes;
 
-    /**
-     * @ORM\OneToMany(
-     *     targetEntity="\Catrobat\AppBundle\Entity\UserLikeSimilarityRelation",
-     *     mappedBy="second_user",
-     *     cascade={"persist", "remove"},
-     *     orphanRemoval=true
-     * )
-     * @var \Doctrine\Common\Collections\Collection|UserLikeSimilarityRelation[]
-     */
-    protected $reverse_relations_of_similar_users_based_on_likes;
+  /**
+   * @ORM\OneToMany(
+   *     targetEntity="\Catrobat\AppBundle\Entity\UserLikeSimilarityRelation",
+   *     mappedBy="second_user",
+   *     cascade={"persist", "remove"},
+   *     orphanRemoval=true
+   * )
+   * @var \Doctrine\Common\Collections\Collection|UserLikeSimilarityRelation[]
+   */
+  protected $reverse_relations_of_similar_users_based_on_likes;
 
-    /**
-     * @ORM\OneToMany(
-     *     targetEntity="\Catrobat\AppBundle\Entity\UserRemixSimilarityRelation",
-     *     mappedBy="first_user",
-     *     cascade={"persist", "remove"},
-     *     orphanRemoval=true
-     * )
-     * @var \Doctrine\Common\Collections\Collection|UserRemixSimilarityRelation[]
-     */
-    protected $relations_of_similar_users_based_on_remixes;
+  /**
+   * @ORM\OneToMany(
+   *     targetEntity="\Catrobat\AppBundle\Entity\UserRemixSimilarityRelation",
+   *     mappedBy="first_user",
+   *     cascade={"persist", "remove"},
+   *     orphanRemoval=true
+   * )
+   * @var \Doctrine\Common\Collections\Collection|UserRemixSimilarityRelation[]
+   */
+  protected $relations_of_similar_users_based_on_remixes;
 
-    /**
-     * @ORM\OneToMany(
-     *     targetEntity="\Catrobat\AppBundle\Entity\UserRemixSimilarityRelation",
-     *     mappedBy="second_user",
-     *     cascade={"persist", "remove"},
-     *     orphanRemoval=true
-     * )
-     * @var \Doctrine\Common\Collections\Collection|UserRemixSimilarityRelation[]
-     */
-    protected $reverse_relations_of_similar_users_based_on_remixes;
+  /**
+   * @ORM\OneToMany(
+   *     targetEntity="\Catrobat\AppBundle\Entity\UserRemixSimilarityRelation",
+   *     mappedBy="second_user",
+   *     cascade={"persist", "remove"},
+   *     orphanRemoval=true
+   * )
+   * @var \Doctrine\Common\Collections\Collection|UserRemixSimilarityRelation[]
+   */
+  protected $reverse_relations_of_similar_users_based_on_remixes;
 
-    /**
-     * @ORM\Column(type="string", length=300, nullable=true)
-     */
-    protected $gplus_access_token;
+  /**
+   * @ORM\Column(type="string", length=300, nullable=true)
+   */
+  protected $gplus_access_token;
 
-    /**
-     * @ORM\Column(type="string", length=300, nullable=true)
-     */
-    protected $gplus_id_token;
+  /**
+   * @ORM\Column(type="string", length=300, nullable=true)
+   */
+  protected $gplus_id_token;
 
-    /**
-     * @ORM\Column(type="string", length=300, nullable=true)
-     */
-    protected $gplus_refresh_token;
+  /**
+   * @ORM\Column(type="string", length=300, nullable=true)
+   */
+  protected $gplus_refresh_token;
 
-    /**
-     * @ORM\Column(type="string", length=300, nullable=true)
-     */
-    protected $facebook_access_token;
+  /**
+   * @ORM\Column(type="string", length=300, nullable=true)
+   */
+  protected $facebook_access_token;
 
-    /**
-     * @ORM\Column(type="boolean", options={"default":false})
-     */
-    protected $limited = false;
+  /**
+   * @ORM\Column(type="boolean", options={"default":false})
+   */
+  protected $limited = false;
 
-    /**
-     * @ORM\Column(type="boolean", options={"default":false})
-     */
-    protected $nolb_user = false;
+  /**
+   * @ORM\Column(type="boolean", options={"default":false})
+   */
+  protected $nolb_user = false;
 
-    public function __construct()
+  /**
+   * @ORM\Column(type="boolean", options={"default":false})
+   */
+  protected $warned = false;
+
+  /**
+   * @ORM\Column(type="smallint", options={"default":0})
+   */
+  protected $times_banned = 0;
+
+  /**
+   * @ORM\Column(type="datetime", nullable=true, options={"default":null})
+   */
+  protected $banned_until = null;
+
+  public function __construct()
+  {
+    parent::__construct();
+    $this->programs = new \Doctrine\Common\Collections\ArrayCollection();
+    $this->country = '';
+  }
+
+  /**
+   *
+   * @param mixed $facebook_access_token
+   */
+  public function setFacebookAccessToken($facebook_access_token)
+  {
+    $this->facebook_access_token = $facebook_access_token;
+  }
+
+  /**
+   *
+   * @return mixed
+   */
+  public function getFacebookAccessToken()
+  {
+    return $this->facebook_access_token;
+  }
+
+  /**
+   *
+   * @param mixed $gplus_access_token
+   */
+  public function setGplusAccessToken($gplus_access_token)
+  {
+    $this->gplus_access_token = $gplus_access_token;
+  }
+
+  /**
+   *
+   * @return mixed
+   */
+  public function getGplusAccessToken()
+  {
+    return $this->gplus_access_token;
+  }
+
+  /**
+   *
+   * @param mixed $gplus_id_token
+   */
+  public function setGplusIdToken($gplus_id_token)
+  {
+    $this->gplus_id_token = $gplus_id_token;
+  }
+
+  /**
+   *
+   * @return mixed
+   */
+  public function getGplusIdToken()
+  {
+    return $this->gplus_id_token;
+  }
+
+  /**
+   *
+   * @param mixed $gplus_refresh_token
+   */
+  public function setGplusRefreshToken($gplus_refresh_token)
+  {
+    $this->gplus_refresh_token = $gplus_refresh_token;
+  }
+
+  /**
+   *
+   * @return mixed
+   */
+  public function getGplusRefreshToken()
+  {
+    return $this->gplus_refresh_token;
+  }
+
+  /**
+   * Get id.
+   *
+   * @return int
+   */
+  public function getId()
+  {
+    return $this->id;
+  }
+
+  /**
+   * Add programs.
+   *
+   * @param \Catrobat\AppBundle\Entity\Program $programs
+   *
+   * @return User
+   */
+  public function addProgram(\Catrobat\AppBundle\Entity\Program $programs)
+  {
+    $this->programs[] = $programs;
+
+    return $this;
+  }
+
+  /**
+   * Remove programs
+   *
+   * @param \Catrobat\AppBundle\Entity\Program $programs
+   */
+  public function removeProgram(\Catrobat\AppBundle\Entity\Program $programs)
+  {
+    $this->programs->removeElement($programs);
+  }
+
+  /**
+   * Get programs.
+   *
+   * @return \Doctrine\Common\Collections\Collection
+   */
+  public function getPrograms()
+  {
+    return $this->programs;
+  }
+
+  public function getUploadToken()
+  {
+    return $this->upload_token;
+  }
+
+  public function setUploadToken($upload_token)
+  {
+    $this->upload_token = $upload_token;
+  }
+
+  public function getCountry()
+  {
+    return $this->country;
+  }
+
+  public function setCountry($country)
+  {
+    $this->country = $country;
+
+    return $this;
+  }
+
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+
+  /**
+   *
+   * @param mixed $additional_email
+   */
+  public function setAdditionalEmail($additional_email)
+  {
+    $this->additional_email = $additional_email;
+  }
+
+  /**
+   *
+   * @return mixed
+   */
+  public function getAdditionalEmail()
+  {
+    return $this->additional_email;
+  }
+
+  public function getAvatar()
+  {
+    return $this->avatar;
+  }
+
+  public function setAvatar($avatar)
+  {
+    $this->avatar = $avatar;
+
+    return $this;
+  }
+
+  /**
+   * Set Ldap Distinguished Name.
+   *
+   * @param string $dn
+   *            Distinguished Name
+   */
+  public function setDn($dn)
+  {
+    $this->dn = strtolower($dn);
+  }
+
+  /**
+   * Get Ldap Distinguished Name.
+   *
+   * @return string Distinguished Name
+   */
+  public function getDn()
+  {
+    return $this->dn;
+  }
+
+  public function isLimited()
+  {
+    return $this->limited;
+  }
+
+  public function setLimited($limited)
+  {
+    $this->limited = $limited;
+  }
+
+  /**
+   * @return mixed
+   */
+  public function getNolbUser()
+  {
+    return $this->nolb_user;
+  }
+
+  /**
+   * @param mixed $nolb_user
+   */
+  public function setNolbUser($nolb_user)
+  {
+    $this->nolb_user = $nolb_user;
+  }
+
+  /**
+   * @return ProgramLike[]|\Doctrine\Common\Collections\Collection
+   */
+  public function getLikes()
+  {
+    return ($this->likes != null) ? $this->likes : new ArrayCollection();
+  }
+
+  /**
+   * @param ProgramLike[]|\Doctrine\Common\Collections\Collection $likes
+   */
+  public function setLikes($likes)
+  {
+    $this->likes = $likes;
+  }
+
+  /**
+   * @return mixed
+   */
+  public function getBannedUntil()
+  {
+    return $this->banned_until;
+  }
+
+  /**
+   * @param mixed $banned_until
+   */
+  public function setBannedUntil($banned_until)
+  {
+    $this->banned_until = $banned_until;
+  }
+
+  /**
+   * @return mixed
+   */
+  public function getTimesBanned()
+  {
+    return $this->times_banned;
+  }
+
+  /**
+   * @param mixed $times_banned
+   */
+  public function setTimesBanned($times_banned)
+  {
+    $this->times_banned = $times_banned;
+  }
+
+  public function getLocked()
+  {
+    return $this->locked;
+  }
+
+  /**
+   * Bans the user
+   * First time: 24h
+   * Second time: 7d
+   * Third time: permanent
+   * @return String $admin_message contains the text for the flash message
+   */
+  public function ban()
+  {
+    $this->times_banned++;
+    $ban_duration = 0;
+    switch ($this->times_banned)
     {
-        parent::__construct();
-        $this->programs = new \Doctrine\Common\Collections\ArrayCollection();
-        $this->country = '';
+      case 1:
+        $time_to_ban = '+1 day';
+        $ban_duration = 1;
+        break;
+      case 2:
+        $time_to_ban = '+7 days';
+        $ban_duration = 7;
+        break;
+      case 3:
+        $time_to_ban = '+90 years';
+        $ban_duration = 99;
+        break;
+      default:
+        // should never happen
+        $time_to_ban = '+7 days';
+        $ban_duration = 100;
+        break;
     }
+    $banned_until = new \DateTime($time_to_ban);
+    $this->banned_until = $banned_until;
+    $this->setLocked(true);
 
-    /**
-     *
-     * @param mixed $facebook_access_token
-     */
-    public function setFacebookAccessToken($facebook_access_token)
-    {
-        $this->facebook_access_token = $facebook_access_token;
-    }
+    return $ban_duration;
+  }
 
-    /**
-     *
-     * @return mixed
-     */
-    public function getFacebookAccessToken()
-    {
-        return $this->facebook_access_token;
-    }
+  public function isWarned()
+  {
+    return $this->warned;
+  }
 
-    /**
-     *
-     * @param mixed $gplus_access_token
-     */
-    public function setGplusAccessToken($gplus_access_token)
-    {
-        $this->gplus_access_token = $gplus_access_token;
-    }
-
-    /**
-     *
-     * @return mixed
-     */
-    public function getGplusAccessToken()
-    {
-        return $this->gplus_access_token;
-    }
-
-    /**
-     *
-     * @param mixed $gplus_id_token
-     */
-    public function setGplusIdToken($gplus_id_token)
-    {
-        $this->gplus_id_token = $gplus_id_token;
-    }
-
-    /**
-     *
-     * @return mixed
-     */
-    public function getGplusIdToken()
-    {
-        return $this->gplus_id_token;
-    }
-
-    /**
-     *
-     * @param mixed $gplus_refresh_token
-     */
-    public function setGplusRefreshToken($gplus_refresh_token)
-    {
-        $this->gplus_refresh_token = $gplus_refresh_token;
-    }
-
-    /**
-     *
-     * @return mixed
-     */
-    public function getGplusRefreshToken()
-    {
-        return $this->gplus_refresh_token;
-    }
-
-    /**
-     * Get id.
-     *
-     * @return int
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    /**
-     * Add programs.
-     *
-     * @param \Catrobat\AppBundle\Entity\Program $programs
-     *
-     * @return User
-     */
-    public function addProgram(\Catrobat\AppBundle\Entity\Program $programs)
-    {
-        $this->programs[] = $programs;
-
-        return $this;
-    }
-
-    /**
-     * Remove programs
-     *
-     * @param \Catrobat\AppBundle\Entity\Program $programs
-     */
-    public function removeProgram(\Catrobat\AppBundle\Entity\Program $programs)
-    {
-        $this->programs->removeElement($programs);
-    }
-
-    /**
-     * Get programs.
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getPrograms()
-    {
-        return $this->programs;
-    }
-
-    public function getUploadToken()
-    {
-        return $this->upload_token;
-    }
-
-    public function setUploadToken($upload_token)
-    {
-        $this->upload_token = $upload_token;
-    }
-
-    public function getCountry()
-    {
-        return $this->country;
-    }
-
-    public function setCountry($country)
-    {
-        $this->country = $country;
-
-        return $this;
-    }
-
-    public function setId($id)
-    {
-        $this->id = $id;
-    }
-
-    /**
-     *
-     * @param mixed $additional_email
-     */
-    public function setAdditionalEmail($additional_email)
-    {
-        $this->additional_email = $additional_email;
-    }
-
-    /**
-     *
-     * @return mixed
-     */
-    public function getAdditionalEmail()
-    {
-        return $this->additional_email;
-    }
-
-    public function getAvatar()
-    {
-        return $this->avatar;
-    }
-
-    public function setAvatar($avatar)
-    {
-        $this->avatar = $avatar;
-
-        return $this;
-    }
-
-    /**
-     * Set Ldap Distinguished Name.
-     *
-     * @param string $dn
-     *            Distinguished Name
-     */
-    public function setDn($dn)
-    {
-        $this->dn = strtolower($dn);
-    }
-
-    /**
-     * Get Ldap Distinguished Name.
-     *
-     * @return string Distinguished Name
-     */
-    public function getDn()
-    {
-        return $this->dn;
-    }
-
-    public function isLimited()
-    {
-        return $this->limited;
-    }
-
-    public function setLimited($limited)
-    {
-        $this->limited = $limited;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getNolbUser()
-    {
-        return $this->nolb_user;
-    }
-
-    /**
-     * @param mixed $nolb_user
-     */
-    public function setNolbUser($nolb_user)
-    {
-        $this->nolb_user = $nolb_user;
-    }
-
-    /**
-     * @return ProgramLike[]|\Doctrine\Common\Collections\Collection
-     */
-    public function getLikes()
-    {
-        return ($this->likes != null) ? $this->likes : new ArrayCollection();
-    }
-
-    /**
-     * @param ProgramLike[]|\Doctrine\Common\Collections\Collection $likes
-     */
-    public function setLikes($likes)
-    {
-        $this->likes = $likes;
-    }
+  /**
+   * @param mixed $warned
+   */
+  public function setWarned($warned)
+  {
+    $this->warned = $warned;
+  }
 }

--- a/src/Catrobat/AppBundle/Features/Web/Context/FeatureContext.php
+++ b/src/Catrobat/AppBundle/Features/Web/Context/FeatureContext.php
@@ -441,8 +441,44 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
       }
       $user_manager->updateUser($user, true);
   }
+    /**
+     * @Given /^there are banned users:$/
+     */
+    public function thereAreBannedUsers(TableNode $table)
+    {
+        /**
+         * @var $user_manager UserManager
+         * @var $user User
+         */
+        $user_manager = $this->kernel->getContainer()->get('usermanager');
+        $users = $table->getHash();
+        $user = null;
+        for ($i = 0; $i < count($users); ++$i ) {
+            $user = $user_manager->createUser();
+            $user->setUsername($users[$i]['name']);
+            $user->setEmail($users[$i]['email']);
+            $user->setAdditionalEmail('');
+            $user->setPlainPassword($users[$i]['password']);
+            $user->setEnabled(true);
+            $user->setUploadToken($users[$i]['token']);
+            $user->setCountry('at');
+            $user->setNolbUser(isset($users[$i]['nolb_status']) ? $users[$i]['nolb_status'] == 'true' : false);
+            $user->setLocked($users[$i]['locked']);
+            if ($users[$i]['banned_until'] == 'null')
+            {
+                $user->setBannedUntil(null);
+            }
+            else
+            {
+                $user->setBannedUntil(new \DateTime($users[$i]['banned_until']));
+            }
+            $user->setTimesBanned($users[$i]['times_banned']);
+            $user_manager->updateUser($user, false);
+        }
+        $user_manager->updateUser($user, true);
+    }
 
-  /**
+    /**
    * @Given /^there are admins:$/
    */
   public function thereAreAdmins(TableNode $table)
@@ -469,6 +505,15 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
     $user_manager->updateUser($user, true);
   }
 
+    /**
+     * @Then /^There should be a new user "([^"]*)"$/
+     */
+    public function thereShouldBeANewUser($arg1)
+    {
+        $em = $this->kernel->getContainer()->get('doctrine')->getManager();
+        $user = $em->getRepository('AppBundle:User')->findOneBy(array('username' => $arg1));
+        assertEquals($arg1, $user->getUsername(), "New user " . $arg1 . " not found!");
+    }
 
   /**
    * @Given /^there are programs:$/

--- a/src/Catrobat/AppBundle/Features/Web/banned_user.feature
+++ b/src/Catrobat/AppBundle/Features/Web/banned_user.feature
@@ -1,0 +1,28 @@
+@homepage
+  Feature:
+    As a banned user, I should not be able to login. But I should also be unbanned after some time.
+
+  Background:
+    Given there are banned users:
+      | name     | password  | token      | email               | locked | times_banned | banned_until |
+      | Catrobat | 123456    | cccccccccc | dev1@pocketcode.org | 0      | 0            | null         |
+      | User1    | 654321    | cccccccccc | dev2@pocketcode.org | 1      | 1            | +2 days      |
+      | User2    | bob       | cccccccccc | dev3@pocketcode.org | 1      | 2            | -3 days      |
+
+
+  Scenario: A banned user should not be able to log in
+    Given I am on "/pocketcode/login"
+    Then I should be on "/pocketcode/login"
+    And I fill in "username" with "User1"
+    And I fill in "password" with "654321"
+    And I press "Login"
+    Then I should see "Your password or username was incorrect."
+
+  Scenario: A banned user who should be automatically unbanned should be able to log in
+    Given I am on "/pocketcode/login"
+    Then I should be on "/pocketcode/login"
+    And I fill in "username" with "User2"
+    And I fill in "password" with "bob"
+    And I press "Login"
+    Then I should be logged in
+    And I should see "Catrobat"

--- a/src/Catrobat/AppBundle/Features/Web/comments.feature
+++ b/src/Catrobat/AppBundle/Features/Web/comments.feature
@@ -13,20 +13,20 @@ Feature: As a visitor I want to write, see and report comments.
       | 3  | program 3 | abcef                   | Gregor   | 333       | 3             | 9     | 22.04.2014 13:00 | 0.8.5   | 0.93             |  true   | true      |                                                                                      |
 
     And there are comments:
-      | program_id | user_id | upload_date      | text                | user_name | reported |
-      | 1          | 0       | 01.01.2013 12:01 | 1 | Superman  | true     |
-      | 1          | 1       | 01.01.2013 12:01 | 2 | Superman  | true     |
-      | 2          | 1       | 01.01.2013 12:01 | 3 | Superman  | true     |
-      | 2          | 1       | 01.01.2013 12:01 | 4 | Superman  | true     |
-      | 2          | 1       | 01.01.2013 12:01 | 5 | Superman  | true     |
-      | 2          | 0       | 01.01.2013 12:01 | 6 | Superman  | true     |
-      | 2          | 0       | 01.01.2013 12:01 | 7 | Superman  | true     |
-      | 2          | 0       | 01.01.2013 12:01 | 8 | Superman  | true     |
-      | 2          | 0       | 01.01.2013 12:01 | 9 | Superman  | true     |
-      | 2          | 0       | 01.01.2013 12:01 | 10 | Superman  | true     |
-      | 2          | 0       | 01.01.2013 12:01 | 11 | Superman  | true     |
-      | 2          | 0       | 01.01.2013 12:01 | 12 | Superman  | true     |
-      | 2          | 0       | 01.01.2013 12:01 | 13 | Superman  | true     |
+      | program_id | user_id | upload_date      | text  | user_name | reported |
+      | 1          | 0       | 01.01.2013 12:01 | 1     | Superman  | true     |
+      | 1          | 1       | 01.01.2013 12:01 | 2     | Superman  | true     |
+      | 2          | 1       | 01.01.2013 12:01 | 3     | Superman  | true     |
+      | 2          | 1       | 01.01.2013 12:01 | 4     | Superman  | true     |
+      | 2          | 1       | 01.01.2013 12:01 | 5     | Superman  | true     |
+      | 2          | 0       | 01.01.2013 12:01 | 6     | Superman  | true     |
+      | 2          | 0       | 01.01.2013 12:01 | 7     | Superman  | true     |
+      | 2          | 0       | 01.01.2013 12:01 | 8     | Superman  | true     |
+      | 2          | 0       | 01.01.2013 12:01 | 9     | Superman  | true     |
+      | 2          | 0       | 01.01.2013 12:01 | 10    | Superman  | true     |
+      | 2          | 0       | 01.01.2013 12:01 | 11    | Superman  | true     |
+      | 2          | 0       | 01.01.2013 12:01 | 12    | Superman  | true     |
+      | 2          | 0       | 01.01.2013 12:01 | 13    | Superman  | true     |
 
     And there are admins:
       | name     | password | token      | email                |
@@ -85,7 +85,7 @@ Feature: As a visitor I want to write, see and report comments.
     And I wait for a second
     Then I should see 1 "#comment-successfully-reported"
 
-  Scenario: When I click the report button, I should be redirected to the login page
+  Scenario: When I click the report button and I am not logged in, I should be redirected to the login page
     Given I am on "/pocketcode/program/2"
     When I click the "report-comment" button
     And I wait 200 milliseconds

--- a/src/Catrobat/AppBundle/Features/Web/register.feature
+++ b/src/Catrobat/AppBundle/Features/Web/register.feature
@@ -26,6 +26,7 @@
     And I should see "CatrobatNew"
     When I am on "/logout"
     Then I should be logged out
+    And There should be a new user "CatrobatNew"
 
   Scenario: Trying to register with different passwords should fail
     Given I am on homepage

--- a/src/Catrobat/AppBundle/Security/UserChecker.php
+++ b/src/Catrobat/AppBundle/Security/UserChecker.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: catroweb
+ * Date: 2/23/17
+ * Time: 4:20 PM
+ */
+
+namespace Catrobat\AppBundle\Security;
+
+
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\Security\Core\Exception\DisabledException;
+use Symfony\Component\Security\Core\User\UserChecker as BaseUserChecker;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+
+/**
+ * UserChecker checks the user account flags.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class UserChecker extends BaseUserChecker
+{
+    protected $entityManager;
+    public function __construct(EntityManager $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     * Unbans user after banned_until was surpassed.
+     * Doesn't unban users that have been locked without setting banned_until
+     */
+    public function checkPreAuth(UserInterface $user)
+    {
+        //do your custom preauth stuff here
+        $real_user = $this->entityManager->getRepository('AppBundle:User')->findOneBy(['username' => $user->getUsername()]);
+        $banned_until = $real_user->getBannedUntil();
+        $current_time = new \DateTime('now');
+
+        if ($real_user->isLocked() AND
+            $banned_until !== null)
+        {
+            if ($current_time > $banned_until)
+            {
+                $real_user->setLocked(false);
+                $real_user->setBannedUntil(null);
+                $this->entityManager->flush();
+            }
+        }
+        parent::checkPreAuth($user);
+    }
+
+}


### PR DESCRIPTION
adds the ablity to bann a user from reported comments

add migration and update user entity

add function to ban user, ban user and delete comment after pressing button

add option to enter a reason for bann, add stub for sending mail

change creation of messages

set user to locked, remove reason, add static reason

add user checker

inject doctrine into user checker

automatically unban user after time

make user manually bannable again

add tests for banned users

add testing if user was created in db

finalize WEB-375 as discussed with s schrimpf

defuse migration bomb