### PR TITLE
SHARE-52 program owner not visible

### DIFF
--- a/assets/css/custom/program.scss
+++ b/assets/css/custom/program.scss
@@ -483,9 +483,11 @@ input[type='number']
 
 @include media-breakpoint-down(md)
 {
-  #program-user
+  #program-top
   {
-    display: none;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
   }
 
   #program-middle


### PR DESCRIPTION
Program owner should also be visible on smaller devices.
Now the program owner will be shown under the program name on smaller devices (md).