### PR TITLE
Web 445 increase description maximal length

### DIFF
--- a/src/Catrobat/AppBundle/Listeners/DescriptionValidator.php
+++ b/src/Catrobat/AppBundle/Listeners/DescriptionValidator.php
@@ -26,7 +26,7 @@ class DescriptionValidator
 
     public function validate(ExtractedCatrobatFile $file)
     {
-        if (strlen($file->getDescription()) > 1000) {
+        if (strlen($file->getDescription()) > 5000) {
             throw new DescriptionTooLongException();
         }
 


### PR DESCRIPTION
Currently, the description is limited to 1000 characters when uploading. Since text is cheap the limit is now increased to 5000 characters.