### PR TITLE
SHARE-65 Use mobile window size for web tests

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -36,9 +36,6 @@ default:
                 default:
                     chrome:
                         api_url: "http://localhost:9222"
-                mobile:
-                    chrome:
-                        api_url: "http://localhost:9222"
 
         VIPSoft\DoctrineDataFixturesExtension\Extension:
             lifetime:    scenario

--- a/tests/behat/features/bootstrap/AdminFeatureContext.php
+++ b/tests/behat/features/bootstrap/AdminFeatureContext.php
@@ -128,22 +128,6 @@ class AdminFeatureContext extends MinkContext implements KernelAwareContext
   }
 
   /**
-   * @BeforeScenario @Mobile
-   */
-  public function resizeWindowMobile()
-  {
-    $this->getSession()->resizeWindow(320, 1000);
-  }
-
-  /**
-   * @BeforeScenario @Tablet
-   */
-  public function resizeWindowTablet()
-  {
-    $this->getSession()->resizeWindow(768, 1000);
-  }
-
-  /**
    * @BeforeScenario @RealOAuth
    */
   public function activateRealOAuthService()

--- a/tests/behat/features/bootstrap/WebFeatureContext.php
+++ b/tests/behat/features/bootstrap/WebFeatureContext.php
@@ -129,7 +129,8 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
    */
   public function setup()
   {
-    $this->getSession()->resizeWindow(1240, 1024);
+    // 15px = scroll bar width
+    $this->getSession()->resizeWindow(320 + 15, 1024);
   }
 
   /**
@@ -155,22 +156,6 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
   }
 
   /**
-   * @BeforeScenario @Mobile
-   */
-  public function resizeWindowMobile()
-  {
-    $this->getSession()->resizeWindow(320, 1000);
-  }
-
-  /**
-   * @BeforeScenario @Tablet
-   */
-  public function resizeWindowTablet()
-  {
-    $this->getSession()->resizeWindow(768, 1000);
-  }
-
-  /**
    * @When /^I wait (\d+) milliseconds$/
    * @param $milliseconds
    */
@@ -180,14 +165,34 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
   }
 
   /**
-   * @Then /^I should see (\d+) "([^"]*)"$/
-   * @param $arg1
-   * @param $arg2
+   * @When /^I open the menu$/
    */
-  public function iShouldSeeNumberOfElements($arg1, $arg2)
+  public function iOpenTheMenu()
   {
-    $programs = $this->getSession()->getPage()->findAll('css', $arg2);
-    Assert::assertEquals($arg1, count($programs));
+    $sidebar_open = $this->getSession()->getPage()->find('css', '#sidebar')->isVisible();
+    if (!$sidebar_open)
+    {
+      $this->getSession()->getPage()->find('css', '#btn-sidebar-toggle')->click();
+    }
+  }
+
+  /**
+   * @Then /^I should see (\d+) "([^"]*)"$/
+   * @param $element_count
+   * @param $css_selector
+   */
+  public function iShouldSeeNumberOfElements($element_count, $css_selector)
+  {
+    $elements = $this->getSession()->getPage()->findAll('css', $css_selector);
+    $count = 0;
+    foreach ($elements as $element)
+    {
+      if ($element->isVisible())
+      {
+        $count++;
+      }
+    }
+    Assert::assertEquals($element_count, $count);
   }
 
   /**
@@ -1737,14 +1742,6 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
   public function iClickOnTheProgramPopupButton()
   {
     $this->iClick("#btn-close-popup");
-  }
-
-  /**
-   * @Given /^I am browsing with my pocketcode app$/
-   */
-  public function iAmBrowsingWithMyPocketcodeApp()
-  {
-    $this->getMink()->setDefaultSessionName("mobile");
   }
 
   /**

--- a/tests/behat/features/web/catro_notification.feature
+++ b/tests/behat/features/web/catro_notification.feature
@@ -35,31 +35,35 @@ Feature: User gets generic notifications additionally to the remix notifications
     And I should not see "Achievement - View"
     And I should see a ".swal2-modal" element
 
-  Scenario: User should see the amount of his notifications in the header
+  Scenario: User should see the amount of his notifications in the menu
     Given I log in as "Catrobat" with the password "123456"
     And I am on "/pocketcode/"
+    And I open the menu
     Then I wait 1000 milliseconds
     And the element "#btn-notifications" should be visible
     And the element ".user-notification-badge" should be visible
 
-  Scenario: User should see the amount of his notifications in the header
+  Scenario: User should see the amount of his notifications in the menu
     Given I log in as "Catrobat" with the password "123456"
     And I am on "/pocketcode/"
+    And I open the menu
     Then I wait 1000 milliseconds
     Then the element "#btn-notifications" should be visible
     And the element ".user-notification-badge" should be visible
     And the ".user-notification-badge" element should contain "2"
 
-  Scenario: User should see the amount of his notifications in the header only if he has notifcations
+  Scenario: User should see the amount of his notifications in the menu only if he has notifcations
     Given I log in as "OtherUser" with the password "123456"
     And I am on "/pocketcode/"
+    And I open the menu
     Then the element "#btn-notifications" should be visible
     And the element ".user-notification-badge" should not be visible
 
-  Scenario: User should see the amount of his notifications in the header
+  Scenario: User should see the amount of his notifications in the menu
     Given there are "105"+ notifications for "Catrobat"
     And I log in as "Catrobat" with the password "123456"
     And I am on "/pocketcode/"
+    And I open the menu
     Then the element "#btn-notifications" should be visible
     And the element ".user-notification-badge" should be visible
     And the ".user-notification-badge" element should contain "99+"

--- a/tests/behat/features/web/program.feature
+++ b/tests/behat/features/web/program.feature
@@ -142,12 +142,10 @@ Feature: As a visitor I want to see a program page
     Then the link of "download" should open "download"
 
   Scenario: I want to download a program from the app with the correct language version
-    Given I am browsing with my pocketcode app
     And I am on "/pocketcode/program/2"
     Then the link of "download" should open "download"
 
   Scenario: I want to download a program from the app with an an old language version
-    Given I am browsing with my pocketcode app
     And I download "/pocketcode/download/1.catrobat"
 
   Scenario: Increasing download counter after apk download

--- a/tests/behat/features/web/showmoreprog.feature
+++ b/tests/behat/features/web/showmoreprog.feature
@@ -55,10 +55,12 @@ Feature: Show more programs button behaviour
       | "#mostViewed .button-show-more"     |
       | "#random .button-show-more"         |
 
-  Scenario Outline: Buttons should disappear after clicking them in desktop format
+  Scenario Outline: Buttons should disappear after clicking them three times (on small phones)
     Given I am on homepage
     Then I wait 300 milliseconds
     When I click <button>
+    And I click <button>
+    And I click <button>
     Then the element <button> should not be visible
 
     Examples:
@@ -71,9 +73,13 @@ Feature: Show more programs button behaviour
   Scenario Outline: Buttons should load more programs
   The number, of how many programs the user should see, should equal the number of programs in the database
   and should be < 37. 36 is the current max number of programs visible after the user clicks the button once.
+  Because we test mobile, we press the button three times.
     Given I am on homepage
+    And I wait 100 milliseconds
+    Then I should see 6 <programs>
     When I click <button>
-    And I wait for a second
+    And I click <button>
+    And I click <button>
     And I wait for a second
     Then I should see 23 <programs>
 
@@ -89,7 +95,7 @@ Feature: Show more programs button behaviour
     And the random program section is empty
     Then I should not see "oldestProg"
     When I click "#newest .button-show-more"
-    And I wait for a second
+    When I click "#newest .button-show-more"
     When I click "#newest .button-show-more"
     And I wait for a second
     Then I should see "oldestProg"


### PR DESCRIPTION
Use mobile window size for tests (320px width).
Fix problems introduced with smaller window size.