### PR TITLE
SHARE-27 No email as username

### DIFF
--- a/src/Catrobat/Requests/CreateUserRequest.php
+++ b/src/Catrobat/Requests/CreateUserRequest.php
@@ -26,7 +26,7 @@ class CreateUserRequest
 
   /**
    * @Assert\NotBlank(message = "errors.username.blank")
-   * @Assert\Regex(pattern="/^[\w@_\-\.]+$/")
+   * @Assert\Regex(pattern="/^[\w_\-\.]{3,180}$/")
    */
   public $username;
 

--- a/tests/behat/features/api/authentication.feature
+++ b/tests/behat/features/api/authentication.feature
@@ -102,3 +102,23 @@ Feature: Authenticate to the system
       | problem       | errorcode | answer                    | httpcode |
       | invalid token | 601       | Upload Token auth failed. | 401      |
 
+  Scenario: Registration of a new user with a too long username
+    Given the HTTP Request:
+      | Method | POST                                                 |
+      | Url    | /pocketcode/api/register/Register.json |
+    And the POST parameters:
+      | Name                 | Value                |
+      | registrationUsername | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa              |
+      | registrationPassword | registrationpassword |
+      | registrationEmail    | test@mail.com        |
+      | registrationCountry  | at                   |
+    And we assume the next generated token will be "rrrrrrrrrrr"
+    When the Request is invoked
+    Then the returned json object will be:
+          """
+          {
+            "statusCode": 602,
+            "answer": "This value is not valid.",
+            "preHeaderMessages": ""
+          }
+          """


### PR DESCRIPTION
- fixes regex that takes care of basic validation of username
- adds bounds (username may be between 3 and 180 chars)
- adds test for it