### PR TITLE
SHARE-57 sidebar notification badge display bug

### DIFF
--- a/assets/css/base/_header.scss
+++ b/assets/css/base/_header.scss
@@ -63,10 +63,6 @@ header {
       text-overflow: ellipsis;
     }
 
-    .user-notification-badge-font {
-      font-size: 11px;
-    }
-
     #custom-avatar {
       border: 2px solid #FFF;
       border-radius: 2px;

--- a/assets/css/base/_sidebar.scss
+++ b/assets/css/base/_sidebar.scss
@@ -53,6 +53,9 @@ $sidebar-width: 250px;
         text-decoration: none;
       }
 
+      .user-notification-badge {
+        display: none;
+      }
     }
   }
 

--- a/assets/js/custom/FetchNotifications.js
+++ b/assets/js/custom/FetchNotifications.js
@@ -7,7 +7,6 @@ function FetchNotifications (countNotificationsUrl, maxAmountToFetch, refreshRat
   
   self.run = function () {
     let userNotificationBadge = $('.user-notification-badge')
-    userNotificationBadge.hide()
     
     $.ajax({
       url    : self.countNotificationsUrl,
@@ -25,7 +24,6 @@ function FetchNotifications (countNotificationsUrl, maxAmountToFetch, refreshRat
         {
           userNotificationBadge.text('')
           userNotificationBadge.hide()
-          
         }
         setTimeout(self.run, refreshRate)
       },

--- a/assets/js/custom/Notifications.js
+++ b/assets/js/custom/Notifications.js
@@ -103,10 +103,12 @@ function Notification (notifications, unseenRemixesGroupedLength, markAsReadUrl,
   
   self.updateBadgeNumber = function () {
     let userNotificationBadge = $('.user-notification-badge')
-    let current_number = userNotificationBadge.data('badge')
+    let current_number = Number(userNotificationBadge.text())
     if (current_number > 1)
     {
-      userNotificationBadge.data('badge', current_number - 1)
+      userNotificationBadge.text(current_number - 1)
+    } else {
+      userNotificationBadge.hide();
     }
   }
   
@@ -133,7 +135,7 @@ function Notification (notifications, unseenRemixesGroupedLength, markAsReadUrl,
     $('#notifications-container').children().remove()
     $('#notifications-summary').hide()
     $('#mark-all-as-seen').hide()
-    $('.user-notification-badge').removeAttr('data-badge')
+    $('.user-notification-badge').hide()
     $('.no-notifications-placeholder').show()
   }
   

--- a/tests/behat/features/web/catro_notification.feature
+++ b/tests/behat/features/web/catro_notification.feature
@@ -23,10 +23,12 @@ Feature: User gets generic notifications additionally to the remix notifications
     And I am on "/pocketcode/user/notifications"
     Then I should see "Achievement - Uploads"
     And I should see "Achievement - View"
+    And the ".user-notification-badge" element should contain "2"
     When I click "#mark-as-read-1"
     And I wait for fadeEffect to finish
     Then I should not see "Achievement - Uploads"
     And I should see "Achievement - View"
+    And the ".user-notification-badge" element should contain "1"
     When I click "#mark-as-read-2"
     And I wait for fadeEffect to finish
     Then I should not see "Achievement - Uploads"
@@ -36,13 +38,14 @@ Feature: User gets generic notifications additionally to the remix notifications
   Scenario: User should see the amount of his notifications in the header
     Given I log in as "Catrobat" with the password "123456"
     And I am on "/pocketcode/"
-    Then I wait 250 milliseconds
+    Then I wait 1000 milliseconds
     And the element "#btn-notifications" should be visible
     And the element ".user-notification-badge" should be visible
 
   Scenario: User should see the amount of his notifications in the header
     Given I log in as "Catrobat" with the password "123456"
     And I am on "/pocketcode/"
+    Then I wait 1000 milliseconds
     Then the element "#btn-notifications" should be visible
     And the element ".user-notification-badge" should be visible
     And the ".user-notification-badge" element should contain "2"


### PR DESCRIPTION
The notification count badge in the sidebar should only be displayed if there are unread notifications.
Now the badge has display:none as default value which will be changed only if notification count > 0.