### PR TITLE
SHARE-10 apiKeyAuthenticator broken

### DIFF
--- a/app/Resources/views/Index/welcome-section.html.twig
+++ b/app/Resources/views/Index/welcome-section.html.twig
@@ -81,6 +81,7 @@
 
   </div>
 
+  {% endif %}   {#{% if not isWebview() %}#}
+
 </div>
 
-{% endif %}

--- a/src/Catrobat/AppBundle/Controller/Api/SecurityController.php
+++ b/src/Catrobat/AppBundle/Controller/Api/SecurityController.php
@@ -3,8 +3,6 @@
 namespace Catrobat\AppBundle\Controller\Api;
 
 use Catrobat\AppBundle\Entity\User;
-use Catrobat\AppBundle\Features\Helpers\FakeOAuthService;
-use Catrobat\AppBundle\Services\OAuthService;
 use Symfony\Component\HttpFoundation\Request;
 use Catrobat\AppBundle\Entity\UserManager;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -304,7 +302,9 @@ class SecurityController extends Controller
    */
   private function signInLdapUser($request, &$retArray)
   {
-    /* @var $authenticator UserAuthenticator */
+    /**
+     * @var $authenticator UserAuthenticator
+     */
     $authenticator = $this->get('user_authenticator');
     $token = null;
     $username = $request->request->get('registrationUsername');

--- a/src/Catrobat/AppBundle/Features/Api/authentication.feature
+++ b/src/Catrobat/AppBundle/Features/Api/authentication.feature
@@ -99,6 +99,6 @@ Feature: Authenticate to the system
     And the response code will be "<httpcode>"
 
     Examples:
-      | problem       | errorcode | answer                                               | httpcode |
-      | invalid token | 601       | Authentication of device failed: invalid auth-token! | 401      |
+      | problem       | errorcode | answer                    | httpcode |
+      | invalid token | 601       | Upload Token auth failed. | 401      |
 

--- a/src/Catrobat/AppBundle/Features/Api/check_token.feature
+++ b/src/Catrobat/AppBundle/Features/Api/check_token.feature
@@ -33,7 +33,7 @@ Feature: Checking a user's token validity
     When I POST these parameters to "/pocketcode/api/checkToken/check.json"
     Then I should get the json object:
       """
-      {"statusCode":601,"answer":"Authentication of device failed: invalid auth-token!","preHeaderMessages":""}
+      {"statusCode":601,"answer":"Upload Token auth failed.", "preHeaderMessages":""}
       """
     And the response code should be "401"
 
@@ -43,7 +43,7 @@ Feature: Checking a user's token validity
     When I POST these parameters to "/pocketcode/api/checkToken/check.json"
     Then I should get the json object:
       """
-      {"statusCode":601,"answer":"Authentication of device failed: invalid auth-token!","preHeaderMessages":""}
+      {"statusCode":601,"answer":"There is no user with name \"doesnotexist\".", "preHeaderMessages":""}
       """
     And the response code should be "401"
     

--- a/src/Catrobat/AppBundle/Features/Api/upload_program.feature
+++ b/src/Catrobat/AppBundle/Features/Api/upload_program.feature
@@ -39,7 +39,7 @@ Feature: Upload a program
     When I POST these parameters to "/pocketcode/api/upload/upload.json"
     Then I should get the json object:
       """
-      {"statusCode":601,"answer":"Authentication of device failed: invalid auth-token!","preHeaderMessages":""}
+      {"statusCode":601,"answer":"There is no user with name \"INVALID\".","preHeaderMessages":""}
       """
 
   Scenario: trying to upload with an invalid token should result in an error
@@ -48,7 +48,7 @@ Feature: Upload a program
     When I POST these parameters to "/pocketcode/api/upload/upload.json"
     Then I should get the json object:
       """
-      {"statusCode":601,"answer":"Authentication of device failed: invalid auth-token!","preHeaderMessages":""}
+      {"statusCode":601,"answer":"Upload Token auth failed.","preHeaderMessages":""}
       """
 
   Scenario: trying to upload with a missing token should result in an error

--- a/src/Catrobat/AppBundle/Security/ApiKeyAuthenticator.php
+++ b/src/Catrobat/AppBundle/Security/ApiKeyAuthenticator.php
@@ -48,9 +48,17 @@ class ApiKeyAuthenticator implements SimplePreAuthenticatorInterface, Authentica
     $upload_token = $request->request->get('token');
     $username = $request->request->get('username');
 
+
     if (!$upload_token)
     {
-      throw new BadCredentialsException('No API key found');
+      throw new BadCredentialsException(
+        $this->translator->trans("errors.token", [], 'catroweb'));
+    }
+
+    if (!$username)
+    {
+      throw new BadCredentialsException(
+        $this->translator->trans("errors.username.blank", [], 'catroweb'));
     }
 
     return new PreAuthenticatedToken($username, $upload_token, $providerKey);
@@ -71,7 +79,8 @@ class ApiKeyAuthenticator implements SimplePreAuthenticatorInterface, Authentica
     $user = $userProvider->loadUserByUsername($token->getUsername());
     if (!$user)
     {
-      throw new AuthenticationException('No user found');
+      throw new AuthenticationException(
+        $this->translator->trans("errors.username.not_exists", [], 'catroweb'));
     }
 
     if ($token->getCredentials() === $user->getUploadToken())
@@ -83,7 +92,8 @@ class ApiKeyAuthenticator implements SimplePreAuthenticatorInterface, Authentica
     }
     else
     {
-      throw new AuthenticationException('Upload Token auth failed.');
+      throw new AuthenticationException(
+        $this->translator->trans("errors.uploadTokenAuthFailed", [], 'catroweb'));
     }
   }
 
@@ -106,17 +116,8 @@ class ApiKeyAuthenticator implements SimplePreAuthenticatorInterface, Authentica
    */
   public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
   {
-    return JsonResponse::create(['statusCode' => StatusCode::LOGIN_ERROR, 'answer' => $this->trans('errors.token'), 'preHeaderMessages' => ''], Response::HTTP_UNAUTHORIZED);
-  }
-
-  /**
-   * @param       $message
-   * @param array $parameters
-   *
-   * @return string
-   */
-  private function trans($message, $parameters = [])
-  {
-    return $this->translator->trans($message, $parameters, 'catroweb');
+    return JsonResponse::create(['statusCode' => StatusCode::LOGIN_ERROR,
+                                 'answer' => $exception->getMessage(), 'preHeaderMessages' => ""],
+      Response::HTTP_UNAUTHORIZED);
   }
 }

--- a/src/Catrobat/AppBundle/Security/UserAuthenticator.php
+++ b/src/Catrobat/AppBundle/Security/UserAuthenticator.php
@@ -44,6 +44,7 @@ class UserAuthenticator
   {
     $user = $this->user_provider->loadUserByUsername($username);
 
-    return $this->authentication_manager->authenticate(new UsernamePasswordToken($user->getUsername(), $password, 'main'));
+    return $this->authentication_manager->authenticate(
+      new UsernamePasswordToken($user->getUsername(), $password, 'main'));
   }
 }

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -569,6 +569,7 @@ errors:
   image.missing: Project XML mentions a file which does not exist in project-folder
   unknown: unknown error
   token: 'Authentication of device failed: invalid auth-token!'
+  uploadTokenAuthFailed: 'Upload Token auth failed.'
   programname:
     rude: Programname must not contain rude wordes.
   program:


### PR DESCRIPTION
The api authentification now returns a useful error response instead of 500 when the username is blank in the request