### PR TITLE
SHARE-38 double tooltip

### DIFF
--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -259,7 +259,7 @@
       </button>
 
       {% if not my_program %}
-        <button type="button" class="btn btn-lg btn-link btn-copy" style="text-shadow: none;"
+        <button type="button" class="btn btn-lg btn-link" style="text-shadow: none;"
                 id="report-program-button">
           <i class="fas fa-ban mr-1"></i>
           {{ "programs.reportProgram"|trans({}, 'catroweb') }}


### PR DESCRIPTION
Double tooltip bug fixed which was caused by a simple copy & paste error.