### PR TITLE
WEB 523

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -5,62 +5,64 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 
 class AppKernel extends Kernel
 {
-    public function registerBundles()
+  public function registerBundles()
+  {
+    $bundles = [
+      new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+      new Symfony\Bundle\SecurityBundle\SecurityBundle(),
+      new Symfony\Bundle\TwigBundle\TwigBundle(),
+      new Symfony\Bundle\MonologBundle\MonologBundle(),
+      new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
+
+      new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+      new Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle(),
+
+      new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
+
+      new Knp\Bundle\PaginatorBundle\KnpPaginatorBundle(),
+
+      //Begin Sonata--Admin
+
+      // Sonata --
+      new Sonata\AdminBundle\SonataAdminBundle(),
+      new Sonata\CoreBundle\SonataCoreBundle(),
+      new Sonata\BlockBundle\SonataBlockBundle(),
+      new Sonata\EasyExtendsBundle\SonataEasyExtendsBundle(),
+      // ...
+      new FOS\UserBundle\FOSUserBundle(),
+      new Sonata\UserBundle\SonataUserBundle(),
+      // ...
+
+      new Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle(),
+      new Knp\Bundle\MenuBundle\KnpMenuBundle(),
+
+      new FR3D\LdapBundle\FR3DLdapBundle(),
+      //End Sonata--Admin,
+
+      new FOS\JsRoutingBundle\FOSJsRoutingBundle(),
+      new FOS\RestBundle\FOSRestBundle(),
+
+      new Liip\ThemeBundle\LiipThemeBundle(),
+      new Bazinga\GeocoderBundle\BazingaGeocoderBundle(),
+      new Catrobat\AppBundle\AppBundle(),
+      new EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundle(),
+
+      new \Symfony\Bundle\AclBundle\AclBundle(),
+    ];
+
+    if (in_array($this->getEnvironment(), ['dev', 'test']))
     {
-        $bundles = array(
-            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new Symfony\Bundle\SecurityBundle\SecurityBundle(),
-            new Symfony\Bundle\TwigBundle\TwigBundle(),
-            new Symfony\Bundle\MonologBundle\MonologBundle(),
-            new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
-
-            new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
-            new Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle(),
-
-            new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
-
-            new Knp\Bundle\PaginatorBundle\KnpPaginatorBundle(),
-
-            //Begin Sonata--Admin
-
-            // Sonata --
-            new Sonata\AdminBundle\SonataAdminBundle(),
-            new Sonata\CoreBundle\SonataCoreBundle(),
-            new Sonata\BlockBundle\SonataBlockBundle(),
-            new Sonata\EasyExtendsBundle\SonataEasyExtendsBundle(),
-            // ...
-            new FOS\UserBundle\FOSUserBundle(),
-            new Sonata\UserBundle\SonataUserBundle(),
-            // ...
-
-            new Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle(),
-            new Knp\Bundle\MenuBundle\KnpMenuBundle(),
-
-            new FR3D\LdapBundle\FR3DLdapBundle(),
-            //End Sonata--Admin,
-
-            new FOS\JsRoutingBundle\FOSJsRoutingBundle(),
-            new FOS\RestBundle\FOSRestBundle(),
-
-            new Liip\ThemeBundle\LiipThemeBundle(),
-            new Bazinga\GeocoderBundle\BazingaGeocoderBundle(),
-            new Catrobat\AppBundle\AppBundle(),
-            new EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundle(),
-
-        );
-
-        if (in_array($this->getEnvironment(), array('dev', 'test'))) {
-            $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
-            $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
-            $bundles[] = new \Symfony\Bundle\MakerBundle\MakerBundle();
-            $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
-        }
-
-        return $bundles;
+      $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
+      $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
+      $bundles[] = new \Symfony\Bundle\MakerBundle\MakerBundle();
+      $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
-    {
-        $loader->load(__DIR__.'/config/config_'.$this->getEnvironment().'.yml');
-    }
+    return $bundles;
+  }
+
+  public function registerContainerConfiguration(LoaderInterface $loader)
+  {
+    $loader->load(__DIR__ . '/config/config_' . $this->getEnvironment() . '.yml');
+  }
 }

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -135,6 +135,6 @@ security:
         - { path: ^/.*, role: IS_AUTHENTICATED_ANONYMOUSLY }
 
 
-    acl:
-        connection: default
+acl:
+    connection: default
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "license": "proprietary",
 
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "ext-SimpleXML": "^7.1",
         "ext-gd": "^7.2",
         "ext-json": "^1.5",
@@ -17,7 +17,7 @@
         "facebook/graph-sdk": "^5.6",
         "fr3d/ldap-bundle": "^3.0",
         "friendsofsymfony/jsrouting-bundle": "^2.2",
-        "friendsofsymfony/rest-bundle": "^2.3",
+        "friendsofsymfony/rest-bundle": "^2.4",
         "friendsofsymfony/user-bundle": "^2.1",
         "geocoder-php/ip-info-provider": "^0.1.0",
         "google/apiclient": "^2.2",
@@ -27,7 +27,7 @@
         "php-http/message": "^1.7",
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^5.2",
-        "sonata-project/admin-bundle": "^3.37",
+        "sonata-project/admin-bundle": "^3.39",
         "sonata-project/doctrine-orm-admin-bundle": "^3.6",
         "sonata-project/user-bundle": "^4.2",
         "symfony/acl-bundle": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c274def7f00b55ca097cd1ae6bcf71c7",
+    "content-hash": "aaeffc2ef7ddb2d617541e7ba675093a",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -2157,16 +2157,16 @@
         },
         {
             "name": "geocoder-php/plugin",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/geocoder-php/plugin.git",
-                "reference": "8a0d58dafabd8550214883e8de68bb6bc6b1d3b1"
+                "reference": "25152b7ad235c6a41589b819c198773ad0816d93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/geocoder-php/plugin/zipball/8a0d58dafabd8550214883e8de68bb6bc6b1d3b1",
-                "reference": "8a0d58dafabd8550214883e8de68bb6bc6b1d3b1",
+                "url": "https://api.github.com/repos/geocoder-php/plugin/zipball/25152b7ad235c6a41589b819c198773ad0816d93",
+                "reference": "25152b7ad235c6a41589b819c198773ad0816d93",
                 "shasum": ""
             },
             "require": {
@@ -2178,7 +2178,7 @@
             },
             "require-dev": {
                 "cache/void-adapter": "^1.0",
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "6.3.*"
             },
             "type": "library",
             "extra": {
@@ -2209,7 +2209,7 @@
             "keywords": [
                 "geocoder plugin"
             ],
-            "time": "2017-08-01T08:55:58+00:00"
+            "time": "2018-09-18T16:19:45+00:00"
         },
         {
             "name": "google/apiclient",
@@ -2272,16 +2272,16 @@
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.68",
+            "version": "v0.70",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "f218f5697aa753fa031a09a14ed56a5a438070e4"
+                "reference": "759a1a246409eae1c723abc72d817205a1d5549f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/f218f5697aa753fa031a09a14ed56a5a438070e4",
-                "reference": "f218f5697aa753fa031a09a14ed56a5a438070e4",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/759a1a246409eae1c723abc72d817205a1d5549f",
+                "reference": "759a1a246409eae1c723abc72d817205a1d5549f",
                 "shasum": ""
             },
             "require": {
@@ -2305,20 +2305,20 @@
             "keywords": [
                 "google"
             ],
-            "time": "2018-09-03T00:22:49+00:00"
+            "time": "2018-09-16T00:22:55+00:00"
         },
         {
             "name": "google/auth",
-            "version": "v1.3.3",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "af72b3f50420c801dc35cc07b1fa429ae027b847"
+                "reference": "196237248e636a3554a7d9e4dfddeb97f450ab5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/af72b3f50420c801dc35cc07b1fa429ae027b847",
-                "reference": "af72b3f50420c801dc35cc07b1fa429ae027b847",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/196237248e636a3554a7d9e4dfddeb97f450ab5c",
+                "reference": "196237248e636a3554a7d9e4dfddeb97f450ab5c",
                 "shasum": ""
             },
             "require": {
@@ -2352,7 +2352,7 @@
                 "google",
                 "oauth2"
             ],
-            "time": "2018-08-27T19:47:35+00:00"
+            "time": "2018-09-17T20:29:21+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -2638,16 +2638,16 @@
         },
         {
             "name": "knplabs/knp-components",
-            "version": "v1.3.9",
+            "version": "v1.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/knp-components.git",
-                "reference": "f0f830361ff0ee83ea5c5ffe49b429d2b0ff4266"
+                "reference": "fc1755ba2b77f83a3d3c99e21f3026ba2a1429be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/knp-components/zipball/f0f830361ff0ee83ea5c5ffe49b429d2b0ff4266",
-                "reference": "f0f830361ff0ee83ea5c5ffe49b429d2b0ff4266",
+                "url": "https://api.github.com/repos/KnpLabs/knp-components/zipball/fc1755ba2b77f83a3d3c99e21f3026ba2a1429be",
+                "reference": "fc1755ba2b77f83a3d3c99e21f3026ba2a1429be",
                 "shasum": ""
             },
             "require": {
@@ -2700,7 +2700,7 @@
                 "pager",
                 "paginator"
             ],
-            "time": "2018-08-03T08:37:27+00:00"
+            "time": "2018-09-11T07:54:48+00:00"
         },
         {
             "name": "knplabs/knp-menu",
@@ -4097,16 +4097,16 @@
         },
         {
             "name": "sonata-project/admin-bundle",
-            "version": "3.38.3",
+            "version": "3.39.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sonata-project/SonataAdminBundle.git",
-                "reference": "871dd6446c53c6204910764679a4396596d141ab"
+                "reference": "09711748fc1c85132ce21b4df4e8d491412314b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sonata-project/SonataAdminBundle/zipball/871dd6446c53c6204910764679a4396596d141ab",
-                "reference": "871dd6446c53c6204910764679a4396596d141ab",
+                "url": "https://api.github.com/repos/sonata-project/SonataAdminBundle/zipball/09711748fc1c85132ce21b4df4e8d491412314b3",
+                "reference": "09711748fc1c85132ce21b4df4e8d491412314b3",
                 "shasum": ""
             },
             "require": {
@@ -4118,7 +4118,6 @@
                 "sonata-project/core-bundle": "^3.9",
                 "sonata-project/exporter": "^1.8",
                 "symfony/asset": "^2.8 || ^3.2 || ^4.0",
-                "symfony/class-loader": "^2.8 || ^3.2",
                 "symfony/config": "^2.8 || ^3.2 || ^4.0",
                 "symfony/console": "^2.8 || ^3.2 || ^4.0",
                 "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
@@ -4154,6 +4153,7 @@
                 "matthiasnoback/symfony-dependency-injection-test": "^1.1",
                 "sensio/generator-bundle": "^3.1",
                 "sonata-project/intl-bundle": "^2.4",
+                "symfony/class-loader": "^2.8 || ^3.2",
                 "symfony/filesystem": "^2.8 || ^3.2 || ^4.0",
                 "symfony/phpunit-bridge": "^4.0",
                 "symfony/yaml": "^2.8 || ^3.2 || ^4.0"
@@ -4198,7 +4198,7 @@
                 "bootstrap",
                 "sonata"
             ],
-            "time": "2018-08-21T17:48:44+00:00"
+            "time": "2018-09-09T08:11:09+00:00"
         },
         {
             "name": "sonata-project/block-bundle",
@@ -4853,16 +4853,16 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v6.1.2",
+            "version": "v6.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "7d760881d266d63c5e7a1155cbcf2ac656a31ca8"
+                "reference": "8ddcb66ac10c392d3beb54829eef8ac1438595f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/7d760881d266d63c5e7a1155cbcf2ac656a31ca8",
-                "reference": "7d760881d266d63c5e7a1155cbcf2ac656a31ca8",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/8ddcb66ac10c392d3beb54829eef8ac1438595f4",
+                "reference": "8ddcb66ac10c392d3beb54829eef8ac1438595f4",
                 "shasum": ""
             },
             "require": {
@@ -4908,7 +4908,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2018-07-13T07:04:35+00:00"
+            "time": "2018-09-11T07:12:52+00:00"
         },
         {
             "name": "symfony/acl-bundle",
@@ -5719,16 +5719,16 @@
         },
         {
             "name": "willdurand/geocoder-bundle",
-            "version": "5.1.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/geocoder-php/BazingaGeocoderBundle.git",
-                "reference": "474afc3b7ef4030a6404262ecccd43c8fc115a34"
+                "reference": "aa416e46cd95af905e14a3c8f670ba5baa0dfbd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/geocoder-php/BazingaGeocoderBundle/zipball/474afc3b7ef4030a6404262ecccd43c8fc115a34",
-                "reference": "474afc3b7ef4030a6404262ecccd43c8fc115a34",
+                "url": "https://api.github.com/repos/geocoder-php/BazingaGeocoderBundle/zipball/aa416e46cd95af905e14a3c8f670ba5baa0dfbd3",
+                "reference": "aa416e46cd95af905e14a3c8f670ba5baa0dfbd3",
                 "shasum": ""
             },
             "require": {
@@ -5740,6 +5740,7 @@
                 "willdurand/geocoder": "^4.0"
             },
             "conflict": {
+                "geocoder-php/nominatim-provider": "<5.0",
                 "willdurand/geocoder": "3.2"
             },
             "require-dev": {
@@ -5758,11 +5759,12 @@
                 "geocoder-php/host-ip-provider": "^4.0",
                 "geocoder-php/ip-info-db-provider": "^4.0",
                 "geocoder-php/ip-info-provider": "^0.1",
+                "geocoder-php/ipstack-provider": "^0.1",
                 "geocoder-php/mapquest-provider": "^4.0",
                 "geocoder-php/mapzen-provider": "^4.0",
                 "geocoder-php/maxmind-binary-provider": "^4.0",
                 "geocoder-php/maxmind-provider": "^4.0",
-                "geocoder-php/nominatim-provider": "^4.0",
+                "geocoder-php/nominatim-provider": "^5.0",
                 "geocoder-php/open-cage-provider": "^4.0",
                 "geocoder-php/pickpoint-provider": "^4.0",
                 "geocoder-php/tomtom-provider": "^4.0",
@@ -5802,7 +5804,7 @@
                 "geocoder",
                 "geocoding"
             ],
-            "time": "2018-02-02T08:41:28+00:00"
+            "time": "2018-09-18T16:23:58+00:00"
         },
         {
             "name": "willdurand/jsonp-callback-validator",
@@ -6759,16 +6761,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.0.3",
+            "version": "v4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "bd088dc940a418f09cda079a9b5c7c478890fb8d"
+                "reference": "fa6ee28600d21d49b2b4e1006b48426cec8e579c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/bd088dc940a418f09cda079a9b5c7c478890fb8d",
-                "reference": "bd088dc940a418f09cda079a9b5c7c478890fb8d",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/fa6ee28600d21d49b2b4e1006b48426cec8e579c",
+                "reference": "fa6ee28600d21d49b2b4e1006b48426cec8e579c",
                 "shasum": ""
             },
             "require": {
@@ -6806,7 +6808,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2018-07-15T17:25:16+00:00"
+            "time": "2018-09-18T07:03:24+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -7354,20 +7356,23 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cecbc684605bb0cc288828eb5d65d93d5c676d3c"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cecbc684605bb0cc288828eb5d65d93d5c676d3c",
-                "reference": "cecbc684605bb0cc288828eb5d65d93d5c676d3c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
@@ -7397,7 +7402,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2018-06-11T11:44:00+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -7540,16 +7545,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.3.4",
+            "version": "7.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0356331bf62896dc56e3a15030b23b73f38b2935"
+                "reference": "7b331efabbb628c518c408fdfcaf571156775de2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0356331bf62896dc56e3a15030b23b73f38b2935",
-                "reference": "0356331bf62896dc56e3a15030b23b73f38b2935",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7b331efabbb628c518c408fdfcaf571156775de2",
+                "reference": "7b331efabbb628c518c408fdfcaf571156775de2",
                 "shasum": ""
             },
             "require": {
@@ -7620,7 +7625,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-09-05T09:58:53+00:00"
+            "time": "2018-09-08T15:14:29+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -8571,7 +8576,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "ext-simplexml": "^7.1",
         "ext-gd": "^7.2",
         "ext-json": "^1.5"

--- a/src/Catrobat/AppBundle/Admin/ApkListAdmin.php
+++ b/src/Catrobat/AppBundle/Admin/ApkListAdmin.php
@@ -20,7 +20,7 @@ class ApkListAdmin extends AbstractAdmin
 
   public function createQuery($context = 'list')
   {
-    $query = parent::createQuery($context);
+    $query = parent::createQuery();
     $query->andWhere(
       $query->expr()->eq($query->getRootAlias() . '.apk_status', ':apk_status')
     );

--- a/src/Catrobat/AppBundle/Admin/ApproveProgramsAdmin.php
+++ b/src/Catrobat/AppBundle/Admin/ApproveProgramsAdmin.php
@@ -21,7 +21,7 @@ class ApproveProgramsAdmin extends AbstractAdmin
 
   public function createQuery($context = 'list')
   {
-    $query = parent::createQuery($context);
+    $query = parent::createQuery();
     $query->andWhere(
       $query->expr()->eq($query->getRootAlias() . '.approved', $query->expr()->literal(false))
     );

--- a/src/Catrobat/AppBundle/Admin/FeaturedProgramAdmin.php
+++ b/src/Catrobat/AppBundle/Admin/FeaturedProgramAdmin.php
@@ -20,7 +20,7 @@ class FeaturedProgramAdmin extends AbstractAdmin
 
   public function createQuery($context = 'list')
   {
-    $query = parent::createQuery($context);
+    $query = parent::createQuery();
     $query->andWhere(
       $query->expr()->isNotNull($query->getRootAlias() . '.program')
     );

--- a/src/Catrobat/AppBundle/Admin/FeaturedUrlAdmin.php
+++ b/src/Catrobat/AppBundle/Admin/FeaturedUrlAdmin.php
@@ -16,7 +16,7 @@ class FeaturedUrlAdmin extends AbstractAdmin
 
   public function createQuery($context = 'list')
   {
-    $query = parent::createQuery($context);
+    $query = parent::createQuery();
     $query->andWhere(
       $query->expr()->isNull($query->getRootAlias() . '.program')
     );

--- a/src/Catrobat/AppBundle/Admin/NolbExampleAdmin.php
+++ b/src/Catrobat/AppBundle/Admin/NolbExampleAdmin.php
@@ -14,7 +14,7 @@ class NolbExampleAdmin extends AbstractAdmin
 
   public function createQuery($context = 'list')
   {
-    $query = parent::createQuery($context);
+    $query = parent::createQuery();
     $query->andWhere(
       $query->expr()->isNotNull($query->getRootAlias() . '.program')
     );

--- a/src/Catrobat/AppBundle/Admin/PendingApkRequestsAdmin.php
+++ b/src/Catrobat/AppBundle/Admin/PendingApkRequestsAdmin.php
@@ -21,7 +21,7 @@ class PendingApkRequestsAdmin extends AbstractAdmin
 
   public function createQuery($context = 'list')
   {
-    $query = parent::createQuery($context);
+    $query = parent::createQuery();
     $query->andWhere(
       $query->expr()->eq($query->getRootAlias() . '.apk_status', ':apk_status')
     );

--- a/src/Catrobat/AppBundle/Admin/ReportAdmin.php
+++ b/src/Catrobat/AppBundle/Admin/ReportAdmin.php
@@ -22,7 +22,7 @@ class ReportAdmin extends AbstractAdmin
 
   public function createQuery($context = 'list')
   {
-    $query = parent::createQuery($context);
+    $query = parent::createQuery();
     $query->andWhere(
       $query->expr()->eq($query->getRootAlias() . '.isReported', $query->expr()->literal(true))
     );

--- a/src/Catrobat/AppBundle/Admin/ReportedProgramsAdmin.php
+++ b/src/Catrobat/AppBundle/Admin/ReportedProgramsAdmin.php
@@ -13,7 +13,7 @@ class ReportedProgramsAdmin extends AbstractAdmin
 {
   public function createQuery($context = 'list')
   {
-    $query = parent::createQuery($context);
+    $query = parent::createQuery();
 
     return $query;
   }

--- a/src/Catrobat/AppBundle/AppBundle.php
+++ b/src/Catrobat/AppBundle/AppBundle.php
@@ -6,8 +6,5 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class AppBundle extends Bundle
 {
-  public function getParent()
-  {
-    return 'FOSUserBundle';
-  }
+
 }


### PR DESCRIPTION
Removed Symfony 3.4 deprications to reduce workload when upgrading to symfony ^4

Still depricated:

- Classloader (wait for new doctrine release)
- Some Sonata Admin stuff (wait for new admin bundle release)