### PR TITLE
SHARE-103 project page without apk buttons for ios

### DIFF
--- a/src/Catrobat/Twig/AppExtension.php
+++ b/src/Catrobat/Twig/AppExtension.php
@@ -108,6 +108,7 @@ class AppExtension extends AbstractExtension
       new TwigFunction('getenv', 'getenv'),
       new TwigFunction('countriesList', [$this, 'getCountriesList']),
       new TwigFunction('isWebview', [$this, 'isWebview']),
+      new TwigFunction('isIOSWebview', [$this, 'isIOSWebview']),
       new TwigFunction('checkCatrobatLanguage', [$this, 'checkCatrobatLanguage']),
       new TwigFunction('getLanguageOptions', [$this, 'getLanguageOptions']),
       new TwigFunction('getMediaPackageImageUrl', [$this, 'getMediaPackageImageUrl']),
@@ -237,8 +238,19 @@ class AppExtension extends AbstractExtension
     $user_agent = $request->headers->get('User-Agent');
 
     // Example Webview: $user_agent = "Catrobat/0.93 PocketCode/0.9.14 Platform/Android";
-    return preg_match('/Catrobat/', $user_agent) || strpos($user_agent, 'Android') != false ||
-      strpos($user_agent, 'iPad') != false || strpos($user_agent, 'iPhone') != false;
+    return preg_match('/Catrobat/', $user_agent) || strpos($user_agent, 'Android') !== false ||
+      strpos($user_agent, 'iPad') !== false || strpos($user_agent, 'iPhone') !== false;
+  }
+
+  /**
+   * @return bool
+   */
+  public function isIOSWebview()
+  {
+    $request = $this->request_stack->getCurrentRequest();
+    $user_agent = $request->headers->get('User-Agent');
+
+    return strpos($user_agent, 'iPad') !== false || strpos($user_agent, 'iPhone') !== false;
   }
 
   /**

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -204,6 +204,7 @@
           </button>
         </div>
 
+        {% if not isIOSWebview() %}
         <div id="apk-generate" class="btn-container col-12 col-xl-6">
           <button class="btn btn-primary">
             <i class="program-big-button-icon mr-3 fab fa-android"></i>
@@ -226,6 +227,7 @@
           </button>
         </div>
       </div>
+      {% endif %}
 
       {% if not program.gamejam or not program.acceptedforgamejam %}
         {% if jam %}

--- a/tests/behat/features/bootstrap/WebFeatureContext.php
+++ b/tests/behat/features/bootstrap/WebFeatureContext.php
@@ -198,6 +198,19 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
     $this->iUseTheUserAgentParameterized("0.998", "PocketCode", "0.9.60", $build_type);
   }
 
+  // @formatter:off
+  /**
+   * @Given /^I use an ios app$/
+   */
+  // @formatter:on
+  public function iUseAnIOSApp()
+  {
+    // see org.catrobat.catroid.ui.WebViewActivity
+    $platform = "iPhone";
+    $user_agent =  " Platform/" . $platform;
+    $this->getSession()->setRequestHeader("User-Agent", $user_agent);
+  }
+
 
   /**
    * @When /^I wait (\d+) milliseconds$/

--- a/tests/behat/features/web/program.feature
+++ b/tests/behat/features/web/program.feature
@@ -227,3 +227,16 @@ Feature: As a visitor I want to see a program page
     Given I am on "/pocketcode/program/1"
     Then I should see "my superman description"
     And I should not see "Show more"
+    
+  Scenario: On the project page there should be all buttons visible to web and android
+    Given I am on "/pocketcode/program/1"
+    Then I should see "Download as program"
+    And I should see "Show Remix Graph"
+    And I should see "Download as app"
+
+  Scenario: On the project page there should be no apk button be visible to ios users
+    Given I use an ios app
+    And I am on "/pocketcode/program/1"
+    Then I should see "Download as program"
+    And I should see "Show Remix Graph"
+    And I should not see "Download as app"


### PR DESCRIPTION
- removed buttons for ios project detail page
- added an twig extension that checks the user agent
- added tests