### PR TITLE
WEB-438_Community Statistics

### DIFF
--- a/app/Resources/translations/catroweb.en.yml
+++ b/app/Resources/translations/catroweb.en.yml
@@ -633,8 +633,6 @@ footer:
   communityStats: Community Stats
   downloads: downloads
   programs: programs
-  downloads_count: '624,589'
-  programs_count: '36,738'
 
 privacy-policy:
   header: Privacy Policy

--- a/app/Resources/views/Default/footer.html.twig
+++ b/app/Resources/views/Default/footer.html.twig
@@ -39,8 +39,9 @@
 
           <div class="col-md-offset-4 col-md-4">
             <h4>{{ "footer.communityStats"|trans({}, "catroweb") }}</h4>
-            <h4>{{ "footer.programs_count"|trans({}, "catroweb") }} <small>{{ "footer.programs"|trans({}, "catroweb") }}</small></h4>
-            <h4>{{ "footer.downloads_count"|trans({}, "catroweb") }} <small>{{ "footer.downloads"|trans({}, "catroweb") }}</small></h4>
+            {% set stats = getCommunityStats()  %}
+            <h4>{{ stats['program_count'] | number_format(0, ",", ".") }} <small>{{ "footer.programs"|trans({}, "catroweb") }}</small></h4>
+            <h4>{{ stats['downloads'] | number_format(0, ",", ".") }} <small>{{ "footer.downloads"|trans({}, "catroweb") }}</small></h4>
           </div>
         </div>
       </div>

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -50,6 +50,10 @@ services:
     catro_notification_service:
         class: Catrobat\AppBundle\Services\CatroNotificationService
         arguments: ["@doctrine.orm.entity_manager"]
+
+    community_statistics_service:
+        class: Catrobat\AppBundle\Services\CommunityStatisticsService
+        arguments: ["@doctrine.orm.entity_manager"]
 # =========================== Repository ===========================
 
     programrepository:

--- a/src/Catrobat/AppBundle/Services/CommunityStatisticsService.php
+++ b/src/Catrobat/AppBundle/Services/CommunityStatisticsService.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright (c) 2017. Catrobat
+ * Imagine that each Catrobat program is a cake, a very special cake that comes with its recipe (programming blocks). All members of the Catrobat community share their cakes along with their recipes. This means that you can enjoy the cakes and learn how to make them yourself!
+ * There are no secret recipes: the instructions on how to make these cakes are open for anyone to use, reuse, modify, and serve as inspiration for new ideas... I mean cakes.
+ *
+ * You can eat the cakes as well as copy other people's recipes to make your own, maybe with different ingredients. This freedom comes with two simple requirements:
+ *
+ * share your cakes along with the recipe
+ * give credit to those who inspired you
+ *
+ *
+ * In setting up the Catrobat community, we decided to adopt this approach since we believe that it supports learning and creativity within the community. By sharing recipes and ingredients (scripts and artwork), people can build upon one another's ideas and everyone will benefit.
+ *
+ * In designing the Catrobat website, we included features to encourage people to share and to give credit to others. On each program page, you can always download the original scripts for the program. If you remix a program (modifying the scripts or artwork, and sharing the result), we encourage you to give credit in the Program Notes, mentioning the people and program that inspired you.
+ *
+ * Learn more about the terms of use of the Catrobat online community on https://share.catrob.at/pocketcode/termsOfUse.
+ *
+ * Version 1.1, 2 April 2013
+ */
+
+namespace Catrobat\AppBundle\Services;
+
+use Catrobat\AppBundle\Entity\CatroNotification;
+use Doctrine\ORM\EntityManager;
+
+class CommunityStatisticsService
+{
+
+  private $em;
+  public function __construct(EntityManager $em)
+  {
+    $this->em = $em;
+  }
+
+  /**
+   * Gets the amount of programs currently uploaded and the amount of downloads
+   *
+   * @return mixed|array array containing key program_count and key downloads
+   *                     ready for json response parsing
+   */
+  public function fetchStatistics()
+  {
+    $dql = "SELECT COUNT(p.id) AS program_count, SUM(p.downloads) AS downloads FROM Catrobat\AppBundle\Entity\Program p";
+    $stats = $this->em->createQuery($dql)
+      ->getScalarResult();
+    return $stats[0];
+  }
+}

--- a/src/Catrobat/AppBundle/Twig/AppExtension.php
+++ b/src/Catrobat/AppBundle/Twig/AppExtension.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Catrobat\AppBundle\Entity\GameJamRepository;
 use Liip\ThemeBundle\ActiveTheme;
 use Symfony\Component\Intl\Intl;
+use Symfony\Component\Intl\NumberFormatter\NumberFormatter;
 
 class AppExtension extends \Twig_Extension
 {
@@ -62,7 +63,8 @@ class AppExtension extends \Twig_Extension
             'flavor' => new \Twig_Function_Method($this, 'getFlavor'),
             'theme' => new \Twig_Function_Method($this, 'getTheme'),
             'getCurrentGameJam' => new \Twig_Function_Method($this, 'getCurrentGameJam'),
-            'getJavascriptPath' => new \Twig_Function_Method($this, 'getJavascriptPath')
+            'getJavascriptPath' => new \Twig_Function_Method($this, 'getJavascriptPath'),
+            'getCommunityStats' => new \Twig_Function_Method($this, 'getCommunityStats')
         );
     }
 
@@ -241,5 +243,29 @@ class AppExtension extends \Twig_Extension
         $jsPath .= $jsFile;
         $jsPath = str_replace("//", "/", $jsPath);
         return $jsPath;
+    }
+
+  /**
+   * Twig extension to provide a function to retrieve the community statistics in any view.
+   * Needed to render the footer.
+   *
+   * See the fetchStatistics implementation of AppBundle\Services\CommunityStatisticsService.php
+   *                                           for details.
+   * @return array|mixed
+   */
+  public function getCommunityStats()
+    {
+      $cms_s = $this->container->get("community_statistics_service");
+      $stats = $cms_s->fetchStatistics();
+
+      /* Numberformatter could be used to apply the locale. However this requires the intl extension to be fully working.
+
+      $nf = new NumberFormatter($this->request_stack->getCurrentRequest()->getLocale(), 1);
+      foreach ($stats as $key => $value)
+      {
+        $stats[$key] = $nf->format($value);
+      }
+      */
+      return $stats;
     }
 }


### PR DESCRIPTION
this adds a CommunityStatisticsService which provides functions which fetch
community related statistics.
For now we provide the program_count and the cumulative downloads.

They are rendered in the footer.