### PR TITLE
WEB-478_Deletion_footer_statistics

### DIFF
--- a/app/Resources/translations/catroweb.en.yml
+++ b/app/Resources/translations/catroweb.en.yml
@@ -639,8 +639,6 @@ footer:
   usefulLinks: Useful Links
   legalities: Legalities
   communityStats: Community Stats
-  downloads: downloads
-  programs: programs
 
 privacy-policy:
   header: Privacy Policy

--- a/app/Resources/views/Default/footer.html.twig
+++ b/app/Resources/views/Default/footer.html.twig
@@ -35,14 +35,6 @@
               </li>
             </ul>
           </div>
-
-
-          <div class="col-md-offset-4 col-md-4">
-            <h4>{{ "footer.communityStats"|trans({}, "catroweb") }}</h4>
-            {% set stats = getCommunityStats()  %}
-            <h4>{{ stats['program_count'] | number_format(0, ",", ".") }} <small>{{ "footer.programs"|trans({}, "catroweb") }}</small></h4>
-            <h4>{{ stats['downloads'] | number_format(0, ",", ".") }} <small>{{ "footer.downloads"|trans({}, "catroweb") }}</small></h4>
-          </div>
         </div>
       </div>
 

--- a/app/Resources/views/components/index/welcome-section.html.twig
+++ b/app/Resources/views/components/index/welcome-section.html.twig
@@ -91,11 +91,5 @@
       <a href="http://play.google.com/store/apps/details?id=org.catrobat.catroid"
          target="_blank">{{ "googlePlay"|trans({}, "catroweb") }}</a>
     </div>
-    <div class="col-md-6 text-right">
-      {# todo add link to new statistic page #}
-      {% set stats = getCommunityStats() %}
-      {{ stats['program_count'] | number_format(0, ",", ".") }} {{ "footer.programs"|trans({}, "catroweb") }}
-      {# <a href="{{ path('homepage_click_stats') }}">{{ "programs.welcome.statistics"|trans({}, "catroweb") }}</a> #}
-    </div>
   </div>
 </div>

--- a/src/Catrobat/AppBundle/Twig/AppExtension.php
+++ b/src/Catrobat/AppBundle/Twig/AppExtension.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Catrobat\AppBundle\Twig;
 
 use Catrobat\AppBundle\Entity\MediaPackageFile;
@@ -82,29 +83,29 @@ class AppExtension extends \Twig_Extension
     {
         $path = $this->translationPath;
         $current_language = $this->request_stack->getCurrentRequest()->getLocale();
-        
+
         if (strpos($current_language, '_DE') !== false || strpos($current_language, '_US') !== false) {
             $current_language = substr($current_language, 0, 2);
         }
-        
+
         $list = array();
-        
+
         $finder = new Finder();
         $finder->files()
             ->in($path)
             ->sortByName();
-        
+
         $isSelectedLangugage = false;
-        
+
         foreach ($finder as $translationFileName) {
             $shortName = $this->getShortLanguageNameFromFileName($translationFileName->getRelativePathname());
-            
+
             $isSelectedLangugage = $current_language === $shortName;
-            
+
             if (strcmp($current_language, $shortName)) {
                 $isSelectedLangugage = true;
             }
-            
+
             $locale = Intl::getLocaleBundle()->getLocaleName($shortName, $shortName);
             if ($locale != null) {
                 $list[] = array(
@@ -114,8 +115,8 @@ class AppExtension extends \Twig_Extension
                 );
             }
         }
-        
-        if (! $isSelectedLangugage) {
+
+        if (!$isSelectedLangugage) {
             $list = $this->setSelectedLanguage($list, $current_language);
         }
         return $list;
@@ -126,7 +127,7 @@ class AppExtension extends \Twig_Extension
         $list = array();
         foreach ($languages as $language) {
             if (strpos($currentLanguage, $language[0]) !== false) {
-                
+
                 $language = array(
                     $language[0],
                     $language[1],
@@ -142,7 +143,7 @@ class AppExtension extends \Twig_Extension
     {
         $firstOccurrence = strpos($filename, '.') + 1;
         $lastOccurrence = strpos($filename, '.', $firstOccurrence);
-        
+
         return substr($filename, $firstOccurrence, $lastOccurrence - $firstOccurrence);
     }
 
@@ -150,10 +151,10 @@ class AppExtension extends \Twig_Extension
     {
         $request = $this->request_stack->getCurrentRequest();
         $user_agent = $request->headers->get('User-Agent');
-        
+
         // Example Webview: $user_agent = "Catrobat/0.93 PocketCode/0.9.14 Platform/Android";
         return preg_match('/Catrobat/', $user_agent) || strpos($user_agent, 'Android') != false ||
-               strpos($user_agent, 'iPad') != false  || strpos($user_agent, 'iPhone') != false;
+            strpos($user_agent, 'iPad') != false || strpos($user_agent, 'iPhone') != false;
     }
 
     /**
@@ -170,17 +171,17 @@ class AppExtension extends \Twig_Extension
         // Example Webview: $user_agent = "Catrobat/0.93 PocketCode/0.9.14 Platform/Android";
         if (preg_match('/Catrobat/', $user_agent)) {
             $user_agent_array = explode("/", $user_agent);
-            
+
             // $user_agent_array = [ "Catrobat", "0.93 PocketCode", 0.9.14 Platform", "Android" ];
             $catrobat_language_array = explode(" ", $user_agent_array[1]);
             // $catrobat_language_array = [ "0.93", "PocketCode" ];
             $catrobat_language = $catrobat_language_array[0] * 1.0;
-            
+
             if ($catrobat_language < $program_catrobat_language) {
                 return false;
             }
         }
-        
+
         return true;
     }
 
@@ -197,7 +198,7 @@ class AppExtension extends \Twig_Extension
 
     /**
      *
-     * @param $object MediaPackageFile            
+     * @param $object MediaPackageFile
      * @return null|string
      */
     public function getMediaPackageImageUrl($object)
@@ -216,7 +217,7 @@ class AppExtension extends \Twig_Extension
 
     /**
      *
-     * @param $object MediaPackageFile            
+     * @param $object MediaPackageFile
      * @return null|string
      */
     public function getMediaPackageSoundUrl($object)
@@ -238,34 +239,35 @@ class AppExtension extends \Twig_Extension
         return $this->gamejamrepository->getCurrentGameJam();
     }
 
-    public function getJavascriptPath($jsFile) {
+    public function getJavascriptPath($jsFile)
+    {
         $jsPath = $this->container->getParameter('jspath');
         $jsPath .= $jsFile;
         $jsPath = str_replace("//", "/", $jsPath);
         return $jsPath;
     }
 
-  /**
-   * Twig extension to provide a function to retrieve the community statistics in any view.
-   * Needed to render the footer.
-   *
-   * See the fetchStatistics implementation of AppBundle\Services\CommunityStatisticsService.php
-   *                                           for details.
-   * @return array|mixed
-   */
-  public function getCommunityStats()
+    /**
+     * Twig extension to provide a function to retrieve the community statistics in any view.
+     * Needed to render the footer.
+     *
+     * See the fetchStatistics implementation of AppBundle\Services\CommunityStatisticsService.php
+     *                                           for details.
+     * @return array|mixed
+     */
+    public function getCommunityStats()
     {
-      $cms_s = $this->container->get("community_statistics_service");
-      $stats = $cms_s->fetchStatistics();
+        $cms_s = $this->container->get("community_statistics_service");
+        $stats = $cms_s->fetchStatistics();
 
-      /* Numberformatter could be used to apply the locale. However this requires the intl extension to be fully working.
+        /* Numberformatter could be used to apply the locale. However this requires the intl extension to be fully working.
 
-      $nf = new NumberFormatter($this->request_stack->getCurrentRequest()->getLocale(), 1);
-      foreach ($stats as $key => $value)
-      {
-        $stats[$key] = $nf->format($value);
-      }
-      */
-      return $stats;
+        $nf = new NumberFormatter($this->request_stack->getCurrentRequest()->getLocale(), 1);
+        foreach ($stats as $key => $value)
+        {
+          $stats[$key] = $nf->format($value);
+        }
+        */
+        return $stats;
     }
 }


### PR DESCRIPTION
It was required by our PO's to remove all statistics from the footers and the welcome section. It was already done by a quick'n dirty fix on live server because of urgency.