### PR TITLE
SHARE-47 Media-Library: Changes Download Filename

### DIFF
--- a/src/Catrobat/Controller/DownloadMediaPackageController.php
+++ b/src/Catrobat/Controller/DownloadMediaPackageController.php
@@ -19,7 +19,8 @@ class DownloadMediaPackageController extends Controller
 {
 
   /**
-   * @Route("/download-media/{id}", name="download_media", defaults={"_format": "json"}, methods={"GET"})
+   * @Route("/download-media/{id}", name="download_media", defaults={"_format": "json"},
+   *                                methods={"GET"})
    *
    * @param Request $request
    * @param         $id
@@ -51,9 +52,15 @@ class DownloadMediaPackageController extends Controller
       $em->flush();
 
       $response = new BinaryFileResponse($file);
+
+      // replace special characters in filename and replace them with -
+      $filename = preg_replace('/[^A-Za-z0-9-_. ()]/', '-', $media_file->getName());
+      // replace multiple following - with a single one
+      $filename = preg_replace('/-+/', '-', $filename);
+
       $d = $response->headers->makeDisposition(
         ResponseHeaderBag::DISPOSITION_ATTACHMENT,
-        $media_file->getId() . '.' . $media_file->getExtension()
+        $filename . '.' . $media_file->getExtension()
       );
       $response->headers->set('Content-Disposition', $d);
 

--- a/tests/behat/features/bootstrap/WebFeatureContext.php
+++ b/tests/behat/features/bootstrap/WebFeatureContext.php
@@ -1533,6 +1533,16 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
   }
 
   /**
+   * @Then /^I should receive a file named "([^"]*)"$/
+   * @param $name
+   */
+  public function iShouldReceiveAFileNamed($name)
+  {
+    $content_disposition = $this->getClient()->getResponse()->headers->get('Content-Disposition');
+    Assert::assertEquals('attachment; filename="' . $name . '"', $content_disposition);
+  }
+
+  /**
    * @Given /^the response code should be "([^"]*)"$/
    * @param $code
    */

--- a/tests/behat/features/web/mediapackage.feature
+++ b/tests/behat/features/web/mediapackage.feature
@@ -18,7 +18,7 @@ Feature:
 
     And there are mediapackage files:
       | id | name       | category | extension | active | file   | flavor                   | author        |
-      | 1  | Dog        | Animals  | png       | 1      | 1.png  | pocketcode               | Bob Schmidt   |
+      | 1  | Dog (😊🐶)   | Animals  | png       | 1      | 1.png  | pocketcode               | Bob Schmidt   |
       | 2  | Bubble     | Fantasy  | mpga      | 1      | 2.mpga | pocketcode               |               |
       | 3  | SexyGrexy  | Bla      | png       | 0      | 3.png  |                          | Micheal John  |
       | 4  | SexyFlavor | Animals  | png       | 1      | 4.png  | pocketflavor             |               |
@@ -32,6 +32,7 @@ Feature:
   Scenario: Download a media file
     When I download "/pocketcode/download-media/1"
     Then I should receive a "png" file
+    And I should receive a file named "Dog (-).png"
     And the response code should be "200"
 
   Scenario: The app needs the filename, so the media file link must provide the media file's name


### PR DESCRIPTION
Changes the file name of downloaded assets in the media library to the name of the file instead of the id.
Adapts test case to test for correct file name.