### PR TITLE
SHARE-55 program statistics text

### DIFF
--- a/assets/css/base/_images.scss
+++ b/assets/css/base/_images.scss
@@ -32,7 +32,7 @@
   width: 2.5em;
   height: 2.5em;
   border-radius: 50%;
-  display: inline-block;
+  position: absolute;
 }
 
 .program-round-icon

--- a/assets/css/custom/program.scss
+++ b/assets/css/custom/program.scss
@@ -90,7 +90,7 @@ h2
     {
       text-align: left;
       float: left;
-      width: 30%;
+      min-width: 30%;
       margin: 0.6em;
 
       > .icon
@@ -102,6 +102,8 @@ h2
       {
         line-height: 35px;
         padding-left: 8px;
+        display:block;
+        margin-left: 3em;
       }
     }
   }
@@ -508,7 +510,7 @@ input[type='number']
       {
         text-align: left;
         float: left;
-        width: 47%;
+        min-width: 47%;
 
         > .icon
         {
@@ -519,6 +521,8 @@ input[type='number']
         {
           line-height: 35px;
           padding-left: 8px;
+          display: block;
+          margin-left: 3em;
         }
       }
     }
@@ -545,6 +549,8 @@ input[type='number']
         > .icon-text {
           line-height: 35px;
           padding-left: 8px;
+          display: block;
+          margin-left: 3em;
         }
       }
     }


### PR DESCRIPTION
fixed the line break problem if there was to less space.
width is now just min width. Also when there still should not be enough
space the multiline text is aligned right to the icon.