### PR TITLE
SHARE-75 Prefer programs of current flavor in api calls

### DIFF
--- a/src/Catrobat/Controller/Api/ListProgramsController.php
+++ b/src/Catrobat/Controller/Api/ListProgramsController.php
@@ -29,7 +29,12 @@ class ListProgramsController extends Controller
    */
   public function listProgramsAction(Request $request, $flavor)
   {
-    return $this->listSortedPrograms($request, 'recent', true, $flavor);
+    if ($flavor == 'pocketcode')
+    {
+      $flavor = null;
+    }
+
+    return $this->listSortedPrograms($request, 'recent', true, false, $flavor);
   }
 
 
@@ -157,27 +162,27 @@ class ListProgramsController extends Controller
    * @param Request $request
    * @param         $sortBy
    * @param bool    $details
+   * @param bool    $useRequestFlavor
    * @param string  $flavor
    *
    * @return ProgramListResponse
    * @throws NonUniqueResultException
    */
-  private function listSortedPrograms(Request $request, $sortBy, $details = true, $flavor = 'pocketcode')
+  private function listSortedPrograms(Request $request, $sortBy, $details = true, $useRequestFlavor = true, $flavor = null)
   {
+    if ($useRequestFlavor === true)
+    {
+      $flavor = $request->attributes->get('flavor');
+    }
+
     /**
      * @var ProgramManager $program_manager
      */
-
     $program_manager = $this->get('programmanager');
+
     $limit = intval($request->query->get('limit', 20));
     $offset = intval($request->query->get('offset', 0));
     $user_id = intval($request->query->get('user_id', 0));
-
-    // setting flavor to null to get all results
-    if ($flavor == 'pocketcode')
-    {
-      $flavor = null;
-    }
 
     if ($sortBy == 'downloads')
     {
@@ -189,7 +194,7 @@ class ListProgramsController extends Controller
         $flavor_count = $program_manager->getTotalPrograms($flavor);
         $new_offset = max($offset - $flavor_count + $count, 0);
         $programs = array_merge($programs, $program_manager->getMostDownloadedPrograms(
-          'pocketcode', $limit - $count, $new_offset
+          '!' . $flavor, $limit - $count, $new_offset
         ));
       }
     }
@@ -203,7 +208,7 @@ class ListProgramsController extends Controller
         $flavor_count = $program_manager->getTotalPrograms($flavor);
         $new_offset = max($offset - $flavor_count + $count, 0);
         $programs = array_merge($programs, $program_manager->getMostViewedPrograms(
-          'pocketcode', $limit - $count, $new_offset
+          '!' . $flavor, $limit - $count, $new_offset
         ));
       }
     }
@@ -221,7 +226,7 @@ class ListProgramsController extends Controller
         $flavor_count = $program_manager->getTotalPrograms($flavor);
         $new_offset = max($offset - $flavor_count + $count, 0);
         $programs = array_merge($programs, $program_manager->getRandomPrograms(
-          'pocketcode', $limit - $count, $new_offset
+          '!' . $flavor, $limit - $count, $new_offset
         ));
       }
     }
@@ -235,7 +240,7 @@ class ListProgramsController extends Controller
         $flavor_count = $program_manager->getTotalPrograms($flavor);
         $new_offset = max($offset - $flavor_count + $count, 0);
         $programs = array_merge($programs, $program_manager->getRecentPrograms(
-          'pocketcode', $limit - $count, $new_offset
+          '!' . $flavor, $limit - $count, $new_offset
         ));
       }
     }
@@ -250,7 +255,7 @@ class ListProgramsController extends Controller
 
       if ($flavor)
       {
-        $numbOfTotalProjects += $program_manager->getTotalPrograms('pocketcode');
+        $numbOfTotalProjects += $program_manager->getTotalPrograms('!' . $flavor);
       }
     }
 

--- a/src/Entity/ProgramManager.php
+++ b/src/Entity/ProgramManager.php
@@ -558,7 +558,7 @@ class ProgramManager
   /**
    * @param $flavor
    *
-   * @return mixed
+   * @return int
    * @throws NonUniqueResultException
    */
   public function getTotalPrograms($flavor)

--- a/src/Repository/ProgramRepository.php
+++ b/src/Repository/ProgramRepository.php
@@ -6,6 +6,7 @@ use App\Entity\Program;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 
 
@@ -46,12 +47,7 @@ class ProgramRepository extends EntityRepository
       ->setFirstResult($offset)
       ->setMaxResults($limit);
 
-    if ($flavor)
-    {
-      $qb
-        ->andWhere($qb->expr()->eq('e.flavor', ':flavor'))
-        ->setParameter('flavor', $flavor);
-    }
+    $qb = $this->addFlavorCondition($qb, $flavor);
 
     return $qb->getQuery()->getResult();
   }
@@ -75,12 +71,7 @@ class ProgramRepository extends EntityRepository
       ->setFirstResult($offset)
       ->setMaxResults($limit);
 
-    if ($flavor)
-    {
-      $qb
-        ->andWhere($qb->expr()->eq('e.flavor', ':flavor'))
-        ->setParameter('flavor', $flavor);
-    }
+    $qb = $this->addFlavorCondition($qb, $flavor);
 
     return $qb->getQuery()->getResult();
   }
@@ -354,12 +345,7 @@ class ProgramRepository extends EntityRepository
       ->setFirstResult($offset)
       ->setMaxResults($limit);
 
-    if ($flavor)
-    {
-      $qb
-        ->andWhere($qb->expr()->eq('e.flavor', ':flavor'))
-        ->setParameter('flavor', $flavor);
-    }
+    $qb = $this->addFlavorCondition($qb, $flavor);
 
     return $qb->getQuery()->getResult();
   }
@@ -413,13 +399,7 @@ class ProgramRepository extends EntityRepository
       ->where($qb->expr()->eq('e.visible', $qb->expr()->literal(true)))
       ->andWhere($qb->expr()->eq('e.private', $qb->expr()->literal(false)));
 
-    if ($flavor)
-    {
-      $qb
-        ->andWhere($qb->expr()->eq('e.flavor', ':flavor'))
-        ->setParameter('flavor', $flavor);
-    }
-
+    $qb = $this->addFlavorCondition($qb, $flavor);
     return $qb->getQuery()->getResult();
   }
 
@@ -721,7 +701,7 @@ class ProgramRepository extends EntityRepository
   /**
    * @param null $flavor
    *
-   * @return mixed
+   * @return int
    * @throws NonUniqueResultException
    */
   public function getTotalPrograms($flavor = null)
@@ -733,14 +713,8 @@ class ProgramRepository extends EntityRepository
       ->where($qb->expr()->eq('e.visible', $qb->expr()->literal(true)))
       ->andWhere($qb->expr()->eq('e.private', $qb->expr()->literal(false)));
 
-    if ($flavor)
-    {
-      $qb
-        ->andWhere($qb->expr()->eq('e.flavor', ':flavor'))
-        ->setParameter('flavor', $flavor);
-    }
-
-    return $qb->getQuery()->getSingleScalarResult();
+    $qb = $this->addFlavorCondition($qb, $flavor);
+    return (int)$qb->getQuery()->getSingleScalarResult();
   }
 
   /**
@@ -1015,5 +989,26 @@ class ProgramRepository extends EntityRepository
 
     return $programs;
 
+  }
+
+  private function addFlavorCondition(QueryBuilder $qb, $flavor)
+  {
+    if ($flavor)
+    {
+      if ($flavor{0} === "!")
+      {
+        $qb
+          ->andWhere($qb->expr()->neq('e.flavor', ':flavor'))
+          ->setParameter('flavor', substr($flavor, 1));
+      }
+      else
+      {
+        $qb
+          ->andWhere($qb->expr()->eq('e.flavor', ':flavor'))
+          ->setParameter('flavor', $flavor);
+      }
+    }
+
+    return $qb;
   }
 }

--- a/tests/behat/features/api/get_most_downloaded_programs.feature
+++ b/tests/behat/features/api/get_most_downloaded_programs.feature
@@ -42,7 +42,7 @@ Feature: Get the most downloaded programs
           "completeTerm":"",
           "CatrobatInformation": {
                                    "BaseUrl":"http://localhost/",
-                                   "TotalProjects": "3",
+                                   "TotalProjects": 3,
                                    "ProjectsExtension":".catrobat"
                                   },
           "preHeaderMessages":""
@@ -64,7 +64,7 @@ Feature: Get the most downloaded programs
           "preHeaderMessages":"",
           "CatrobatInformation": {
                          "BaseUrl":"http://localhost/",
-                         "TotalProjects": "3",
+                         "TotalProjects": 3,
                          "ProjectsExtension":".catrobat"
                         }
       }

--- a/tests/behat/features/api/get_most_viewed_programs.feature
+++ b/tests/behat/features/api/get_most_viewed_programs.feature
@@ -42,7 +42,7 @@ Feature: Get the most downloaded programs
           "preHeaderMessages":"",
           "CatrobatInformation": {
                                    "BaseUrl":"http://localhost\/",
-                                   "TotalProjects":"3",
+                                   "TotalProjects":3,
                                    "ProjectsExtension":".catrobat"
                                   }
       }
@@ -63,7 +63,7 @@ Feature: Get the most downloaded programs
           "preHeaderMessages":"",
           "CatrobatInformation": {
                                    "BaseUrl":"http://localhost\/",
-                                   "TotalProjects":"3",
+                                   "TotalProjects":3,
                                    "ProjectsExtension":".catrobat"
                                   }
       }

--- a/tests/behat/features/api/get_recent_programs.feature
+++ b/tests/behat/features/api/get_recent_programs.feature
@@ -42,7 +42,7 @@ Feature: Get the most recent programs
           "preHeaderMessages":"",
           "CatrobatInformation": {
                                    "BaseUrl":"http://localhost/",
-                                   "TotalProjects":"3",
+                                   "TotalProjects":3,
                                    "ProjectsExtension":".catrobat"
                                   }
       }
@@ -63,7 +63,7 @@ Feature: Get the most recent programs
           "preHeaderMessages":"",
           "CatrobatInformation": {
                                    "BaseUrl":"http://localhost/",
-                                   "TotalProjects":"3",
+                                   "TotalProjects":3,
                                    "ProjectsExtension":".catrobat"
                                   }
       }

--- a/tests/behat/features/flavor/flavor_filter.feature
+++ b/tests/behat/features/flavor/flavor_filter.feature
@@ -6,14 +6,15 @@ Feature: Filtering programs with specific flavor
 
   Background:
     Given there are programs:
-      | name         | flavor         |
-      | Invaders     | pocketcode     |
-      | Simple click | pocketphiropro |
-      | A new world  | pocketcode     |
-      | Soon to be   | pocketphiropro |
+      | name         | flavor     |
+      | Invaders     | pocketcode |
+      | Simple click | luna       |
+      | A new world  | pocketcode |
+      | Soon to be   | luna       |
+      | Just for fun | luna       |
 
 
-  Scenario: Get most viewed programs of flavor
+  Scenario: Get most viewed programs of flavor pocketcode
 
     When I get the most viewed programs with "pocketcode/api/projects/mostViewed.json"
     Then I should get following programs:
@@ -22,8 +23,20 @@ Feature: Filtering programs with specific flavor
       | A new world  |
       | Simple click |
       | Soon to be   |
+      | Just for fun |
 
-  Scenario: Get most downloaded programs of flavor
+  Scenario: Get most viewed programs of flavor luna
+
+    When I get the most viewed programs with "luna/api/projects/mostViewed.json"
+    Then I should get following programs:
+      | name         |
+      | Simple click |
+      | Soon to be   |
+      | Just for fun |
+      | Invaders     |
+      | A new world  |
+
+  Scenario: Get most downloaded programs of pocketcode
 
     When I get the most downloaded programs with "pocketcode/api/projects/mostDownloaded.json"
     Then I should get following programs:
@@ -32,8 +45,20 @@ Feature: Filtering programs with specific flavor
       | A new world  |
       | Simple click |
       | Soon to be   |
+      | Just for fun |
 
-  Scenario: Get recent programs of flavor
+  Scenario: Get most downloaded programs of flavor luna
+
+    When I get the most downloaded programs with "luna/api/projects/mostDownloaded.json"
+    Then I should get following programs:
+      | name         |
+      | Simple click |
+      | Soon to be   |
+      | Just for fun |
+      | Invaders     |
+      | A new world  |
+
+  Scenario: Get recent programs of flavor pocketcode
 
     When I get the recent programs with "pocketcode/api/projects/recent.json"
     Then I should get following programs:
@@ -42,8 +67,20 @@ Feature: Filtering programs with specific flavor
       | A new world  |
       | Simple click |
       | Soon to be   |
+      | Just for fun |
 
-  Scenario: Get all programs of a user no matter the flavor
+  Scenario: Get recent programs of flavor luna
+
+    When I get the recent programs with "luna/api/projects/recent.json"
+    Then I should get following programs:
+      | name         |
+      | Simple click |
+      | Soon to be   |
+      | Just for fun |
+      | Invaders     |
+      | A new world  |
+
+  Scenario: Get all programs of a user no matter the flavor (pocketcode)
 
     Given All programs are from the same user
     When I get the user's programs with "pocketcode/api/projects/userPrograms.json"
@@ -53,4 +90,18 @@ Feature: Filtering programs with specific flavor
       | Simple click |
       | A new world  |
       | Soon to be   |
+      | Just for fun |
+
+  Scenario: Get all programs of a user no matter the flavor (luna)
+
+    Given All programs are from the same user
+    When I get the user's programs with "luna/api/projects/userPrograms.json"
+    Then I should get following programs:
+      | name         |
+      | Invaders     |
+      | Simple click |
+      | A new world  |
+      | Soon to be   |
+      | Just for fun |
+
     


### PR DESCRIPTION
Prefer programs tagged with the current flavor in the `api/project/`
API calls, which are used e.g. on the home page.

Adapt tests and test with two different flavors (pocketcode and luna).