### PR TITLE
SHARE-51 introducing UUIDs

### DIFF
--- a/assets/js/custom/remixgraph.builder.js
+++ b/assets/js/custom/remixgraph.builder.js
@@ -83,7 +83,7 @@ var NetworkBuilder = function (programID, remixGraphLayerId, remixGraphTranslati
       var found2 = false
       for (var key in descendantRelations)
       {
-        if (self.programID == descendantRelations[key])
+        if (self.programID === descendantRelations[key])
         {
           found = true
           break
@@ -92,7 +92,7 @@ var NetworkBuilder = function (programID, remixGraphLayerId, remixGraphTranslati
       
       for (var key in ancestorRelations)
       {
-        if (self.programID == ancestorRelations[key])
+        if (self.programID === ancestorRelations[key])
         {
           found2 = true
           break
@@ -109,7 +109,7 @@ var NetworkBuilder = function (programID, remixGraphLayerId, remixGraphTranslati
   self.stepBuildNodes = function () {
     for (var nodeIndex = 0; nodeIndex < self.remixGraphData.catrobatNodes.length; ++nodeIndex)
     {
-      var nodeId = parseInt(self.remixGraphData.catrobatNodes[nodeIndex])
+      var nodeId = self.remixGraphData.catrobatNodes[nodeIndex]
       /*
        var found = false;
        for (var key in groupNodes) {
@@ -127,8 +127,8 @@ var NetworkBuilder = function (programID, remixGraphLayerId, remixGraphTranslati
       var nodeData = {
         id         : CATROBAT_NODE_PREFIX + '_' + nodeId,
         //value: (nodeId == remixData.id) ? 3 : 2,
-        borderWidth: (nodeId == self.programID) ? 6 : 3,
-        size       : (nodeId == self.programID) ? 40 : 20,
+        borderWidth: (nodeId === self.programID) ? 6 : 3,
+        size       : (nodeId === self.programID) ? 40 : 20,
         shape      : 'circularImage',
         image      : self.catrobatProgramThumbnails[nodeId]
       }
@@ -152,7 +152,7 @@ var NetworkBuilder = function (programID, remixGraphLayerId, remixGraphTranslati
         name    : self.remixGraphTranslations.programNotAvailable,
         username: self.remixGraphTranslations.programUnknownUser
       }
-      var nodeId = parseInt(self.remixGraphData.scratchNodes[nodeIndex])
+      var nodeId = self.remixGraphData.scratchNodes[nodeIndex]
       var programData = unavailableProgramData
       var programImageUrl = IMAGE_NOT_AVAILABLE_URL
       

--- a/src/Catrobat/Commands/CSVUserSimilaritiesCommand.php
+++ b/src/Catrobat/Commands/CSVUserSimilaritiesCommand.php
@@ -86,7 +86,7 @@ class CSVUserSimilaritiesCommand extends ContainerAwareCommand
     $statement = $this->entity_manager->getConnection()
       ->prepare("SELECT MAX(id) as id_of_last_user FROM fos_user");
     $statement->execute();
-    $id_of_last_user = intval($statement->fetch()['id_of_last_user']);
+    $id_of_last_user = $statement->fetch()['id_of_last_user'];
     echo PHP_EOL . 'Last ID: ' . $id_of_last_user . PHP_EOL;
 
     $output_string = '';

--- a/src/Catrobat/Commands/ResetCommand.php
+++ b/src/Catrobat/Commands/ResetCommand.php
@@ -135,7 +135,7 @@ class ResetCommand extends ContainerAwareCommand
     foreach ($server_json['CatrobatProjects'] as $program)
     {
       $url = $base_url . $program['DownloadUrl'];
-      $name = $dir . intval($program['ProjectId']) . '.catrobat';
+      $name = $dir . $program['ProjectId'] . '.catrobat';
       $output->writeln('Saving <' . $url . '> to <' . $name . '>');
       try
       {
@@ -162,7 +162,7 @@ class ResetCommand extends ContainerAwareCommand
       foreach ($server_json['CatrobatProjects'] as $program)
       {
         $url = $base_url . $program['DownloadUrl'];
-        $name = $dir . intval($program['ProjectId']) . '.catrobat';
+        $name = $dir . $program['ProjectId'] . '.catrobat';
         $output->writeln('Saving <' . $url . '> to <' . $name . '>');
         try
         {

--- a/src/Catrobat/Commands/WebShareProgramImport.php
+++ b/src/Catrobat/Commands/WebShareProgramImport.php
@@ -63,7 +63,7 @@ class WebShareProgramImport extends ContainerAwareCommand
     foreach ($server_json['CatrobatProjects'] as $program)
     {
       $url = $base_url . $program['DownloadUrl'];
-      $name = $dir . intval($program['ProjectId']) . '.catrobat';
+      $name = $dir . $program['ProjectId'] . '.catrobat';
       $output->writeln('Saving <' . $url . '> to <' . $name . '>');
       file_put_contents($name, file_get_contents($url));
     }

--- a/src/Catrobat/Controller/Api/ListProgramsController.php
+++ b/src/Catrobat/Controller/Api/ListProgramsController.php
@@ -3,6 +3,7 @@
 namespace App\Catrobat\Controller\Api;
 
 use App\Entity\ProgramManager;
+use Doctrine\DBAL\Types\GuidType;
 use Doctrine\ORM\NonUniqueResultException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -177,12 +178,12 @@ class ListProgramsController extends Controller
 
     /**
      * @var ProgramManager $program_manager
+     * @var GuidType $user_id
      */
     $program_manager = $this->get('programmanager');
-
-    $limit = intval($request->query->get('limit', 20));
-    $offset = intval($request->query->get('offset', 0));
-    $user_id = intval($request->query->get('user_id', 0));
+    $limit = intval($request->get('limit', 20));
+    $offset = intval($request->get('offset', 0));
+    $user_id = $request->get('user_id', 0);
 
     if ($sortBy == 'downloads')
     {

--- a/src/Catrobat/Controller/Api/ProgramController.php
+++ b/src/Catrobat/Controller/Api/ProgramController.php
@@ -25,8 +25,8 @@ class ProgramController extends Controller
    */
   public function showProgramAction(Request $request)
   {
-    $id = intval($request->query->get('id'));
     /** @var ProgramManager $program_manager */
+    $id = $request->get('id', 0);
     $program_manager = $this->get('programmanager');
 
     $programs = [];

--- a/src/Catrobat/Controller/Api/RecommenderController.php
+++ b/src/Catrobat/Controller/Api/RecommenderController.php
@@ -5,12 +5,13 @@ namespace App\Catrobat\Controller\Api;
 use App\Catrobat\RecommenderSystem\RecommenderManager;
 use App\Catrobat\Responses\ProgramListResponse;
 use App\Catrobat\StatusCode;
+use Doctrine\DBAL\Types\GuidType;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use App\Entity\Program;
 use App\Entity\ProgramManager;
 use App\Entity\UserTestGroup;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -43,7 +44,7 @@ class RecommenderController extends Controller
   {
     $limit = intval($request->query->get('limit', $this->DEFAULT_LIMIT));
     $offset = intval($request->query->get('offset', $this->DEFAULT_OFFSET));
-    $program_id = intval($request->query->get('program_id'));
+    $program_id = $request->query->get('program_id');
 
     /** @var ProgramManager $program_manager */
     $program_manager = $this->get('programmanager');
@@ -58,10 +59,10 @@ class RecommenderController extends Controller
 
   /**
    * @Route("/api/projects/recsys_specific_programs/{id}.json", name="api_recsys_specific_programs",
-   *   defaults={"_format": "json"}, requirements={"id":"\d+"}, methods={"GET"})
+   *   defaults={"_format": "json"},  methods={"GET"})
    *
    * @param Request $request
-   * @param         $id
+   * @param GuidType $id
    *
    * @return ProgramListResponse|JsonResponse
    */
@@ -102,7 +103,7 @@ class RecommenderController extends Controller
   {
     $is_test_environment = ($this->get('kernel')->getEnvironment() == 'test');
     $test_user_id_for_like_recommendation = $is_test_environment ?
-      intval($request->query->get('test_user_id_for_like_recommendation', 0)) : 0;
+      $request->query->get('test_user_id_for_like_recommendation', 0) : "";
     $limit = intval($request->query->get('limit', $this->DEFAULT_LIMIT));
     $offset = intval($request->query->get('offset', $this->DEFAULT_OFFSET));
 
@@ -112,7 +113,7 @@ class RecommenderController extends Controller
     $programs = [];
     $is_user_specific_recommendation = false;
 
-    $user = ($test_user_id_for_like_recommendation == 0) ?
+    $user = ($test_user_id_for_like_recommendation == "") ?
       $this->getUser() : $this->get('usermanager')->find($test_user_id_for_like_recommendation);
 
     /** @var RecommenderManager $recommender_manager */

--- a/src/Catrobat/Controller/Ci/ApkStatusController.php
+++ b/src/Catrobat/Controller/Ci/ApkStatusController.php
@@ -4,7 +4,6 @@ namespace App\Catrobat\Controller\Ci;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\HttpFoundation\Request;
 use App\Entity\Program;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -18,15 +17,13 @@ class ApkStatusController extends Controller
 {
 
   /**
-   * @Route("/ci/status/{id}", name="ci_status", defaults={"_format": "json"},
-   *   requirements={"id": "\d+"}, methods={"GET"})
+   * @Route("/ci/status/{id}", name="ci_status", defaults={"_format": "json"}, methods={"GET"})
    *
-   * @param Request $request
    * @param Program $program
    *
    * @return JsonResponse
    */
-  public function getApkStatusAction(Request $request, Program $program)
+  public function getApkStatusAction(Program $program)
   {
     $result = [];
     switch ($program->getApkStatus())

--- a/src/Catrobat/Controller/Ci/BuildApkController.php
+++ b/src/Catrobat/Controller/Ci/BuildApkController.php
@@ -2,12 +2,15 @@
 
 namespace App\Catrobat\Controller\Ci;
 
+use App\Catrobat\Services\ApkRepository;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use App\Entity\Program;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use App\Entity\ProgramManager;
 use Symfony\Component\Finder\Exception\AccessDeniedException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
@@ -20,8 +23,7 @@ class BuildApkController extends Controller
 {
 
   /**
-   * @Route("/ci/build/{id}", name="ci_build", defaults={"_format": "json"},
-   *   requirements={"id": "\d+"}, methods={"GET"})
+   * @Route("/ci/build/{id}", name="ci_build", defaults={"_format": "json"}, methods={"GET"})
    *
    * @param Program $program
    *
@@ -56,20 +58,20 @@ class BuildApkController extends Controller
 
 
   /**
-   * @Route("/ci/upload/{id}", name="ci_upload_apk", defaults={"_format": "json"},
-   *   requirements={"id": "\d+"}, methods={"GET", "POST"})
+   * @Route("/ci/upload/{id}", name="ci_upload_apk", defaults={"_format": "json"}, methods={"GET", "POST"})
    *
    * @param Request $request
    * @param Program $program
    *
    * @return JsonResponse
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function uploadApkAction(Request $request, Program $program)
   {
     /**
-     * @var $apkrepository \App\Catrobat\Services\ApkRepository
+     * @var $apkrepository ApkRepository
+     * @var $file File
      */
 
     $config = $this->container->getParameter('jenkins');
@@ -95,14 +97,14 @@ class BuildApkController extends Controller
 
 
   /**
-   * @Route("/ci/failed/{id}", name="ci_failed_apk", defaults={"_format": "json"}, requirements={"id": "\d+"}, methods={"GET"})
+   * @Route("/ci/failed/{id}", name="ci_failed_apk", defaults={"_format": "json"}, methods={"GET"})
    *
    * @param Request $request
    * @param Program $program
    *
    * @return JsonResponse
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function failedApkAction(Request $request, Program $program)
   {

--- a/src/Catrobat/Controller/Ci/DownloadApkController.php
+++ b/src/Catrobat/Controller/Ci/DownloadApkController.php
@@ -2,6 +2,7 @@
 
 namespace App\Catrobat\Controller\Ci;
 
+use App\Catrobat\Services\ApkRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,7 +20,7 @@ class DownloadApkController extends Controller
 {
 
   /**
-   * @Route("/ci/download/{id}", name="ci_download", requirements={"id": "\d+"}, methods={"GET"})
+   * @Route("/ci/download/{id}", name="ci_download", methods={"GET"})
    *
    * @param Request $request
    * @param Program $program
@@ -30,7 +31,7 @@ class DownloadApkController extends Controller
    */
   public function downloadApkAction(Request $request, Program $program)
   {
-    /* @var $apkrepository \App\Catrobat\Services\ApkRepository */
+    /* @var $apkrepository ApkRepository */
 
     if (!$program->isVisible())
     {

--- a/src/Catrobat/Controller/Web/ProfileController.php
+++ b/src/Catrobat/Controller/Web/ProfileController.php
@@ -5,9 +5,15 @@ namespace App\Catrobat\Controller\Web;
 use App\Entity\FollowNotification;
 use App\Entity\User;
 use App\Catrobat\StatusCode;
+use App\Entity\UserManager;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\DBAL\Types\GuidType;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -21,23 +27,23 @@ class ProfileController extends Controller
   const MAX_AVATAR_SIZE = 300;
 
   /**
-   * @Route("/profile/{id}", name="profile", requirements={"id":"\d+"}, defaults={"id" = 0}, methods={"GET"})
+   * @Route("/profile/{id}", name="profile", defaults={"id" = 0}, methods={"GET"})
    * @Route("/profile/")  // Overwrite for FosUser Profile Route (We don't use it!)
    *
    * @param Request $request
-   * @param integer $id
+   * @param GuidType $id
    *
    * @throws \Exception
    *
-   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   * @return RedirectResponse
    */
-  public function profileAction(Request $request, $id = 0)
+  public function profileAction(Request $request, $id)
   {
     /**
      * @var $user User
      */
-    $id = (integer)$id;
-    $twig = 'UserManagement/Profile/profileHandler.html.twig';
+
+    $user = null;
     $my_profile = false;
 
     if ($id === 0 || ($this->getUser() && $this->getUser()->getId() === $id))
@@ -65,7 +71,7 @@ class ProfileController extends Controller
     $secondMail = $user->getAdditionalEmail();
     $followerCount = $user->getFollowers()->count();
 
-    return $this->get('templating')->renderResponse($twig, [
+    return $this->get('templating')->renderResponse('UserManagement/Profile/profileHandler.html.twig', [
       'profile'        => $user,
       'program_count'  => $program_count,
       'follower_count' => $followerCount,
@@ -78,6 +84,7 @@ class ProfileController extends Controller
       'username'       => $user->getUsername(),
       'myProfile'      => $my_profile,
     ]);
+
   }
 
 
@@ -86,7 +93,7 @@ class ProfileController extends Controller
    *
    * @param Request $request
    *
-   * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
+   * @return JsonResponse|RedirectResponse
    */
   public function countrySaveAction(Request $request)
   {
@@ -126,13 +133,13 @@ class ProfileController extends Controller
    *
    * @param Request $request
    *
-   * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
+   * @return JsonResponse|RedirectResponse
    */
   public function passwordSaveAction(Request $request)
   {
     /**
-     * @var \App\Entity\User        $user
-     * @var \App\Entity\UserManager $userManager
+     * @var User        $user
+     * @var UserManager $userManager
      */
     $user = $this->getUser();
     if (!$user)
@@ -187,12 +194,12 @@ class ProfileController extends Controller
    *
    * @param Request $request
    *
-   * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
+   * @return JsonResponse|RedirectResponse
    */
   public function emailSaveAction(Request $request)
   {
     /**
-     * @var \App\Entity\User
+     * @var User
      */
     $user = $this->getUser();
     if (!$user)
@@ -313,7 +320,7 @@ class ProfileController extends Controller
    *
    * @param Request $request
    *
-   * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
+   * @return JsonResponse|RedirectResponse
    */
   public function uploadAvatarAction(Request $request)
   {
@@ -349,15 +356,15 @@ class ProfileController extends Controller
   /**
    * @Route("/deleteAccount", name="profile_delete_account", methods={"POST"})
    *
-   * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @return JsonResponse|RedirectResponse
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function deleteAccountAction()
   {
     /**
      * @var $user User
-     * @var $em   \Doctrine\ORM\EntityManager
+     * @var $em   EntityManager
      */
     $user = $this->getUser();
     if (!$user)
@@ -388,13 +395,13 @@ class ProfileController extends Controller
 
 
   /**
-   * @Route("/followUser/{id}", name="follow_user", methods = {"GET"}, requirements={"id":"\d+"}, defaults={"id" = 0})
+   * @Route("/followUser/{id}", name="follow_user", methods = {"GET"}, defaults={"id" = 0})
    *
-   * @param         $id
+   * @param GuidType $id
    *
    * @throws \Exception
    *
-   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   * @return RedirectResponse
    */
   public function followUser($id)
   {
@@ -428,11 +435,11 @@ class ProfileController extends Controller
 
 
   /**
-   * @Route("/unfollowUser/{id}", name="unfollow_user", methods = {"GET"},requirements={"id":"\d+"}, defaults={"id" = 0})
+   * @Route("/unfollowUser/{id}", name="unfollow_user", methods = {"GET"}, defaults={"id" = 0})
    *
-   * @param $id
+   * @param GuidType $id
    *
-   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   * @return RedirectResponse
    */
   public function unfollowUser($id)
   {

--- a/src/Catrobat/Controller/Web/ProgramController.php
+++ b/src/Catrobat/Controller/Web/ProgramController.php
@@ -20,6 +20,7 @@ use App\Entity\User;
 use App\Entity\UserComment;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\DBAL\Types\GuidType;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\OptimisticLockException;
@@ -42,11 +43,10 @@ class ProgramController extends Controller
 {
 
   /**
-   * @Route("/program/remixgraph/{id}", name="program_remix_graph",
-   *   requirements={"id":"\d+"}, methods={"GET"})
+   * @Route("/program/remixgraph/{id}", name="program_remix_graph", methods={"GET"})
    *
    * @param Request $request
-   * @param integer $id
+   * @param GuidType $id
    *
    * @return JsonResponse
    * @throws ORMException
@@ -87,12 +87,11 @@ class ProgramController extends Controller
 
 
   /**
-   * @Route("/program/{id}", name="program", requirements={"id":"\d+"})
-   * @Route("/details/{id}", name="catrobat_web_detail", requirements={"id":"\d+"},
-   *   methods={"GET"})
+   * @Route("/program/{id}", name="program")
+   * @Route("/details/{id}", name="catrobat_web_detail", methods={"GET"})
    *
    * @param Request $request
-   * @param integer $id
+   * @param GuidType $id
    *
    * @return JsonResponse
    * @throws Error
@@ -207,10 +206,10 @@ class ProgramController extends Controller
 
 
   /**
-   * @Route("/program/like/{id}", name="program_like", requirements={"id":"\d+"}, methods={"GET"})
+   * @Route("/program/like/{id}", name="program_like", methods={"GET"})
    *
    * @param Request $request
-   * @param integer $id
+   * @param GuidType $id
    *
    * @return JsonResponse|RedirectResponse
    * @throws Exception
@@ -223,6 +222,7 @@ class ProgramController extends Controller
      * @var Program                  $program
      * @var CatroNotification        $notification
      * @var CatroNotificationService $notification_service
+     * @var Program                  $program
      */
 
     $type = intval($request->query->get('type', ProgramLike::TYPE_THUMBS_UP));
@@ -348,10 +348,9 @@ class ProgramController extends Controller
 
 
   /**
-   * @Route("/profileDeleteProgram/{id}", name="profile_delete_program", requirements={"id":"\d+"},
-   *    defaults={"id" = 0}, methods={"GET"})
+   * @Route("/profileDeleteProgram/{id}", name="profile_delete_program", defaults={"id" = 0}, methods={"GET"})
    *
-   * @param integer $id
+   * @param GuidType $id
    *
    * @return JsonResponse|RedirectResponse
    * @throws Exception
@@ -397,9 +396,9 @@ class ProgramController extends Controller
 
   /**
    * @Route("/profileToggleProgramVisibility/{id}", name="profile_toggle_program_visibility",
-   *   requirements={"id":"\d+"}, defaults={"id" = 0}, methods={"GET"})
+   *   defaults={"id" = 0}, methods={"GET"})
    *
-   * @param integer $id
+   * @param GuidType $id
    *
    * @return Response
    * @throws Exception
@@ -447,9 +446,9 @@ class ProgramController extends Controller
 
   /**
    * @Route("/editProgramDescription/{id}/{newDescription}", name="edit_program_description",
-   *   options={"expose"=true}, requirements={"id":"\d+"}, methods={"GET"})
+   *   options={"expose"=true}, methods={"GET"})
    *
-   * @param integer $id
+   * @param GuidType $id
    * @param string  $newDescription
    *
    * @return Response
@@ -582,11 +581,9 @@ class ProgramController extends Controller
                                              $like_type_count, $total_like_count, $elapsed_time,
                                              $referrer, $program_comments, $request)
   {
-    $rec_by_page_id = intval($request->query
-      ->get('rec_by_page_id', RecommendedPageId::INVALID_PAGE));
+    $rec_by_page_id = intval($request->query->get('rec_by_page_id', RecommendedPageId::INVALID_PAGE));
     $rec_by_program_id = intval($request->query->get('rec_by_program_id', 0));
     $rec_user_specific = intval($request->query->get('rec_user_specific', 0));
-
     $rec_tag_by_program_id = intval($request->query->get('rec_from', 0));
 
     if (RecommendedPageId::isValidRecommendedPageId($rec_by_page_id))

--- a/src/Catrobat/Controller/Web/TutorialController.php
+++ b/src/Catrobat/Controller/Web/TutorialController.php
@@ -5,10 +5,12 @@ namespace App\Catrobat\Controller\Web;
 use App\Entity\Program;
 use App\Entity\StarterCategory;
 use App\Catrobat\Services\ScreenshotRepository;
+use Doctrine\DBAL\Types\GuidType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Twig\Error\Error;
 
 
 /**
@@ -21,8 +23,8 @@ class TutorialController extends Controller
   /**
    * @Route("/help", name="catrobat_web_help", methods={"GET"})
    *
-   * @return \Symfony\Component\HttpFoundation\Response
-   * @throws \Twig\Error\Error
+   * @return Response
+   * @throws Error
    */
   public function helpAction()
   {
@@ -36,8 +38,8 @@ class TutorialController extends Controller
    * @Route("/stepByStep/{page}", name="catrobat_web_stepByStep", defaults={"page" = 1},
    *                                requirements={"page":"\d+"}, methods={"GET"})
    *
-   * @return \Symfony\Component\HttpFoundation\Response
-   * @throws \Twig\Error\Error
+   * @return Response
+   * @throws Error
    */
   public function stepByStepAction()
   {
@@ -51,8 +53,8 @@ class TutorialController extends Controller
    *
    * @param $page
    *
-   * @return \Symfony\Component\HttpFoundation\Response
-   * @throws \Twig\Error\Error
+   * @return Response
+   * @throws Error
    */
   public function tutorialCardsAction($page)
   {
@@ -83,8 +85,8 @@ class TutorialController extends Controller
   /**
    * @Route("/starter-programs", name="catrobat_web_starter", methods={"GET"})
    *
-   * @return \Symfony\Component\HttpFoundation\Response
-   * @throws \Twig\Error\Error
+   * @return Response
+   * @throws Error
    */
   public function starterProgramsAction()
   {
@@ -105,11 +107,10 @@ class TutorialController extends Controller
 
 
   /**
-   * @Route("/category-programs/{id}", name="catrobat_web_category_programs", requirements={"id":"\d+"},
-   *                                   methods={"GET"})
+   * @Route("/category-programs/{id}", name="catrobat_web_category_programs", methods={"GET"})
    *
    * @param Request $request
-   * @param         $id
+   * @param GuidType  $id
    *
    * @return JsonResponse
    */
@@ -139,8 +140,8 @@ class TutorialController extends Controller
   /**
    * @Route("/pocket-game-jam", name="catrobat_web_game_jam", methods={"GET"})
    *
-   * @return \Symfony\Component\HttpFoundation\Response
-   * @throws \Twig\Error\Error
+   * @return Response
+   * @throws Error
    */
   public function gameJamAction()
   {

--- a/src/Catrobat/Controller/Web/UserNotificationController.php
+++ b/src/Catrobat/Controller/Web/UserNotificationController.php
@@ -12,6 +12,8 @@ use App\Catrobat\RecommenderSystem\RecommendedPageId;
 use App\Catrobat\Services\Formatter\ElapsedTimeStringFormatter;
 use App\Catrobat\StatusCode;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -126,8 +128,8 @@ class UserNotificationController extends Controller
    * @Route("/user/notifications/seen", name="user_notifications_seen", methods={"GET"})
    *
    * @return JsonResponse
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function userNotificationsSeenAction()
   {
@@ -148,15 +150,15 @@ class UserNotificationController extends Controller
 
   /**
    * @Route("/user/notification/ancestor/{ancestor_id}/descendant/{descendant_id}", name="see_user_notification",
-   *        requirements={"ancestor_id":"\d+", "descendant_id":"\d+"}, methods={"GET"})
+   *        methods={"GET"})
    *
    * @param Request $request
    * @param         $ancestor_id
    * @param         $descendant_id
    *
-   * @return \Symfony\Component\HttpFoundation\RedirectResponse
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @return RedirectResponse
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function seeUserNotificationAction(Request $request, $ancestor_id, $descendant_id)
   {
@@ -200,8 +202,8 @@ class UserNotificationController extends Controller
    * @param $notification_id
    *
    * @return JsonResponse
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function markCatroNotificationAsRead($notification_id)
   {

--- a/src/Catrobat/RecommenderSystem/RecommenderManager.php
+++ b/src/Catrobat/RecommenderSystem/RecommenderManager.php
@@ -638,7 +638,7 @@ class RecommenderManager
     $statement = $this->entity_manager->getConnection()
       ->prepare("SELECT MAX(id) as id_of_last_user FROM fos_user");
     $statement->execute();
-    $id_of_last_user = intval($statement->fetch()['id_of_last_user']);
+    $id_of_last_user = $statement->fetch()['id_of_last_user'];
     $user_remix_relations = [];
 
     for ($user_id = 1; $user_id <= $id_of_last_user; $user_id++)

--- a/src/Entity/Extension.php
+++ b/src/Entity/Extension.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Zend\Ldap\Collection;
 
 /**
  * @ORM\Entity
@@ -32,7 +33,7 @@ class Extension
   protected $prefix;
 
   /**
-   * @var \Doctrine\Common\Collections\Collection|Program[]
+   * @var Collection|Program[]
    *
    * @ORM\ManyToMany(targetEntity="\App\Entity\Program", mappedBy="extensions")
    */
@@ -73,7 +74,7 @@ class Extension
   }
 
   /**
-   * @return Program[]|\Doctrine\Common\Collections\Collection
+   * @return Program[]|Collection
    */
   public function getPrograms()
   {

--- a/src/Entity/GameJam.php
+++ b/src/Entity/GameJam.php
@@ -2,6 +2,8 @@
 
 namespace App\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -63,8 +65,8 @@ class GameJam
 
   public function __construct()
   {
-    $this->programs = new \Doctrine\Common\Collections\ArrayCollection();
-    $this->sample_programs = new \Doctrine\Common\Collections\ArrayCollection();
+    $this->programs = new ArrayCollection();
+    $this->sample_programs = new ArrayCollection();
   }
 
   /**
@@ -200,7 +202,7 @@ class GameJam
   /**
    * Get programs
    *
-   * @return \Doctrine\Common\Collections\Collection
+   * @return Collection
    */
   public function getPrograms()
   {
@@ -234,7 +236,7 @@ class GameJam
   /**
    * Get samplePrograms
    *
-   * @return \Doctrine\Common\Collections\Collection
+   * @return Collection
    */
   public function getSamplePrograms()
   {

--- a/src/Entity/Program.php
+++ b/src/Entity/Program.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 
@@ -36,8 +37,8 @@ class Program
 
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer")
-   * @ORM\GeneratedValue(strategy="AUTO")
+   * @ORM\Column(name="id", type="guid")
+   * @ORM\GeneratedValue(strategy="UUID")
    */
   protected $id;
 
@@ -63,7 +64,7 @@ class Program
   protected $user;
 
   /**
-   * @var \Doctrine\Common\Collections\Collection|Tag[]
+   * @var Collection|Tag[]
    *
    * @ORM\ManyToMany(targetEntity="\App\Entity\Tag", inversedBy="programs")
    * @ORM\JoinTable(
@@ -79,7 +80,7 @@ class Program
   protected $tags;
 
   /**
-   * @var \Doctrine\Common\Collections\Collection|Extension[]
+   * @var Collection|Extension[]
    *
    * @ORM\ManyToMany(targetEntity="\App\Entity\Extension", inversedBy="programs")
    * @ORM\JoinTable(
@@ -181,7 +182,7 @@ class Program
    *     cascade={"persist", "remove"},
    *     orphanRemoval=true
    * )
-   * @var \Doctrine\Common\Collections\Collection|ProgramRemixRelation[]
+   * @var Collection|ProgramRemixRelation[]
    */
   protected $catrobat_remix_ancestor_relations;
 
@@ -192,7 +193,7 @@ class Program
    *     cascade={"persist", "remove"},
    *     orphanRemoval=true
    * )
-   * @var \Doctrine\Common\Collections\Collection|ProgramRemixBackwardRelation[]
+   * @var Collection|ProgramRemixBackwardRelation[]
    */
   protected $catrobat_remix_backward_parent_relations;
 
@@ -203,7 +204,7 @@ class Program
    *     cascade={"persist", "remove"},
    *     orphanRemoval=true
    * )
-   * @var \Doctrine\Common\Collections\Collection|ProgramRemixRelation[]
+   * @var Collection|ProgramRemixRelation[]
    */
   protected $catrobat_remix_descendant_relations;
 
@@ -214,7 +215,7 @@ class Program
    *     cascade={"persist", "remove"},
    *     orphanRemoval=true
    * )
-   * @var \Doctrine\Common\Collections\Collection|ProgramRemixBackwardRelation[]
+   * @var Collection|ProgramRemixBackwardRelation[]
    */
   protected $catrobat_remix_backward_child_relations;
 
@@ -225,7 +226,7 @@ class Program
    *     cascade={"persist", "remove"},
    *     orphanRemoval=true
    * )
-   * @var \Doctrine\Common\Collections\Collection|ScratchProgramRemixRelation[]
+   * @var Collection|ScratchProgramRemixRelation[]
    */
   protected $scratch_remix_parent_relations;
 
@@ -236,7 +237,7 @@ class Program
    *     cascade={"persist", "remove"},
    *     orphanRemoval=true
    * )
-   * @var \Doctrine\Common\Collections\Collection|ProgramLike[]
+   * @var Collection|ProgramLike[]
    */
   protected $likes;
 
@@ -1069,7 +1070,7 @@ class Program
   }
 
   /**
-   * @return \Doctrine\Common\Collections\Collection
+   * @return Collection
    */
   public function getProgramDownloads()
   {
@@ -1079,7 +1080,7 @@ class Program
   /**
    * @param ProgramDownloads $program_download
    *
-   * @return ProgramDownloads[]|\Doctrine\Common\Collections\Collection
+   * @return ProgramDownloads[]|Collection
    */
   public function addProgramDownloads(ProgramDownloads $program_download)
   {
@@ -1155,14 +1156,10 @@ class Program
    * Set as remix root.
    *
    * @param bool $is_remix_root
-   *
-   * @return Program
    */
   public function setRemixRoot($is_remix_root)
   {
     $this->remix_root = $is_remix_root;
-
-    return $this;
   }
 
   /**
@@ -1176,7 +1173,7 @@ class Program
   }
 
   /**
-   * @return ProgramRemixRelation[]|\Doctrine\Common\Collections\Collection
+   * @return ProgramRemixRelation[]|Collection
    */
   public function getCatrobatRemixAncestorRelations()
   {
@@ -1186,7 +1183,7 @@ class Program
   }
 
   /**
-   * @return ProgramRemixBackwardRelation[]|\Doctrine\Common\Collections\Collection
+   * @return ProgramRemixBackwardRelation[]|Collection
    */
   public function getCatrobatRemixBackwardParentRelations()
   {
@@ -1196,7 +1193,7 @@ class Program
   }
 
   /**
-   * @return ProgramRemixRelation[]|\Doctrine\Common\Collections\Collection
+   * @return ProgramRemixRelation[]|Collection
    */
   public function getCatrobatRemixDescendantRelations()
   {
@@ -1222,7 +1219,7 @@ class Program
   }
 
   /**
-   * @return ScratchProgramRemixRelation[]|\Doctrine\Common\Collections\Collection
+   * @return ScratchProgramRemixRelation[]|Collection
    */
   public function getScratchRemixParentRelations()
   {
@@ -1232,7 +1229,7 @@ class Program
   }
 
   /**
-   * @return ProgramLike[]|\Doctrine\Common\Collections\Collection
+   * @return ProgramLike[]|Collection
    */
   public function getLikes()
   {
@@ -1240,7 +1237,7 @@ class Program
   }
 
   /**
-   * @param ProgramLike[]|\Doctrine\Common\Collections\Collection $likes
+   * @param ProgramLike[]|Collection $likes
    */
   public function setLikes($likes)
   {
@@ -1248,7 +1245,7 @@ class Program
   }
 
   /**
-   * @return Tag[]|\Doctrine\Common\Collections\Collection
+   * @return Tag[]|Collection
    */
   public function getTags()
   {
@@ -1256,7 +1253,7 @@ class Program
   }
 
   /**
-   * @return Extension[]|\Doctrine\Common\Collections\Collection
+   * @return Extension[]|Collection
    */
   public function getExtensions()
   {

--- a/src/Entity/ProgramLike.php
+++ b/src/Entity/ProgramLike.php
@@ -46,27 +46,27 @@ class ProgramLike
 
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer", nullable=false)
+   * @ORM\Column(type="guid", nullable=false)
    */
   protected $program_id;
 
   /**
    * @ORM\ManyToOne(targetEntity="\App\Entity\Program", inversedBy="likes", fetch="LAZY")
    * @ORM\JoinColumn(name="program_id", referencedColumnName="id")
-   * @var \App\Entity\Program
+   * @var Program
    */
   protected $program;
 
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer", nullable=false)
+   * @ORM\Column(type="guid", nullable=false)
    */
   protected $user_id;
 
   /**
    * @ORM\ManyToOne(targetEntity="\App\Entity\User", inversedBy="likes", fetch="LAZY")
    * @ORM\JoinColumn(name="user_id", referencedColumnName="id")
-   * @var \App\Entity\User
+   * @var User
    */
   protected $user;
 
@@ -82,8 +82,8 @@ class ProgramLike
   protected $created_at;
 
   /**
-   * @param \App\Entity\Program $program
-   * @param \App\Entity\User    $user
+   * @param Program $program
+   * @param User    $user
    * @param int                                $type
    */
   public function __construct(Program $program, User $user, $type)

--- a/src/Entity/ProgramManager.php
+++ b/src/Entity/ProgramManager.php
@@ -14,6 +14,7 @@ use App\Catrobat\Services\CatrobatFileExtractor;
 use App\Catrobat\Services\ExtractedCatrobatFile;
 use App\Catrobat\Services\ProgramFileRepository;
 use App\Catrobat\Services\ScreenshotRepository;
+use Doctrine\DBAL\Types\GuidType;
 use App\Repository\ProgramLikeRepository;
 use App\Repository\ProgramRepository;
 use App\Repository\TagRepository;
@@ -462,7 +463,7 @@ class ProgramManager
   }
 
   /**
-   * @param      $user_id
+   * @param GuidType $user_id
    * @param bool $include_debug_build_programs If programs marked as debug_build should be returned
    *
    * @return Program[]

--- a/src/Entity/ProgramRemixBackwardRelation.php
+++ b/src/Entity/ProgramRemixBackwardRelation.php
@@ -21,7 +21,7 @@ class ProgramRemixBackwardRelation implements ProgramRemixRelationInterface, Pro
 
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer", nullable=false)
+   * @ORM\Column(type="guid")
    */
   protected $parent_id;
 
@@ -29,13 +29,13 @@ class ProgramRemixBackwardRelation implements ProgramRemixRelationInterface, Pro
    * @ORM\ManyToOne(targetEntity="\App\Entity\Program", inversedBy="catrobat_remix_backward_child_relations",
    *                                                                   fetch="LAZY")
    * @ORM\JoinColumn(name="parent_id", referencedColumnName="id")
-   * @var \App\Entity\Program
+   * @var Program
    */
   protected $parent;
 
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer", nullable=false)
+   * @ORM\Column(type="guid")
    */
   protected $child_id;
 
@@ -43,7 +43,7 @@ class ProgramRemixBackwardRelation implements ProgramRemixRelationInterface, Pro
    * @ORM\ManyToOne(targetEntity="\App\Entity\Program", inversedBy="catrobat_remix_backward_parent_relations",
    *                                                                   fetch="LAZY")
    * @ORM\JoinColumn(name="child_id", referencedColumnName="id")
-   * @var \App\Entity\Program
+   * @var Program
    */
   protected $child;
 
@@ -59,8 +59,8 @@ class ProgramRemixBackwardRelation implements ProgramRemixRelationInterface, Pro
   protected $seen_at;
 
   /**
-   * @param \App\Entity\Program $parent
-   * @param \App\Entity\Program $child
+   * @param Program $parent
+   * @param Program $child
    */
   public function __construct(Program $parent, Program $child)
   {

--- a/src/Entity/ProgramRemixRelation.php
+++ b/src/Entity/ProgramRemixRelation.php
@@ -22,7 +22,7 @@ class ProgramRemixRelation implements ProgramRemixRelationInterface, ProgramCatr
 
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer", nullable=false)
+   * @ORM\Column(type="guid")
    */
   protected $ancestor_id;
 
@@ -30,13 +30,13 @@ class ProgramRemixRelation implements ProgramRemixRelationInterface, ProgramCatr
    * @ORM\ManyToOne(targetEntity="\App\Entity\Program", inversedBy="catrobat_remix_descendant_relations",
    *                                                                   fetch="LAZY")
    * @ORM\JoinColumn(name="ancestor_id", referencedColumnName="id")
-   * @var \App\Entity\Program
+   * @var Program
    */
   protected $ancestor;
 
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer", nullable=false)
+   * @ORM\Column(type="guid")
    */
   protected $descendant_id;
 
@@ -44,7 +44,7 @@ class ProgramRemixRelation implements ProgramRemixRelationInterface, ProgramCatr
    * @ORM\ManyToOne(targetEntity="\App\Entity\Program", inversedBy="catrobat_remix_ancestor_relations",
    *                                                                   fetch="LAZY")
    * @ORM\JoinColumn(name="descendant_id", referencedColumnName="id")
-   * @var \App\Entity\Program
+   * @var Program
    */
   protected $descendant;
 
@@ -66,8 +66,8 @@ class ProgramRemixRelation implements ProgramRemixRelationInterface, ProgramCatr
   protected $seen_at;
 
   /**
-   * @param \App\Entity\Program $ancestor
-   * @param \App\Entity\Program $descendant
+   * @param Program $ancestor
+   * @param Program $descendant
    * @param int                                $depth
    */
   public function __construct(Program $ancestor, Program $descendant, $depth)
@@ -93,7 +93,7 @@ class ProgramRemixRelation implements ProgramRemixRelationInterface, ProgramCatr
   }
 
   /**
-   * @param \App\Entity\Program $ancestor
+   * @param Program $ancestor
    *
    * @return ProgramRemixRelation
    */
@@ -122,7 +122,7 @@ class ProgramRemixRelation implements ProgramRemixRelationInterface, ProgramCatr
   }
 
   /**
-   * @param \App\Entity\Program $descendant
+   * @param Program $descendant
    *
    * @return ProgramRemixRelation
    */

--- a/src/Entity/RemixManager.php
+++ b/src/Entity/RemixManager.php
@@ -11,6 +11,7 @@ use App\Repository\ProgramRepository;
 use App\Repository\ScratchProgramRemixRepository;
 use App\Repository\ScratchProgramRepository;
 use DateTime;
+use Doctrine\DBAL\Types\GuidType;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
@@ -415,7 +416,7 @@ class RemixManager
   }
 
   /**
-   * @param int $program_id
+   * @param GuidType $program_id
    *
    * @return array
    */
@@ -664,7 +665,7 @@ class RemixManager
   }
 
   /**
-   * @param int $program_id
+   * @param GuidType $program_id
    *
    * @return int
    */

--- a/src/Entity/ScratchProgramRemixRelation.php
+++ b/src/Entity/ScratchProgramRemixRelation.php
@@ -20,13 +20,13 @@ class ScratchProgramRemixRelation implements ProgramRemixRelationInterface
 
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer", nullable=false)
+   * @ORM\Column(type="guid")
    */
   protected $scratch_parent_id;
 
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer", nullable=false)
+   * @ORM\Column(type="guid")
    */
   protected $catrobat_child_id;
 
@@ -37,13 +37,14 @@ class ScratchProgramRemixRelation implements ProgramRemixRelationInterface
    *     fetch="LAZY"
    * )
    * @ORM\JoinColumn(name="catrobat_child_id", referencedColumnName="id")
-   * @var \App\Entity\Program
+   * @var Program
    */
   protected $catrobat_child;
 
   /**
-   * @param int                                $scratch_parent_id
-   * @param \App\Entity\Program $catrobat_child
+   * ScratchProgramRemixRelation constructor.
+   * @param $scratch_parent_id
+   * @param Program $catrobat_child
    */
   public function __construct($scratch_parent_id, Program $catrobat_child)
   {

--- a/src/Entity/Tag.php
+++ b/src/Entity/Tag.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -30,7 +31,7 @@ class Tag
   }
 
   /**
-   * @var \Doctrine\Common\Collections\Collection|Program[]
+   * @var Collection|Program[]
    *
    * @ORM\ManyToMany(targetEntity="\App\Entity\Program", mappedBy="tags")
    */
@@ -91,7 +92,7 @@ class Tag
   protected $fr;
 
   /**
-   * @return Program[]|\Doctrine\Common\Collections\Collection
+   * @return Program[]|Collection
    */
   public function getPrograms()
   {

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use FR3D\LdapBundle\Model\LdapUserInterface;
 use Sonata\UserBundle\Entity\BaseUser as BaseUser;
 use Doctrine\ORM\Mapping as ORM;
@@ -16,8 +17,8 @@ class User extends BaseUser implements LdapUserInterface
 
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer")
-   * @ORM\GeneratedValue(strategy="AUTO")
+   * @ORM\Column(name="id", type="guid")
+   * @ORM\GeneratedValue(strategy="UUID")
    */
   protected $id;
 
@@ -68,7 +69,7 @@ class User extends BaseUser implements LdapUserInterface
    *     cascade={"persist", "remove"},
    *     orphanRemoval=true
    * )
-   * @var \Doctrine\Common\Collections\Collection|ProgramLike[]
+   * @var Collection|ProgramLike[]
    */
   protected $likes;
 
@@ -79,7 +80,7 @@ class User extends BaseUser implements LdapUserInterface
    *     cascade={"persist", "remove"},
    *     orphanRemoval=true
    * )
-   * @var \Doctrine\Common\Collections\Collection|UserLikeSimilarityRelation[]
+   * @var Collection|UserLikeSimilarityRelation[]
    */
   protected $relations_of_similar_users_based_on_likes;
 
@@ -90,7 +91,7 @@ class User extends BaseUser implements LdapUserInterface
    *     cascade={"persist", "remove"},
    *     orphanRemoval=true
    * )
-   * @var \Doctrine\Common\Collections\Collection|UserLikeSimilarityRelation[]
+   * @var Collection|UserLikeSimilarityRelation[]
    */
   protected $reverse_relations_of_similar_users_based_on_likes;
 
@@ -101,7 +102,7 @@ class User extends BaseUser implements LdapUserInterface
    *     cascade={"persist", "remove"},
    *     orphanRemoval=true
    * )
-   * @var \Doctrine\Common\Collections\Collection|UserRemixSimilarityRelation[]
+   * @var Collection|UserRemixSimilarityRelation[]
    */
   protected $relations_of_similar_users_based_on_remixes;
 
@@ -112,7 +113,7 @@ class User extends BaseUser implements LdapUserInterface
    *     cascade={"persist", "remove"},
    *     orphanRemoval=true
    * )
-   * @var \Doctrine\Common\Collections\Collection|UserRemixSimilarityRelation[]
+   * @var Collection|UserRemixSimilarityRelation[]
    */
   protected $reverse_relations_of_similar_users_based_on_remixes;
 
@@ -241,7 +242,7 @@ class User extends BaseUser implements LdapUserInterface
   /**
    * Get programs.
    *
-   * @return \Doctrine\Common\Collections\Collection
+   * @return Collection
    */
   public function getPrograms()
   {
@@ -368,7 +369,7 @@ class User extends BaseUser implements LdapUserInterface
   }
 
   /**
-   * @return ProgramLike[]|\Doctrine\Common\Collections\Collection
+   * @return ProgramLike[]|Collection
    */
   public function getLikes()
   {
@@ -376,7 +377,7 @@ class User extends BaseUser implements LdapUserInterface
   }
 
   /**
-   * @param ProgramLike[]|\Doctrine\Common\Collections\Collection $likes
+   * @param ProgramLike[]|Collection $likes
    */
   public function setLikes($likes)
   {

--- a/src/Entity/UserLikeSimilarityRelation.php
+++ b/src/Entity/UserLikeSimilarityRelation.php
@@ -21,7 +21,7 @@ class UserLikeSimilarityRelation
 
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer", nullable=false)
+   * @ORM\Column(type="guid")
    */
   protected $first_user_id;
 
@@ -29,13 +29,13 @@ class UserLikeSimilarityRelation
    * @ORM\ManyToOne(targetEntity="\App\Entity\User", inversedBy="relations_of_similar_users_based_on_likes",
    *                                                                fetch="LAZY")
    * @ORM\JoinColumn(name="first_user_id", referencedColumnName="id")
-   * @var \App\Entity\User
+   * @var User
    */
   protected $first_user;
 
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer", nullable=false)
+   * @ORM\Column(type="guid")
    */
   protected $second_user_id;
 
@@ -43,7 +43,7 @@ class UserLikeSimilarityRelation
    * @ORM\ManyToOne(targetEntity="\App\Entity\User", inversedBy="reverse_relations_of_similar_users_based_on_likes",
    *                                                                fetch="LAZY")
    * @ORM\JoinColumn(name="second_user_id", referencedColumnName="id")
-   * @var \App\Entity\User
+   * @var User
    */
   protected $second_user;
 

--- a/src/Entity/UserRemixSimilarityRelation.php
+++ b/src/Entity/UserRemixSimilarityRelation.php
@@ -21,7 +21,7 @@ class UserRemixSimilarityRelation
 
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer", nullable=false)
+   * @ORM\Column(type="guid")
    */
   protected $first_user_id;
 
@@ -29,13 +29,13 @@ class UserRemixSimilarityRelation
    * @ORM\ManyToOne(targetEntity="\App\Entity\User", inversedBy="relations_of_similar_users_based_on_remixes",
    *                                                                fetch="LAZY")
    * @ORM\JoinColumn(name="first_user_id", referencedColumnName="id")
-   * @var \App\Entity\User
+   * @var User
    */
   protected $first_user;
 
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer", nullable=false)
+   * @ORM\Column(type="guid")
    */
   protected $second_user_id;
 
@@ -43,7 +43,7 @@ class UserRemixSimilarityRelation
    * @ORM\ManyToOne(targetEntity="\App\Entity\User", inversedBy="reverse_relations_of_similar_users_based_on_remixes",
    *                                                                fetch="LAZY")
    * @ORM\JoinColumn(name="second_user_id", referencedColumnName="id")
-   * @var \App\Entity\User
+   * @var User
    */
   protected $second_user;
 

--- a/src/Migrations/2019/Version20190801093025.php
+++ b/src/Migrations/2019/Version20190801093025.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190801093025 extends AbstractMigration
+{
+  public function getDescription(): string
+  {
+    return '';
+  }
+
+  public function up(Schema $schema): void
+  {
+    // this up() migration is not auto generated!
+    $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+    // deleting all user.id / program.id foreign keys to allow changing the type
+    $this->addSql('ALTER TABLE CatroNotification DROP FOREIGN KEY FK_22087FCAAC24F853');
+    $this->addSql('ALTER TABLE CatroNotification DROP FOREIGN KEY FK_22087FCA606F7D0E');
+    $this->addSql('ALTER TABLE CatroNotification DROP FOREIGN KEY FK_22087FCA8D93D649');
+    $this->addSql('ALTER TABLE CatroNotification DROP FOREIGN KEY FK_22087FCA3EB8070A');
+    $this->addSql('ALTER TABLE click_statistics DROP FOREIGN KEY FK_D9945A6E3EB8070A');
+    $this->addSql('ALTER TABLE click_statistics DROP FOREIGN KEY FK_D9945A6E7140A621');
+    $this->addSql('ALTER TABLE click_statistics DROP FOREIGN KEY FK_D9945A6EA76ED395');
+    $this->addSql('ALTER TABLE gamejams_sampleprograms DROP FOREIGN KEY FK_8EADA1363EB8070A');
+    $this->addSql('ALTER TABLE homepage_click_statistics DROP FOREIGN KEY FK_99AECB2F3EB8070A');
+    $this->addSql('ALTER TABLE homepage_click_statistics DROP FOREIGN KEY FK_99AECB2FA76ED395');
+    $this->addSql('ALTER TABLE featured DROP FOREIGN KEY FK_3C1359D43EB8070A');
+    $this->addSql('ALTER TABLE fos_user_user_group DROP FOREIGN KEY FK_B3C77447A76ED395');
+    $this->addSql('ALTER TABLE Notification DROP FOREIGN KEY FK_A765AD328D93D649');
+    $this->addSql('ALTER TABLE program_downloads DROP FOREIGN KEY FK_1D41556A1748903F');
+    $this->addSql('ALTER TABLE program_downloads DROP FOREIGN KEY FK_1D41556A3EB8070A');
+    $this->addSql('ALTER TABLE program_downloads DROP FOREIGN KEY FK_1D41556A7140A621');
+    $this->addSql('ALTER TABLE program_extension DROP FOREIGN KEY FK_C985CCA83EB8070A');
+    $this->addSql('ALTER TABLE ProgramInappropriateReport DROP FOREIGN KEY FK_ED222248A76ED395');
+    $this->addSql('ALTER TABLE ProgramInappropriateReport DROP FOREIGN KEY FK_ED2222483EB8070A');
+    $this->addSql('ALTER TABLE program DROP FOREIGN KEY FK_92ED77849D8F32D0');
+    $this->addSql('ALTER TABLE program DROP FOREIGN KEY FK_92ED7784A76ED395');
+    $this->addSql('ALTER TABLE program_downloads DROP FOREIGN KEY FK_1D41556AA76ED395');
+    $this->addSql('ALTER TABLE program_like DROP FOREIGN KEY FK_A18515B43EB8070A');
+    $this->addSql('ALTER TABLE program_like DROP FOREIGN KEY FK_A18515B4A76ED395');
+    $this->addSql('ALTER TABLE program_remix_relation DROP FOREIGN KEY FK_E5AD23B4C671CEA1');
+    $this->addSql('ALTER TABLE program_remix_relation DROP FOREIGN KEY FK_E5AD23B41844467D');
+    $this->addSql('ALTER TABLE program_remix_backward_relation DROP FOREIGN KEY FK_C294015B727ACA70');
+    $this->addSql('ALTER TABLE program_remix_backward_relation DROP FOREIGN KEY FK_C294015BDD62C21B');
+    $this->addSql('ALTER TABLE program_tag DROP FOREIGN KEY FK_88B68E093EB8070A');
+    $this->addSql('ALTER TABLE scratch_program_remix_relation DROP FOREIGN KEY FK_3B275E756F212B35');
+    $this->addSql('ALTER TABLE user_comment DROP FOREIGN KEY FK_CC794C66F1496545');
+    $this->addSql('ALTER TABLE user_like_similarity_relation DROP FOREIGN KEY FK_132DCA08B4E2BF69');
+    $this->addSql('ALTER TABLE user_like_similarity_relation DROP FOREIGN KEY FK_132DCA08B02C53F8');
+    $this->addSql('ALTER TABLE user_remix_similarity_relation DROP FOREIGN KEY FK_143F09C7B4E2BF69');
+    $this->addSql('ALTER TABLE user_remix_similarity_relation DROP FOREIGN KEY FK_143F09C7B02C53F8');
+    $this->addSql('ALTER TABLE user_user DROP FOREIGN KEY FK_F7129A803AD8644E');
+    $this->addSql('ALTER TABLE user_user DROP FOREIGN KEY FK_F7129A80233D34C1');
+    $this->addSql('DROP TABLE user_user');
+
+    // changing all integer id's for user and program to char36 guid types.
+    $this->addSql('ALTER TABLE CatroNotification CHANGE program_id program_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE CatroNotification CHANGE user user CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\', CHANGE like_from like_from CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\', CHANGE follower_id follower_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE click_statistics CHANGE program_id program_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\', CHANGE rec_from_program_id rec_from_program_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE click_statistics CHANGE user_id user_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE featured CHANGE program_id program_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE fos_user CHANGE id id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE fos_user_user_group CHANGE user_id user_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE homepage_click_statistics CHANGE program_id program_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE homepage_click_statistics CHANGE user_id user_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE gamejams_sampleprograms CHANGE program_id program_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE Notification CHANGE user user CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE program CHANGE id id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE program CHANGE user_id user_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\', CHANGE approved_by_user approved_by_user CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE program_tag CHANGE program_id program_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE program_downloads CHANGE program_id program_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\', CHANGE rec_from_program_id rec_from_program_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\', CHANGE recommended_by_program_id recommended_by_program_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE program_downloads CHANGE user_id user_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE program_extension CHANGE program_id program_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE ProgramInappropriateReport CHANGE user_id user_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE ProgramInappropriateReport CHANGE program_id program_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE program_like CHANGE user_id user_id CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE program_like CHANGE program_id program_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE program_remix_relation CHANGE ancestor_id ancestor_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\', CHANGE descendant_id descendant_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE program_remix_backward_relation CHANGE parent_id parent_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\', CHANGE child_id child_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE scratch_program_remix_relation CHANGE scratch_parent_id scratch_parent_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\', CHANGE catrobat_child_id catrobat_child_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE user_comment CHANGE programs programs CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE user_like_similarity_relation CHANGE first_user_id first_user_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\', CHANGE second_user_id second_user_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+    $this->addSql('ALTER TABLE user_remix_similarity_relation CHANGE first_user_id first_user_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\', CHANGE second_user_id second_user_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\'');
+
+    // auto generated
+    $this->addSql('ALTER TABLE acl_classes CHANGE id id INT UNSIGNED AUTO_INCREMENT NOT NULL');
+    $this->addSql('ALTER TABLE acl_security_identities CHANGE id id INT UNSIGNED AUTO_INCREMENT NOT NULL');
+    $this->addSql('ALTER TABLE acl_object_identities CHANGE id id INT UNSIGNED AUTO_INCREMENT NOT NULL');
+    $this->addSql('ALTER TABLE acl_entries CHANGE id id INT UNSIGNED AUTO_INCREMENT NOT NULL');
+
+    // recreating all foreign keys.
+    $this->addSql('ALTER TABLE CatroNotification ADD CONSTRAINT FK_22087FCA3EB8070A FOREIGN KEY (program_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE CatroNotification ADD CONSTRAINT FK_22087FCA606F7D0E FOREIGN KEY (like_from) REFERENCES fos_user (id)');
+    $this->addSql('ALTER TABLE CatroNotification ADD CONSTRAINT FK_22087FCA8D93D649 FOREIGN KEY (user) REFERENCES fos_user (id)');
+    $this->addSql('ALTER TABLE CatroNotification ADD CONSTRAINT FK_22087FCAAC24F853 FOREIGN KEY (follower_id) REFERENCES fos_user (id)');
+    $this->addSql('ALTER TABLE click_statistics ADD CONSTRAINT FK_D9945A6E3EB8070A FOREIGN KEY (program_id) REFERENCES program (id) ON DELETE SET NULL');
+    $this->addSql('ALTER TABLE click_statistics ADD CONSTRAINT FK_D9945A6E7140A621 FOREIGN KEY (rec_from_program_id) REFERENCES program (id) ON DELETE SET NULL');
+    $this->addSql('ALTER TABLE click_statistics ADD CONSTRAINT FK_D9945A6EA76ED395 FOREIGN KEY (user_id) REFERENCES fos_user (id) ON DELETE SET NULL');
+    $this->addSql('ALTER TABLE featured ADD CONSTRAINT FK_3C1359D43EB8070A FOREIGN KEY (program_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE fos_user_user_group ADD CONSTRAINT FK_B3C77447A76ED395 FOREIGN KEY (user_id) REFERENCES fos_user (id) ON DELETE CASCADE');
+    $this->addSql('ALTER TABLE gamejams_sampleprograms ADD CONSTRAINT FK_8EADA1363EB8070A FOREIGN KEY (program_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE homepage_click_statistics ADD CONSTRAINT FK_99AECB2FA76ED395 FOREIGN KEY (user_id) REFERENCES fos_user (id)');
+    $this->addSql('ALTER TABLE homepage_click_statistics ADD CONSTRAINT FK_99AECB2F3EB8070A FOREIGN KEY (program_id) REFERENCES program (id) ON DELETE SET NULL');
+    $this->addSql('ALTER TABLE Notification ADD CONSTRAINT FK_A765AD328D93D649 FOREIGN KEY (user) REFERENCES fos_user (id)');
+    $this->addSql('ALTER TABLE program ADD CONSTRAINT FK_92ED77849D8F32D0 FOREIGN KEY (approved_by_user) REFERENCES fos_user (id)');
+    $this->addSql('ALTER TABLE program ADD CONSTRAINT FK_92ED7784A76ED395 FOREIGN KEY (user_id) REFERENCES fos_user (id)');
+    $this->addSql('ALTER TABLE program_downloads ADD CONSTRAINT FK_1D41556AA76ED395 FOREIGN KEY (user_id) REFERENCES fos_user (id) ON DELETE SET NULL');
+    $this->addSql('ALTER TABLE program_downloads ADD CONSTRAINT FK_1D41556A1748903F FOREIGN KEY (recommended_by_program_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE program_downloads ADD CONSTRAINT FK_1D41556A3EB8070A FOREIGN KEY (program_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE program_downloads ADD CONSTRAINT FK_1D41556A7140A621 FOREIGN KEY (rec_from_program_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE program_extension ADD CONSTRAINT FK_C985CCA83EB8070A FOREIGN KEY (program_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE ProgramInappropriateReport ADD CONSTRAINT FK_ED222248A76ED395 FOREIGN KEY (user_id) REFERENCES fos_user (id) ON DELETE SET NULL');
+    $this->addSql('ALTER TABLE ProgramInappropriateReport ADD CONSTRAINT FK_ED2222483EB8070A FOREIGN KEY (program_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE program_like ADD CONSTRAINT FK_A18515B4A76ED395 FOREIGN KEY (user_id) REFERENCES fos_user (id)');
+    $this->addSql('ALTER TABLE program_like ADD CONSTRAINT FK_A18515B43EB8070A FOREIGN KEY (program_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE program_remix_backward_relation ADD CONSTRAINT FK_C294015B727ACA70 FOREIGN KEY (parent_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE program_remix_backward_relation ADD CONSTRAINT FK_C294015BDD62C21B FOREIGN KEY (child_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE program_remix_relation ADD CONSTRAINT FK_E5AD23B4C671CEA1 FOREIGN KEY (ancestor_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE program_remix_relation ADD CONSTRAINT FK_E5AD23B41844467D FOREIGN KEY (descendant_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE program_tag ADD CONSTRAINT FK_88B68E093EB8070A FOREIGN KEY (program_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE scratch_program_remix_relation ADD CONSTRAINT FK_3B275E756F212B35 FOREIGN KEY (catrobat_child_id) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE user_comment ADD CONSTRAINT FK_CC794C66F1496545 FOREIGN KEY (programs) REFERENCES program (id)');
+    $this->addSql('ALTER TABLE user_like_similarity_relation ADD CONSTRAINT FK_132DCA08B4E2BF69 FOREIGN KEY (first_user_id) REFERENCES fos_user (id)');
+    $this->addSql('ALTER TABLE user_like_similarity_relation ADD CONSTRAINT FK_132DCA08B02C53F8 FOREIGN KEY (second_user_id) REFERENCES fos_user (id)');
+    $this->addSql('ALTER TABLE user_remix_similarity_relation ADD CONSTRAINT FK_143F09C7B4E2BF69 FOREIGN KEY (first_user_id) REFERENCES fos_user (id)');
+    $this->addSql('ALTER TABLE user_remix_similarity_relation ADD CONSTRAINT FK_143F09C7B02C53F8 FOREIGN KEY (second_user_id) REFERENCES fos_user (id)');
+    $this->addSql('CREATE TABLE user_user (user_source CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\', user_target CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\', INDEX IDX_F7129A803AD8644E (user_source), INDEX IDX_F7129A80233D34C1 (user_target), PRIMARY KEY(user_source, user_target)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
+    $this->addSql('ALTER TABLE user_user ADD CONSTRAINT FK_F7129A803AD8644E FOREIGN KEY (user_source) REFERENCES fos_user (id) ON DELETE CASCADE');
+    $this->addSql('ALTER TABLE user_user ADD CONSTRAINT FK_F7129A80233D34C1 FOREIGN KEY (user_target) REFERENCES fos_user (id) ON DELETE CASCADE');
+  }
+
+  public function down(Schema $schema): void
+  {
+    // this down() migration is auto-generated, please modify it to your needs
+    $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+  }
+}

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -356,7 +356,7 @@
   <script src="{{ asset('compiled/js/Program.js') }}"></script>
   <script src="{{ asset('compiled/js/ProgramReport.js') }}"></script>
   <script>
-    new ProgramReport({{ program.id }}, '{{ path('catrobat_api_report_program') }}', '{{ url('login') }}',
+    new ProgramReport('{{ program.id }}', '{{ path('catrobat_api_report_program') }}', '{{ url('login') }}',
       "{{ 'success.report'                          |trans({}, 'catroweb') }}",
       '{{ "error"                                   |trans({}, "catroweb") }}',
       '{{ "programs.report"                         |trans({}, "catroweb") }}',
@@ -373,7 +373,7 @@
   </script>
   <script src="{{ asset('compiled/js/ProgramComments.js') }}"></script>
   <script>
-    new ProgramComments({{ program_details.id }}, 5, 5, 5, {{ (program_details.comments|length) }},
+    new ProgramComments('{{ program_details.id }}', 5, 5, 5, {{ (program_details.comments|length) }},
       "{{ 'cancel'                                  |trans({}, 'catroweb') }}",
       "{{ 'deleteIt'                                |trans({}, 'catroweb') }}",
       "{{ 'reportIt'                                |trans({}, 'catroweb') }}",
@@ -394,7 +394,7 @@
   </script>
   <script src="{{ asset('compiled/js/ProgramDescription.js') }}"></script>
   <script>
-    new ProgramDescription({{ program.id }},
+    new ProgramDescription('{{ program.id }}',
       '{{ ("show-more")                             |trans({}, "catroweb") }}',
       '{{ ("show-less")                             |trans({}, "catroweb") }}',
         {{ constant('App\\Catrobat\\StatusCode::OK') }},
@@ -476,7 +476,7 @@
     })
 
     var undefined
-    var programID = {{ program.id }};
+    var programID = '{{ program.id }}';
     var recs = new ProjectLoader('#recommendations', '{{ path('api_recsys_programs') }}', programID)
     recs.initRecsys()
 
@@ -485,7 +485,7 @@
     specificRecommender.init()
 
     let more_from_this_user = new ProjectLoader('#more-from-this-user-recommendations', '{{ path('api_user_programs') }}')
-    more_from_this_user.initMoreFromThisUser({{ program.user.id }}, programID)
+    more_from_this_user.initMoreFromThisUser('{{ program.user.id }}', programID)
 
     counter = 10
     var cachedRemixData = null
@@ -677,7 +677,7 @@
         $.ajaxSetup({async: false})
         $.post("{{ path('click_stats') }}", {
           type     : type,
-          recFromID: {{ program.id }},
+          recFromID: '{{ program.id }}',
           recID    : additions
         }, function (data) {
           if (data === 'error')

--- a/templates/UserManagement/Profile/myProfile.html.twig
+++ b/templates/UserManagement/Profile/myProfile.html.twig
@@ -74,17 +74,17 @@
         '{{ "myprofile.notChangeVisibilityReason"|trans({}, "catroweb") }}'
       )
       profile.init()
-      programs.initProfile({{ app.user.id }})
     {% else %}
       programs = new ProjectLoader('#user-programs', '{{ path('api_user_programs') }}')
-      programs.initProfile({{ app.user.id }})
     {% endif %}
 
-    let follows = new ProfileLoader({{ app.user.id }} ,'{{ path('list_follow', { type: 'follows' }) }}',
+    programs.initProfile('{{ app.user.id }}')
+
+    let follows = new ProfileLoader('{{ app.user.id }}' ,'{{ path('list_follow', { type: 'follows' }) }}',
     '{{ path('profile') }}', '#list-follows', '{{ asset('images/default/avatar_default.png') }}')
     follows.init()
 
-    let follower = new ProfileLoader({{ app.user.id }} ,'{{ path('list_follow', { type: 'follower' }) }}',
+    let follower = new ProfileLoader('{{ app.user.id }}' ,'{{ path('list_follow', { type: 'follower' }) }}',
     '{{ path('profile') }}', '#list-follower', '{{ asset('images/default/avatar_default.png') }}')
     follower.init()
   </script>

--- a/templates/UserManagement/Profile/profile.html.twig
+++ b/templates/UserManagement/Profile/profile.html.twig
@@ -110,7 +110,7 @@
   </script>
   <script src="{{ asset('compiled/js/ProfileLoader.js') }}"></script>
   <script>
-    let follower = new ProfileLoader({{ profile.id }} , '{{ path('list_follow',  { type: 'follower' }) }}',
+    let follower = new ProfileLoader('{{ profile.id }}' , '{{ path('list_follow',  { type: 'follower' }) }}',
       '{{ path('profile') }}', '#list-follower', '{{ asset('images/default/avatar_default.png') }}')
     follower.init()
   </script>

--- a/tests/PhpSpec/spec/App/Catrobat/Listeners/RemixUpdaterSpec.php
+++ b/tests/PhpSpec/spec/App/Catrobat/Listeners/RemixUpdaterSpec.php
@@ -218,7 +218,7 @@ class RemixUpdaterSpec extends ObjectBehavior
                                                                                         AsyncHttpClient $async_http_client)
   {
     $first_expected_url = 'https://scratch.mit.edu/projects/117697631/';
-    $second_expected_url = '/app/program/3570';
+    $second_expected_url = '/pocketcode/program/3570';
     $expected_scratch_info = [[
       'id'          => 117697631,
       'creator'     => ['username' => 'Techno-CAT'],

--- a/tests/PhpSpec/spec/App/Catrobat/Services/ExtractedCatrobatFileSpec.php
+++ b/tests/PhpSpec/spec/App/Catrobat/Services/ExtractedCatrobatFileSpec.php
@@ -42,13 +42,13 @@ class ExtractedCatrobatFileSpec extends ObjectBehavior
   {
     $this->getRemixUrlsString()->shouldReturn('やねうら部屋(びっくりハウス) remix お化け屋敷 '
       . '[https://scratch.mit.edu/projects/117697631/], '
-      . 'The Periodic Table [/app/program/3570]');
+      . 'The Periodic Table [/pocketcode/program/3570]');
   }
 
   public function it_gets_relative_and_absolute_remix_urls()
   {
     $first_expected_url = 'https://scratch.mit.edu/projects/117697631/';
-    $second_expected_url = '/app/program/3570';
+    $second_expected_url = '/pocketcode/program/3570';
     $new_program_id = 3571;
 
     $urls = $this->getRemixesData($new_program_id, true);

--- a/tests/behat/features/api/authentication.feature
+++ b/tests/behat/features/api/authentication.feature
@@ -5,14 +5,14 @@ Feature: Authenticate to the system
   Background:
 
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-      | User1    | vwxyz    | aaaaaaaaaa |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
+      | User1    | vwxyz    | aaaaaaaaaa |  2 |
 
 
   Scenario: Registration of a new user
     Given the HTTP Request:
-      | Method | POST                                                 |
+      | Method | POST                                          |
       | Url    | /app/api/loginOrRegister/loginOrRegister.json |
     And the POST parameters:
       | Name                 | Value                |
@@ -22,12 +22,12 @@ Feature: Authenticate to the system
       | registrationCountry  | at                   |
     And we assume the next generated token will be "rrrrrrrrrrr"
     When the Request is invoked
-    Then the returned json object will be:
+    Then I should get the json object:
           """
           {
-            "token": "rrrrrrrrrrr",
             "statusCode": 201,
             "answer": "Registration successful!",
+            "token": "rrrrrrrrrrr",
             "preHeaderMessages": ""
           }
           """
@@ -35,7 +35,7 @@ Feature: Authenticate to the system
   Scenario Outline: Troubleshooting
     Given the registration problem "<problem>"
     When such a Request is invoked
-    Then the returned json object will be:
+    Then I should get the json object:
           """
           {
             "statusCode": <errorcode>,
@@ -57,11 +57,11 @@ Feature: Authenticate to the system
       | registrationUsername | Catrobat |
       | registrationPassword | 12345    |
     When the Request is invoked
-    Then the returned json object will be:
+    Then I should get the json object:
           """
           {
-            "token": "cccccccccc",
             "statusCode": 200,
+            "token": "cccccccccc",
             "preHeaderMessages": ""
           }
           """
@@ -75,7 +75,7 @@ Feature: Authenticate to the system
       | username | Catrobat   |
       | token    | cccccccccc |
     When the Request is invoked
-    Then the returned json object will be:
+    Then I should get the json object:
           """
           {
             "statusCode": 200,
@@ -88,7 +88,7 @@ Feature: Authenticate to the system
   Scenario Outline: Troubleshooting
     Given the check token problem "<problem>"
     When such a Request is invoked
-    Then the returned json object will be:
+    Then I should get the json object:
           """
           {
             "statusCode": <errorcode>,
@@ -114,7 +114,7 @@ Feature: Authenticate to the system
       | registrationCountry  | at                   |
     And we assume the next generated token will be "rrrrrrrrrrr"
     When the Request is invoked
-    Then the returned json object will be:
+    Then I should get the json object:
           """
           {
             "statusCode": 602,

--- a/tests/behat/features/api/check_token.feature
+++ b/tests/behat/features/api/check_token.feature
@@ -3,9 +3,9 @@ Feature: Checking a user's token validity
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-      | User1    | vwxyz    | aaaaaaaaaa |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
+      | User1    | vwxyz    | aaaaaaaaaa |  2 |
     And there are programs:
       | id | name      | description | owned by | downloads | views | upload time      | version |
       | 1  | program 1 | p1          | Catrobat | 3         | 12    | 01.01.2013 12:00 | 0.8.5   |

--- a/tests/behat/features/api/download_program.feature
+++ b/tests/behat/features/api/download_program.feature
@@ -3,8 +3,8 @@ Feature: Download programs
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc | 1  |
     And there are downloadable programs:
       | id | name      | description | owned by | downloads | views | upload time      | version | visible |
       | 1  | program 1 | p1          | Catrobat | 3         | 12    | 01.01.2013 12:00 | 0.8.5   | true    |

--- a/tests/behat/features/api/download_statistics.feature
+++ b/tests/behat/features/api/download_statistics.feature
@@ -3,8 +3,8 @@ Feature: Downloaded program statistics
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
     And there are downloadable programs:
       | id | name      | description | owned by | downloads | views | upload time      | version | visible |
       | 1  | program 1 | p1          | Catrobat | 3         | 12    | 01.01.2013 12:00 | 0.8.5   | true    |

--- a/tests/behat/features/api/get_featured_programs.feature
+++ b/tests/behat/features/api/get_featured_programs.feature
@@ -5,9 +5,9 @@ Feature: Get featured programs
     Given the server name is "pocketcode.org"
     And I use a secure connection
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-      | User1    | vwxyz    | aaaaaaaaaa |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
+      | User1    | vwxyz    | aaaaaaaaaa |  2 |
     And there are programs:
       | id | name         | description | owned by | downloads | views | upload time      | version |
       | 1  | Invaders     | p1          | Catrobat | 3         | 12    | 01.01.2013 12:00 | 0.8.5   |
@@ -25,7 +25,6 @@ Feature: Get featured programs
       | IOS test     | yes    | 0        | yes      |
       | Mega Game1   | no     | 1        | yes      |
 
-
   Scenario: show featured programs with limit 1 and offset 1
     Given I have a parameter "limit" with value "1"
     And I have a parameter "offset" with value "1"
@@ -36,7 +35,7 @@ Feature: Get featured programs
         "CatrobatProjects":
           [
              {
-              "ProjectId": 4,
+              "ProjectId": "(.*?)",
               "ProjectName":"Soon to be",
               "Author":"User1",
               "FeaturedImage": "resources_test/featured/featured_3.jpg"
@@ -63,19 +62,19 @@ Feature: Get featured programs
         "CatrobatProjects":
           [
             {
-              "ProjectId": 3,
+              "ProjectId": "(.*?)",
               "ProjectName":"A new world",
               "Author":"User1",
               "FeaturedImage":"resources_test/featured/featured_2.jpg"
             },
             {
-              "ProjectId": 4,
+              "ProjectId": "(.*?)",
               "ProjectName":"Soon to be",
               "Author":"User1",
               "FeaturedImage": "resources_test/featured/featured_3.jpg"
             },
             {
-              "ProjectId": 1,
+              "ProjectId": "(.*?)",
               "ProjectName": "Invaders",
               "Author": "Catrobat",
               "FeaturedImage": "resources_test/featured/featured_1.jpg"
@@ -101,13 +100,13 @@ Feature: Get featured programs
         "CatrobatProjects":
           [
             {
-              "ProjectId": 3,
+              "ProjectId": "(.*?)",
               "ProjectName":"A new world",
               "Author":"User1",
               "FeaturedImage":"resources_test/featured/featured_2.jpg"
              },
              {
-              "ProjectId": 4,
+              "ProjectId": "(.*?)",
               "ProjectName":"Soon to be",
               "Author":"User1",
               "FeaturedImage": "resources_test/featured/featured_3.jpg"
@@ -131,19 +130,19 @@ Feature: Get featured programs
         "CatrobatProjects":
           [
             {
-              "ProjectId": 3,
+              "ProjectId": "(.*?)",
               "ProjectName":"A new world",
               "Author":"User1",
               "FeaturedImage":"resources_test/featured/featured_2.jpg"
              },
              {
-              "ProjectId": 4,
+              "ProjectId": "(.*?)",
               "ProjectName":"Soon to be",
               "Author":"User1",
               "FeaturedImage": "resources_test/featured/featured_3.jpg"
              },
              {
-              "ProjectId": 1,
+              "ProjectId": "(.*?)",
               "ProjectName":"Invaders",
               "Author":"Catrobat",
               "FeaturedImage": "resources_test/featured/featured_1.jpg"
@@ -167,7 +166,7 @@ Feature: Get featured programs
         "CatrobatProjects":
           [
             {
-              "ProjectId": 5,
+              "ProjectId": "(.*?)",
               "ProjectName":"IOS test",
               "Author":"User1",
               "FeaturedImage":"resources_test/featured/featured_5.jpg"

--- a/tests/behat/features/api/get_media_lib_json_edge_cases.feature
+++ b/tests/behat/features/api/get_media_lib_json_edge_cases.feature
@@ -73,7 +73,7 @@ Feature: Getting data from the media lib api even though no data is present shou
     """
     {
       "statusCode": 522,
-      "message": "category Space not found in package Looks because the package doesn't contain any categories"
+      "message": "category Space not found in package Looks because the package doesn(.*?)t contain any categories"
     }
     """
 

--- a/tests/behat/features/api/get_most_downloaded_programs.feature
+++ b/tests/behat/features/api/get_most_downloaded_programs.feature
@@ -3,9 +3,9 @@ Feature: Get the most downloaded programs
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-      | User1    | vwxyz    | aaaaaaaaaa |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
+      | User1    | vwxyz    | aaaaaaaaaa |  2 |
     And there are programs:
       | id | name      | description | owned by | downloads | views | upload time      | version |
       | 1  | program 1 | p1          | Catrobat | 3         | 12    | 01.01.2013 12:00 | 0.8.5   |
@@ -22,30 +22,30 @@ Feature: Get the most downloaded programs
       """
       {
           "CatrobatProjects":[{
-                                "ProjectId": 2,
+                                "ProjectId": "(.*?)",
                                 "ProjectName":"program 2",
                                 "ProjectNameShort":"program 2",
                                 "Author":"Catrobat",
                                 "Description":"",
                                 "Version":"0.8.5",
-                                "Views":"9",
-                                "Downloads":"333",
+                                "Views": 9,
+                                "Downloads": 333,
                                 "Private":false,
-                                "Uploaded": 1398171600,
+                                "Uploaded": 1398164400,
                                 "UploadedString":"3 months ago",
                                 "ScreenshotBig":"images/default/screenshot.png",
                                 "ScreenshotSmall":"images/default/thumbnail.png",
-                                "ProjectUrl":"app/program/2",
-                                "DownloadUrl":"app/download/2.catrobat",
+                                "ProjectUrl":"app/program/(.*?)",
+                                "DownloadUrl":"app/download/(.*?).catrobat",
                                 "FileSize":0
                             }],
           "completeTerm":"",
+          "preHeaderMessages":"",
           "CatrobatInformation": {
                                    "BaseUrl":"http://localhost/",
                                    "TotalProjects": 3,
                                    "ProjectsExtension":".catrobat"
-                                  },
-          "preHeaderMessages":""
+                                  }
       }
       """
 
@@ -57,7 +57,7 @@ Feature: Get the most downloaded programs
       """
       {
           "CatrobatProjects":[{
-                                "ProjectId": 2,
+                                "ProjectId": "(.*?)",
                                 "ProjectName":"program 2"
                             }],
           "completeTerm":"",

--- a/tests/behat/features/api/get_most_viewed_programs.feature
+++ b/tests/behat/features/api/get_most_viewed_programs.feature
@@ -3,9 +3,9 @@ Feature: Get the most downloaded programs
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-      | User1    | vwxyz    | aaaaaaaaaa |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
+      | User1    | vwxyz    | aaaaaaaaaa |  2 |
     And there are programs:
       | id | name      | description | owned by | downloads | views | upload time      | version |
       | 1  | program 1 | p1          | Catrobat | 3         | 12    | 01.01.2013 12:00 | 0.8.5   |
@@ -21,21 +21,21 @@ Feature: Get the most downloaded programs
       """
       {
           "CatrobatProjects":[{
-                                "ProjectId": 2,
+                                "ProjectId": "(.*?)",
                                 "ProjectName":"program 2",
                                 "ProjectNameShort":"program 2",
                                 "Author":"Catrobat",
                                 "Description":"",
                                 "Version":"0.8.5",
-                                "Views":"90",
-                                "Downloads":"333",
+                                "Views": 90,
+                                "Downloads": 333,
                                 "Private":false,
-                                "Uploaded": 1359723600,
+                                "Uploaded": 1359720000,
                                 "UploadedString":"1 year ago",
                                 "ScreenshotBig":"images/default/screenshot.png",
                                 "ScreenshotSmall":"images/default/thumbnail.png",
-                                "ProjectUrl":"app/program/2",
-                                "DownloadUrl":"app/download/2.catrobat",
+                                "ProjectUrl":"app/program/(.*?)",
+                                "DownloadUrl":"app/download/(.*?).catrobat",
                                 "FileSize":0
                             }],
           "completeTerm":"",
@@ -56,7 +56,7 @@ Feature: Get the most downloaded programs
       """
       {
           "CatrobatProjects":[{
-                                "ProjectId": 2,
+                                "ProjectId": "(.*?)",
                                 "ProjectName":"program 2"
                             }],
           "completeTerm":"",

--- a/tests/behat/features/api/get_random_programs.feature
+++ b/tests/behat/features/api/get_random_programs.feature
@@ -3,9 +3,9 @@ Feature: Get the random programs
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-      | User1    | vwxyz    | aaaaaaaaaa |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
+      | User1    | vwxyz    | aaaaaaaaaa |  2 |
     And there are programs:
       | id | name      | description | owned by | downloads | views | upload time      | version | visible |
       | 1  | program 1 | p1          | Catrobat | 1         | 4     | 01.01.2013 12:00 | 0.8.5   | true    |

--- a/tests/behat/features/api/get_recent_programs.feature
+++ b/tests/behat/features/api/get_recent_programs.feature
@@ -3,9 +3,9 @@ Feature: Get the most recent programs
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-      | User1    | vwxyz    | aaaaaaaaaa |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
+      | User1    | vwxyz    | aaaaaaaaaa |  2 |
     And there are programs:
       | id | name      | description | owned by | downloads | views | upload time      | version |
       | 1  | program 1 | p1          | Catrobat | 3         | 12    | 01.01.2013 12:00 | 0.8.5   |
@@ -21,21 +21,21 @@ Feature: Get the most recent programs
       """
       {
           "CatrobatProjects":[{
-                                "ProjectId": 2,
+                                "ProjectId": "(.*?)",
                                 "ProjectName":"program 2",
                                 "ProjectNameShort":"program 2",
                                 "Author":"Catrobat",
                                 "Description":"",
                                 "Version":"0.8.5",
-                                "Views":"9",
-                                "Downloads":"33",
+                                "Views":9,
+                                "Downloads":33,
                                 "Private":false,
-                                "Uploaded": 1359723600,
+                                "Uploaded": 1359720000,
                                 "UploadedString":"1 year ago",
                                 "ScreenshotBig":"images/default/screenshot.png",
                                 "ScreenshotSmall":"images/default/thumbnail.png",
-                                "ProjectUrl":"app/program/2",
-                                "DownloadUrl":"app/download/2.catrobat",
+                                "ProjectUrl":"app/program/(.*?)",
+                                "DownloadUrl":"app/download/(.*?).catrobat",
                                 "FileSize":0
                             }],
           "completeTerm":"",
@@ -56,7 +56,7 @@ Feature: Get the most recent programs
       """
       {
           "CatrobatProjects":[{
-                                "ProjectId": 2,
+                                "ProjectId": "(.*?)",
                                 "ProjectName":"program 2"
                             }],
           "completeTerm":"",

--- a/tests/behat/features/api/get_recommended_programs_homepage.feature
+++ b/tests/behat/features/api/get_recommended_programs_homepage.feature
@@ -7,11 +7,11 @@ Feature: Get recommended programs on homepage
 
   Background:
     Given there are users:
-      | id | name      | password | token      |
-      | 1  | Catrobat1 | 12345    | cccccccccc |
-      | 2  | Catrobat2 | 12345    | cccccccccc |
-      | 3  | Catrobat3 | 12345    | cccccccccc |
-      | 4  | Catrobat4 | 12345    | cccccccccc |
+      | id | name      | password | token      | id |
+      | 1  | Catrobat1 | 12345    | cccccccccc |  1 |
+      | 2  | Catrobat2 | 12345    | cccccccccc |  2 |
+      | 3  | Catrobat3 | 12345    | cccccccccc |  3 |
+      | 4  | Catrobat4 | 12345    | cccccccccc |  4 |
     And there are programs:
       | id | name    | description | owned by  | downloads | views | upload time      | version | remix_root | debug |
       | 1  | Game    | p4          | Catrobat4 | 5         | 1     | 01.03.2013 12:00 | 0.8.5   | true       | false |
@@ -75,7 +75,7 @@ Feature: Get recommended programs on homepage
       | Catrobat2 | 1          | 1    | 01.01.2017 12:00 |
       | Catrobat2 | 2          | 3    | 01.01.2017 12:00 |
       | Catrobat2 | 3          | 2    | 01.01.2017 12:00 |
-    Given I have a parameter "test_user_id_for_like_recommendation" with value "1"
+    And I have a parameter "test_user_id_for_like_recommendation" with value "1"
     And I have a parameter "limit" with value "10"
     And I have a parameter "offset" with value "0"
     When I GET "/app/api/projects/recsys_general_programs.json" with these parameters
@@ -97,7 +97,7 @@ Feature: Get recommended programs on homepage
       | Catrobat2 | 1          | 1    | 01.01.2017 12:00 |
       | Catrobat2 | 2          | 3    | 01.01.2017 12:00 |
       | Catrobat2 | 3          | 2    | 01.01.2017 12:00 |
-    Given I have a parameter "test_user_id_for_like_recommendation" with value "1"
+    And I have a parameter "test_user_id_for_like_recommendation" with value "1"
     And I have a parameter "limit" with value "10"
     And I have a parameter "offset" with value "0"
     When I GET "/app/api/projects/recsys_general_programs.json" with these parameters
@@ -121,7 +121,7 @@ Feature: Get recommended programs on homepage
       | Catrobat3 | 1          | 2    | 01.01.2017 12:00 |
       | Catrobat3 | 3          | 1    | 01.01.2017 12:00 |
       | Catrobat3 | 4          | 4    | 01.01.2017 12:00 |
-    Given I have a parameter "test_user_id_for_like_recommendation" with value "1"
+    And I have a parameter "test_user_id_for_like_recommendation" with value "1"
     And I have a parameter "limit" with value "10"
     And I have a parameter "offset" with value "0"
     When I GET "/app/api/projects/recsys_general_programs.json" with these parameters
@@ -152,7 +152,7 @@ Feature: Get recommended programs on homepage
       | Catrobat3 | 4          | 4    | 01.01.2017 12:00 |
       | Catrobat4 | 1          | 2    | 01.01.2017 12:00 |
       | Catrobat4 | 5          | 1    | 01.01.2017 12:00 |
-    Given I have a parameter "test_user_id_for_like_recommendation" with value "1"
+    And I have a parameter "test_user_id_for_like_recommendation" with value "1"
     And I have a parameter "limit" with value "10"
     And I have a parameter "offset" with value "0"
     When I GET "/app/api/projects/recsys_general_programs.json" with these parameters

--- a/tests/behat/features/api/get_user_programs.feature
+++ b/tests/behat/features/api/get_user_programs.feature
@@ -5,10 +5,10 @@ Feature: Get users programs
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-      | User1    | vwxyz    | aaaaaaaaaa |
-      | NewUser  | 54321    | bbbbbbbbbb |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
+      | User1    | vwxyz    | aaaaaaaaaa |  2 |
+      | NewUser  | 54321    | bbbbbbbbbb |  3 |
     And there are programs:
       | id | name            | description | owned by | downloads | views | upload time      | version |
       | 1  | Galaxy War      | p1          | User1    | 3         | 12    | 01.01.2013 12:00 | 0.8.5   |
@@ -31,39 +31,39 @@ Feature: Get users programs
     """
       {
           "CatrobatProjects":[{
-                                "ProjectId": 2,
+                                "ProjectId": "(.*?)",
                                 "ProjectName":"Minions",
                                 "ProjectNameShort":"Minions",
                                 "Author":"Catrobat",
                                 "Description":"",
                                 "Version":"0.8.5",
-                                "Views":"9",
-                                "Downloads":"33",
+                                "Views":9,
+                                "Downloads":33,
                                 "Private":false,
-                                "Uploaded": 1359723600,
+                                "Uploaded": 1359720000,
                                 "UploadedString":"1 year ago",
                                 "ScreenshotBig":"images/default/screenshot.png",
                                 "ScreenshotSmall":"images/default/thumbnail.png",
-                                "ProjectUrl":"app/program/2",
-                                "DownloadUrl":"app/download/2.catrobat",
+                                "ProjectUrl":"app/program/(.*?)",
+                                "DownloadUrl":"app/download/(.*?).catrobat",
                                 "FileSize":0
                             },
                             {
-                                "ProjectId": 6,
+                                "ProjectId": "(.*?)",
                                 "ProjectName":"Whack the Marko",
                                 "ProjectNameShort":"Whack the Marko",
                                 "Author":"Catrobat",
                                 "Description":"Universe",
                                 "Version":"0.8.5",
-                                "Views":"33",
-                                "Downloads":"2",
+                                "Views":33,
+                                "Downloads":2,
                                 "Private":false,
-                                "Uploaded": 1328101200,
+                                "Uploaded": 1328097600,
                                 "UploadedString":"more than one year ago",
                                 "ScreenshotBig":"images/default/screenshot.png",
                                 "ScreenshotSmall":"images/default/thumbnail.png",
-                                "ProjectUrl":"app/program/6",
-                                "DownloadUrl":"app/download/6.catrobat",
+                                "ProjectUrl":"app/program/(.*?)",
+                                "DownloadUrl":"app/download/(.*?).catrobat",
                                 "FileSize":0
                             }],
           "completeTerm":"",

--- a/tests/behat/features/api/list_programs_debug_build.feature
+++ b/tests/behat/features/api/list_programs_debug_build.feature
@@ -2,7 +2,10 @@
 Feature: List programs with and without debug build type
 
   Background:
-    Given there are tags:
+    Given there are users:
+      | name              | password | token      | id |
+      | GeneratedUser1    | vwxyz    | aaaaaaaaaa |  1 |
+    And there are tags:
       | id | en     | de         |
       | 1  | Games  | Spiele     |
       | 2  | Story  | Geschichte |
@@ -13,42 +16,42 @@ Feature: List programs with and without debug build type
       | 2  | Lego  | LEGO   |
       | 3  | Phiro | PHIRO  |
     And there are programs:
-      | id | name          | description | downloads | views | upload time      | version | debug | tags_id | extensions |
-      | 1  | program 1     | p1          | 3         | 12    | 01.01.2013 12:00 | 0.9.10  | false | 1,2     | Lego,Drone |
-      | 2  | program 2     |             | 333       | 9     | 22.04.2014 13:00 | 0.9.10  | false | 3       |            |
-      | 3  | debug program | new one     | 450       | 80    | 01.04.2019 09:00 | 1.0.12  | true  | 1,2,3   | Lego,Phiro |
-      | 4  | program 4     |             | 133       | 33    | 01.01.2012 13:00 | 0.9.10  | false | 1       | Lego       |
+      | id | name          | description | downloads | views | upload time      | version | debug | tags_id | extensions | owned by        |
+      | 1  | program 1     | p1          | 3         | 12    | 01.01.2013 12:00 | 0.9.10  | false | 1,2     | Lego,Drone | GeneratedUser1  |
+      | 2  | program 2     |             | 333       | 9     | 22.04.2014 13:00 | 0.9.10  | false | 3       |            | GeneratedUser1  |
+      | 3  | debug program | new one     | 450       | 80    | 01.04.2019 09:00 | 1.0.12  | true  | 1,2,3   | Lego,Phiro | GeneratedUser1  |
+      | 4  | program 4     |             | 133       | 33    | 01.01.2012 13:00 | 0.9.10  | false | 1       | Lego       | GeneratedUser1  |
     And the current time is "01.08.2019 00:00"
     And I store the following json object as "debug_program":
       """
       {
         "CatrobatProjects": [
           {
-            "ProjectId": 3,
+            "ProjectId": "(.*?)",
             "ProjectName": "debug program",
             "ProjectNameShort": "debug program",
             "Author": "GeneratedUser1",
             "Description": "new one",
             "Version": "1.0.12",
-            "Views": "80",
-            "Downloads": "450",
+            "Views": 80,
+            "Downloads": 450,
             "Private": false,
-            "Uploaded": 1554109200,
+            "Uploaded": 1554102000,
             "UploadedString": "4 months ago",
             "ScreenshotBig": "images/default/screenshot.png",
             "ScreenshotSmall": "images/default/thumbnail.png",
-            "ProjectUrl": "app/program/3",
-            "DownloadUrl": "app/download/3.catrobat",
+            "ProjectUrl": "app/program/(.*?)",
+            "DownloadUrl": "app/download/(.*?).catrobat",
             "FileSize": 0
           }
         ],
         "completeTerm": "",
+        "preHeaderMessages": "",
         "CatrobatInformation": {
           "BaseUrl": "http://localhost/",
           "TotalProjects": 4,
           "ProjectsExtension": ".catrobat"
-        },
-        "preHeaderMessages": ""
+        }
       }
       """
     And I store the following json object as "debug_program_id":
@@ -56,7 +59,7 @@ Feature: List programs with and without debug build type
       {
         "CatrobatProjects": [
           {
-            "ProjectId": 3,
+            "ProjectId": "(.*?)",
             "ProjectName": "debug program"
           }
         ],
@@ -74,31 +77,31 @@ Feature: List programs with and without debug build type
       {
         "CatrobatProjects": [
           {
-            "ProjectId": 2,
+            "ProjectId": "(.*?)",
             "ProjectName": "program 2",
             "ProjectNameShort": "program 2",
             "Author": "GeneratedUser1",
             "Description": "",
             "Version": "0.9.10",
-            "Views": "9",
-            "Downloads": "333",
+            "Views": 9,
+            "Downloads": 333,
             "Private": false,
-            "Uploaded": 1398171600,
+            "Uploaded": 1398164400,
             "UploadedString": "more than one year ago",
             "ScreenshotBig": "images/default/screenshot.png",
             "ScreenshotSmall": "images/default/thumbnail.png",
-            "ProjectUrl": "app/program/2",
-            "DownloadUrl": "app/download/2.catrobat",
+            "ProjectUrl": "app/program/(.*?)",
+            "DownloadUrl": "app/download/(.*?).catrobat",
             "FileSize": 0
           }
         ],
         "completeTerm": "",
+        "preHeaderMessages": "",
         "CatrobatInformation": {
           "BaseUrl": "http://localhost/",
           "TotalProjects": 3,
           "ProjectsExtension": ".catrobat"
-        },
-        "preHeaderMessages": ""
+        }
       }
       """
     And I store the following json object as "program_2_id":
@@ -106,7 +109,7 @@ Feature: List programs with and without debug build type
       {
         "CatrobatProjects": [
           {
-            "ProjectId": 2,
+            "ProjectId": "(.*?)",
             "ProjectName": "program 2"
           }
         ],
@@ -124,31 +127,31 @@ Feature: List programs with and without debug build type
       {
         "CatrobatProjects": [
           {
-            "ProjectId": 4,
+            "ProjectId": "(.*?)",
             "ProjectName": "program 4",
             "ProjectNameShort": "program 4",
             "Author": "GeneratedUser1",
             "Description": "",
             "Version": "0.9.10",
-            "Views": "33",
-            "Downloads": "133",
+            "Views": 33,
+            "Downloads": 133,
             "Private": false,
-            "Uploaded": 1325422800,
+            "Uploaded": 1325419200,
             "UploadedString": "more than one year ago",
             "ScreenshotBig": "images/default/screenshot.png",
             "ScreenshotSmall": "images/default/thumbnail.png",
-            "ProjectUrl": "app/program/4",
-            "DownloadUrl": "app/download/4.catrobat",
+            "ProjectUrl": "app/program/(.*?)",
+            "DownloadUrl": "app/download/(.*?).catrobat",
             "FileSize": 0
           }
         ],
         "completeTerm": "",
+        "preHeaderMessages": "",
         "CatrobatInformation": {
           "BaseUrl": "http://localhost/",
           "TotalProjects": 3,
           "ProjectsExtension": ".catrobat"
-        },
-        "preHeaderMessages": ""
+        }
       }
       """
     And I store the following json object as "program_4_id":
@@ -156,7 +159,7 @@ Feature: List programs with and without debug build type
       {
         "CatrobatProjects": [
           {
-            "ProjectId": 4,
+            "ProjectId": "(.*?)",
             "ProjectName": "program 4"
           }
         ],

--- a/tests/behat/features/api/program_details.feature
+++ b/tests/behat/features/api/program_details.feature
@@ -3,16 +3,15 @@ Feature: Get details for a specific program
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-      | User1    | vwxyz    | aaaaaaaaaa |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
+      | User1    | vwxyz    | aaaaaaaaaa |  2 |
     And there are programs:
       | id | name      | description | owned by | downloads | views | upload time      | version | FileSize |
       | 1  | program 1 | p1          | Catrobat | 3         | 12    | 01.01.2013 12:00 | 0.8.5   | 1024     |
       | 2  | program 2 |             | Catrobat | 333       | 9     | 22.04.2014 13:00 | 0.8.5   | 2621440  |
       | 3  | program 3 |             | User1    | 133       | 33    | 01.01.2012 13:00 | 0.8.5   | 1337     |
     And the current time is "01.08.2014 13:00"
-
 
   Scenario: show details of a program with given id
     Given I have a parameter "id" with value "2"
@@ -21,21 +20,21 @@ Feature: Get details for a specific program
       """
       {
           "CatrobatProjects":[{
-                                "ProjectId": 2,
+                                "ProjectId": "(.*?)",
                                 "ProjectName":"program 2",
                                 "ProjectNameShort":"program 2",
                                 "Author":"Catrobat",
                                 "Description":"",
                                 "Version":"0.8.5",
-                                "Views":"9",
-                                "Downloads":"333",
+                                "Views":9,
+                                "Downloads":333,
                                 "Private":false,
-                                "Uploaded": 1398171600,
+                                "Uploaded": 1398164400,
                                 "UploadedString":"3 months ago",
                                 "ScreenshotBig":"images/default/screenshot.png",
                                 "ScreenshotSmall":"images/default/thumbnail.png",
-                                "ProjectUrl":"app/program/2",
-                                "DownloadUrl":"app/download/2.catrobat",
+                                "ProjectUrl":"app/program/(.*?)",
+                                "DownloadUrl":"app/download/(.*?).catrobat",
                                 "FileSize":2.5
 
                             }],

--- a/tests/behat/features/api/program_rudewordfilter.feature
+++ b/tests/behat/features/api/program_rudewordfilter.feature
@@ -13,7 +13,7 @@ Feature: Checking for rude words
     When I upload this program
     Then I should get the json object:
     """
-    {"statusCode":511,"answer":"Programname must not contain rude wordes.","preHeaderMessages":""}
+    {"statusCode":511,"answer":"Program name must not contain rude wordes.","preHeaderMessages":""}
     """
 
   Scenario: upload a program with a rude word in description should be rejected

--- a/tests/behat/features/api/register_and_login.feature
+++ b/tests/behat/features/api/register_and_login.feature
@@ -18,7 +18,7 @@ Feature: Login with an existing account or register a new one
     When I POST these parameters to "/app/api/register/Register.json"
     Then I should get the json object:
       """
-      {"token":"rrrrrrrrrrr","statusCode":201,"answer":"Registration successful!","preHeaderMessages":""}
+      {"statusCode":201,"answer":"Registration successful!","token":"rrrrrrrrrrr","preHeaderMessages":""}
       """
 
 

--- a/tests/behat/features/api/search.feature
+++ b/tests/behat/features/api/search.feature
@@ -34,25 +34,25 @@ Feature: Search programs
       | limit  | 1      |
       | offset | 0      |
     When the Request is invoked
-    Then the returned json object will be:
+    Then I should get the json object:
       """
       {
         "CatrobatProjects": [{
-          "ProjectId": 1,
+          "ProjectId": "(.*?)",
           "ProjectName": "Galaxy War",
           "ProjectNameShort": "Galaxy War",
           "Author": "User1",
           "Description": "p1",
           "Version": "0.8.5",
-          "Views": "12",
-          "Downloads": "3",
+          "Views": 12,
+          "Downloads": 3,
           "Private": false,
-          "Uploaded": 1357041600,
+          "Uploaded": 1357038000,
           "UploadedString": "more than one year ago",
           "ScreenshotBig": "images\/default\/screenshot.png",
           "ScreenshotSmall": "images\/default\/thumbnail.png",
-          "ProjectUrl": "app\/program\/1",
-          "DownloadUrl": "app\/download\/1.catrobat",
+          "ProjectUrl": "app\/program\/(.*?)",
+          "DownloadUrl": "app\/download\/(.*?).catrobat",
           "FileSize": 0
         }],
         "completeTerm": "",
@@ -68,16 +68,16 @@ Feature: Search programs
   Scenario: No programs are found
 
     When searching for "NOTHINGTOBEFIOUND"
-    Then the returned json object will be:
+    Then I should get the json object:
       """
       {
-       "completeTerm":"",
-       "CatrobatInformation": {
-         "BaseUrl":"https://pocketcode.org/",
-         "TotalProjects":0,
-         "ProjectsExtension":".catrobat"
-       },
-       "CatrobatProjects":[],
-       "preHeaderMessages":""
+        "CatrobatProjects":[],
+        "completeTerm":"",
+        "preHeaderMessages":"",
+        "CatrobatInformation": {
+          "BaseUrl":"https://pocketcode.org/",
+          "TotalProjects":0,
+          "ProjectsExtension":".catrobat"
+        }
       }
       """

--- a/tests/behat/features/api/search_extension_programs.feature
+++ b/tests/behat/features/api/search_extension_programs.feature
@@ -5,9 +5,9 @@ Feature: Search extensions programs
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-      | User1    | vwxyz    | aaaaaaaaaa |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
+      | User1    | vwxyz    | aaaaaaaaaa |  2 |
     And there are extensions:
       | id | name         | prefix  |
       | 1  | Arduino      | ARDUINO |

--- a/tests/behat/features/api/search_programs.feature
+++ b/tests/behat/features/api/search_programs.feature
@@ -5,10 +5,10 @@ Feature: Search programs
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-      | User1    | vwxyz    | aaaaaaaaaa |
-      | NewUser  | 54321    | bbbbbbbbbb |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
+      | User1    | vwxyz    | aaaaaaaaaa |  2 |
+      | NewUser  | 54321    | bbbbbbbbbb |  3 |
     And there are programs:
       | id | name            | description | owned by | downloads | views | upload time      | version |
       | 1  | Galaxy War      | p1          | User1    | 3         | 12    | 01.01.2013 12:00 | 0.8.5   |
@@ -42,21 +42,21 @@ Feature: Search programs
     """
     {
      "CatrobatProjects":[{
-         "ProjectId":1,
+         "ProjectId": "(.*?)",
          "ProjectName":"Galaxy War",
          "ProjectNameShort":"Galaxy War",
          "Author":"User1",
          "Description":"p1",
          "Version":"0.8.5",
-         "Views":"12",
-         "Downloads":"3",
+         "Views":12,
+         "Downloads":3,
          "Private":false,
-         "Uploaded":1357041600,
+         "Uploaded":1357038000,
          "UploadedString":"more than one year ago",
          "ScreenshotBig":"images/default/screenshot.png",
          "ScreenshotSmall":"images/default/thumbnail.png",
-         "ProjectUrl":"app/program/1",
-         "DownloadUrl":"app/download/1.catrobat",
+         "ProjectUrl":"app/program/(.*?)",
+         "DownloadUrl":"app/download/(.*?).catrobat",
          "FileSize":0
      }],
      "completeTerm":"",
@@ -103,14 +103,14 @@ Feature: Search programs
     Then I should get the json object:
     """
     {
+      "CatrobatProjects":[],
       "completeTerm":"",
+      "preHeaderMessages":"",
       "CatrobatInformation": {
         "BaseUrl":"http:\/\/localhost\/",
         "TotalProjects":0,
         "ProjectsExtension":".catrobat"
-    },
-    "CatrobatProjects":[],
-    "preHeaderMessages":""
+    }
     }
     """
 

--- a/tests/behat/features/api/search_tagged_programs.feature
+++ b/tests/behat/features/api/search_tagged_programs.feature
@@ -5,10 +5,10 @@ Feature: Search tagged programs
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-      | User1    | vwxyz    | aaaaaaaaaa |
-      | Bob      | vewqw    | eeeeeeeeee |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
+      | User1    | vwxyz    | aaaaaaaaaa |  2 |
+      | Bob      | vewqw    | eeeeeeeeee |  3 |
     And there are tags:
       | id | en     | de         |
       | 1  | Games  | Spiele     |

--- a/tests/behat/features/api/upload.feature
+++ b/tests/behat/features/api/upload.feature
@@ -4,14 +4,14 @@ Feature: Upload a program to the website
   Background:
 
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-      | User1    | vwxyz    | aaaaaaaaaa |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
+      | User1    | vwxyz    | aaaaaaaaaa |  2 |
 
   Scenario: Upload program
     Given the HTTP Request:
-      | Method | POST                               |
-      | Url    | /app/api/upload/upload.json |
+      | Method | POST                         |
+      | Url    | /app/api/upload/upload.json  |
     And the POST parameters:
       | Name         | Value                  |
       | username     | Catrobat               |
@@ -21,10 +21,10 @@ Feature: Upload a program to the website
     And the POST parameter "fileChecksum" contains the MD5 sum of the attached file
     And we assume the next generated token will be "rrrrrrrrrrr"
     When the Request is invoked
-    Then the returned json object will be:
+    Then the returned json object with id "1" will be:
           """
           {
-            "projectId": 1,
+            "projectId": "1",
             "statusCode": 200,
             "answer": "Your project was uploaded successfully!",
             "token": "rrrrrrrrrrr",
@@ -35,7 +35,7 @@ Feature: Upload a program to the website
   Scenario Outline: Troubleshooting
     Given the upload problem "<problem>"
     When such a Request is invoked
-    Then the returned json object will be:
+    Then I should get the json object:
           """
           {
             "statusCode": <errorcode>,

--- a/tests/behat/features/api/upload_program.feature
+++ b/tests/behat/features/api/upload_program.feature
@@ -3,9 +3,9 @@ Feature: Upload a program
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-      | User1    | vwxyz    | aaaaaaaaaa |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
+      | User1    | vwxyz    | aaaaaaaaaa |  2 |
     And there are programs:
       | id | name      | description | owned by | downloads | views | upload time      | version |
       | 1  | program 1 | p1          | Catrobat | 3         | 12    | 01.01.2013 12:00 | 0.8.5   |
@@ -18,11 +18,10 @@ Feature: Upload a program
     And I have a valid Catrobat file
     And I have a parameter "fileChecksum" with the md5checksum of "test.catrobat"
     When I POST these parameters to "/app/api/upload/upload.json"
-    Then I should get the json object with random "token" and "projectId":
+    Then I should get the json object:
       """
-      {"projectId":"","statusCode":200,"answer":"Your project was uploaded successfully!","token":"","preHeaderMessages":""}
+      {"projectId":"(.*?)","statusCode":200,"answer":"Your project was uploaded successfully!","token":"(.*?)","preHeaderMessages":""}
       """
-    And the returned "projectId" should be a number
 
   Scenario: missing all prameters will result in an error
     Given I have a parameter "username" with value "Catrobat"

--- a/tests/behat/features/api/upload_program_with_Extension.feature
+++ b/tests/behat/features/api/upload_program_with_Extension.feature
@@ -3,8 +3,8 @@ Feature: Upload a program with extensions
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
     And there are programs:
       | id | name      | description | owned by | downloads | views | upload time      | version |
       | 1  | program 1 | p1          | Catrobat | 3         | 12    | 01.01.2013 12:00 | 0.8.5   |
@@ -16,7 +16,6 @@ Feature: Upload a program with extensions
       | 4  | Phiro        | PHIRO   |
       | 5  | Raspberry Pi | RASPI   |
 
-
   Scenario: upload a program with extensions
     Given I have a program with Arduino, Lego and Phiro extensions
     When I upload this program
@@ -24,7 +23,7 @@ Feature: Upload a program with extensions
 
   Scenario: update a program with extensions
     Given I have a program with Arduino, Lego and Phiro extensions
-    And I upload this program
+    And I upload this program with id "2"
     When I upload the program again without extensions
-    Then the program should be marked with no extensions in the database
+    Then the program with id "2" should be marked with no extensions in the database
 

--- a/tests/behat/features/api/upload_program_with_Tag.feature
+++ b/tests/behat/features/api/upload_program_with_Tag.feature
@@ -3,11 +3,8 @@ Feature: Upload a program with tag
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
-    And there are programs:
-      | id | name      | description | owned by | downloads | views | upload time      | version |
-      | 1  | program 1 | p1          | Catrobat | 3         | 12    | 01.01.2013 12:00 | 0.8.5   |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
     And there are tags:
       | id | en    | de         |
       | 1  | Games | Spiele     |

--- a/tests/behat/features/api/upload_remixed_program_again.feature
+++ b/tests/behat/features/api/upload_remixed_program_again.feature
@@ -3,8 +3,8 @@ Feature: Upload a remixed program with multiple parents
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
 
     And there are programs:
       | id | name      | description | owned by | downloads | views | upload time      | version | remix_root |

--- a/tests/behat/features/api/upload_remixed_program_again_complex.feature
+++ b/tests/behat/features/api/upload_remixed_program_again_complex.feature
@@ -3,8 +3,8 @@ Feature: Upload a remixed program with multiple parents
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
 
     And there are programs:
       | id | name      | description | owned by | downloads | views | upload time      | version | remix_root |

--- a/tests/behat/features/api/upload_remixed_program_with_more_parents.feature
+++ b/tests/behat/features/api/upload_remixed_program_with_more_parents.feature
@@ -68,10 +68,10 @@ Feature: Upload a remixed program with multiple parents
   Scenario: program upload with parent-URL referring to no existing Catrobat programs should not add any remix relations
   (except self referencing relation)
     Given I have a program with "catrobatLanguageVersion" set to "0.993" and "url" set to "Program 10 [/app/program/10], Program 11 [https://share.catrob.at/app/program/11]"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have no Catrobat ancestors except self-relation
     And the uploaded program should have no Scratch parents
     And the uploaded program should have no Catrobat forward descendants except self-relation
@@ -80,10 +80,10 @@ Feature: Upload a remixed program with multiple parents
   Scenario: program upload with parent-URL referring to multiple existing Catrobat root programs
   but Catrobat language version 0.992 should not add any remix relations (except self referencing relation)
     Given I have a program with "catrobatLanguageVersion" set to "0.992" and "url" set to "Program 1 [/app/program/1], Program 8 [https://share.catrob.at/app/program/8]"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have no Catrobat ancestors except self-relation
     And the uploaded program should have no Scratch parents
     And the uploaded program should have no Catrobat forward descendants except self-relation
@@ -92,10 +92,10 @@ Feature: Upload a remixed program with multiple parents
   Scenario: program upload with parent-URL referring to multiple existing Catrobat root programs
   but Catrobat language version 0.991 should not add any remix relations (except self referencing relation)
     Given I have a program with "catrobatLanguageVersion" set to "0.991" and "url" set to "Program 1 [/app/program/1], Program 8 [https://share.catrob.at/app/program/8]"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have no Catrobat ancestors except self-relation
     And the uploaded program should have no Scratch parents
     And the uploaded program should have no Catrobat forward descendants except self-relation
@@ -104,10 +104,10 @@ Feature: Upload a remixed program with multiple parents
   Scenario: program upload with parent-URL referring to multiple existing Catrobat root programs
   but Catrobat language version 0.99 should not add any remix relations (except self referencing relation)
     Given I have a program with "catrobatLanguageVersion" set to "0.99" and "url" set to "Program 1 [/app/program/1], Program 8 [https://share.catrob.at/app/program/8]"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have no Catrobat ancestors except self-relation
     And the uploaded program should have no Scratch parents
     And the uploaded program should have no Catrobat forward descendants except self-relation
@@ -116,10 +116,10 @@ Feature: Upload a remixed program with multiple parents
   Scenario: program upload with parent-URL referring to multiple existing Catrobat root programs
   but Catrobat language version 0.92 should not add any remix relations (except self referencing relation)
     Given I have a program with "catrobatLanguageVersion" set to "0.92" and "url" set to "Program 1 [/app/program/1], Program 8 [https://share.catrob.at/app/program/8]"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have no Catrobat ancestors except self-relation
     And the uploaded program should have no Scratch parents
     And the uploaded program should have no Catrobat forward descendants except self-relation
@@ -140,10 +140,10 @@ Feature: Upload a remixed program with multiple parents
     #               (7)
     #-------------------------------------------------------------------------------------------------------------------
     Given I have a program with "catrobatLanguageVersion" set to "0.993" and "url" set to "Program 1 [/app/program/1], Program 8 [https://share.catrob.at/app/program/8]"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should not be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have a Catrobat forward ancestor having id "1" and depth "1"
     And the uploaded program should have a Catrobat forward ancestor having id "8" and depth "1"
     And the uploaded program should have no further Catrobat forward ancestors
@@ -164,10 +164,10 @@ Feature: Upload a remixed program with multiple parents
     #
     #-------------------------------------------------------------------------------------------------------------------
     Given I have a program with "catrobatLanguageVersion" set to "0.999" and "url" set to "Music Inventor [https://scratch.mit.edu/projects/29495624], The Colour Divide - Trailer [https://scratch.mit.edu/projects/70058680/]"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have no Catrobat ancestors except self-relation
     And the uploaded program should have a Scratch parent having id "29495624"
     And the uploaded program should have a Scratch parent having id "70058680"
@@ -194,10 +194,10 @@ Feature: Upload a remixed program with multiple parents
     #
     #-------------------------------------------------------------------------------------------------------------------
     Given I have a program with "catrobatLanguageVersion" set to "1" and "url" set to "Program 2 [/pocketalice/program/2], Merge 1 [Program 7 [/app/program/7], Program 9 [https://share.catrob.at/app/program/9]]"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should not be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have a Catrobat forward ancestor having id "1" and depth "2"
     And the uploaded program should have a Catrobat forward ancestor having id "1" and depth "4"
     And the uploaded program should have a Catrobat forward ancestor having id "1" and depth "5"
@@ -247,10 +247,10 @@ Feature: Upload a remixed program with multiple parents
     #       This test will also check that no backward parents of parent program will be linked to the uploaded program.
     #-------------------------------------------------------------------------------------------------------------------
     Given I have a program with "catrobatLanguageVersion" set to "1.0" and "url" set to "The Colour Divide - Trailer [https://scratch.mit.edu/projects/70058680/], Merge 2 [Program 2 [/pocketalice/program/2], Merge 1 [Program 6 [/app/program/6], Program 8 [https://share.catrob.at/app/program/8]]]"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should not be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have a Catrobat forward ancestor having id "1" and depth "2"
     And the uploaded program should have a Catrobat forward ancestor having id "1" and depth "3"
     And the uploaded program should have a Catrobat forward ancestor having id "1" and depth "4"
@@ -298,10 +298,10 @@ Feature: Upload a remixed program with multiple parents
     #       This test will also check that no backward parents of parent program will be linked to the uploaded program.
     #-------------------------------------------------------------------------------------------------------------------
     Given I have a program with "catrobatLanguageVersion" set to "1.1" and "url" set to "The Colour Divide - Trailer [https://scratch.mit.edu/projects/70058680/], Merge 2 [Program 2 [/pocketalice/program/2], Merge 1 [Program 6 [/app/program/6], Program 8 [https://share.catrob.at/app/program/8]]]"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should not be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have a Catrobat forward ancestor having id "1" and depth "2"
     And the uploaded program should have a Catrobat forward ancestor having id "1" and depth "3"
     And the uploaded program should have a Catrobat forward ancestor having id "1" and depth "4"

--- a/tests/behat/features/api/upload_remixed_program_with_one_parent.feature
+++ b/tests/behat/features/api/upload_remixed_program_with_one_parent.feature
@@ -3,8 +3,8 @@ Feature: Upload a remixed program with one parent
 
   Background:
     Given there are users:
-      | name     | password | token      |
-      | Catrobat | 12345    | cccccccccc |
+      | name     | password | token      | id |
+      | Catrobat | 12345    | cccccccccc |  1 |
 
     And there are programs:
       | id | name      | description | owned by | downloads | views | upload time      | version | remix_root |
@@ -37,10 +37,10 @@ Feature: Upload a remixed program with one parent
 
   Scenario: program upload with no parent-URL should not add any remix relations (except self referencing relation)
     Given I have a program with "url" set to ""
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have no Catrobat ancestors except self-relation
     And the uploaded program should have no Scratch parents
     And the uploaded program should have no Catrobat forward descendants except self-relation
@@ -48,10 +48,10 @@ Feature: Upload a remixed program with one parent
 
   Scenario: program upload with local program name parent-URL should not add any remix relations (except self referencing relation)
     Given I have a program with "url" set to "My first program"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have no Catrobat ancestors except self-relation
     And the uploaded program should have no Scratch parents
     And the uploaded program should have no Catrobat forward descendants except self-relation
@@ -59,10 +59,10 @@ Feature: Upload a remixed program with one parent
 
   Scenario: program upload with invalid parent-URL should not add any remix relations (except self referencing relation)
     Given I have a program with "url" set to "https://www.google.com"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have no Catrobat ancestors except self-relation
     And the uploaded program should have no Scratch parents
     And the uploaded program should have no Catrobat forward descendants except self-relation
@@ -71,10 +71,10 @@ Feature: Upload a remixed program with one parent
   Scenario: program upload with parent-URL referring to own Catrobat program should not add any remix relations
   (except self referencing relation)
     Given I have a program with "url" set to "/app/program/10"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have no Catrobat ancestors except self-relation
     And the uploaded program should have no Scratch parents
     And the uploaded program should have no Catrobat forward descendants except self-relation
@@ -83,10 +83,10 @@ Feature: Upload a remixed program with one parent
   Scenario: program upload with parent-URL referring to no existing Catrobat program should not add any remix relations
   (except self referencing relation)
     Given I have a program with "url" set to "/app/program/11"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have no Catrobat ancestors except self-relation
     And the uploaded program should have no Scratch parents
     And the uploaded program should have no Catrobat forward descendants except self-relation
@@ -103,10 +103,10 @@ Feature: Upload a remixed program with one parent
     #             (3)
     #-------------------------------------------------------------------------------------------------------------------
     Given I have a program with "url" set to "/app/program/1"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should not be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have a Catrobat forward ancestor having id "1" and depth "1"
     And the uploaded program should have no further Catrobat forward ancestors
     And the uploaded program should have no Catrobat backward parents
@@ -125,10 +125,11 @@ Feature: Upload a remixed program with one parent
     #            (3) (10)      <-- to be added (uploaded program will get ID "10")
     #-------------------------------------------------------------------------------------------------------------------
     Given I have a program with "url" set to "/pocketalice/program/2"
-    When I upload a program
+    When I upload the program with the id "10"
+
     Then the uploaded program should not be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have a Catrobat forward ancestor having id "2" and depth "1"
     And the uploaded program should have a Catrobat forward ancestor having id "1" and depth "2"
     And the uploaded program should have no further Catrobat forward ancestors
@@ -149,10 +150,10 @@ Feature: Upload a remixed program with one parent
     #             (10)      <-- to be added (uploaded program will get ID "10")
     #-------------------------------------------------------------------------------------------------------------------
     Given I have a program with "url" set to "/pocketalice/program/3"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should not be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have a Catrobat forward ancestor having id "3" and depth "1"
     And the uploaded program should have a Catrobat forward ancestor having id "2" and depth "2"
     And the uploaded program should have a Catrobat forward ancestor having id "1" and depth "3"
@@ -172,10 +173,10 @@ Feature: Upload a remixed program with one parent
     #
     #-------------------------------------------------------------------------------------------------------------------
     Given I have a program with "url" set to "https://scratch.mit.edu/projects/70058680"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have no Catrobat ancestors except self-relation
     And the uploaded program should have a Scratch parent having id "70058680"
     And the uploaded program should have no further Scratch parents
@@ -229,10 +230,10 @@ Feature: Upload a remixed program with one parent
       | 70058680          | 9                 |
 
     Given I have a program with "url" set to "/pocketalice/program/9"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should not be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have a Catrobat forward ancestor having id "9" and depth "1"
     And the uploaded program should have a Catrobat forward ancestor having id "6" and depth "2"
     And the uploaded program should have a Catrobat forward ancestor having id "5" and depth "2"
@@ -290,10 +291,10 @@ Feature: Upload a remixed program with one parent
       | 70058680          | 8                 |
 
     Given I have a program with "url" set to "/pocketalice/program/5"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should not be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have a Catrobat forward ancestor having id "5" and depth "1"
     And the uploaded program should have a Catrobat forward ancestor having id "4" and depth "2"
     And the uploaded program should have no further Catrobat forward ancestors
@@ -353,10 +354,10 @@ Feature: Upload a remixed program with one parent
       | 70058680          | 8                 |
 
     Given I have a program with "url" set to "/pocketalice/program/7"
-    When I upload a program
+    When I upload the program with the id "10"
     Then the uploaded program should not be a remix root
     And the uploaded program should have remix migration date NOT NULL
-    And the uploaded program should have a Catrobat forward ancestor having id "10" and depth "0"
+    And the uploaded program should have a Catrobat forward ancestor having its own id and depth "0"
     And the uploaded program should have a Catrobat forward ancestor having id "7" and depth "1"
     And the uploaded program should have no further Catrobat forward ancestors
     And the uploaded program should have no Catrobat backward parents

--- a/tests/behat/features/api/upload_validation.feature
+++ b/tests/behat/features/api/upload_validation.feature
@@ -48,7 +48,7 @@ Feature: All uploaded programs have to be validated.
     When I upload a program
     Then I should get the json object:
     """
-      {"statusCode":519,"answer":"Sorry, you are using an old version of Pocket Code. Please update to the lastest version.","preHeaderMessages":""}
+      {"statusCode":519,"answer":"Sorry, you are using an old version of Pocket Code. Please update to the latest version.","preHeaderMessages":""}
     """
 
     Examples:
@@ -75,7 +75,7 @@ Feature: All uploaded programs have to be validated.
     When I upload a program
     Then I should get the json object:
     """
-      {"statusCode":518,"answer":"Sorry, your programm contains an old version of the Catrobat language! Are you using the latest version of Pocket Code?","preHeaderMessages":""}
+      {"statusCode":518,"answer":"Sorry, your program contains an old version of the Catrobat language! Are you using the latest version of Pocket Code?","preHeaderMessages":""}
     """
 
 

--- a/tests/behat/features/bootstrap/AdminFeatureContext.php
+++ b/tests/behat/features/bootstrap/AdminFeatureContext.php
@@ -310,7 +310,6 @@ class AdminFeatureContext extends MinkContext implements KernelAwareContext
   }
 
   /**
-   *
    * @return User
    */
   public function getDefaultUser()
@@ -319,7 +318,6 @@ class AdminFeatureContext extends MinkContext implements KernelAwareContext
   }
 
   /**
-   *
    * @return \Symfony\Component\HttpKernel\Profiler\Profiler
    */
   public function getSymfonyProfile()
@@ -362,16 +360,17 @@ class AdminFeatureContext extends MinkContext implements KernelAwareContext
   }
 
   /**
-   * @param        $file
-   * @param        $user
+   * @param $file
+   * @param $user
    * @param string $flavor
-   * @param null   $request_parameters
-   *
-   * @return null|\Symfony\Component\HttpFoundation\Response
+   * @param null $request_parameters
+   * @return \Symfony\Component\HttpFoundation\Response|null
+   * @throws \Doctrine\ORM\ORMException
+   * @throws \Doctrine\ORM\OptimisticLockException
    */
   public function upload($file, $user, $flavor = 'pocketcode', $request_parameters = null)
   {
-    return $this->symfony_support->upload($file, $user, $flavor, $request_parameters);
+    return $this->symfony_support->upload($file, $user, null, $flavor, $request_parameters);
   }
 
   // endregion GETTER & SETTER
@@ -482,6 +481,7 @@ class AdminFeatureContext extends MinkContext implements KernelAwareContext
     foreach ($program_stats as $program_stat)
     {
       $program = $this->getProgramManger()->find($program_stat['program_id']);
+
       $config = [
         'downloaded_at' => $program_stat['downloaded_at'],
         'ip'            => $program_stat['ip'],
@@ -941,6 +941,7 @@ class AdminFeatureContext extends MinkContext implements KernelAwareContext
         'username' => isset($program['owned by']) ? $program['owned by'] : "",
       ]);
       @$config = [
+        'id'                  => $program['id'], // overwrite auto generation for testing purposes
         'name'                => $program['name'],
         'description'         => $program['description'],
         'views'               => $program['views'],

--- a/tests/behat/features/bootstrap/BaseContext.php
+++ b/tests/behat/features/bootstrap/BaseContext.php
@@ -57,7 +57,6 @@ class BaseContext implements KernelAwareContext
     return $this->symfony_support;
   }
 
-
   /**
    *
    * @return \Symfony\Bundle\FrameworkBundle\Client
@@ -415,16 +414,18 @@ class BaseContext implements KernelAwareContext
   }
 
   /**
-   * @param        $file
-   * @param        $user
+   * @param $file
+   * @param $user
+   * @param $desired_id
    * @param string $flavor
-   * @param null   $request_parameters
-   *
+   * @param null $request_parameters
    * @return \Symfony\Component\HttpFoundation\Response|null
+   * @throws \Doctrine\ORM\ORMException
+   * @throws \Doctrine\ORM\OptimisticLockException
    */
-  public function upload($file, $user, $flavor = 'pocketcode', $request_parameters = null)
+  public function upload($file, $user, $desired_id=null, $flavor = 'pocketcode', $request_parameters = null)
   {
-    return $this->symfony_support->upload($file, $user, $flavor, $request_parameters);
+    return $this->symfony_support->upload($file, $user, $desired_id, $flavor, $request_parameters);
   }
 
   /**

--- a/tests/behat/features/bootstrap/FlavorFeatureContext.php
+++ b/tests/behat/features/bootstrap/FlavorFeatureContext.php
@@ -45,7 +45,7 @@ class FlavorFeatureContext extends BaseContext
   {
     $user = $this->insertUser();
     $program = $this->getStandardProgramFile();
-    $response = $this->upload($program, $user, 'pocketphiro');
+    $response = $this->upload($program, $user, 1,'pocketphiro');
     Assert::assertEquals(200, $response->getStatusCode(), 'Wrong response code. ' . $response->getContent());
   }
 
@@ -67,7 +67,7 @@ class FlavorFeatureContext extends BaseContext
   {
     $user = $this->insertUser();
     $program = $this->getStandardProgramFile();
-    $response = $this->upload($program, $user);
+    $response = $this->upload($program, $user, 1);
     Assert::assertEquals(200, $response->getStatusCode(), 'Wrong response code. ' . $response->getContent());
   }
 
@@ -158,8 +158,14 @@ class FlavorFeatureContext extends BaseContext
    */
   public function iGetTheUserSProgramsWith($url)
   {
+    /**
+     * @var $user \App\Entity\User
+     * @var $pr \App\Repository\ProgramRepository
+     */
+    $user = $this->getUserManager()->findAll()[0];
+
     $this->getClient()->request('GET', $url, [
-      'user_id' => 1,
+      'user_id' => $user->getId(),
     ]);
   }
 }

--- a/tests/behat/features/bootstrap/GamejamFeatureContext.php
+++ b/tests/behat/features/bootstrap/GamejamFeatureContext.php
@@ -129,6 +129,21 @@ class GamejamFeatureContext extends BaseContext
   }
 
   /**
+   * @Given the program has the id :arg1
+   */
+  public function theProgramHasTheId($id)
+  {
+    /**
+     * @var \App\Entity\Program $program
+     */
+    $program = $this->getProgramManger()->findAll()[0];
+    $program->setId($id);
+    $this->getManager()->persist($program);
+    $this->getManager()->flush();
+  }
+
+
+  /**
    * @Given I already filled the google form
    */
   public function iAlreadyFilledTheGoogleForm()
@@ -222,7 +237,7 @@ class GamejamFeatureContext extends BaseContext
   public function iUploadMyGame()
   {
     $file = $this->getSymfonySupport()->getDefaultProgramFile();
-    $this->getSymfonySupport()->upload($file, null);
+    $this->getSymfonySupport()->upload($file, null, null);
   }
 
   /**
@@ -262,15 +277,17 @@ class GamejamFeatureContext extends BaseContext
   }
 
   /**
-   * @Then The returned url should be
+   * @Then The returned url with id :id should be
    * @param PyStringNode $string
    */
-  public function theReturnedUrlShouldBe(PyStringNode $string)
+  public function theReturnedUrlShouldBe($id, PyStringNode $string)
   {
-    $answer = json_decode($this->getClient()
-      ->getResponse()
-      ->getContent(), true);
-    Assert::assertEquals($string->getRaw(), $answer['form']);
+    $answer = (array) json_decode($this->getClient()->getResponse()->getContent());
+
+    $form_url = $answer['form'];
+    $form_url = preg_replace("/&id=.*?&mail=/", "&id=" . $id ."&mail=", $form_url, -1);
+
+    Assert::assertEquals($string->getRaw(), $form_url);
   }
 
   /**
@@ -419,8 +436,8 @@ class GamejamFeatureContext extends BaseContext
   public function iUpdateMyProgram()
   {
     $file = $this->getSymfonySupport()->getDefaultProgramFile();
-    $this->getSymfonySupport()->upload($file, $this->i);
-    $this->getSymfonySupport()->upload($file, $this->i);
+    $this->getSymfonySupport()->upload($file, $this->i, null);
+    $this->getSymfonySupport()->upload($file, $this->i, null);
   }
 
   /**

--- a/tests/behat/features/bootstrap/WebFeatureContext.php
+++ b/tests/behat/features/bootstrap/WebFeatureContext.php
@@ -641,10 +641,14 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
       $user->setEnabled(true);
       $user->setUploadToken($users[$i]['token']);
       $user->setCountry('at');
-      $user_manager->updateUser($user, false);
+      $user_manager->updateUser($user, true);
+
+      if (array_key_exists('id', $users[$i])) {
+        $user->setId($users[$i]['id']);
+        $em = $this->kernel->getContainer()->get('doctrine')->getManager();
+        $em->flush();
+      }
     }
-    $em = $this->kernel->getContainer()->get('doctrine')->getManager();
-    $em->flush();
   }
 
   /**
@@ -799,6 +803,17 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
       $program->setPrivate(isset($programs[$i]['private']) ? $programs[$i]['private'] : 0);
       $program->setDebugBuild(isset($programs[$i]['debug']) ? $programs[$i]['debug'] == 'true' : false);
 
+      $em->persist($program);
+
+      // overwrite id if desired
+      if (array_key_exists('id', $programs[$i])) {
+        $program->setId($programs[$i]['id']);
+        $em->persist($program);
+        $em->flush();
+        $program_repo = $em->getRepository('App\Entity\Program');
+        $program = $program_repo->find($programs[$i]['id']);
+      }
+
       if (isset($programs[$i]['tags_id']) && $programs[$i]['tags_id'] != null)
       {
         $tag_repo = $em->getRepository('App\Entity\Tag');
@@ -831,8 +846,6 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
         $file_repo = $this->kernel->getContainer()->get('filerepository');
         $file_repo->saveProgramfile(new File(self::FIXTUREDIR . 'test.catrobat'), $i);
       }
-
-      $em->persist($program);
     }
     $em->flush();
   }
@@ -1600,6 +1613,17 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
       $program->setApproved(false);
       $program->setRemixRoot(isset($programs[$i]['remix_root']) ? $programs[$i]['remix_root'] == 'true' : true);
       $program->setDebugBuild(isset($programs[$i]['debug']) ? $programs[$i]['debug'] : false);
+
+      $em->persist($program);
+
+      // overwrite id if desired
+      if (array_key_exists('id', $programs[$i])) {
+        $program->setId($programs[$i]['id']);
+        $em->persist($program);
+        $em->flush();
+        $program_repo = $em->getRepository('App\Entity\Program');
+        $program = $program_repo->find($programs[$i]['id']);
+      }
 
       if (isset($programs[$i]['tags_id']) && $programs[$i]['tags_id'] != null)
       {
@@ -2622,7 +2646,7 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
    */
   public function iClickOnTheFirstRecommendedHomepageProgram()
   {
-    $arg1 = '#program-1 .homepage-recommended-programs';
+    $arg1 = '.homepage-recommended-programs';
     $this->assertSession()->elementExists('css', $arg1);
 
     $this
@@ -2999,6 +3023,13 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
         $program->setRemixRoot(true);
         $program->setDebugBuild(isset($programs[$i]['debug']) ? $programs[$i]['debug'] : false);
         $em->persist($program);
+
+        // overwrite id if desired
+        if (array_key_exists('id', $programs[$i])) {
+          $program->setId($programs[$i]['id']);
+          $em->persist($program);
+          $em->flush();
+        }
       }
       $em->flush();
     } catch (Exception $e)

--- a/tests/behat/features/ci/apk_download.feature
+++ b/tests/behat/features/ci/apk_download.feature
@@ -2,11 +2,11 @@ Feature:
 
   Background:
     Given there are programs:
-      | name              | apk status | visible |
-      | Galaxy War        | none       | true    |
-      | My little program | pending    | true    |
-      | Bunny             | ready      | true    |
-      | Whack a Marko     | ready      | false   |
+      | name              | apk status | visible | id |
+      | Galaxy War        | none       | true    | 1  |
+      | My little program | pending    | true    | 2  |
+      | Bunny             | ready      | true    | 3  |
+      | Whack a Marko     | ready      | false   | 4  |
 
   Scenario:
     When I want to download the apk file of "Bunny"

--- a/tests/behat/features/ci/apk_generation.feature
+++ b/tests/behat/features/ci/apk_generation.feature
@@ -11,13 +11,13 @@ Feature:
     And the jenkins token is "SECRETTOKEN"
     When I start an apk generation of my program
     Then following parameters are sent to jenkins:
-      | parameter | value                                                          |
-      | job       | Build-Program                                                  |
-      | token     | SECRETTOKEN                                                    |
-      | SUFFIX    | generated1                                                     |
-      | DOWNLOAD  | http://pocketcode.org/app/download/1.catrobat           |
-      | UPLOAD    | http://pocketcode.org/app/ci/upload/1?token=UPLOADTOKEN |
-      | ONERROR   | http://pocketcode.org/app/ci/failed/1?token=UPLOADTOKEN |
+      | parameter | value                                                         |
+      | job       | /Build-Program/                                               |
+      | token     | /SECRETTOKEN/                                                 |
+      | SUFFIX    | /generated(.*?)/                                              |
+      | DOWNLOAD  | #http://pocketcode.org/app/download/(.*?).catrobat#           |
+      | UPLOAD    | #http://pocketcode.org/app/ci/upload/(.*?)?token=UPLOADTOKEN# |
+      | ONERROR   | #http://pocketcode.org/app/ci/failed/(.*?)?token=UPLOADTOKEN# |
     And the program apk status will be flagged "pending"
 
   Scenario: Accept the compiled apk from jenkins
@@ -46,10 +46,9 @@ Feature:
     Then the program apk status will still be flagged "ready"
 
   Scenario: reset apk status after an update
-    Given I have a program "My little program" with id "1"
+    Given I have a program "My little program2" with id "1"
     And the program apk status is flagged "ready"
     When I update this program
     Then the program apk status will still be flagged "none"
     And the apk file will be deleted
-        
-        
+

--- a/tests/behat/features/ci/get_apk_status.feature
+++ b/tests/behat/features/ci/get_apk_status.feature
@@ -3,7 +3,7 @@ Feature: Get the APK status of a program
   Scenario: get the apk status pending
     Given I have a program "My little program" with id "1"
     And the program apk status is flagged "pending"
-    When I GET "/app/ci/status/1"
+    When I GET "/app/ci/status/@id@" with program id "1"
     Then will get the following JSON:
         """
         { 
@@ -15,12 +15,12 @@ Feature: Get the APK status of a program
   Scenario: get the apk status ready
     Given I have a program "My little program" with id "1"
     And the program apk status is flagged "ready"
-    When I GET "/app/ci/status/1"
+    When I GET "/app/ci/status/@id@" with program id "1"
     Then will get the following JSON:
         """
         { 
           "status" : "ready",
-          "url" : "http://localhost/app/ci/download/1?fname=My%20little%20program",
+          "url" : "http://localhost/app/ci/download/(.*)?fname=My%20little%20program",
           "label" : "Download Apk"
         }
         """
@@ -28,11 +28,11 @@ Feature: Get the APK status of a program
   Scenario: get the apk status none
     Given I have a program "My little program" with id "1"
     And the program apk status is flagged "none"
-    When I GET "/app/ci/status/1"
+    When I GET "/app/ci/status/@id@" with program id "1"
     Then will get the following JSON:
         """
         {
-          "status" : "none",
-          "label" : "Generate Apk"
+          "label" : "Generate Apk",
+          "status" : "none"
         }
         """

--- a/tests/behat/features/gamejam/api.feature
+++ b/tests/behat/features/gamejam/api.feature
@@ -16,6 +16,7 @@ Feature:
   Scenario:
     Given There is an ongoing game jam
     And I already submitted my game
+    And the program has the id "1"
     And I already filled the google form
     When I GET "/pocketalice/api/gamejam/submissions.json"
     Then I should receive my program

--- a/tests/behat/features/gamejam/google_form.feature
+++ b/tests/behat/features/gamejam/google_form.feature
@@ -8,7 +8,7 @@ Feature: On upload a google form link should be created with some parameters set
           """
     And I am "Catrobat" with email "catrobat@catrob.at"
     When I submit a game which gets the id "1"
-    Then The returned url should be
+    Then The returned url with id "1" should be
           """
           https://someurl.google.com/myform?name=Catrobat&id=1&mail=catrobat@catrob.at
           """

--- a/tests/behat/features/gamejam/jam_submission.feature
+++ b/tests/behat/features/gamejam/jam_submission.feature
@@ -5,6 +5,7 @@ Feature: Submitting games to a game jam
 
     Given There is an ongoing game jam
     When I submit a game
+    And the program has the id "1"
     Then I should get the url to the google form
     But The game is not yet accepted
 
@@ -12,6 +13,7 @@ Feature: Submitting games to a game jam
   Scenario: Accepting a game
 
     Given I submitted a game
+    And the program has the id "1"
     When I fill out the google form
     Then My game should be accepted
 
@@ -21,6 +23,7 @@ Feature: Submitting games to a game jam
 
     Given There is an ongoing game jam
     And I already submitted my game
+    And the program has the id "1"
     And I already filled the google form
     When I resubmit my game
     Then It should be updated
@@ -33,6 +36,7 @@ Feature: Submitting games to a game jam
 
     Given There is an ongoing game jam
     And I already submitted my game
+    And the program has the id "1"
     But I did not fill out the google form
     When I resubmit my game
     Then It should be updated

--- a/tests/behat/features/gamejam/program_snapshots.feature
+++ b/tests/behat/features/gamejam/program_snapshots.feature
@@ -5,5 +5,6 @@ Feature: To avoid accidental losing program files due to overriding on limited a
   Scenario:
     Given I have a limited account
     When I update my program
+    And the program has the id "1"
     Then A copy of this program will be stored on the server
      

--- a/tests/behat/features/web/click_statistics.feature
+++ b/tests/behat/features/web/click_statistics.feature
@@ -6,6 +6,7 @@ Feature: Creating click statistics by clicking on tags, extensions and recommend
       | name      | password | token      | email               |
       | Catrobat  | 123456   | cccccccccc | dev1@pocketcode.org |
       | OtherUser | 123456   | dddddddddd | dev2@pocketcode.org |
+
     And there are extensions:
       | id | name         | prefix  |
       | 1  | Arduino      | ARDUINO |
@@ -13,6 +14,7 @@ Feature: Creating click statistics by clicking on tags, extensions and recommend
       | 3  | Lego         | LEGO    |
       | 4  | Phiro        | PHIRO   |
       | 5  | Raspberry Pi | RASPI   |
+
     And there are tags:
       | id | en           | de           |
       | 1  | Game         | Spiel        |
@@ -72,7 +74,7 @@ Feature: Creating click statistics by clicking on tags, extensions and recommend
     Given I am on "/app"
     Then I wait for AJAX to finish
     When I click on the first featured homepage program
-    And I wait 500 milliseconds
+    And I wait 100 milliseconds
     Then There should be one homepage click database entry with type is "featured" and program id is "2"
     And There should be no recommended click statistic database entry
     And I should see "Galaxy"
@@ -83,7 +85,7 @@ Feature: Creating click statistics by clicking on tags, extensions and recommend
     Given I am on "/app"
     Then I wait for AJAX to finish
     When I click on a newest homepage program having program id "2"
-    And I wait 500 milliseconds
+    And I wait 100 milliseconds
     Then There should be one homepage click database entry with type is "newest" and program id is "2"
     And There should be no recommended click statistic database entry
     And I should see "Galaxy"
@@ -94,7 +96,7 @@ Feature: Creating click statistics by clicking on tags, extensions and recommend
     Given I am on "/app"
     Then I wait for AJAX to finish
     When I click on a most downloaded homepage program having program id "3"
-    And I wait 500 milliseconds
+    And I wait 100 milliseconds
     Then There should be one homepage click database entry with type is "mostDownloaded" and program id is "3"
     And There should be no recommended click statistic database entry
     And I should see "Alone"
@@ -105,7 +107,7 @@ Feature: Creating click statistics by clicking on tags, extensions and recommend
     Given I am on "/app"
     Then I wait for AJAX to finish
     When I click on a most viewed homepage program having program id "4"
-    And I wait 500 milliseconds
+    And I wait 100 milliseconds
     Then There should be one homepage click database entry with type is "mostViewed" and program id is "4"
     And There should be no recommended click statistic database entry
     And I should see "Trolol"
@@ -116,7 +118,7 @@ Feature: Creating click statistics by clicking on tags, extensions and recommend
     Given I am on "/app"
     Then I wait for AJAX to finish
     When I click on a random homepage program having program id "2"
-    And I wait 500 milliseconds
+    And I wait 100 milliseconds
     Then There should be one homepage click database entry with type is "random" and program id is "2"
     And There should be no recommended click statistic database entry
     And I should see "Galaxy"
@@ -126,21 +128,21 @@ Feature: Creating click statistics by clicking on tags, extensions and recommend
   Scenario: Create one statistic entry from recommended programs on homepage
     Given there are programs:
       | id | name    | description | owned by  | downloads | apk_downloads | views | upload time      | version |
-      | 1  | Minions | p1          | Catrobat  | 3         | 2             | 12    | 01.01.2013 12:00 | 0.8.5   |
-      | 2  | Galaxy  | p2          | OtherUser | 10        | 12            | 13    | 01.02.2013 12:00 | 0.8.5   |
-      | 3  | Alone   | p3          | Catrobat  | 5         | 55            | 2     | 01.03.2013 12:00 | 0.8.5   |
+      | 21 | Minions | p1          | Catrobat  | 3         | 2             | 12    | 01.01.2013 12:00 | 0.8.5   |
+      | 22 | Galaxy  | p2          | OtherUser | 10        | 12            | 13    | 01.02.2013 12:00 | 0.8.5   |
+      | 23 | Alone   | p3          | Catrobat  | 5         | 55            | 2     | 01.03.2013 12:00 | 0.8.5   |
 
     And there are likes:
       | username  | program_id | type | created at       |
-      | Catrobat  | 1          | 1    | 01.01.2017 12:00 |
-      | Catrobat  | 2          | 2    | 01.01.2017 12:00 |
-      | OtherUser | 1          | 4    | 01.01.2017 12:00 |
+      | Catrobat  | 21         | 1    | 01.01.2017 12:00 |
+      | Catrobat  | 22         | 2    | 01.01.2017 12:00 |
+      | OtherUser | 21         | 4    | 01.01.2017 12:00 |
     Given I am on "/app"
-    Then I wait 500 milliseconds
-    Then I should see a recommended homepage program having ID "1" and name "Minions"
+    Then I wait 100 milliseconds
+    Then I should see a recommended homepage program having ID "21" and name "Minions"
     When I click on the first recommended homepage program
-    And I wait 500 milliseconds
-    Then There should be one database entry with type is "rec_homepage" and "program_id" is "1"
+    And I wait 100 milliseconds
+    Then There should be one database entry with type is "rec_homepage" and "program_id" is "21"
     Then There should be one database entry with type is "rec_homepage" and "user_specific_recommendation" is "false"
     And There should be no homepage click statistic database entry
     And I should see "Minions"
@@ -156,7 +158,7 @@ Feature: Creating click statistics by clicking on tags, extensions and recommend
     And I am on "/app/program/1"
     Then There should be recommended specific programs
     When I click on the first recommended specific program
-    And I wait 500 milliseconds
+    And I wait 100 milliseconds
     Then There should be one database entry with type is "rec_specific_programs" and "program_id" is "3"
     And I should see "Alone"
     And I should see "p3"

--- a/tests/behat/features/web/follow.feature
+++ b/tests/behat/features/web/follow.feature
@@ -3,23 +3,23 @@ Feature: Follow feature on profiles
 
   Background:
     Given there are users:
-      | name       | password | token      | email                |
-      | Catrobat   | 123456   | cccccccccc | dev1@pocketcode.org  |
-      | Catrobat2  | 123456   | dddddddddd | dev2@pocketcode.org  |
-      | Catrobat3  | 123456   | eeeeeeeeee | dev3@pocketcode.org  |
-      | Catrobat4  | 123456   | ffffffffff | dev4@pocketcode.org  |
-      | Catrobat5  | 123456   | gggggggggg | dev5@pocketcode.org  |
-      | Catrobat6  | 123456   | hhhhhhhhhh | dev6@pocketcode.org  |
-      | Catrobat7  | 123456   | iiiiiiiiii | dev7@pocketcode.org  |
-      | Catrobat8  | 123456   | jjjjjjjjjj | dev8@pocketcode.org  |
-      | Catrobat9  | 123456   | kkkkkkkkkk | dev9@pocketcode.org  |
-      | Catrobat10 | 123456   | llllllllll | dev10@pocketcode.org |
-      | Catrobat11 | 123456   | mmmmmmmmmm | dev11@pocketcode.org |
-      | Catrobat12 | 123456   | nnnnnnnnnn | dev12@pocketcode.org |
-      | Catrobat13 | 123456   | oooooooooo | dev13@pocketcode.org |
-      | Catrobat14 | 123456   | pppppppppp | dev14@pocketcode.org |
-      | Catrobat15 | 123456   | qqqqqqqqqq | dev15@pocketcode.org |
-      | Catrobat16 | 123456   | rrrrrrrrrr | dev16@pocketcode.org |
+      | name       | password | token      | email                | id |
+      | Catrobat   | 123456   | cccccccccc | dev1@pocketcode.org  |  1 |
+      | Catrobat2  | 123456   | dddddddddd | dev2@pocketcode.org  |  2 |
+      | Catrobat3  | 123456   | eeeeeeeeee | dev3@pocketcode.org  |  3 |
+      | Catrobat4  | 123456   | ffffffffff | dev4@pocketcode.org  |  4 |
+      | Catrobat5  | 123456   | gggggggggg | dev5@pocketcode.org  |  5 |
+      | Catrobat6  | 123456   | hhhhhhhhhh | dev6@pocketcode.org  |  6 |
+      | Catrobat7  | 123456   | iiiiiiiiii | dev7@pocketcode.org  |  7 |
+      | Catrobat8  | 123456   | jjjjjjjjjj | dev8@pocketcode.org  |  8 |
+      | Catrobat9  | 123456   | kkkkkkkkkk | dev9@pocketcode.org  |  9 |
+      | Catrobat10 | 123456   | llllllllll | dev10@pocketcode.org | 10 |
+      | Catrobat11 | 123456   | mmmmmmmmmm | dev11@pocketcode.org | 11 |
+      | Catrobat12 | 123456   | nnnnnnnnnn | dev12@pocketcode.org | 12 |
+      | Catrobat13 | 123456   | oooooooooo | dev13@pocketcode.org | 13 |
+      | Catrobat14 | 123456   | pppppppppp | dev14@pocketcode.org | 14 |
+      | Catrobat15 | 123456   | qqqqqqqqqq | dev15@pocketcode.org | 15 |
+      | Catrobat16 | 123456   | rrrrrrrrrr | dev16@pocketcode.org | 16 |
 
   Scenario: Follow button and counter should show up on Profile site
     Given I am on "/app/profile/1"

--- a/tests/behat/features/web/my_profile.feature
+++ b/tests/behat/features/web/my_profile.feature
@@ -6,9 +6,9 @@ Feature:
 
   Background:
     Given there are users:
-      | name     | password | token      | email               |
-      | Catrobat | 123456   | cccccccccc | dev1@app.org |
-      | User1    | 654321   | cccccccccc | dev2@app.org |
+      | name     | password | token      | email        | id |
+      | Catrobat | 123456   | cccccccccc | dev1@app.org |  1 |
+      | User1    | 654321   | cccccccccc | dev2@app.org |  2 |
     And there are programs:
       | id | name       | description | owned by | downloads | apk_downloads | views | upload time      | version | language version | private |
       | 1  | program 1  | p1          | Catrobat | 3         | 2             | 12    | 01.01.2013 12:00 | 0.8.5   | 0.6              | 0       |

--- a/tests/behat/features/web/private_program.feature
+++ b/tests/behat/features/web/private_program.feature
@@ -3,9 +3,9 @@ Feature: As a visitor I want to see a program page
 
   Background:
     Given there are users:
-      | name           | password | token      | email               |
-      | myUsername     | 123456   | cccccccccc | dev1@pocketcode.org |
-      | randomUsername | 123456   | cccccccccc | dev2@pocketcode.org |
+      | name           | password | token      | email               | id |
+      | myUsername     | 123456   | cccccccccc | dev1@pocketcode.org |  1 |
+      | randomUsername | 123456   | cccccccccc | dev2@pocketcode.org |  2 |
     And there are programs:
       | id | name      | description | owned by   | downloads | apk_downloads | views | upload time      | version | language version | visible | apk_ready | private |
       | 1  | program 1 | ......      | myUsername | 3         | 2             | 12    | 01.01.2013 12:00 | 0.8.5   | 0.94             | true    | true      | 0       |
@@ -19,53 +19,53 @@ Feature: As a visitor I want to see a program page
     And I should not see "program 3"
 
   Scenario: Your own private programs should always be visible to you
-    Given I am on "/pocketcode/login"
+    Given I am on "/app/login"
     And I fill in "username" with "myUsername"
     And I fill in "password" with "123456"
     And I press "Login"
-    When I am on "/pocketcode/program/1"
+    When I am on "/app/program/1"
     Then I should see "program 1"
-    When I am on "/pocketcode/program/2"
+    When I am on "/app/program/2"
     Then I should see "program 2"
-    When I am on "/pocketcode/program/3"
+    When I am on "/app/program/3"
     Then I should see "program 3"
 
-  Scenario: Private programs should not be accessible when not logged in
-    When I am on "/pocketcode/program/1"
+  Scenario: Private programs should be accessible when not logged in over the link
+    When I am on "/app/program/1"
     Then I should see "program 1"
-    When I am on "/pocketcode/program/2"
+    When I am on "/app/program/2"
     Then I should see "program 2"
-    When I am on "/pocketcode/program/3"
-    Then I should not see "program 3"
+    When I am on "/app/program/3"
+    Then I should see "program 3"
 
-  Scenario: Private programs from a different user should not be accessible to you
-    Given I am on "/pocketcode/login"
+  Scenario: Private programs from a different user should be accessible to you
+    Given I am on "/app/login"
     And I fill in "username" with "randomUsername"
     And I fill in "password" with "123456"
     And I press "Login"
-    When I am on "/pocketcode/program/1"
+    When I am on "/app/program/1"
     Then I should see "program 1"
-    When I am on "/pocketcode/program/2"
+    When I am on "/app/program/2"
     Then I should see "program 2"
-    When I am on "/pocketcode/program/3"
-    Then I should not see "program 3"
+    When I am on "/app/program/3"
+    Then I should see "program 3"
 
   Scenario: MyProfile statistics should count private programs
-    Given I am on "/pocketcode/login"
+    Given I am on "/app/login"
     And I fill in "username" with "myUsername"
     And I fill in "password" with "123456"
     And I press "Login"
-    When I am on "/pocketcode/profile/1"
+    When I am on "/app/profile/1"
     Then I should see "program 1"
     And I should see "program 2"
     And I should see "program 3"
 
   Scenario: Profile statistics of a different user should not count private programs
-    Given I am on "/pocketcode/login"
+    Given I am on "/app/login"
     And I fill in "username" with "randomUsername"
     And I fill in "password" with "123456"
     And I press "Login"
-    When I am on "/pocketcode/profile/1"
+    When I am on "/app/profile/1"
     Then I should see "program 1"
     And I should see "program 2"
     And I should not see "program 3"

--- a/tests/behat/features/web/profile.feature
+++ b/tests/behat/features/web/profile.feature
@@ -3,10 +3,10 @@ Feature: As a visitor I want to see user profiles
 
   Background:
     Given there are users:
-      | name      | password | token      | email               |
-      | Christian | 123456   | cccccccccc | dev1@pocketcode.org |
-      | Gregor    | 654321   | cccccccccc | dev2@pocketcode.org |
-      | User1     | 654321   | cccccccccc | dev3pocketcode.org |
+      | name      | password | token      | email               | id |
+      | Christian | 123456   | cccccccccc | dev1@pocketcode.org | 1  |
+      | Gregor    | 654321   | cccccccccc | dev2@pocketcode.org | 2  |
+      | User1     | 654321   | cccccccccc | dev3@pocketcode.org | 3  |
 
     And there are programs:
       | id  | name       | description        | owned by  | downloads | apk_downloads | views | upload time      | version |

--- a/tests/behat/features/web/program.feature
+++ b/tests/behat/features/web/program.feature
@@ -3,11 +3,9 @@ Feature: As a visitor I want to see a program page
 
   Background:
     Given there are users:
-      | name     | password | token      | email               |
-      | Superman | 123456   | cccccccccc | dev1@pocketcode.org |
-      | Gregor   | 123456   | cccccccccc | dev2@pocketcode.org |
-    # the id will not be used in the featureContext because of the autoincrement.
-    # only here for better readability
+      | name     | password | token      | email               | id |
+      | Superman | 123456   | cccccccccc | dev1@pocketcode.org | 1  |
+      | Gregor   | 123456   | cccccccccc | dev2@pocketcode.org | 2  |
     And there are programs:
       | id | name      | description             | owned by | downloads | apk_downloads | views | upload time      | version | language version | visible | apk_ready |
       | 1  | program 1 | my superman description | Superman | 3         | 2             | 12    | 01.01.2013 12:00 | 0.8.5   | 0.94             | true    | true      |

--- a/tests/behat/features/web/project_loader_on_no_projects.feature
+++ b/tests/behat/features/web/project_loader_on_no_projects.feature
@@ -3,11 +3,11 @@ Feature: Project loader should hide project containers or show a message if ther
 
   Background:
     Given there are users:
-      | name     | password | token      | email               |
-      | Catrobat | 123456   | cccccccccc | dev1@app.org |
-      | User2    | 654321   | cccccccccc | dev2@app.org |
-      | User3    | 654321   | cccccccccc | dev3@app.org |
-      | User4    | 654321   | cccccccccc | dev4@app.org |
+      | name     | password | token      | email        | id |
+      | Catrobat | 123456   | cccccccccc | dev1@app.org |  1 |
+      | User2    | 654321   | cccccccccc | dev2@app.org |  2 |
+      | User3    | 654321   | cccccccccc | dev3@app.org |  3 |
+      | User4    | 654321   | cccccccccc | dev4@app.org |  4 |
 
   #  index
   Scenario: When there are no programs there should not be containers on the homepage

--- a/tests/behat/features/web/user_projects.feature
+++ b/tests/behat/features/web/user_projects.feature
@@ -3,11 +3,11 @@ Feature: There should be all projects of a user presented on a profile page
 
   Background:
     Given there are users:
-      | name     | password | token      | email               |
-      | Catrobat | 123456   | cccccccccc | dev1@pocketcode.org |
-      | User2    | 654321   | cccccccccc | dev2@pocketcode.org |
-      | User3    | 654321   | cccccccccc | dev3@pocketcode.org |
-      | User4    | 654321   | cccccccccc | dev4@pocketcode.org |
+      | name     | password | token      | email               | id |
+      | Catrobat | 123456   | cccccccccc | dev1@pocketcode.org |  1 |
+      | User2    | 654321   | cccccccccc | dev2@pocketcode.org |  2 |
+      | User3    | 654321   | cccccccccc | dev3@pocketcode.org |  3 |
+      | User4    | 654321   | cccccccccc | dev4@pocketcode.org |  4 |
     And there are programs:
       | id | name       | description | owned by | downloads | apk_downloads | views | upload time      | version |
       | 1  | oldestProg | p1          | Catrobat | 3         | 2             | 12    | 01.01.2009 12:00 | 0.8.5   |

--- a/tests/behat/features/web/visited_programs.feature
+++ b/tests/behat/features/web/visited_programs.feature
@@ -4,8 +4,8 @@ Feature: Pocketcode homepage visited programs
 
   Background:
     Given there are users:
-      | name     | password | token      | email               |
-      | Catrobat | 123456   | cccccccccc | dev1@pocketcode.org |
+      | name     | password | token      | email               | id |
+      | Catrobat | 123456   | cccccccccc | dev1@pocketcode.org |  1 |
     And there are programs:
       | id | name      | description | owned by | downloads | apk_downloads | views | upload time      | version |
       | 1  | program 1 | p1          | Catrobat | 3         | 2             | 12    | 01.01.2013 12:00 | 0.8.5   |

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -613,13 +613,13 @@ errors:
   token: 'Authentication of device failed: invalid auth-token!'
   uploadTokenAuthFailed: 'Upload Token auth failed.'
   programname:
-    rude: Programname must not contain rude wordes.
+    rude: Program name must not contain rude wordes.
   program:
     invalid: Invalid program.
   languageversion:
-    tooold: 'Sorry, your programm contains an old version of the Catrobat language! Are you using the latest version of Pocket Code?'
+    tooold: 'Sorry, your program contains an old version of the Catrobat language! Are you using the latest version of Pocket Code?'
   programversion:
-    tooold: 'Sorry, you are using an old version of Pocket Code. Please update to the lastest version.'
+    tooold: 'Sorry, you are using an old version of Pocket Code. Please update to the latest version.'
 
 success:
   text: Success


### PR DESCRIPTION
The program.id and user.id have been updated from using integers
to using UUIDs. This means the user now sees different links
when beeing on a program/profile page.

- A new migration was added which updates all foreign key constraints
and all entities which use the program or user id.

- some entites have been updaterd too work with uuids

- Routing annotions have been changed since they accept now strings and not ints

- some logic changes files have been applied to work with strings and not ints

- the behat feature and context files have been updated to work with fixed ids.