### PR TITLE
SHARE-41 Delete Logs

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -630,6 +630,11 @@ services:
     tags:
       - { name: console.command }
 
+  catrowebadmin.command.clean.logs:
+    class: App\Catrobat\Commands\CleanLogsCommand
+    tags:
+      - { name: console.command }
+
   catrowebadmin.command.init:
     class: App\Catrobat\Commands\InitDirectoriesCommand
     arguments:

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -15,6 +15,7 @@ parameters:
   catrobat.mediapackage.path:  "resources_test/mediapackage/"
   catrobat.backup.dir:         "%catrobat.pubdir%resources_test/backups/"
   catrobat.snapshot.dir:       "%catrobat.pubdir%resources_test/snapshots/"
+  catrobat.logs.dir:           "%kernel.project_dir%/tests/testdata/log/"
   jenkins:
     url: https://jenkins.catrob.at/buildByToken/buildWithParameters
     job: "Build-Program"

--- a/src/Catrobat/Controller/Admin/MaintainController.php
+++ b/src/Catrobat/Controller/Admin/MaintainController.php
@@ -10,6 +10,7 @@ use App\Catrobat\Commands\CleanLogsCommand;
 use App\Catrobat\Commands\CreateBackupCommand;
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -87,10 +88,17 @@ class MaintainController extends Controller
     $command = new CleanLogsCommand();
     $command->setContainer($this->container);
 
-    $return = $command->run(new ArrayInput([]), new NullOutput());
-    if ($return == 0)
+    $output = new BufferedOutput();
+    $return = $command->run(new ArrayInput([]), $output);
+    if ($return === 0)
     {
-      $this->addFlash('sonata_flash_success', 'Reset log files OK');
+      $this->addFlash('sonata_flash_success', 'Clean log files OK');
+    }
+    else
+    {
+      $message = "<strong>Failed cleaning log files:</strong><br />\n";
+      $message .= str_replace("\n", "<br />\n", $output->fetch());
+      $this->addFlash('sonata_flash_error', $message);
     }
 
     return new RedirectResponse($this->admin->generateUrl("list"));

--- a/tests/phpUnit/Admin/CleanupTest.php
+++ b/tests/phpUnit/Admin/CleanupTest.php
@@ -1,0 +1,56 @@
+<?php
+
+
+namespace phpUnit\Admin;
+
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class CleanupTest extends KernelTestCase
+{
+
+  /**
+   * @test
+   */
+  public function cleanLogs()
+  {
+    // setup app
+    $kernel = static::createKernel();
+    $application = new Application($kernel);
+    $command = $application->find('catrobat:clean:logs');
+
+    /* alternative to $application->find() without using command name. */
+//    $kernel->boot();
+//    $command = new CleanLogsCommand();
+//    $command->setContainer($kernel->getContainer());
+
+    $log_dir = $kernel->getContainer()->getParameter('catrobat.logs.dir');
+
+    // fill directory
+    $test_log_dir = $log_dir . DIRECTORY_SEPARATOR . 'test';
+    @mkdir($test_log_dir);
+    for ($i = 0; $i < 10; $i++)
+    {
+      tempnam($test_log_dir, '');
+    }
+
+    for ($i = 0; $i < 4; $i++)
+    {
+      tempnam($log_dir, '');
+    }
+
+    // run command
+    $commandTester = new CommandTester($command);
+    $return = $commandTester->execute([]);
+    $this->assertEquals(0, $return);
+
+    // check if directory is empty
+    $this->assertEmpty(array_diff(scandir($log_dir), ['.', '..', '.gitignore']),
+      'Not all files in log directory got deleted.');
+
+
+  }
+
+}


### PR DESCRIPTION
Fixes the clean logs command and the clean logs tool in admin backend.
It deletes everything inside the log folder.

Includes a PHPUnit Test.