### PR TITLE
SHARE 95 keep ascpect ratio in thumbnails

### DIFF
--- a/assets/css/base/_brain.scss
+++ b/assets/css/base/_brain.scss
@@ -260,6 +260,7 @@ $program-tile-width: 85px;
       width: 100%;
 
       > img {
+        object-fit: cover;
         max-width: $program-tile-width !important;
         max-height: $program-tile-width;
       }

--- a/public/resources/screenshots/.gitignore
+++ b/public/resources/screenshots/.gitignore
@@ -1,4 +1,4 @@
-# Ignore everything in this directory
-*
-# Except this file
+# Ignore everything in this directory	
+*	
+# Except this file	
 !.gitignore

--- a/src/Catrobat/Services/ScreenshotRepository.php
+++ b/src/Catrobat/Services/ScreenshotRepository.php
@@ -3,6 +3,7 @@
 namespace App\Catrobat\Services;
 
 use App\Catrobat\Exceptions\InvalidStorageDirectoryException;
+use mysql_xdevapi\Exception;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
@@ -108,7 +109,7 @@ class ScreenshotRepository
   {
     $screen = $this->getImagick();
     $screen->readImage($filepath);
-    $screen->resizeImage(480, 480, \Imagick::FILTER_LANCZOS, 1);
+    $screen->cropThumbnailImage(480, 480);
     $screen->writeImage($this->screenshot_dir . $this->generateFileNameFromId($id));
     $screen->destroy();
   }
@@ -123,7 +124,7 @@ class ScreenshotRepository
   {
     $thumb = $this->getImagick();
     $thumb->readImage($filepath);
-    $thumb->resizeImage(80, 80, \Imagick::FILTER_LANCZOS, 1);
+    $thumb->cropThumbnailImage(80, 80);
     $thumb->writeImage($this->thumbnail_dir . $this->generateFileNameFromId($id));
     $thumb->destroy();
   }
@@ -276,7 +277,7 @@ class ScreenshotRepository
   {
     $screen = $this->getImagick();
     $screen->readImage($filepath);
-    $screen->resizeImage(480, 480, \Imagick::FILTER_LANCZOS, 1);
+    $screen->cropThumbnailImage(480, 480);
     $screen->writeImage($this->tmp_dir . $this->generateFileNameFromId($id));
     $screen->destroy();
   }
@@ -291,7 +292,7 @@ class ScreenshotRepository
   {
     $thumb = $this->getImagick();
     $thumb->readImage($filepath);
-    $thumb->resizeImage(80, 80, \Imagick::FILTER_LANCZOS, 1);
+    $thumb->cropThumbnailImage(80, 80);
     $thumb->writeImage($this->tmp_dir . "thumb/" . $this->generateFileNameFromId($id));
     $thumb->destroy();
   }

--- a/src/Entity/ProgramManager.php
+++ b/src/Entity/ProgramManager.php
@@ -129,6 +129,9 @@ class ProgramManager
    */
   public function addProgram(AddProgramRequest $request)
   {
+    /**
+     * @var $program Program
+     */
     $file = $request->getProgramfile();
 
     $extracted_file = $this->file_extractor->extract($file);


### PR DESCRIPTION
Thumbnails are generated when the user uploads a project / we import a project.
Until now images were just reduced in size (fixed width, height -> square), which resulted in distorted images
Now we crop a square with the correct size using imagicks cropThumbnail function to keep the aspect ratios as they were.