### PR TITLE
SHARE-73 program page username only in details section

### DIFF
--- a/assets/css/custom/program.scss
+++ b/assets/css/custom/program.scss
@@ -34,24 +34,6 @@ a
     float: left;
   }
 
-  #program-user
-  {
-    float: right;
-    text-transform: none;
-
-    > .img-author
-    {
-      float: left;
-      margin-right: 5px;
-    }
-
-    a
-    {
-      font-size: $font-size-h1 - 5;
-      color: $content-default-link-color;
-      text-decoration: none;
-    }
-  }
 }
 
 h2
@@ -96,29 +78,32 @@ h2
   border-top: 1px solid $default-text-color;
   padding-top: 25px;
   padding-bottom: 25px;
-  width: 100%;
   display: table;
+  width: 100%;
 
-  > div
+  > #program-bottom-container
   {
-    display: table-cell;
-    width: 20%;
+    width: 90%;
+    margin-left: 9%;
 
-    > .icon
+    > div
     {
+      text-align: left;
       float: left;
-    }
+      width: 30%;
+      margin: 0.6em;
 
-    > .icon-text
-    {
-      line-height: 35px;
-      padding-left: 8px;
-    }
-  }
+      > .icon
+      {
+        float: left;
+      }
 
-  #icon-author
-  {
-    display: none;
+      > .icon-text
+      {
+        line-height: 35px;
+        padding-left: 8px;
+      }
+    }
   }
 }
 
@@ -493,14 +478,6 @@ input[type='number']
 
 @include media-breakpoint-down(md)
 {
-  .headline {
-    text-align: center;
-    width: 100%;
-  }
-}
-
-@include media-breakpoint-down(md)
-{
   #program-top
   {
     display: flex;
@@ -519,19 +496,57 @@ input[type='number']
 
   #program-bottom
   {
-    padding: 25px;
-    display: block;
+    border-top: 1px solid $default-text-color;
+    padding-top: 25px;
+    padding-bottom: 25px;
+    display: table;
+    width: 100%;
 
-    #icon-author
+    > #program-bottom-container
     {
-      display: block;
+      > div
+      {
+        text-align: left;
+        float: left;
+        width: 47%;
+
+        > .icon
+        {
+          float: left;
+        }
+
+        > .icon-text
+        {
+          line-height: 35px;
+          padding-left: 8px;
+        }
+      }
     }
+  }
+}
 
-    > div
-    {
-      display: block;
-      width: 100%;
-      margin-bottom: 5px;
+@include media-breakpoint-down(sm) {
+  #program-bottom {
+    border-top: 1px solid $default-text-color;
+    padding-top: 25px;
+    padding-bottom: 25px;
+    display: table;
+    width: 100%;
+
+    > #program-bottom-container {
+      > div {
+        text-align: left;
+        width: 100%;
+
+        > .icon {
+          float: left;
+        }
+
+        > .icon-text {
+          line-height: 35px;
+          padding-left: 8px;
+        }
+      }
     }
   }
 }
@@ -580,7 +595,7 @@ input[type='number']
 
 #recsys-headline, #recsys-specific-programs-headline
 {
-  margin-top: 10px;
+  margin: 0.85em;
   text-align: center;
 }
 

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -32,13 +32,10 @@
 {% endblock %}
 
 {% block body %}
+
   <div id="program-top" class="h1">
     <div id="program-name" class="headline">
       {{ program.name }}
-    </div>
-
-    <div id="program-user">
-      <a href="{{ url('profile', { id : program.user.id }) }}">{{ program.user }}</a>
     </div>
     <div class="clear"></div>
   </div>
@@ -278,40 +275,42 @@
   {% endif %}
 
   <div id="program-bottom">
-    <div id="icon-author">
-      <div class="program-round-icon-container"><i class="program-round-icon fas fa-user"></i></div>
-      <a href="{{ url('profile', { id : program.user.id }) }}"
-         class="icon-text">{{ program.user }}</a>
-    </div>
-    <div>
-      <div class="program-round-icon-container"><i class="program-round-icon far fa-clock"></i>
+    <div id="program-bottom-container">
+      <div id="icon-author">
+        <div class="program-round-icon-container"><i class="program-round-icon fas fa-user"></i></div>
+        <a href="{{ url('profile', { id : program.user.id }) }}"
+           class="icon-text">{{ program.user }}</a>
       </div>
-      <span class="icon-text">{{ program_details.age }}</span>
-    </div>
-    <div>
-      <div class="program-round-icon-container"><i class="program-round-icon fas fa-file-alt"></i>
+      <div>
+        <div class="program-round-icon-container"><i class="program-round-icon far fa-clock"></i>
+        </div>
+        <span class="icon-text">{{ program_details.age }}</span>
       </div>
-      <span class="icon-text">{{ program_details.filesize }} MB</span>
-    </div>
-    <div>
-      <div class="program-round-icon-container"><i class="program-round-icon fas fa-download"></i>
+      <div>
+        <div class="program-round-icon-container"><i class="program-round-icon fas fa-file-alt"></i>
+        </div>
+        <span class="icon-text">{{ program_details.filesize }} MB</span>
       </div>
-      <span
-          class="icon-text">{{ "programs.downloads"|trans({ '%downloads%' : program_details.downloads }, "catroweb") }}
-      </span>
-    </div>
-    <div>
-      <div class="program-round-icon-container"><i class="program-round-icon fas fa-eye"></i></div>
-      <span
-          class="icon-text">{{ "programs.views"|trans({ '%views%' : program_details.views }, "catroweb") }}</span>
-    </div>
-    <div>
-      <div class="program-round-icon-container"><i class="program-round-icon fas fa-sitemap"></i>
+      <div>
+        <div class="program-round-icon-container"><i class="program-round-icon fas fa-download"></i>
+        </div>
+        <span
+            class="icon-text">{{ "programs.downloads"|trans({ '%downloads%' : program_details.downloads }, "catroweb") }}
+        </span>
       </div>
-      <a id="remix-graph-modal-link" href="#remix-graph-modal" class="icon-text">
-        {{ "programs.remixes"|transchoice(program_details.remixesLength,
-          { '%remixes%' : program_details.remixesLength }, "catroweb") }}
-      </a>
+      <div>
+        <div class="program-round-icon-container"><i class="program-round-icon fas fa-eye"></i></div>
+        <span
+            class="icon-text">{{ "programs.views"|trans({ '%views%' : program_details.views }, "catroweb") }}</span>
+      </div>
+      <div>
+        <div class="program-round-icon-container"><i class="program-round-icon fas fa-sitemap"></i>
+        </div>
+        <a id="remix-graph-modal-link" href="#remix-graph-modal" class="icon-text">
+          {{ "programs.remixes"|transchoice(program_details.remixesLength,
+            { '%remixes%' : program_details.remixesLength }, "catroweb") }}
+        </a>
+      </div>
     </div>
   </div>
 

--- a/tests/behat/features/web/program.feature
+++ b/tests/behat/features/web/program.feature
@@ -38,7 +38,7 @@ Feature: As a visitor I want to see a program page
 
   Scenario: Viewing the uploader's profile page
     Given I am on "/pocketcode/program/1"
-    And I click "#program-user a"
+    And I click "#icon-author a"
     Then I should be on "/pocketcode/profile/1"
 
   Scenario: I should not see the report button for my own programs


### PR DESCRIPTION
- program owners username is now consistently only visible in the program details
- fixed css to work with one detail icon more (username)
![mobile](https://user-images.githubusercontent.com/40868718/57692808-ffed2d00-7647-11e9-899b-10f8459a7e87.PNG)
![md](https://user-images.githubusercontent.com/40868718/57692807-ffed2d00-7647-11e9-90cf-23f8180ce2f0.PNG)
![lg](https://user-images.githubusercontent.com/40868718/57692809-ffed2d00-7647-11e9-9a24-cde8f19042d3.PNG)


