### PR TITLE
WEB-394 Cant download program

### DIFF
--- a/app/config/commands.yml
+++ b/app/config/commands.yml
@@ -19,6 +19,16 @@ services:
               tags:
                 -  { name: console.command }
 
+      catrowebadmin.command.clean.invalid:
+              class: Catrobat\AppBundle\Commands\InvalidFileUploadCleanupCommand
+              tags:
+                -  { name: console.command }
+
+      catrowebadmin.command.clean.invalid.revert:
+              class: Catrobat\AppBundle\Commands\InvalidFileUploadCleanupCommand
+              tags:
+                -  { name: console.command }
+
       catrowebadmin.command.init:
               class: Catrobat\AppBundle\Commands\InitDirectoriesCommand
               arguments: ["@catrowebadmin.filesystem","%catrobat.file.storage.dir%"]

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -28,6 +28,7 @@ parameters:
       catrobat.snapshot.dir:          "%kernel.root_dir%/../Resources/Snapshots"
       catrobat.translations.dir:      "%kernel.root_dir%/Resources/translations"
       catrobat.logs.dir:              "%kernel.root_dir%/logs/"
+      catrobat.invalidupload.dir:     "%kernel.root_dir%/../src/Catrobat/AppBundle/Commands/invisible_programs/"
 
       # TODO check max_version usage and use it so only one value has to be changed
       catrobat.max_version:           "0.995"

--- a/src/Catrobat/AppBundle/Commands/InvalidFileUploadCleanupCommand.php
+++ b/src/Catrobat/AppBundle/Commands/InvalidFileUploadCleanupCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Catrobat\AppBundle\Commands;
+
+use Catrobat\AppBundle\Entity\Program;
+use Catrobat\AppBundle\Entity\ProgramRepository;
+use Doctrine\ORM\EntityManager;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+class InvalidFileUploadCleanupCommand extends ContainerAwareCommand
+{
+
+  protected function configure()
+  {
+    $this->setName('catrobat:clean:invalid-upload')
+      ->setDescription('Sets all files given in command file to invisible.
+      File is just given by name (not path) and has to be located in Commands/invisible_programs')
+      ->addArgument('file', InputArgument::REQUIRED, 'File with the programs that terminate with 528 error');
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+    $finder = new Finder();
+    $file_name = $input->getArgument('file');
+    $finder->files()->name($file_name);
+    $folder = $this->getContainer()->getParameter('catrobat.invalidupload.dir');
+
+    $content = '';
+    foreach ($finder->in($folder) as $file)
+    {
+      $content = $file->getContents();
+    }
+    $ids = explode(",\n", $content);
+
+    /** @var ProgramRepository $pr */
+    $pr = $this->getContainer()->get('programrepository');
+
+    $fs = new Filesystem();
+    /** @var EntityManager $em */
+    $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+
+    foreach ($ids as $id)
+    {
+      /** @var Program $program */
+      $program = $pr->find($id);
+      if (!$program)
+      {
+        $output->writeln("[Error] Program with id <" . $id . "> doesnt exist! Skipping...");
+        continue;
+      }
+      $program->setVisible(false);
+      $output->writeln($program->getName() . ' set to invisible');
+      $em->persist($program);
+    }
+    $em->flush();
+    $fs->copy($folder . $file_name, $folder . "/executed/" . date('Y-m-d_H:i:s') . '_done');
+    $fs->remove($folder . $file_name);
+  }
+} 

--- a/src/Catrobat/AppBundle/Commands/InvalidFileUploadCleanupRevertCommand.php
+++ b/src/Catrobat/AppBundle/Commands/InvalidFileUploadCleanupRevertCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Catrobat\AppBundle\Commands;
+
+use Catrobat\AppBundle\Entity\Program;
+use Catrobat\AppBundle\Entity\ProgramRepository;
+use Doctrine\ORM\EntityManager;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+class InvalidFileUploadCleanupRevertCommand extends ContainerAwareCommand
+{
+
+  protected function configure()
+  {
+    $this->setName('catrobat:clean:invalid-upload:revert')
+      ->setDescription('Sets all files given in command file to visible.
+      File is just given by name (not path) and has to be located in Commands/invisible_programs')
+      ->addArgument('file', InputArgument::REQUIRED, 'File with the programs that should be visible again');
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+    $finder = new Finder();
+    $file_name = $input->getArgument('file');
+    $finder->files()->name($file_name);
+    $folder = $this->getContainer()->getParameter('catrobat.invalidupload.dir');
+
+    $content = '';
+    foreach ($finder->in($folder) as $file)
+    {
+      $content = $file->getContents();
+    }
+    $ids = explode(",\n", $content);
+
+    /** @var ProgramRepository $pr */
+    $pr = $this->getContainer()->get('programrepository');
+
+    $fs = new Filesystem();
+    /** @var EntityManager $em */
+    $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+
+    foreach ($ids as $id)
+    {
+      /** @var Program $program */
+      $program = $pr->find($id);
+      if (!$program)
+      {
+        $output->writeln("[Error] Program with id <" . $id . "> doesnt exist! Skipping...");
+        continue;
+      }
+      $program->setVisible(true);
+      $output->writeln($program->getName() . ' set to visible');
+      $em->persist($program);
+    }
+    $em->flush();
+    $fs->copy($folder . $file_name, $folder . "/executed/" . date('Y-m-d_H:i:s') . '_revert');
+    $fs->remove($folder . $file_name);
+  }
+} 

--- a/src/Catrobat/AppBundle/Commands/invisible_programs/executed/.gitignore
+++ b/src/Catrobat/AppBundle/Commands/invisible_programs/executed/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/src/Catrobat/AppBundle/Controller/DownloadProgramController.php
+++ b/src/Catrobat/AppBundle/Controller/DownloadProgramController.php
@@ -5,10 +5,14 @@ namespace Catrobat\AppBundle\Controller;
 use Catrobat\AppBundle\Entity\NolbExampleProgram;
 use Catrobat\AppBundle\Entity\NolbExampleRepository;
 use Catrobat\AppBundle\Entity\User;
+use Catrobat\AppBundle\Exceptions\Upload\InvalidFileUploadException;
 use Catrobat\AppBundle\RecommenderSystem\RecommendedPageId;
+use Catrobat\AppBundle\StatusCode;
+use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Catrobat\AppBundle\Entity\ProgramManager;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Catrobat\AppBundle\Services\ProgramFileRepository;
@@ -19,66 +23,84 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class DownloadProgramController extends Controller
 {
-    /**
-     * @Route("/download/{id}.catrobat", name="download", options={"expose"=true}, defaults={"_format": "json"})
-     * @Method({"GET"})
-     */
-    public function downloadProgramAction(Request $request, $id) {
-        /* @var $program_manager ProgramManager */
-        /* @var $file_repository ProgramFileRepository */
+  /**
+   * @Route("/download/{id}.catrobat", name="download", options={"expose"=true}, defaults={"_format": "json"})
+   * @Method({"GET"})
+   */
+  public function downloadProgramAction(Request $request, $id)
+  {
+    /* @var $program_manager ProgramManager */
+    /* @var $file_repository ProgramFileRepository */
 
-        $referrer = $request->getSession()->get('referer');
-        $program_manager = $this->get('programmanager');
-        $file_repository = $this->get('filerepository');
+    $referrer = $request->getSession()->get('referer');
+    $program_manager = $this->get('programmanager');
+    $file_repository = $this->get('filerepository');
 
-        $program = $program_manager->find($id);
-        if (!$program) {
-            throw new NotFoundHttpException();
-        }
-        if (!$program->isVisible()) {
-            throw new NotFoundHttpException();
-        }
-
-        $rec_by_page_id = intval($request->query->get('rec_by_page_id', RecommendedPageId::INVALID_PAGE));
-        $rec_by_program_id = intval($request->query->get('rec_by_program_id', 0));
-        $rec_user_specific = intval($request->query->get('rec_user_specific', 0)) == 1 ? true : false;
-
-        $rec_tag_by_program_id = intval($request->query->get('rec_from', 0));
-
-      $file = $file_repository->getProgramFile($id);
-      if ($file->isFile()) {
-        $downloaded = $request->getSession()->get('downloaded', array());
-        if (!in_array($program->getId(), $downloaded))
-        {
-            $this->increaseGenderedDownloadsIfNolbExampleProgram($program);
-            $this->get('programmanager')->increaseDownloads($program);
-            $downloaded[] = $program->getId();
-            $request->getSession()->set('downloaded', $downloaded);
-            $request->attributes->set('download_statistics_program_id', $id);
-            $request->attributes->set('referrer', $referrer);
-
-            if (RecommendedPageId::isValidRecommendedPageId($rec_by_page_id)) {
-                // all recommendations (except tag-recommendations -> see below)
-                $request->attributes->set('rec_by_page_id', $rec_by_page_id);
-                $request->attributes->set('rec_by_program_id', $rec_by_program_id);
-                $request->attributes->set('rec_user_specific', $rec_user_specific);
-            } else if ($rec_tag_by_program_id > 0) {
-                // tag-recommendations
-                $request->attributes->set('rec_from', $rec_tag_by_program_id);
-            }
-        }
-
-            $response = new BinaryFileResponse($file);
-            $d = $response->headers->makeDisposition(
-                ResponseHeaderBag::DISPOSITION_ATTACHMENT,
-                $program->getId() . '.catrobat'
-            );
-            $response->headers->set('Content-Disposition', $d);
-
-            return $response;
-        }
-        throw new NotFoundHttpException();
+    $program = $program_manager->find($id);
+    if (!$program)
+    {
+      throw new NotFoundHttpException();
     }
+    if (!$program->isVisible())
+    {
+      throw new NotFoundHttpException();
+    }
+
+    $rec_by_page_id = intval($request->query->get('rec_by_page_id', RecommendedPageId::INVALID_PAGE));
+    $rec_by_program_id = intval($request->query->get('rec_by_program_id', 0));
+    $rec_user_specific = intval($request->query->get('rec_user_specific', 0)) == 1 ? true : false;
+    $rec_tag_by_program_id = intval($request->query->get('rec_from', 0));
+    try
+    {
+      $file = $file_repository->getProgramFile($id);
+    }
+    catch (FileNotFoundException $e)
+    {
+      $logger = $this->get('logger');
+      $logger->err('[FILE] failed to get program file with id: ' . $id);
+      return JsonResponse::create('Invalid file upload', StatusCode::INVALID_FILE_UPLOAD);
+    }
+
+    if ($file->isFile())
+    {
+      $downloaded = $request->getSession()->get('downloaded', []);
+      if (!in_array($program->getId(), $downloaded))
+      {
+        $this->increaseGenderedDownloadsIfNolbExampleProgram($program);
+        $this->get('programmanager')->increaseDownloads($program);
+        $downloaded[] = $program->getId();
+        $request->getSession()->set('downloaded', $downloaded);
+        $request->attributes->set('download_statistics_program_id', $id);
+        $request->attributes->set('referrer', $referrer);
+
+        if (RecommendedPageId::isValidRecommendedPageId($rec_by_page_id))
+        {
+          // all recommendations (except tag-recommendations -> see below)
+          $request->attributes->set('rec_by_page_id', $rec_by_page_id);
+          $request->attributes->set('rec_by_program_id', $rec_by_program_id);
+          $request->attributes->set('rec_user_specific', $rec_user_specific);
+        }
+        else
+        {
+          if ($rec_tag_by_program_id > 0)
+          {
+            // tag-recommendations
+            $request->attributes->set('rec_from', $rec_tag_by_program_id);
+          }
+        }
+      }
+
+      $response = new BinaryFileResponse($file);
+      $d = $response->headers->makeDisposition(
+        ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+        $program->getId() . '.catrobat'
+      );
+      $response->headers->set('Content-Disposition', $d);
+
+      return $response;
+    }
+    throw new NotFoundHttpException();
+  }
 
   /**
    * @param $program
@@ -92,12 +114,12 @@ class DownloadProgramController extends Controller
     $user = $this->getUser();
     if ($user AND $user->getNolbUser())
     {
-        $nolb_example_repository = $this->get('nolbexamplerepository');
-        $nolb_example_program = $nolb_example_repository->getIfNolbExampleProgram($program);
-        if ($nolb_example_program)
-        {
-          $this->increaseGenderedDownloads($user, $nolb_example_program);
-        }
+      $nolb_example_repository = $this->get('nolbexamplerepository');
+      $nolb_example_program = $nolb_example_repository->getIfNolbExampleProgram($program);
+      if ($nolb_example_program)
+      {
+        $this->increaseGenderedDownloads($user, $nolb_example_program);
+      }
     }
   }
 

--- a/src/Catrobat/AppBundle/Entity/ProgramManager.php
+++ b/src/Catrobat/AppBundle/Entity/ProgramManager.php
@@ -159,17 +159,34 @@ class ProgramManager
       return null;
     }
 
-
-    if ($extracted_file->getScreenshotPath() == null)
+    try
     {
-      // Todo: maybe for later implementations
+      if ($extracted_file->getScreenshotPath() == null)
+      {
+        // Todo: maybe for later implementations
+      }
+      else
+      {
+        $this->screenshot_repository->makeTempProgramAssetsPerm($program->getId());
+      }
+      $this->file_repository->makeTempProgramPerm($program->getId());
     }
-    else
+    catch (\Exception $e)
     {
-      $this->screenshot_repository->makeTempProgramAssetsPerm($program->getId());
+      $program_id = $program->getId();
+      $this->entity_manager->remove($program);
+      $this->entity_manager->flush();
+      try
+      {
+        $this->screenshot_repository->deletePermProgramAssets($program_id);
+        $this->file_repository->deleteProgramFile($program_id);
+      }
+      catch (IOException $error)
+      {
+        throw $error;
+      }
+      return null;
     }
-    $this->file_repository->makeTempProgramPerm($program->getId());
-
 
     $this->entity_manager->persist($program);
     $this->entity_manager->flush();

--- a/src/Catrobat/AppBundle/Exceptions/Upload/InvalidFileUploadException.php
+++ b/src/Catrobat/AppBundle/Exceptions/Upload/InvalidFileUploadException.php
@@ -1,0 +1,13 @@
+<?php
+namespace Catrobat\AppBundle\Exceptions\Upload;
+
+use Catrobat\AppBundle\Exceptions\InvalidCatrobatFileException;
+use Catrobat\AppBundle\StatusCode;
+
+class InvalidFileUploadException extends InvalidCatrobatFileException
+{
+    public function __construct()
+    {
+        parent::__construct('error.upload.invalid_file_upload', StatusCode::INVALID_FILE_UPLOAD);
+    }
+}

--- a/src/Catrobat/AppBundle/Services/ProgramFileRepository.php
+++ b/src/Catrobat/AppBundle/Services/ProgramFileRepository.php
@@ -51,6 +51,11 @@ class ProgramFileRepository
     }
   }
 
+  public function deleteProgramFile($id)
+  {
+    $this->filesystem->remove($this->directory . $id . ".catrobat");
+  }
+
   public function saveProgramfile(File $file, $id)
   {
     $this->filesystem->copy($file->getPathname(), $this->directory . $id . '.catrobat');

--- a/src/Catrobat/AppBundle/Services/ScreenshotRepository.php
+++ b/src/Catrobat/AppBundle/Services/ScreenshotRepository.php
@@ -199,6 +199,13 @@ class ScreenshotRepository
       ]);
   }
 
+  public function deletePermProgramAssets($id)
+  {
+    $this->deleteScreenshot($id);
+    $this->deleteThumbnail($id);
+    $this->deleteTempFilesForProgram($id);
+  }
+
   /**
    * @desc This function empties the tmp folder.
    *       When this function is used while a user is

--- a/src/Catrobat/AppBundle/StatusCode.php
+++ b/src/Catrobat/AppBundle/StatusCode.php
@@ -29,6 +29,8 @@ class StatusCode
   const MEDIA_LIB_PACKAGE_NOT_FOUND = 523;
   const PROGRAM_NAME_TOO_LONG = 526;
   const DESCRIPTION_TOO_LONG = 527;
+  // upload failed but program still in DB
+  const INVALID_FILE_UPLOAD = 528;
 
   const LOGIN_ERROR = 601;
   const REGISTRATION_ERROR = 602;


### PR DESCRIPTION
Makes the correct cleanup of Temporary files that get created during upload. Previously if the upload was interrupted (whatever cause) those files persisted and an entry was wirtten into the database. This PR should fix that.
Also 2 new commands get implemented; one to set all programs that got affected by this to invisible and another command that makes it possible to set visible.