### PR TITLE
SHARE-49 private programs are now really private

### DIFF
--- a/src/Catrobat/Controller/Api/ListProgramsController.php
+++ b/src/Catrobat/Controller/Api/ListProgramsController.php
@@ -214,7 +214,12 @@ class ListProgramsController extends Controller
     }
     elseif ($sortBy == 'user')
     {
-      $programs = $program_manager->getUserPrograms($user_id);
+      if ($this->getUser() !== null && $this->getUser()->getId() === $user_id) {
+        $programs = $program_manager->getUserPrograms($user_id);
+      }
+      else {
+        $programs = $program_manager->getPublicUserPrograms($user_id);
+      }
     }
     elseif ($sortBy == 'random')
     {

--- a/src/Catrobat/Controller/Web/ProfileController.php
+++ b/src/Catrobat/Controller/Web/ProfileController.php
@@ -39,17 +39,17 @@ class ProfileController extends Controller
     $id = (integer)$id;
     $twig = 'UserManagement/Profile/profileHandler.html.twig';
     $my_profile = false;
-    $program_count = 0;
 
     if ($id === 0 || ($this->getUser() && $this->getUser()->getId() === $id))
     {
       $user = $this->getUser();
       $my_profile = true;
+      $program_count = count($this->get('programmanager')->getUserPrograms($id));
     }
     else
     {
       $user = $this->get('usermanager')->find($id);
-      $program_count = count($this->get('programmanager')->getUserPrograms($id));
+      $program_count = count($this->get('programmanager')->getPublicUserPrograms($id));
     }
 
     if (!$user)

--- a/src/Catrobat/Controller/Web/ProgramController.php
+++ b/src/Catrobat/Controller/Web/ProgramController.php
@@ -124,6 +124,12 @@ class ProgramController extends Controller
       }
     }
 
+//    Right now everyone should find even private programs via the correct link! SHARE-49
+//    if ($program->getPrivate() && $program->getUser()->getId() !== $this->getUser()->getId()) {
+//      // only program owners should be allowed to see their programs
+//      throw $this->createNotFoundException('Unable to find Project entity.');
+//    }
+
     if ($program->isDebugBuild())
     {
       /** @var AppRequest $app_request */

--- a/src/Catrobat/Services/OAuthService.php
+++ b/src/Catrobat/Services/OAuthService.php
@@ -848,9 +848,9 @@ class OAuthService
     $program_manager = $this->container->get('programmanager');
     $em = $this->container->get('doctrine.orm.entity_manager');
 
-    $user_programms = $program_manager->getUserPrograms($user->getId(), true);
+    $user_programs = $program_manager->getUserPrograms($user->getId(), true);
 
-    foreach ($user_programms as $user_program)
+    foreach ($user_programs as $user_program)
     {
       $em->remove($user_program);
       $em->flush();

--- a/src/Entity/ProgramManager.php
+++ b/src/Entity/ProgramManager.php
@@ -473,6 +473,20 @@ class ProgramManager
   }
 
   /**
+   * @param      $user_id
+   * @param bool $include_debug_build_programs If programs marked as debug_build should be returned
+   *
+   * @return Program[]
+   */
+  public function getPublicUserPrograms($user_id, bool $include_debug_build_programs = false)
+  {
+    $debug_build = ($include_debug_build_programs === true) ?
+      true : $this->app_request->isDebugBuildRequest();
+
+    return $this->program_repository->getPublicUserPrograms($user_id, $debug_build);
+  }
+
+  /**
    * @return array
    *
    * @internal

--- a/src/Repository/ProgramRepository.php
+++ b/src/Repository/ProgramRepository.php
@@ -789,6 +789,30 @@ class ProgramRepository extends EntityRepository
   }
 
   /**
+   * @param      $user_id
+   * @param bool $debug_build If debug builds should be included
+   *
+   * @return Program[]
+   */
+  public function getPublicUserPrograms($user_id, bool $debug_build)
+  {
+    $qb = $this->createQueryBuilder('e');
+
+    $qb
+      ->select('e')
+      ->leftJoin('e.user', 'f')
+      ->where($qb->expr()->eq('e.visible', $qb->expr()->literal(true)))
+      ->andWhere($qb->expr()->eq('e.private', $qb->expr()->literal(false)))
+      ->andWhere($qb->expr()->eq('f.id', ':user_id'))
+      ->setParameter('user_id', $user_id)
+      ->orderBy('e.uploaded_at', 'DESC');
+
+    $qb = $this->addDebugBuildCondition($qb, $debug_build, 'e');
+
+    return $qb->getQuery()->getResult();
+  }
+
+  /**
    * @param bool        $debug_build If debug builds should be included
    * @param string|null $flavor
    *

--- a/tests/behat/features/web/private_program.feature
+++ b/tests/behat/features/web/private_program.feature
@@ -1,0 +1,73 @@
+@homepage
+Feature: As a visitor I want to see a program page
+
+  Background:
+    Given there are users:
+      | name           | password | token      | email               |
+      | myUsername     | 123456   | cccccccccc | dev1@pocketcode.org |
+      | randomUsername | 123456   | cccccccccc | dev2@pocketcode.org |
+    And there are programs:
+      | id | name      | description | owned by   | downloads | apk_downloads | views | upload time      | version | language version | visible | apk_ready | private |
+      | 1  | program 1 | ......      | myUsername | 3         | 2             | 12    | 01.01.2013 12:00 | 0.8.5   | 0.94             | true    | true      | 0       |
+      | 2  | program 2 | ......      | myUsername | 333       | 3             | 9     | 22.04.2014 13:00 | 0.8.5   | 0.93             | true    | true      | 0       |
+      | 3  | program 3 | ......      | myUsername | 0         | 0             | 1     | 22.04.2014 13:00 | 0.8.5   | 0.93             | true    | true      | 1       |
+
+  Scenario: Private programs should not be visible on the homepage
+    Given I am on "/"
+    Then I should see "program 1"
+    And I should see "program 2"
+    And I should not see "program 3"
+
+  Scenario: Your own private programs should always be visible to you
+    Given I am on "/pocketcode/login"
+    And I fill in "username" with "myUsername"
+    And I fill in "password" with "123456"
+    And I press "Login"
+    When I am on "/pocketcode/program/1"
+    Then I should see "program 1"
+    When I am on "/pocketcode/program/2"
+    Then I should see "program 2"
+    When I am on "/pocketcode/program/3"
+    Then I should see "program 3"
+
+  Scenario: Private programs should not be accessible when not logged in
+    When I am on "/pocketcode/program/1"
+    Then I should see "program 1"
+    When I am on "/pocketcode/program/2"
+    Then I should see "program 2"
+    When I am on "/pocketcode/program/3"
+    Then I should not see "program 3"
+
+  Scenario: Private programs from a different user should not be accessible to you
+    Given I am on "/pocketcode/login"
+    And I fill in "username" with "randomUsername"
+    And I fill in "password" with "123456"
+    And I press "Login"
+    When I am on "/pocketcode/program/1"
+    Then I should see "program 1"
+    When I am on "/pocketcode/program/2"
+    Then I should see "program 2"
+    When I am on "/pocketcode/program/3"
+    Then I should not see "program 3"
+
+  Scenario: MyProfile statistics should count private programs
+    Given I am on "/pocketcode/login"
+    And I fill in "username" with "myUsername"
+    And I fill in "password" with "123456"
+    And I press "Login"
+    When I am on "/pocketcode/profile/1"
+    Then I should see "program 1"
+    And I should see "program 2"
+    And I should see "program 3"
+
+  Scenario: Profile statistics of a different user should not count private programs
+    Given I am on "/pocketcode/login"
+    And I fill in "username" with "randomUsername"
+    And I fill in "password" with "123456"
+    And I press "Login"
+    When I am on "/pocketcode/profile/1"
+    Then I should see "program 1"
+    And I should see "program 2"
+    And I should not see "program 3"
+    And I should see "Amount of programs: 2"
+


### PR DESCRIPTION
- userprofile:
   statistics -> program counter includes private programs only on your own profile.
   On a different profile the counter only counts public programs.

  programs-loader -> only loads public programs for profiles except your own profile (private included)

- api:
   user program api now only returns public programs except when requesting for your own id

- program pages:
   when a program is private the program can only be found by its owner.

- also added tests