### PR TITLE
Mastersthesis - Recommender System Changes

### DIFF
--- a/src/Catrobat/Controller/Api/RecommenderController.php
+++ b/src/Catrobat/Controller/Api/RecommenderController.php
@@ -173,10 +173,14 @@ class RecommenderController extends Controller
       $programs = array_slice($all_programs, $offset, $limit);
     }
 
+    // Recommendations for guest user (or logged in users who receive zero recommendations)
     if (($user == null) || ($programs_count == 0))
     {
-      $programs_count = $program_manager->getTotalLikedProgramsCount($flavor);
-      $programs = $program_manager->getMostLikedPrograms($flavor, $limit, $offset);
+      $recommender_manager = $this->get('recommendermanager');
+      $all_programs = $recommender_manager->recommendHomepageProgramsForGuests($flavor);
+
+      $programs_count = count($all_programs);
+      $programs = array_slice($all_programs, $offset, $limit);
     }
     else
     {

--- a/tests/behat/features/api/get_recommended_programs_homepage.feature
+++ b/tests/behat/features/api/get_recommended_programs_homepage.feature
@@ -24,8 +24,9 @@ Feature: Get recommended programs on homepage
       | 8  | Other5  | p7          | Catrobat3 | 1         | 9     | 01.02.2013 12:00 | 0.8.5   | true       |
       | 9  | Other6  | p7          | Catrobat2 | 1         | 9     | 01.02.2013 12:00 | 0.8.5   | true       |
 
-  Scenario: Test if most liked recommendations fallback is active when similar users only like same programs
-  (i.e. they don't like any differing programs)
+  Scenario: Test if recommendation fallback is active when similar users only like same programs
+  (i.e. they don't like any differing programs).
+
     Given there are like similar users:
       | first_user_id | second_user_id | similarity |
       | 1             | 2              | 0.3        |
@@ -43,8 +44,8 @@ Feature: Get recommended programs on homepage
     Then I should get a total of "2" projects
     Then I should get following programs:
       | Name    |
-      | Game    |
       | Minions |
+      | Game    |
 
   Scenario: No recommendations because there are no liked programs
     Given I have a parameter "test_user_id_for_like_recommendation" with value "1"


### PR DESCRIPTION

In order to get more data for the online experiment, which is conducted as part of a mastersthesis, the original changes to the recommender system, which targeted personalized recommendations for users, are expanded to also effect guest users (users who are not logged in). The changes regard the recommendations on the homepage (the section Recommended Programs). The changes aim to increase the recommender systems aggregated diversity (recommend a more diverse set of items). Therefore changes to the function which recommends programs to guest users have been made (prior the recommendation list consisted of most liked programs, now a new function has been introduced in RecommenderManager.php which diversifies the former recommendation list a bit). Also the corresponding behat test has been updated.