### PR TITLE
SHARE-46 remove recommended programs section

### DIFF
--- a/assets/css/custom/index.scss
+++ b/assets/css/custom/index.scss
@@ -16,6 +16,10 @@ h1 {
   }
 }
 
+#recommended {
+  display: none;
+}
+
 .visited-program {
   opacity: 0.6;
   a {

--- a/tests/behat/features/web/recsys.feature
+++ b/tests/behat/features/web/recsys.feature
@@ -36,6 +36,6 @@ Feature: Recommendations on homepage (a.k.a. index page)
 
     When I am on "/pocketcode/"
     And the selected language is "English"
-    And I should see "Recommended programs"
-    And the element "#recommended" should be visible
+    And I should not see "Recommended programs"
+    And the element "#recommended" should not be visible
     Then I should not see any recommended homepage programs


### PR DESCRIPTION
Only show recommended programs section on main page if there are some available programs. Otherwise this section will be hidden.