### PR TITLE
WIP SHARE-35 Status Codes misleading

### DIFF
--- a/src/Catrobat/Controller/Api/MediaPackageController.php
+++ b/src/Catrobat/Controller/Api/MediaPackageController.php
@@ -120,7 +120,7 @@ class MediaPackageController extends Controller
     }
 
     return JsonResponse::create([
-        'statusCode' => StatusCode::OK,
+        'statusCode' => Response::HTTP_OK,
         'data'       => $json_response_array,
       ]
     );
@@ -174,7 +174,7 @@ class MediaPackageController extends Controller
     }
 
     return JsonResponse::create([
-        'statusCode' => StatusCode::OK,
+        'statusCode' => Response::HTTP_OK,
         'data'       => $json_response_array,
       ]
     );

--- a/src/Catrobat/Controller/Api/RecommenderController.php
+++ b/src/Catrobat/Controller/Api/RecommenderController.php
@@ -77,7 +77,12 @@ class RecommenderController extends Controller
     $program = $program_manager->find($id);
     if ($program == null)
     {
-      return JsonResponse::create(['statusCode' => StatusCode::INVALID_PROGRAM]);
+      return JsonResponse::create(
+        [
+          'statusCode' => StatusCode::INVALID_PROGRAM,
+          'answer' =>  $this->trans('errors.program.invalid'),
+        ]
+      );
     }
 
     $programs_count = $program_manager->getRecommendedProgramsCount($id, $flavor);
@@ -132,5 +137,16 @@ class RecommenderController extends Controller
     }
 
     return new ProgramListResponse($programs, $programs_count, true, $is_user_specific_recommendation);
+  }
+
+  /**
+   * @param       $message
+   * @param array $parameters
+   *
+   * @return string
+   */
+  private function trans($message, $parameters = [])
+  {
+    return $this->get('translator')->trans($message, $parameters, 'catroweb');
   }
 }

--- a/src/Catrobat/Controller/Api/ReportController.php
+++ b/src/Catrobat/Controller/Api/ReportController.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpFoundation\Request;
 use App\Entity\ProgramManager;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use App\Catrobat\StatusCode;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use App\Entity\ProgramInappropriateReport;
@@ -84,7 +85,7 @@ class ReportController extends Controller
 
     $response = [];
     $response['answer'] = $this->trans('success.report');
-    $response['statusCode'] = StatusCode::OK;
+    $response['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($response);
   }

--- a/src/Catrobat/Controller/Api/SecurityController.php
+++ b/src/Catrobat/Controller/Api/SecurityController.php
@@ -7,6 +7,7 @@ use Symfony\Component\HttpFoundation\Request;
 use App\Entity\UserManager;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use App\Catrobat\StatusCode;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use App\Catrobat\Requests\LoginUserRequest;
@@ -32,7 +33,7 @@ class SecurityController extends Controller
   public function checkTokenAction()
   {
     return JsonResponse::create([
-      'statusCode'        => StatusCode::OK,
+      'statusCode'        => Response::HTTP_OK,
       'answer'            => $this->trans('success.token'),
       'preHeaderMessages' => "  \n",
     ]);
@@ -62,7 +63,7 @@ class SecurityController extends Controller
     $retArray = [];
 
     $this->signInLdapUser($request, $retArray);
-    if (array_key_exists('statusCode', $retArray) && ($retArray['statusCode'] === StatusCode::OK || $retArray['statusCode'] === StatusCode::LOGIN_ERROR))
+    if (array_key_exists('statusCode', $retArray) && ($retArray['statusCode'] === Response::HTTP_OK || $retArray['statusCode'] === StatusCode::LOGIN_ERROR))
     {
       return JsonResponse::create($retArray);
     }
@@ -253,7 +254,7 @@ class SecurityController extends Controller
       if (!$user)
       {
         $this->signInLdapUser($request, $retArray);
-        if (array_key_exists('statusCode', $retArray) && ($retArray['statusCode'] === StatusCode::OK || $retArray['statusCode'] === StatusCode::LOGIN_ERROR))
+        if (array_key_exists('statusCode', $retArray) && ($retArray['statusCode'] === Response::HTTP_OK || $retArray['statusCode'] === StatusCode::LOGIN_ERROR))
         {
           return JsonResponse::create($retArray);
         }
@@ -268,7 +269,7 @@ class SecurityController extends Controller
         $dd = null;
         if ($correct_pass)
         {
-          $retArray['statusCode'] = StatusCode::OK;
+          $retArray['statusCode'] = Response::HTTP_OK;
           $user->setUploadToken($tokenGenerator->generateToken());
           $retArray['token'] = $user->getUploadToken();
           $retArray['email'] = $user->getEmail();
@@ -277,7 +278,7 @@ class SecurityController extends Controller
         else
         {
           $this->signInLdapUser($request, $retArray);
-          if (array_key_exists('statusCode', $retArray) && ($retArray['statusCode'] === StatusCode::OK || $retArray['statusCode'] === StatusCode::LOGIN_ERROR))
+          if (array_key_exists('statusCode', $retArray) && ($retArray['statusCode'] === Response::HTTP_OK || $retArray['statusCode'] === StatusCode::LOGIN_ERROR))
           {
             return JsonResponse::create($retArray);
           }
@@ -311,7 +312,7 @@ class SecurityController extends Controller
     try
     {
       $token = $authenticator->authenticate($username, $request->request->get('registrationPassword'));
-      $retArray['statusCode'] = StatusCode::OK;
+      $retArray['statusCode'] = Response::HTTP_OK;
       $retArray['token'] = $token->getUser()->getUploadToken();
       $retArray['preHeaderMessages'] = '';
 

--- a/src/Catrobat/Controller/Api/UploadController.php
+++ b/src/Catrobat/Controller/Api/UploadController.php
@@ -15,6 +15,7 @@ use App\Entity\ProgramManager;
 use App\Catrobat\Services\TokenGenerator;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use App\Catrobat\StatusCode;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use App\Catrobat\Exceptions\Upload\MissingChecksumException;
 use App\Catrobat\Exceptions\Upload\InvalidChecksumException;
@@ -272,7 +273,7 @@ class UploadController
     $this->usermanager->updateUser($user);
 
     $response['projectId'] = $program->getId();
-    $response['statusCode'] = StatusCode::OK;
+    $response['statusCode'] = Response::HTTP_OK;
     $response['answer'] = $this->trans('success.upload');
     $response['token'] = $user->getUploadToken();
     if ($gamejam !== null && !$program->isAcceptedForGameJam())

--- a/src/Catrobat/Controller/Web/CommentsController.php
+++ b/src/Catrobat/Controller/Web/CommentsController.php
@@ -47,7 +47,7 @@ class CommentsController extends Controller
     $comment->setIsReported(true);
     $em->flush();
 
-    return new Response(StatusCode::OK);
+    return new Response(Response::HTTP_OK);
   }
 
 
@@ -93,7 +93,7 @@ class CommentsController extends Controller
     $em->remove($comment);
     $em->flush();
 
-    return new Response(StatusCode::OK);
+    return new Response(Response::HTTP_OK);
   }
 
 
@@ -148,6 +148,6 @@ class CommentsController extends Controller
       $notification_service->addNotification($notification);
     }
 
-    return new Response(StatusCode::OK);
+    return new Response(Response::HTTP_OK);
   }
 }

--- a/src/Catrobat/Controller/Web/ProfileController.php
+++ b/src/Catrobat/Controller/Web/ProfileController.php
@@ -8,6 +8,7 @@ use App\Catrobat\StatusCode;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -117,7 +118,7 @@ class ProfileController extends Controller
     $this->get('usermanager')->updateUser($user);
 
     return JsonResponse::create([
-      'statusCode' => StatusCode::OK,
+      'statusCode' => Response::HTTP_OK,
     ]);
   }
 
@@ -176,7 +177,7 @@ class ProfileController extends Controller
     $this->get('usermanager')->updateUser($user);
 
     return JsonResponse::create([
-      'statusCode'     => StatusCode::OK,
+      'statusCode'     => Response::HTTP_OK,
       'saved_password' => "supertoll",
     ]);
   }
@@ -258,7 +259,7 @@ class ProfileController extends Controller
     $this->get('usermanager')->updateUser($user);
 
     return JsonResponse::create([
-      'statusCode' => StatusCode::OK,
+      'statusCode' => Response::HTTP_OK,
     ]);
   }
 
@@ -295,7 +296,7 @@ class ProfileController extends Controller
     $this->get('usermanager')->updateUser($user);
 
     return JsonResponse::create([
-      'statusCode'   => StatusCode::OK,
+      'statusCode'   => Response::HTTP_OK,
       'image_base64' => $image_base64,
     ]);
   }
@@ -336,7 +337,7 @@ class ProfileController extends Controller
     $em->flush();
 
     return JsonResponse::create([
-      'statusCode' => StatusCode::OK,
+      'statusCode' => Response::HTTP_OK,
       'count'      => count($user_comments),
     ]);
   }

--- a/src/Catrobat/Controller/Web/ProgramController.php
+++ b/src/Catrobat/Controller/Web/ProgramController.php
@@ -193,6 +193,7 @@ class ProgramController extends Controller
   {
     /**
      * @var ProgramManager           $program_manager
+     * @var Program                  $program
      * @var User                     $user
      * @var CatroNotification        $notification
      * @var CatroNotificationService $notification_service
@@ -205,8 +206,12 @@ class ProgramController extends Controller
     {
       if ($request->isXmlHttpRequest())
       {
-        return JsonResponse::create(['statusCode' => StatusCode::INVALID_PARAM,
-                                     'message'    => 'Invalid like type given!']);
+        return JsonResponse::create(
+          [
+            'statusCode' => StatusCode::INVALID_PARAM,
+            'message'    => 'Invalid like type given!'
+          ]
+        );
       }
       else
       {
@@ -219,8 +224,12 @@ class ProgramController extends Controller
     {
       if ($request->isXmlHttpRequest())
       {
-        return JsonResponse::create(['statusCode' => StatusCode::INVALID_PARAM,
-                                     'message'    => 'Program with given ID does not exist!']);
+        return JsonResponse::create(
+          [
+            'statusCode' => StatusCode::INVALID_PARAM,
+            'message'    => 'Program with given ID does not exist!'
+          ]
+        );
       }
       else
       {
@@ -292,12 +301,18 @@ class ProgramController extends Controller
       return $this->redirectToRoute('program', ['id' => $id]);
     }
 
-    return new JsonResponse(['statusCode' => StatusCode::OK, 'data' => [
-      'id'             => $id,
-      'likeType'       => $new_type,
-      'likeTypeCount'  => $like_type_count,
-      'totalLikeCount' => $total_like_count,
-    ]]);
+    return new JsonResponse(
+      [
+        'statusCode' => Response::HTTP_OK,
+        'data' =>
+          [
+          'id'             => $id,
+          'likeType'       => $new_type,
+          'likeTypeCount'  => $like_type_count,
+          'totalLikeCount' => $total_like_count,
+          ]
+      ]
+    );
   }
 
 
@@ -449,16 +464,22 @@ class ProgramController extends Controller
 
     if (strlen($newDescription) > $max_description_size)
     {
-      return JsonResponse::create(['statusCode' => StatusCode::DESCRIPTION_TOO_LONG,
-                                   'message'    => $translator
-                                     ->trans("programs.tooLongDescription", [], "catroweb")]);
+      return JsonResponse::create(
+        [
+          'statusCode' => StatusCode::DESCRIPTION_TOO_LONG,
+          'message'    => $translator->trans("programs.tooLongDescription", [], "catroweb")
+        ]
+      );
     }
 
     if ($rude_word_filter->containsRudeWord($newDescription))
     {
-      return JsonResponse::create(['statusCode' => StatusCode::RUDE_WORD_IN_DESCRIPTION,
-                                   'message'    => $translator
-                                     ->trans("programs.rudeWordsInDescription", [], "catroweb")]);
+      return JsonResponse::create(
+        [
+          'statusCode' => StatusCode::RUDE_WORD_IN_DESCRIPTION,
+          'message'    => $translator->trans("programs.rudeWordsInDescription", [], "catroweb")
+        ]
+      );
     }
 
     $user = $this->getUser();
@@ -485,7 +506,7 @@ class ProgramController extends Controller
     $em->persist($program);
     $em->flush();
 
-    return JsonResponse::create(['statusCode' => StatusCode::OK]);
+    return JsonResponse::create(['statusCode' => Response::HTTP_OK]);
   }
 
 

--- a/src/Catrobat/Listeners/NameValidator.php
+++ b/src/Catrobat/Listeners/NameValidator.php
@@ -9,6 +9,7 @@ use App\Catrobat\Exceptions\Upload\MissingProgramNameException;
 use App\Catrobat\Exceptions\Upload\NameTooLongException;
 use App\Catrobat\Exceptions\Upload\RudewordInNameException;
 use App\Catrobat\StatusCode;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Class NameValidator
@@ -53,7 +54,7 @@ class NameValidator
     {
       throw new MissingProgramNameException();
     }
-    elseif (strlen($file->getName()) > StatusCode::OK)
+    elseif (strlen($file->getName()) > Response::HTTP_OK)
     {
       throw new NameTooLongException();
     }

--- a/src/Catrobat/Listeners/VersionValidator.php
+++ b/src/Catrobat/Listeners/VersionValidator.php
@@ -7,6 +7,7 @@ use App\Catrobat\Exceptions\InvalidCatrobatFileException;
 use App\Catrobat\StatusCode;
 use App\Catrobat\Exceptions\Upload\OldCatrobatLanguageVersionException;
 use App\Catrobat\Exceptions\Upload\OldApplicationVersionException;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Class VersionValidator
@@ -62,7 +63,7 @@ class VersionValidator
         }
         break;
       default:
-        throw new InvalidCatrobatFileException('unsupported platform', StatusCode::INTERNAL_SERVER_ERROR);
+        throw new InvalidCatrobatFileException('unsupported platform', Response::HTTP_INTERNAL_SERVER_ERROR);
 
     }
   }

--- a/src/Catrobat/Services/OAuthService.php
+++ b/src/Catrobat/Services/OAuthService.php
@@ -81,7 +81,7 @@ class OAuthService
     {
       $retArray['is_oauth_user'] = false;
     }
-    $retArray['statusCode'] = StatusCode::OK;
+    $retArray['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($retArray);
   }
@@ -113,7 +113,7 @@ class OAuthService
     {
       $retArray['email_available'] = false;
     }
-    $retArray['statusCode'] = StatusCode::OK;
+    $retArray['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($retArray);
   }
@@ -147,7 +147,7 @@ class OAuthService
     {
       $retArray['username_available'] = false;
     }
-    $retArray['statusCode'] = StatusCode::OK;
+    $retArray['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($retArray);
   }
@@ -182,7 +182,7 @@ class OAuthService
     {
       $retArray['token_available'] = false;
     }
-    $retArray['statusCode'] = StatusCode::OK;
+    $retArray['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($retArray);
   }
@@ -422,7 +422,7 @@ class OAuthService
       return $this->returnErrorCode($e);
     }
 
-    $retArray['statusCode'] = StatusCode::OK;
+    $retArray['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($retArray);
   }
@@ -493,7 +493,7 @@ class OAuthService
       // should not happen, but who knows
       $retArray['token_invalid'] = true;
       $retArray['reason'] = 'No Facebook User with given ID in database';
-      $retArray['statusCode'] = StatusCode::OK;
+      $retArray['statusCode'] = Response::HTTP_OK;
 
       return JsonResponse::create($retArray);
     }
@@ -530,7 +530,7 @@ class OAuthService
       $retArray['token_invalid'] = true;
       $retArray['reason'] = 'There was an error during Facebook token check';
       $retArray['details'] = 'Error code: ' . $error->code . ', error subcode: ' . $error->subcode . ', error message: ' . $error->message;
-      $retArray['statusCode'] = StatusCode::OK;
+      $retArray['statusCode'] = Response::HTTP_OK;
 
       return JsonResponse::create($retArray);
     }
@@ -548,7 +548,7 @@ class OAuthService
     {
       $retArray['token_invalid'] = true;
       $retArray['reason'] = 'Token data does not match application data';
-      $retArray['statusCode'] = StatusCode::OK;
+      $retArray['statusCode'] = Response::HTTP_OK;
 
       return JsonResponse::create($retArray);
     }
@@ -557,7 +557,7 @@ class OAuthService
     {
       $retArray['token_invalid'] = true;
       $retArray['reason'] = 'Token has been invalidated';
-      $retArray['statusCode'] = StatusCode::OK;
+      $retArray['statusCode'] = Response::HTTP_OK;
 
       return JsonResponse::create($retArray);
     }
@@ -569,7 +569,7 @@ class OAuthService
     if ($time_to_expiry->m == 0 && $time_to_expiry->d < $limit)
     {
       $retArray['token_invalid'] = true;
-      $retArray['statusCode'] = StatusCode::OK;
+      $retArray['statusCode'] = Response::HTTP_OK;
       $retArray['reason'] = 'Token will expire soon or has been expired';
       $retArray['details'] = 'Token expires at: ' . $expires->format('Y-m-d H:i:s') .
         ', current timestamp: ' . $current_timestamp->format('Y-m-d H:i:s') .
@@ -580,7 +580,7 @@ class OAuthService
       return JsonResponse::create($retArray);
     }
     $retArray['token_invalid'] = false;
-    $retArray['statusCode'] = StatusCode::OK;
+    $retArray['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($retArray);
   }
@@ -768,7 +768,7 @@ class OAuthService
     {
       $retArray['token_available'] = false;
     }
-    $retArray['statusCode'] = StatusCode::OK;
+    $retArray['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($retArray);
   }
@@ -1338,7 +1338,7 @@ class OAuthService
    */
   private function setLoginOAuthUserStatusCode(&$retArray)
   {
-    $retArray['statusCode'] = StatusCode::OK;
+    $retArray['statusCode'] = Response::HTTP_OK;
   }
 
   /**
@@ -1438,7 +1438,7 @@ class OAuthService
     }
 
     $retArray['deleted'] = $deleted;
-    $retArray['statusCode'] = StatusCode::OK;
+    $retArray['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($retArray);
   }

--- a/src/Catrobat/Services/TestEnv/FakeFacebookPostService.php
+++ b/src/Catrobat/Services/TestEnv/FakeFacebookPostService.php
@@ -4,6 +4,7 @@ namespace App\Catrobat\Services\TestEnv;
 
 use App\Catrobat\Services\FacebookPostService;
 use App\Catrobat\StatusCode;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Class FakeFacebookPostService
@@ -44,7 +45,7 @@ class FakeFacebookPostService
       return $this->facebook_service->removeFbPost($post_id);
     }
 
-    return StatusCode::OK;
+    return Response::HTTP_OK;
   }
 
   /**

--- a/src/Catrobat/StatusCode.php
+++ b/src/Catrobat/StatusCode.php
@@ -2,78 +2,83 @@
 
 namespace App\Catrobat;
 
+use Symfony\Component\HttpFoundation\Response;
+
 /**
  * Class StatusCode
  * @package Catrobat
  */
 class StatusCode
 {
-  const OK = 200;
-  const INTERNAL_SERVER_ERROR = 500;
-  const MISSING_POST_DATA = 501;
-  const UPLOAD_EXCEEDING_FILESIZE = 502;
-  const MISSING_CHECKSUM = 503;
-  const INVALID_CHECKSUM = 504;
-  const INVALID_FILE = 505;
-  const INVALID_PROGRAM = 506;
-  const PROJECT_XML_MISSING = 507;
-  const INVALID_XML = 508;
-  const MISSING_PROGRAM_TITLE = 509;
-  const IMAGE_MISSING = 524;
-  const UNEXPECTED_FILE = 525;
-  const RUDE_WORD_IN_PROGRAM_NAME = 511;
-  const RUDE_WORD_IN_DESCRIPTION = 512;
-  const UPLOAD_UNSUPPORTED_MIME_TYPE = 516;
-  const UPLOAD_UNSUPPORTED_FILE_TYPE = 517;
-  const OLD_CATROBAT_LANGUAGE = 518;
-  const OLD_APPLICATION_VERSION = 519;
-  const INVALID_PARAM = 520;
-  const FILE_UPLOAD_FAILED = 521;
-  const MEDIA_LIB_CATEGORY_NOT_FOUND = 522;
-  const MEDIA_LIB_PACKAGE_NOT_FOUND = 523;
-  const PROGRAM_NAME_TOO_LONG = 526;
-  const DESCRIPTION_TOO_LONG = 527;
-  const INVALID_FILE_UPLOAD = 528;  // upload failed but program still in DB
-  const NOT_MY_PROGRAM = 529;
-  const NO_ADMIN_RIGHTS = 530;
-  const NOT_LOGGED_IN = 531;
-  const PASSWORD_INVALID = 532;
+  const UPLOAD_EXCEEDING_FILESIZE = Response::HTTP_REQUEST_ENTITY_TOO_LARGE;
 
-  const LOGIN_ERROR = 601;
-  const REGISTRATION_ERROR = 602;
+  const MISSING_POST_DATA         = Response::HTTP_UNPROCESSABLE_ENTITY;
+  const MISSING_CHECKSUM          = Response::HTTP_UNPROCESSABLE_ENTITY;
+  const INVALID_CHECKSUM          = Response::HTTP_UNPROCESSABLE_ENTITY;
+  const INVALID_FILE              = Response::HTTP_UNPROCESSABLE_ENTITY;
+  const INVALID_PROGRAM           = Response::HTTP_UNPROCESSABLE_ENTITY;
+  const PROJECT_XML_MISSING       = Response::HTTP_UNPROCESSABLE_ENTITY;
+  const INVALID_XML               = Response::HTTP_UNPROCESSABLE_ENTITY;
+  const MISSING_PROGRAM_TITLE     = Response::HTTP_UNPROCESSABLE_ENTITY;
+  const IMAGE_MISSING             = Response::HTTP_UNPROCESSABLE_ENTITY;
+  const UNEXPECTED_FILE           = Response::HTTP_UNPROCESSABLE_ENTITY;
+  const RUDE_WORD_IN_PROGRAM_NAME = Response::HTTP_UNPROCESSABLE_ENTITY;
+  const RUDE_WORD_IN_DESCRIPTION  = Response::HTTP_UNPROCESSABLE_ENTITY;
+  const INVALID_PARAM             = Response::HTTP_UNPROCESSABLE_ENTITY;
+  const FILE_UPLOAD_FAILED        = Response::HTTP_UNPROCESSABLE_ENTITY;
 
-  const USER_PASSWORD_MISSING = 751;
-  const USER_USERNAME_PASSWORD_EQUAL = 752;
-  const USER_PASSWORD_TOO_SHORT = 753;
-  const USER_PASSWORD_TOO_LONG = 754;
+  const LOGIN_ERROR         = Response::HTTP_UNAUTHORIZED;
+  const REGISTRATION_ERROR  = Response::HTTP_UNAUTHORIZED;
+  const NOT_LOGGED_IN       = Response::HTTP_UNAUTHORIZED;
+  const PASSWORD_INVALID    = Response::HTTP_UNAUTHORIZED;
+  const NO_ADMIN_RIGHTS     = Response::HTTP_FORBIDDEN;
+
+  const USER_PASSWORD_MISSING                 = 751;
+  const USER_USERNAME_PASSWORD_EQUAL          = 752;
+  const USER_PASSWORD_TOO_SHORT               = 753;
+  const USER_PASSWORD_TOO_LONG                = 754;
   const USER_NEW_PASSWORD_BOARD_UPDATE_FAILED = 755;
-  const USER_UPDATE_EMAIL_FAILED = 756;
-  const USER_ADD_EMAIL_EXISTS = 757;
-  const USER_UPDATE_CITY_FAILED = 758;
-  const USER_UPDATE_COUNTRY_FAILED = 759;
-  const USER_UPDATE_GENDER_FAILED = 760;
-  const USER_UPDATE_BIRTHDAY_FAILED = 761;
-  const USER_USERNAME_MISSING = 762;
-  const USER_USERNAME_INVALID_CHARACTER = 763;
-  const USER_USERNAME_INVALID = 764;
-  const USER_EMAIL_INVALID = 765;
-  const USER_COUNTRY_INVALID = 766;
-  const USER_REGISTRATION_FAILED = 767;
-  const USER_UPDATE_LANGUAGE_FAILED = 768;
-  const USER_POST_DATA_MISSING = 769;
-  const USER_RECOVERY_NOT_FOUND = 770;
-  const USER_RECOVERY_HASH_CREATION_FAILED = 771;
-  const USER_RECOVERY_EXPIRED = 772;
-  const USER_AVATER_CREATION_FAILED = 773;
-  const USER_PASSWORD_NOT_EQUAL_PASSWORD2 = 774;
-  const USER_NAME_IS_EMAIL_ADDRESS = 775;
-  const USER_AVATAR_UPLOAD_ERROR = 776;
-  const USER_ADD_USERNAME_EXISTS = 777;
-  const USER_EMAIL_MISSING = 778;
-  const USER_EMAIL_ALREADY_EXISTS = 779;
+  const USER_UPDATE_EMAIL_FAILED              = 756;
+  const USER_ADD_EMAIL_EXISTS                 = 757;
+  const USER_UPDATE_CITY_FAILED               = 758;
+  const USER_UPDATE_COUNTRY_FAILED            = 759;
+  const USER_UPDATE_GENDER_FAILED             = 760;
+  const USER_UPDATE_BIRTHDAY_FAILED           = 761;
+  const USER_USERNAME_MISSING                 = 762;
+  const USER_USERNAME_INVALID_CHARACTER       = 763;
+  const USER_USERNAME_INVALID                 = 764;
+  const USER_EMAIL_INVALID                    = 765;
+  const USER_COUNTRY_INVALID                  = 766;
+  const USER_REGISTRATION_FAILED              = 767;
+  const USER_UPDATE_LANGUAGE_FAILED           = 768;
+  const USER_POST_DATA_MISSING                = 769;
+  const USER_RECOVERY_NOT_FOUND               = 770;
+  const USER_RECOVERY_HASH_CREATION_FAILED    = 771;
+  const USER_RECOVERY_EXPIRED                 = 772;
+  const USER_AVATER_CREATION_FAILED           = 773;
+  const USER_PASSWORD_NOT_EQUAL_PASSWORD2     = 774;
+  const USER_NAME_IS_EMAIL_ADDRESS            = 775;
+  const USER_AVATAR_UPLOAD_ERROR              = 776;
+  const USER_ADD_USERNAME_EXISTS              = 777;
+  const USER_EMAIL_MISSING                    = 778;
+  const USER_EMAIL_ALREADY_EXISTS             = 779;
+  const FB_POST_ERROR                         = 790;
+  const FB_DELETE_ERROR                       = 791;
 
-  const NO_GAME_JAM = 900;
+  const NO_GAME_JAM                   = 900;
 
-  const FB_POST_ERROR = 790;
-  const FB_DELETE_ERROR = 791;
+  const UPLOAD_UNSUPPORTED_MIME_TYPE  = 916;
+  const UPLOAD_UNSUPPORTED_FILE_TYPE  = 917;
+  const OLD_CATROBAT_LANGUAGE         = 918;
+  const OLD_APPLICATION_VERSION       = 919;
+
+
+  const MEDIA_LIB_CATEGORY_NOT_FOUND  = 922;
+  const MEDIA_LIB_PACKAGE_NOT_FOUND   = 923;
+
+
+  const PROGRAM_NAME_TOO_LONG         = 926;
+  const DESCRIPTION_TOO_LONG          = 927;
+  const INVALID_FILE_UPLOAD           = 928;  // upload failed but program still in DB
+
 }

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -357,7 +357,7 @@
       '{{ "programs.reportRadioButtonCopyright"     |trans({}, "catroweb") }}',
       '{{ "programs.reportRadioButtonSpam"          |trans({}, "catroweb") }}',
       '{{ "programs.reportRadioButtonDislike"       |trans({}, "catroweb") }}',
-        {{ constant('App\\Catrobat\\StatusCode::OK') }},
+        {{ constant('Symfony\\Component\\HttpFoundation\\Response::HTTP_OK') }},
         {{ logged_in }}
     )
   </script>
@@ -377,7 +377,7 @@
       "{{ 'programs.deleted_popup'                  |trans({}, 'catroweb') }}",
       "{{ 'programs.noAdminRights'                  |trans({}, 'catroweb') }}",
       "{{ 'somethingWentWrong'                      |trans({}, 'catroweb') }}",
-      "{{ constant('App\\Catrobat\\StatusCode::OK') }}",
+      "{{ constant('Symfony\\Component\\HttpFoundation\\Response::HTTP_OK') }}",
       "{{ constant('App\\Catrobat\\StatusCode::NOT_LOGGED_IN') }}",
       "{{ constant('App\\Catrobat\\StatusCode::NO_ADMIN_RIGHTS') }}"
     )
@@ -387,7 +387,7 @@
     new ProgramDescription({{ program.id }},
       '{{ ("show-more")                             |trans({}, "catroweb") }}',
       '{{ ("show-less")                             |trans({}, "catroweb") }}',
-        {{ constant('App\\Catrobat\\StatusCode::OK') }},
+        {{ constant('Symfony\\Component\\HttpFoundation\\Response::HTTP_OK') }},
         {{ constant('App\\Catrobat\\StatusCode::DESCRIPTION_TOO_LONG') }},
         {{ constant('App\\Catrobat\\StatusCode::RUDE_WORD_IN_DESCRIPTION') }}
     )
@@ -609,7 +609,7 @@
           type   : 'get',
           data   : {type: type},
           success: function (data) {
-            if (data.statusCode !== {{ constant('App\\Catrobat\\StatusCode::OK') }})
+            if (data.statusCode !== {{ constant('Symfony\\Component\\HttpFoundation\\Response::HTTP_OK') }})
             {
               if (data.statusCode === {{ constant('App\\Catrobat\\StatusCode::LOGIN_ERROR') }})
               {

--- a/templates/UserManagement/Profile/myProfile.html.twig
+++ b/templates/UserManagement/Profile/myProfile.html.twig
@@ -51,7 +51,7 @@
         '{{ path('profile_delete_program') }}', '{{ path('profile_delete_account') }}',
         '{{ path('profile_toggle_program_visibility') }}',
         '{{ path('profile_upload_avatar') }}',
-        {{ constant('App\\Catrobat\\StatusCode::OK') }},
+        {{ constant('Symfony\\Component\\HttpFoundation\\Response::HTTP_OK') }},
         {{ constant('App\\Catrobat\\StatusCode::USER_EMAIL_ALREADY_EXISTS') }},
         {{ constant('App\\Catrobat\\StatusCode::USER_EMAIL_MISSING') }},
         {{ constant('App\\Catrobat\\StatusCode::USER_EMAIL_INVALID') }},

--- a/tests/behat/features/api/authentication.feature
+++ b/tests/behat/features/api/authentication.feature
@@ -46,7 +46,7 @@ Feature: Authenticate to the system
 
     Examples:
       | problem           | errorcode | answer                   |
-      | no password given | 602       | The password is missing. |
+      | no password given | 401       | The password is missing. |
 
   Scenario: Retrieve the upload token of a user
     Given the HTTP Request:
@@ -100,7 +100,7 @@ Feature: Authenticate to the system
 
     Examples:
       | problem       | errorcode | answer                    | httpcode |
-      | invalid token | 601       | Upload Token auth failed. | 401      |
+      | invalid token | 401       | Upload Token auth failed. | 401      |
 
   Scenario: Registration of a new user with a too long username
     Given the HTTP Request:
@@ -117,7 +117,7 @@ Feature: Authenticate to the system
     Then the returned json object will be:
           """
           {
-            "statusCode": 602,
+            "statusCode": 401,
             "answer": "This value is not valid.",
             "preHeaderMessages": ""
           }

--- a/tests/behat/features/api/check_token.feature
+++ b/tests/behat/features/api/check_token.feature
@@ -33,7 +33,7 @@ Feature: Checking a user's token validity
     When I POST these parameters to "/pocketcode/api/checkToken/check.json"
     Then I should get the json object:
       """
-      {"statusCode":601,"answer":"Upload Token auth failed.", "preHeaderMessages":""}
+      {"statusCode":401,"answer":"Upload Token auth failed.", "preHeaderMessages":""}
       """
     And the response code should be "401"
 
@@ -43,7 +43,7 @@ Feature: Checking a user's token validity
     When I POST these parameters to "/pocketcode/api/checkToken/check.json"
     Then I should get the json object:
       """
-      {"statusCode":601,"answer":"There is no user with name \"doesnotexist\".", "preHeaderMessages":""}
+      {"statusCode":401,"answer":"There is no user with name \"doesnotexist\".", "preHeaderMessages":""}
       """
     And the response code should be "401"
     

--- a/tests/behat/features/api/get_media_lib_json_edge_cases.feature
+++ b/tests/behat/features/api/get_media_lib_json_edge_cases.feature
@@ -15,7 +15,7 @@ Feature: Getting data from the media lib api even though no data is present shou
     Then I should get the json object:
     """
     {
-      "statusCode": 523,
+      "statusCode": 923,
       "message": "Looks not found"
     }
     """
@@ -37,7 +37,7 @@ Feature: Getting data from the media lib api even though no data is present shou
     Then I should get the json object:
     """
     {
-      "statusCode": 523,
+      "statusCode": 923,
       "message": "Looks not found"
     }
     """
@@ -50,7 +50,7 @@ Feature: Getting data from the media lib api even though no data is present shou
     Then I should get the json object:
     """
     {
-      "statusCode": 522,
+      "statusCode": 922,
       "message": "category Space not found in package Looks because the package doesn't contain any categories"
     }
     """
@@ -66,7 +66,7 @@ Feature: Getting data from the media lib api even though no data is present shou
     Then I should get the json object:
     """
     {
-      "statusCode": 522,
+      "statusCode": 922,
       "message": "category Space not found in package Looks"
     }
     """
@@ -91,7 +91,7 @@ Feature: Getting data from the media lib api even though no data is present shou
     Then I should get the json object:
     """
     {
-      "statusCode": 522,
+      "statusCode": 922,
       "message": "category Animals not found"
     }
     """

--- a/tests/behat/features/api/program_rudewordfilter.feature
+++ b/tests/behat/features/api/program_rudewordfilter.feature
@@ -13,7 +13,7 @@ Feature: Checking for rude words
     When I upload this program
     Then I should get the json object:
     """
-    {"statusCode":511,"answer":"Programname must not contain rude wordes.","preHeaderMessages":""}
+    {"statusCode":422,"answer":"Programname must not contain rude wordes.","preHeaderMessages":""}
     """
 
   Scenario: upload a program with a rude word in description should be rejected
@@ -22,7 +22,7 @@ Feature: Checking for rude words
     When I upload this program
     Then I should get the json object:
       """
-      {"statusCode":512,"answer":"Description must not contain rude wordes.","preHeaderMessages":""}
+      {"statusCode":422,"answer":"Description must not contain rude wordes.","preHeaderMessages":""}
       """
 
   Scenario Outline: a program with a rude word in description should be rejected

--- a/tests/behat/features/api/register_and_login.feature
+++ b/tests/behat/features/api/register_and_login.feature
@@ -84,5 +84,5 @@ Feature: Login with an existing account or register a new one
     When I POST these parameters to "/pocketcode/api/login/Login.json"
     Then I should get the json object:
       """
-      {"statusCode":601, "answer":"The password or username was incorrect.","preHeaderMessages":""}
+      {"statusCode":401, "answer":"The password or username was incorrect.","preHeaderMessages":""}
       """

--- a/tests/behat/features/api/report_program.feature
+++ b/tests/behat/features/api/report_program.feature
@@ -29,7 +29,7 @@ Feature: Report a program
     When I POST these parameters to "/pocketcode/api/reportProgram/reportProgram.json"
     Then I should get the json object:
       """
-      {"statusCode":506,"answer":"Invalid program.","preHeaderMessages":""}
+      {"statusCode":422,"answer":"Invalid program.","preHeaderMessages":""}
       """
 
   Scenario: report program with missing parameter
@@ -39,5 +39,5 @@ Feature: Report a program
     When I POST these parameters to "/pocketcode/api/reportProgram/reportProgram.json"
     Then I should get the json object:
     """
-      {"statusCode":501,"answer":"POST-Data not correct or missing!","preHeaderMessages":""}
+      {"statusCode":422,"answer":"POST-Data not correct or missing!","preHeaderMessages":""}
     """

--- a/tests/behat/features/api/upload.feature
+++ b/tests/behat/features/api/upload.feature
@@ -46,6 +46,6 @@ Feature: Upload a program to the website
 
     Examples:
       | problem              | errorcode | answer                                               |
-      | no authentication    | 601       | Authentication of device failed: invalid auth-token! |
-      | missing parameters   | 501       | POST-Data not correct or missing!                    |
-      | invalid program file | 505       | invalid file                                         |
+      | no authentication    | 401       | Authentication of device failed: invalid auth-token! |
+      | missing parameters   | 422       | POST-Data not correct or missing!                    |
+      | invalid program file | 422       | invalid file                                         |

--- a/tests/behat/features/api/upload_program.feature
+++ b/tests/behat/features/api/upload_program.feature
@@ -30,7 +30,7 @@ Feature: Upload a program
     When I POST these parameters to "/pocketcode/api/upload/upload.json"
     Then I should get the json object:
       """
-      {"statusCode":501,"answer":"POST-Data not correct or missing!","preHeaderMessages":""}
+      {"statusCode":422,"answer":"POST-Data not correct or missing!","preHeaderMessages":""}
       """
 
   Scenario: trying to upload with an invalid user should result in an error
@@ -39,7 +39,7 @@ Feature: Upload a program
     When I POST these parameters to "/pocketcode/api/upload/upload.json"
     Then I should get the json object:
       """
-      {"statusCode":601,"answer":"There is no user with name \"INVALID\".","preHeaderMessages":""}
+      {"statusCode":401,"answer":"There is no user with name \"INVALID\".","preHeaderMessages":""}
       """
 
   Scenario: trying to upload with an invalid token should result in an error
@@ -48,7 +48,7 @@ Feature: Upload a program
     When I POST these parameters to "/pocketcode/api/upload/upload.json"
     Then I should get the json object:
       """
-      {"statusCode":601,"answer":"Upload Token auth failed.","preHeaderMessages":""}
+      {"statusCode":401,"answer":"Upload Token auth failed.","preHeaderMessages":""}
       """
 
   Scenario: trying to upload with a missing token should result in an error
@@ -56,7 +56,7 @@ Feature: Upload a program
     When I POST these parameters to "/pocketcode/api/upload/upload.json"
     Then I should get the json object:
       """
-      {"statusCode":601,"answer":"Authentication of device failed: invalid auth-token!","preHeaderMessages":""}
+      {"statusCode":401,"answer":"Authentication of device failed: invalid auth-token!","preHeaderMessages":""}
       """
 
   Scenario: uploading the same program again should result in an update
@@ -72,7 +72,7 @@ Feature: Upload a program
     When I POST these parameters to "/pocketcode/api/upload/upload.json"
     Then I should get the json object:
       """
-      {"statusCode":503,"answer":"Client did not send fileChecksum! Are you using an outdated version of Pocket Code?","preHeaderMessages":""}
+      {"statusCode":422,"answer":"Client did not send fileChecksum! Are you using an outdated version of Pocket Code?","preHeaderMessages":""}
       """
 
   Scenario: program with invalid file checksum are rejected
@@ -83,7 +83,7 @@ Feature: Upload a program
     When I POST these parameters to "/pocketcode/api/upload/upload.json"
     Then I should get the json object:
       """
-      {"statusCode":504,"answer":"invalid checksum","preHeaderMessages":""}
+      {"statusCode":422,"answer":"invalid checksum","preHeaderMessages":""}
       """
 
   Scenario:

--- a/tests/behat/features/api/upload_validation.feature
+++ b/tests/behat/features/api/upload_validation.feature
@@ -8,14 +8,14 @@ Feature: All uploaded programs have to be validated.
     When I upload a program with a missing code.xml
     Then I should get the json object:
       """
-      {"statusCode":507,"answer":"unknown error: project_xml_not_found!","preHeaderMessages":""}
+      {"statusCode":422,"answer":"unknown error: project_xml_not_found!","preHeaderMessages":""}
       """
 
   Scenario: program must have a valid code.xml
     When I upload a program with an invalid code.xml
     Then I should get the json object:
       """
-      {"statusCode":508,"answer":"invalid code xml","preHeaderMessages":""}
+      {"statusCode":422,"answer":"invalid code xml","preHeaderMessages":""}
       """
     And the response code should be "200"
 
@@ -40,7 +40,7 @@ Feature: All uploaded programs have to be validated.
     When I upload an invalid program file
     Then I should get the json object:
       """
-      {"statusCode":505,"answer":"invalid file","preHeaderMessages":""}
+      {"statusCode":422,"answer":"invalid file","preHeaderMessages":""}
       """
 
   Scenario Outline: user should not be able to upload a program with an old pocketcode version
@@ -48,7 +48,7 @@ Feature: All uploaded programs have to be validated.
     When I upload a program
     Then I should get the json object:
     """
-      {"statusCode":519,"answer":"Sorry, you are using an old version of Pocket Code. Please update to the lastest version.","preHeaderMessages":""}
+      {"statusCode":919,"answer":"Sorry, you are using an old version of Pocket Code. Please update to the lastest version.","preHeaderMessages":""}
     """
 
     Examples:
@@ -75,7 +75,7 @@ Feature: All uploaded programs have to be validated.
     When I upload a program
     Then I should get the json object:
     """
-      {"statusCode":518,"answer":"Sorry, your programm contains an old version of the Catrobat language! Are you using the latest version of Pocket Code?","preHeaderMessages":""}
+      {"statusCode":918,"answer":"Sorry, your programm contains an old version of the Catrobat language! Are you using the latest version of Pocket Code?","preHeaderMessages":""}
     """
 
 


### PR DESCRIPTION
StatusCode::OK
  - overrides HTTP Status code and is therefore replaced by its standardised equivalent

StatusCode::INTERNAL_SERVER_ERROR
  - use standardised HTTP instead

StatusCode::MISSING_POST_DATA
  - 501 is the wrong error code for missing post data. changed to standardised 422(Unprocessable Entity)

StatusCode::UPLOAD_EXCEEDING_FILESIZE
  - 502 is the wrong error code. use 413 instead

StatusCode::MISSING_POST_DATA
StatusCode::MISSING_CHECKSUM
StatusCode::INVALID_CHECKSUM
StatusCode::INVALID_FILE
StatusCode::INVALID_PROGRAM
StatusCode::PROJECT_XML_MISSING
StatusCode::INVALID_XML
StatusCode::MISSING_PROGRAM_TITLE
StatusCode::IMAGE_MISSING
StatusCode::UNEXPECTED_FILE
StatusCode::RUDE_WORD_IN_PROGRAM_NAME
StatusCode::RUDE_WORD_IN_DESCRIPTION
StatusCode::INVALID_PARAM
StatusCode::FILE_UPLOAD_FAILED
 - all these statuscodes are changed to Web Standard. More granularity can be found in message send with status code.

StatusCode::LOGIN_ERROR
StatusCode::REGISTRATION_ERROR
StatusCode::NOT_LOGGED_IN
StatusCode::PASSWORD_INVALID
 - status codes changed to a more meaningful HTTP Status code. Granularity through message.

StatusCode::NOT_MY_PROGRAM
 - never used so removed

All other StatusCodes are changed to the proprietary space 9xx or 7xx.
All broken tests has been fixed accordingly.