### PR TITLE
Web 451 console command delete apks

### DIFF
--- a/app/config/commands.yml
+++ b/app/config/commands.yml
@@ -3,6 +3,10 @@ services:
               class: Symfony\Component\Filesystem\Filesystem
               public: false
 
+      catrowebadmin.command.clean.oldapk:
+              class: Catrobat\AppBundle\Commands\CleanOldApkCommand
+              tags:
+              -  { name: console.command }
 
       catrowebadmin.command.clean.apk:
               class: Catrobat\AppBundle\Commands\CleanApkCommand

--- a/src/Catrobat/AppBundle/Commands/CleanOldApkCommand.php
+++ b/src/Catrobat/AppBundle/Commands/CleanOldApkCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Catrobat\AppBundle\Commands;
+
+use Catrobat\AppBundle\Entity\Program;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+define("HOURS", 24);
+define("MINUTES", 60);
+define("SECONDS", 60);
+
+
+class CleanOldApkCommand extends ContainerAwareCommand
+{
+  protected function configure()
+  {
+    $this->setName('catrobat:clean:old-apk')
+      ->setDescription('Delete all APKs older than X days and resets the status to NONE')
+      ->addArgument('days');
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+    $days = $input->getArgument('days');
+
+    if (!is_numeric($days))
+    {
+      $output->writeln('You have to enter a numeric value as parameter!');
+
+      return -1;
+    }
+
+    $output->writeln('Deleting all APKs older than ' . $days . ' days.');
+    $last_point_of_time_to_save = time() - ((int)$days * HOURS * MINUTES * SECONDS);
+
+    $directory = $this->getContainer()->getParameter('catrobat.apk.dir');
+    $filesystem = new Filesystem();
+    $finder = new Finder();
+    $finder->in($directory)->depth(0);
+    $removed_apk_ids = new \ArrayObject();
+    $amount_of_files = sizeOf($finder);
+
+    foreach ($finder as $file)
+    {
+      $access_time = $file->getATime();
+      if ($access_time < $last_point_of_time_to_save)
+      {
+        $filesystem->remove($file);
+        $removed_apk_ids->append(explode('.', $file->getFilename())[0]);
+      }
+    }
+
+    $output->writeln('Files removed (' . sizeOf($removed_apk_ids) . '/' . $amount_of_files . ')');
+
+    if (!sizeOf($removed_apk_ids))
+    {
+      $output->writeln('No projects have been reset.');
+
+      return 0;
+    }
+    $query = $this->createQueryToUpdateTheStatusOfRemovedApks($removed_apk_ids);
+    $result = $query->getSingleScalarResult();
+    $output->writeln('Reset the apk status of ' . $result . ' projects');
+
+    return 0;
+  }
+
+
+  private function createQueryToUpdateTheStatusOfRemovedApks($removed_apk_ids)
+  {
+    $id_query_part = '';
+    $i = 0;
+    foreach ($removed_apk_ids as $apk_id)
+    {
+      if ($i != 0)
+      {
+        $id_query_part .= 'OR ';
+      }
+      $id_query_part .= 'p.id = ' . $apk_id . ' ';
+      $i++;
+    }
+
+    if ($id_query_part != '')
+    {
+      $id_query_part = ' AND (' . $id_query_part . ')';
+    }
+
+    /* @var $em \Doctrine\ORM\EntityManager */
+    $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+    $query = $em->createQuery("UPDATE Catrobat\AppBundle\Entity\Program p 
+                      SET p.apk_status = :status WHERE p.apk_status != :status" . $id_query_part);
+    $query->setParameter('status', Program::APK_NONE);
+
+    return $query;
+  }
+}


### PR DESCRIPTION
This was done to make more space available on our hard drives and get rid
    of old APK files, but still keep the newest APKs available to the users.
    
    Example call:
     >php bin/console catrobat:clean:old-apk 3
    
This would delete all APKs older than three days. The age of APKs depends
    on the time of their last access. (Unix atime)
    
This command depends on the fact that APKs are saved with their ID
    as filename to work correctly.
 