### PR TITLE
SHARE-84 Report program - request uri too long

### DIFF
--- a/assets/js/custom/ProgramReport.js
+++ b/assets/js/custom/ProgramReport.js
@@ -94,7 +94,7 @@ function ProgramReport (programId, reportUrl, loginUrl, reportSentText, errorTex
   
   function reportProgram (reason, category)
   {
-    $.get(reportUrl, {
+    $.post(reportUrl, {
       program : programId,
       category: category,
       note    : reason


### PR DESCRIPTION
changed method from get to post when calling thereportPorgram Api to circumvent uri too long problem