### PR TITLE
Web 441 allow editing of a program description

### DIFF
--- a/app/Resources/views/program.html.twig
+++ b/app/Resources/views/program.html.twig
@@ -37,7 +37,10 @@
 
 {% block body %}
   <div id="program-top" class="h1">
-    <div id="program-name">{{ program.name }}</div>
+    <div id="program-name">
+      {{ program.name }}
+    </div>
+
     <div id="program-user">
       <a href="{{ url('profile', { id : program.user.id }) }}">{{ program.user }}</a>
     </div>
@@ -88,7 +91,16 @@
     </div>
 
     <div id="info">
-      <h2>{{ "description"|trans({}, "catroweb") }}</h2>
+      <div class="h2">
+        <span>
+          {{ "description"|trans({}, "catroweb") }}
+          {% if app.user and my_program %}
+            <a href="#" data-toggle="tooltip" title="Change the program Description">
+              <i id="edit-description-button" class="ml-3 fa fa-pencil-square-o"></i>
+            </a>
+          {% endif %}
+        </span>
+      </div>
 
       <div id="description">
         {% if program.description %}
@@ -97,6 +109,23 @@
           {{ "noDescription"|trans({}, "catroweb") }}
         {% endif %}
       </div>
+
+
+      {% if app.user and my_program %}
+        <div id="edit-description-ui">
+          <div id="edit-description-error" style="display:none;" class="alert alert-danger"></div>
+          <textarea id="edit-description" name="edit-description" class="mt-2 mb-2" title="_edit-description"
+                    maxlength="{{ max_description_size }}" style="width: 100%" rows="10" >
+{% if program.description %}{{ program.description }}{% else %}{{ "noDescription"|trans({}, "catroweb") }}{% endif %}
+          </textarea>
+
+          <button id="edit-description-submit-button" class="btn btn-primary p-3 mb-5">
+            <i class="fa fa-floppy-o mr-2"></i>
+            Save Description change
+          </button>
+        </div>
+
+      {% endif %}
 
       {% if  program.tags|length > 0  or program.extensions|length > 0 %}
         <div id="tag-extension-container">
@@ -891,5 +920,88 @@
             }
         });
     });
+
+
+    $(function() {
+
+      let description = $("#description");
+      let editDescriptionUI = $("#edit-description-ui");
+      let editDescriptionButton = $("#edit-description-button");
+      let editDescription = $("#edit-description");
+      let editDescriptionSubmitButton = $("#edit-description-submit-button");
+      let editDescriptionError = $("#edit-description-error");
+
+      // set default visibilities
+      initDescriptionEdit();
+
+
+      function initDescriptionEdit() {
+          editDescriptionUI.hide();
+          description.show();
+      }
+
+
+      // increase icon size while hovering over it
+      editDescriptionButton.hover(
+        function() {
+        editDescriptionButton.addClass("fa-lg")
+      },
+        function() {
+        editDescriptionButton.removeClass("fa-lg")
+      });
+
+
+      editDescriptionButton.click(function() {
+        if (description.is(':visible')) {
+          description.hide();
+          editDescriptionUI.show()
+        }
+        else {
+          description.show();
+          editDescriptionUI.hide()
+        }
+      });
+
+
+      editDescriptionSubmitButton.click(function() {
+        let newDescription = editDescription.val().trim();
+        if (newDescription === description.text().trim()) {
+          editDescriptionUI.hide();
+          description.show();
+          return
+        }
+
+        let pId = {{ program.id }};
+        let url = Routing.generate('edit_program_description', { id: pId,  newDescription: newDescription });
+        $.get(url, function(data) {
+          if (data.statusCode === {{ constant('Catrobat\\AppBundle\\StatusCode::OK') }}) {
+            description.text(newDescription);
+            editDescription.removeClass("danger");
+            editDescriptionError.hide();
+            editDescriptionUI.hide();
+            description.show()
+          }
+          else if (data.statusCode === {{ constant('Catrobat\\AppBundle\\StatusCode::DESCRIPTION_TOO_LONG') }} ||
+          data.statusCode === {{ constant('Catrobat\\AppBundle\\StatusCode::RUDE_WORD_IN_DESCRIPTION') }} ) {
+            editDescription.addClass("danger");
+            editDescriptionError.show();
+            editDescriptionError.text(data.message)
+          }
+        });
+      });
+
+
+      // save session when edit description text changes
+      //let oldVal = "";
+      //editDescription.on("change keyup paste", function() {
+      //  let currentVal = $(this).val();
+      //  if(currentVal !== oldVal) {
+      //    oldVal = currentVal;
+      //    sessionStorage.setItem('editDescriptionStorage', editDescription.text());
+      //  }
+      //});
+    })
+
+
   </script>
 {% endblock %}

--- a/app/config/listeners.yml
+++ b/app/config/listeners.yml
@@ -25,7 +25,7 @@ services:
 
       catroweb.file.validator.description:
             class: Catrobat\AppBundle\Listeners\DescriptionValidator
-            arguments:    ["@rudewordfilter"]
+            autowire: true
             tags:
             - { name: kernel.event_listener, event: catrobat.program.before, method: onProgramBeforeInsert }
 

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -35,6 +35,12 @@ translate_word:
   options:
     expose: true
 
+edit_program_description:
+  path:  /editProgramDescription/{id}/{newDescription}
+  controller: Catrobat\AppBundle\Controller\Web\ProgramController:editProgramDescription
+  options:
+    expose: true
+
 
 # ===== FOS User Bundle =====
 fos_user:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -30,6 +30,7 @@ parameters:
       catrobat.logs.dir:              "%kernel.root_dir%/logs/"
       catrobat.invalidupload.dir:     "%kernel.root_dir%/../src/Catrobat/AppBundle/Commands/invisible_programs/"
       catrobat.max_version:           "0.996"
+      catrobat.max_description_upload_size: 4000
 
 #      This can drastically improve DX by reducing the time to load classes
       container.dumper.inline_class_loader: true

--- a/src/Catrobat/AppBundle/Features/Web/Context/FeatureContext.php
+++ b/src/Catrobat/AppBundle/Features/Web/Context/FeatureContext.php
@@ -1010,6 +1010,14 @@ class FeatureContext extends MinkContext implements KernelAwareContext, CustomSn
     }
 
     /**
+     * @Given /^the element "([^"]*)" should not exist$/
+     */
+    public function theElementShouldNotExist($element)
+    {
+      $this->assertSession()->elementNotExists('css', $element);
+    }
+
+    /**
      * @Given /^the element "([^"]*)" should not be visible$/
      */
     public function theElementShouldNotBeVisible($element)

--- a/src/Catrobat/AppBundle/Features/Web/oauth.feature
+++ b/src/Catrobat/AppBundle/Features/Web/oauth.feature
@@ -1,4 +1,4 @@
-#@homepage
+@homepage @disabled
 Feature: Open Authentication
   I want to be able to sign in as Facebook and Google+ user
 

--- a/src/Catrobat/AppBundle/Features/Web/oauth_autoconnect.feature
+++ b/src/Catrobat/AppBundle/Features/Web/oauth_autoconnect.feature
@@ -1,4 +1,4 @@
-@homepage
+@homepage @disabled
 Feature: Open Authentication
   I want to be able to sign in as Facebook and Google+ user
 

--- a/src/Catrobat/AppBundle/Features/Web/program.feature
+++ b/src/Catrobat/AppBundle/Features/Web/program.feature
@@ -158,3 +158,35 @@ Feature: As a visitor I want to see a program page
       When I click on the first featured homepage program
       Then I wait 500 milliseconds
       Then I should see "Dapiest"
+
+    Scenario: Changing description is not possible if not logged in
+      Given I am on "/pocketcode/program/1"
+      Then the element "#edit-description-button" should not exist
+      And the element "#edit-description-ui" should not exist
+
+    Scenario: Changing description is not possible if it's not my program
+      Given I am on "/pocketcode/login"
+      And I fill in "username" with "Gregor"
+      And I fill in "password" with "123456"
+      And I press "Login"
+      And I am on "/pocketcode/program/1"
+      Then the element "#edit-description-button" should not exist
+      And the element "#edit-description-ui" should not exist
+
+    Scenario: Changing description is possible if it's my program
+      Given I am on "/pocketcode/login"
+      And I fill in "username" with "Gregor"
+      And I fill in "password" with "123456"
+      And I press "Login"
+      And I am on "/pocketcode/program/2"
+      Then the element "#edit-description-button" should be visible
+      When I click "#edit-description-button"
+      Then the element "#description" should not be visible
+      And the element "#edit-description" should be visible
+      And the element "#edit-description-submit-button" should be visible
+      When I fill in "edit-description" with "This is a new description"
+      And I click "#edit-description-submit-button"
+      And I wait 250 milliseconds
+      Then the element "#description" should be visible
+      And the element "#edit-description-ui" should not be visible
+      And I should see "This is a new description"

--- a/src/Catrobat/AppBundle/Listeners/DescriptionValidator.php
+++ b/src/Catrobat/AppBundle/Listeners/DescriptionValidator.php
@@ -9,14 +9,17 @@ use Catrobat\AppBundle\Services\RudeWordFilter;
 use Catrobat\AppBundle\StatusCode;
 use Catrobat\AppBundle\Exceptions\Upload\DescriptionTooLongException;
 use Catrobat\AppBundle\Exceptions\Upload\RudewordInDescriptionException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class DescriptionValidator
 {
     private $rudeWordFilter;
+    private $container;
 
-    public function __construct(RudeWordFilter $rudeWordFilter)
+    public function __construct(RudeWordFilter $rudeWordFilter, ContainerInterface $container)
     {
         $this->rudeWordFilter = $rudeWordFilter;
+        $this->container = $container;
     }
 
     public function onProgramBeforeInsert(ProgramBeforeInsertEvent $event)
@@ -26,7 +29,9 @@ class DescriptionValidator
 
     public function validate(ExtractedCatrobatFile $file)
     {
-        if (strlen($file->getDescription()) > 1000) {
+      $max_description_size = $this->container->get('kernel')->getContainer()
+        ->getParameter("catrobat.max_description_upload_size");
+        if (strlen($file->getDescription()) > $max_description_size) {
             throw new DescriptionTooLongException();
         }
 

--- a/src/Catrobat/AppBundle/StatusCode.php
+++ b/src/Catrobat/AppBundle/StatusCode.php
@@ -31,6 +31,7 @@ class StatusCode
   const DESCRIPTION_TOO_LONG = 527;
   // upload failed but program still in DB
   const INVALID_FILE_UPLOAD = 528;
+  const NOT_MY_PROGRAM = 529;
 
   const LOGIN_ERROR = 601;
   const REGISTRATION_ERROR = 602;

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -56,6 +56,8 @@ programs:
     There is no way to restore your actions!
     Yes, delete it!
     Cancel
+  tooLongDescription: The program description is too long!
+  rudeWordsInDescription: You can't use rude words in your description!
   most:
     viewed: Most viewed
     downloaded: Most downloaded


### PR DESCRIPTION
WEB 441 Allow editing of a program description
    
    - When logged in a user now can edit the program description of his programs
      The description edit button is only visible on programs the user owns.
      (Same protection on the server side)
    - when the edit button is clicked a text area filled with the current
      description opens. The text-area text can be modified. When the submit button
      is pressed the changed description will be flushed to the database
    - validation -> no rude words, max 4000chars
    - added a parameter to the service file -> server upload description
      limit (4000 chars)
    - added new translations
    - added new status codes
    - added behat features


![screenshot 13](https://user-images.githubusercontent.com/40868718/44956423-3de45f80-aec4-11e8-931e-166d1b6b7145.png)

 