### PR TITLE
Center featured program images on large screens

### DIFF
--- a/app/Resources/views/components/bootstrap/bootstrap-carousel.html.twig
+++ b/app/Resources/views/components/bootstrap/bootstrap-carousel.html.twig
@@ -16,13 +16,13 @@
       {% if loop.first %}
         <div class="item active">
           <a href="{{ slide.url }}">
-            <img src="{{ asset(slide.image) }}" alt="featured program">
+            <img class="center-block img-responsive" src="{{ asset(slide.image) }}" alt="featured program">
           </a>
         </div>
       {% else %}
         <div class="item">
           <a href="{{ slide.url }}">
-            <img src="{{ asset(slide.image) }}" alt="featured program">
+            <img class="center-block img-responsive" src="{{ asset(slide.image) }}" alt="featured program">
           </a>
         </div>
       {% endif %}


### PR DESCRIPTION
I used the solution found here[1] to center featured program images on
large screens (width ≥ 1200px). Note that this will work on Bootstrap 3
only but won't on Bootstrap 4. This solution has already been used
here[2].

[1] https://stackoverflow.com/a/25453550
[2] https://github.com/Catrobat/Catroweb-Symfony/blob/84daa4d57e54fa2d8720a88b438c636cc8f30c49/app/Resources/SonataUserBundle/views/Security/login.html.twig#L23
___
Before the fix:
![share catrob at_pocketcode_before](https://user-images.githubusercontent.com/1794599/52435044-151a6300-2b11-11e9-8b82-3cd0197363b1.png)

After the fix:
![share catrob at_pocketcode_after](https://user-images.githubusercontent.com/1794599/52435051-18adea00-2b11-11e9-9a73-97b22c7ffac8.png)
___
Note that I did not test the code automatically nor manually. To create the second image, I used following JavaScript code
```javascript
$('.carousel-inner img').addClass('img-responsive center-block');
```
I tried to set up the Catroweb environment for Ubuntu but finally gave up :disappointed: I hope it's still ok to submit the pull request :sweat_smile: If the :bug: has already been fixed or doesn't work, feel free to close it. It's not important, just one that bugged me a lot.