### PR TITLE
SHARE-117 added change project screenshot/thumbnail functionality

### DIFF
--- a/assets/css/base/_catro_bootstrap.scss
+++ b/assets/css/base/_catro_bootstrap.scss
@@ -399,3 +399,53 @@ $galaxy-button-background-color: #9583b2;
 .title-color-right {
   color: $theme-logo-color-secondary;
 }
+
+.upload-image {
+  position: relative;
+  top: -45px;
+  text-align: center;
+  margin: 0 auto;
+  font-size: 1.2em;
+
+  span {
+    font-size: $default-font-size + 0.125;
+    cursor: pointer;
+  }
+
+  .button-show-ajax {
+    margin: 0 auto;
+  }
+
+  > div {
+    position: relative;
+    display: inline-block;
+    overflow: hidden;
+    background-color: rgba(255, 255, 255, 0.8);
+    border-radius: 5px;
+    font-weight: bold;
+    padding: 4px 15px;
+    border: 1px rgba($primary, 0.8);
+    @include transition(width 250ms);
+    max-width: 100%;
+    @include force-word-break();
+
+    &:hover {
+      top: -2px;
+      padding-top: 6px;
+      padding-bottom: 6px;
+      border: 1px rgba($primary, 0.95);
+      background-color: rgba(255, 255, 255, 0.95);
+      margin-bottom: -4px;
+    }
+
+    input {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      opacity: 0.001;
+      cursor: pointer;
+    }
+  }
+}

--- a/assets/css/custom/profile.scss
+++ b/assets/css/custom/profile.scss
@@ -85,57 +85,6 @@
   width: 100%;
 }
 
-#avatar-upload {
-  position: relative;
-  top: -45px;
-  text-align: center;
-  margin: 0 auto;
-  font-size: 1.2em;
-
-  span {
-    font-size: $default-font-size + 0.125;
-    cursor: pointer;
-  }
-
-  .button-show-ajax {
-    margin: 0 auto;
-  }
-
-  > div {
-    position: relative;
-    display: inline-block;
-    overflow: hidden;
-    background-color: rgba(255, 255, 255, 0.8);
-    border-radius: 5px;
-    font-weight: bold;
-    padding: 4px 15px;
-    border: 1px rgba($primary, 0.8);
-    @include transition(width 250ms);
-    max-width: 100%;
-    @include force-word-break();
-
-    &:hover {
-      top: -2px;
-      padding-top: 6px;
-      padding-bottom: 6px;
-      border: 1px rgba($primary, 0.95);
-      background-color: rgba(255, 255, 255, 0.95);
-      margin-bottom: -4px;
-    }
-
-    input {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      opacity: 0.001;
-      cursor: pointer;
-    }
-  }
-}
-
-
 /* My Programs */
 
 .program {

--- a/assets/css/custom/program.scss
+++ b/assets/css/custom/program.scss
@@ -41,12 +41,20 @@ h2
   margin: 0;
 }
 
+
+#project-thumbnail-big
+{
+  width: 300px;
+  height: 300px;
+}
+
 #program-middle
 {
   #image
   {
     float: left;
     position: relative;
+    max-width: 300px;
   }
 
   #info
@@ -494,6 +502,7 @@ input[type='number']
     {
       text-align: center;
       float: none;
+      max-width: none;
     }
   }
 

--- a/assets/js/custom/ImageUpload.js
+++ b/assets/js/custom/ImageUpload.js
@@ -1,0 +1,56 @@
+function setImageUploadListener(upload_url, upload_button_container_id, image_container_id,
+                                statusCode_OK, statusCode_UPLOAD_EXCEEDING_FILESIZE,
+                                statusCode_UPLOAD_UNSUPPORTED_MIME_TYPE)
+{
+  $(upload_button_container_id).find('input[type=file]').change(function (data) {
+
+    $('.error-message').addClass('d-none')
+
+    let file = data.target.files[0]
+
+    let image_upload = $(upload_button_container_id)
+    image_upload.find('span').hide()
+    image_upload.find('.button-show-ajax').show()
+
+    let reader = new FileReader()
+
+    reader.onerror = function () {
+      $('.text-img-upload-error').removeClass('d-none')
+    }
+
+    reader.onload = function (event) {
+      $.post(upload_url, {image: event.currentTarget.result}, function (data) {
+        switch (parseInt(data.statusCode))
+        {
+          case statusCode_OK:
+            $('.text-img-upload-success').removeClass('d-none')
+            if (data.image_base64 === null) {
+              let src = $(image_container_id).attr('src')
+              let d = new Date()
+              $(image_container_id).attr('src', src + '?a=' + d.getDate())
+            }
+            else {
+              $(image_container_id).attr('src', data.image_base64)
+            }
+            break
+
+          case statusCode_UPLOAD_EXCEEDING_FILESIZE:
+            $('.text-img-upload-too-large').removeClass('d-none')
+            break
+
+          case statusCode_UPLOAD_UNSUPPORTED_MIME_TYPE:
+            $('.text-mime-type-not-supported').removeClass('d-none')
+            break
+
+          default:
+            $('.text-img-upload-error').removeClass('d-none')
+        }
+
+        let image_upload = $(upload_button_container_id)
+        image_upload.find('span').show()
+        image_upload.find('.button-show-ajax').hide()
+      })
+    }
+    reader.readAsDataURL(file)
+  })
+}

--- a/assets/js/custom/MyProfile.js
+++ b/assets/js/custom/MyProfile.js
@@ -15,9 +15,6 @@ let MyProfile = function (profile_url, save_username,
                           statusCode_USER_PASSWORD_TOO_LONG,
                           statusCode_USER_PASSWORD_NOT_EQUAL_PASSWORD2,
                           statusCode_PASSWORD_INVALID,
-                          statusCode_UPLOAD_EXCEEDING_FILESIZE,
-                          statusCode_UPLOAD_UNSUPPORTED_MIME_TYPE,
-                          MAX_UPLOAD_SIZE,
                           successText, checkMailText, passwordUpdatedText,
                           programCanNotChangeVisibilityTitle,
                           programCanNotChangeVisibilityText) {
@@ -35,10 +32,6 @@ let MyProfile = function (profile_url, save_username,
   self.regex_email = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
   self.data_changed = false
   self.delete_account_url = delete_account_url
-  
-  self.init = function () {
-    self.setAvatarUploadListener()
-  }
   
   let passwordEditContainer = $('#password-edit-container')
   let usernameEditContainer = $('#username-edit-container')
@@ -371,56 +364,4 @@ let MyProfile = function (profile_url, save_username,
       $('#save-password').show()
     })
   })
-  
-  self.setAvatarUploadListener = function () {
-    $('#avatar-upload').find('input[type=file]').change(function (data) {
-      $('.error-message').addClass('d-none')
-      
-      let file = data.target.files[0]
-      if (file.size > MAX_UPLOAD_SIZE)
-      {
-        $('.text-avatar-toolarge').removeClass('d-none')
-        return
-      }
-      
-      let avatarUpload = $('#avatar-upload')
-      avatarUpload.find('span').hide()
-      avatarUpload.find('.button-show-ajax').show()
-      
-      let reader = new FileReader()
-      
-      reader.onerror = function () {
-        $('.text-avatar-uploadError').removeClass('d-none')
-      }
-      
-      reader.onload = function (evt) {
-        self.filename = evt.currentTarget.result
-        $.post(self.upload_url, {image: evt.currentTarget.result}, function (data) {
-          switch (parseInt(data.statusCode))
-          {
-            
-            case statusCode_OK:
-              $('#avatar-img').attr('src', data.image_base64)
-              break
-            
-            case statusCode_UPLOAD_EXCEEDING_FILESIZE:
-              $('.text-avatar-toolarge').removeClass('d-none')
-              break
-            
-            case statusCode_UPLOAD_UNSUPPORTED_MIME_TYPE:
-              $('.text-avatar-noSupport').removeClass('d-none')
-              break
-            
-            default:
-              $('.text-avatar-uploadError').removeClass('d-none')
-          }
-          
-          let avatarUpload = $('#avatar-upload')
-          avatarUpload.find('span').show()
-          avatarUpload.find('.button-show-ajax').hide()
-        })
-      }
-      reader.readAsDataURL(file)
-    })
-  }
 }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -57,6 +57,19 @@ services:
     # fetching services directly from the container via $container->get() won't work.
     # The best practice is to be explicit about your dependencies anyway.
 
+    #
+    # setup special, global auto wiring rules:
+    #
+    #   Here one can bind variable names to specific parameters or services. This allows dependency injection
+    #   of specific strings or classes. E.g $kernel_root_dir used as parameter in an constructor signals the
+    #   dependency service that the "kernel.root_dir" parameter string must be injected.
+    #
+    #   It is also possible to inject the ParameterBagInterface with which one has easy access to all defined parameters
+    #
+    bind:
+      App\Catrobat\Services\ScreenshotRepository: '@screenshotrepository' # must be removed when merging with SHARE-120
+
+
   #  makes classes in src/Catrobat available to be used as services
   #  this creates a service per class whose id is the fully-qualified class name
   App\Catrobat\:

--- a/src/Catrobat/Services/ScreenshotRepository.php
+++ b/src/Catrobat/Services/ScreenshotRepository.php
@@ -87,6 +87,7 @@ class ScreenshotRepository
     $this->tmp_path = $tmp_path;
   }
 
+
   /**
    * @param $screenshot_filepath
    * @param $id
@@ -97,6 +98,34 @@ class ScreenshotRepository
   {
     $this->saveScreenshot($screenshot_filepath, $id);
     $this->saveThumbnail($screenshot_filepath, $id);
+  }
+
+  /**
+   * @param $image
+   * @param $id
+   */
+  public function storeImageInTmp($image, $id)
+  {
+    $filesystem = new Filesystem();
+    $tmp_file_path = $this->tmp_dir . $this->generateFileNameFromId($id);
+    if ($filesystem->exists($tmp_file_path)) {
+      $filesystem->remove($tmp_file_path);
+    }
+    $filesystem->copy($image, $tmp_file_path);
+  }
+
+  /**
+   * @param $image
+   * @param $id
+   *
+   * @throws \ImagickException
+   */
+  public function updateProgramAssets($image, $id)
+  {
+    $this->storeImageInTmp($image, $id);
+    $tmp_file_path = $this->tmp_dir . $this->generateFileNameFromId($id);
+    $this->saveScreenshot($tmp_file_path, $id);
+    $this->saveThumbnail($tmp_file_path, $id);
   }
 
   /**

--- a/src/Utils/ImageUtils.php
+++ b/src/Utils/ImageUtils.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Utils;
+
+use App\Catrobat\StatusCode;
+use Exception;
+
+
+/**
+ * Class ImageBase64Checks
+ */
+class ImageUtils {
+
+  /**
+   * @param $image_base64
+   * @param $MAX_UPLOAD_SIZE
+   * @param $MAX_IMAGE_SIZE
+   *
+   * @return string
+   * @throws Exception
+   */
+  public static function checkAndResizeBase64Image($image_base64, $MAX_IMAGE_SIZE = 300, $MAX_UPLOAD_SIZE = 5*1024*1024)
+  {
+    $image_data = explode(';base64,', $image_base64);
+    $data_regx = '/data:(.+)/';
+
+    if (!preg_match($data_regx, $image_data[0]))
+    {
+      throw new Exception(StatusCode::UPLOAD_UNSUPPORTED_FILE_TYPE);
+    }
+
+    $image_type = preg_replace('/data:(.+)/', '\\1', $image_data[0]);
+    $image = null;
+
+    switch ($image_type)
+    {
+      case 'image/jpg':
+      case 'image/jpeg':
+        $image = imagecreatefromjpeg($image_base64);
+        break;
+      case 'image/png':
+        $image = imagecreatefrompng($image_base64);
+        break;
+      case 'image/gif':
+        $image = imagecreatefromgif($image_base64);
+        break;
+      default:
+        throw new Exception(StatusCode::UPLOAD_UNSUPPORTED_MIME_TYPE);
+    }
+
+    if (!$image)
+    {
+      throw new Exception(StatusCode::UPLOAD_UNSUPPORTED_FILE_TYPE);
+    }
+
+    // https://en.wikipedia.org/wiki/Base64 not exact but enough for our checks
+    $image_size = (strlen($image_base64) * (3/4));
+
+    if ($image_size > $MAX_UPLOAD_SIZE)
+    {
+      throw new Exception(StatusCode::UPLOAD_EXCEEDING_FILESIZE);
+    }
+
+    $width = imagesx($image);
+    $height = imagesy($image);
+
+    if ($width === 0 || $height === 0)
+    {
+      throw new Exception(StatusCode::UPLOAD_UNSUPPORTED_FILE_TYPE);
+    }
+
+    if ($MAX_IMAGE_SIZE !== null && max($width, $height) > $MAX_IMAGE_SIZE)
+    {
+      $new_image = imagecreatetruecolor($MAX_IMAGE_SIZE, $MAX_IMAGE_SIZE);
+      if (!$new_image)
+      {
+        throw new Exception(StatusCode::USER_AVATAR_UPLOAD_ERROR);
+      }
+
+      imagesavealpha($new_image, true);
+      imagefill($new_image, 0, 0, imagecolorallocatealpha($new_image, 0, 0, 0, 127));
+
+      if (!imagecopyresized($new_image, $image, 0, 0, 0, 0, $MAX_IMAGE_SIZE, $MAX_IMAGE_SIZE, $width, $height))
+      {
+        imagedestroy($new_image);
+        throw new Exception(StatusCode::USER_AVATAR_UPLOAD_ERROR);
+      }
+
+      ob_start();
+      if (!imagepng($new_image))
+      {
+        imagedestroy($new_image);
+        throw new Exception(StatusCode::USER_AVATAR_UPLOAD_ERROR);
+      }
+
+      $image_base64 = 'data:image/png;base64,' . base64_encode(ob_get_clean());
+    }
+
+    return $image_base64;
+  }
+}

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -42,17 +42,8 @@
 
   <div id="program-middle">
     <div id="image" class="image-container">
-      {% if isWebview() %}
-        <a href="{% if (checkCatrobatLanguage(program_details.languageVersion)) %}{{ program_details.downloadUrl }}{% else %}javascript:program.showUpdateAppPopup();{% endif %}">
-          <img id="img-screenshot" width="300" height="300" id="screenshot"
-               src="{{ asset(program_details.screenshotBig) }}"/>
-        </a>
-      {% endif %}
 
-      {% if not isWebview() %}
-        <img id="img-screenshot" width="300" height="300" id="screenshot"
-             src="{{ asset(program_details.screenshotBig) }}"/>
-      {% endif %}
+      {% include 'Program/projectThumbnail.html.twig' %}
 
       <div id="program-like-container">
         <div>

--- a/templates/Program/projectThumbnail.html.twig
+++ b/templates/Program/projectThumbnail.html.twig
@@ -1,0 +1,45 @@
+{% if my_program %}
+  <div class="d-none error-message text-img-upload-too-large alert alert-danger">
+    {{ 'profile.avatar.pictureTooLarge'|trans({}, 'catroweb') }}
+  </div>
+  <div class="d-none error-message text-img-upload-error alert alert-danger">
+    {{ 'profile.avatar.uploadError'|trans({}, 'catroweb') }}
+  </div>
+  <div class="d-none error-message text-mime-type-not-supported alert alert-danger">
+    {{ 'profile.avatar.noSupport'|trans({}, 'catroweb') }}
+  </div>
+  <div class="d-none error-message text-img-upload-success alert alert-success">
+    {{ 'success.imgUpload'|trans({}, 'catroweb') }}
+  </div>
+{% endif %}
+
+{% if isWebview() %}
+<a href="{% if (checkCatrobatLanguage(program_details.languageVersion)) %}{{ program_details.downloadUrl }}{% else %}javascript:program.showUpdateAppPopup();{% endif %}">
+  {% endif %}
+
+  <img alt="project thumbnail" id="project-thumbnail-big"
+       src="{{ asset(program_details.screenshotBig) }}"/>
+
+  {% if my_program %}
+    <div id="change-project-thumbnail-button" class="upload-image">
+      <div>
+        <input type="file" name="file">
+        <a href="">{{ 'profile.changePicture'|trans({}, 'catroweb') }}</a>
+        <div class="button-show-ajax"><i class="fa fa-spinner fa-pulse fa-2x fa-fw" aria-hidden="true"></i></div>
+      </div>
+    </div>
+  {% endif %}
+
+
+  {% if isWebview() %}
+</a>
+{% endif %}
+<script src="{{ asset('compiled/js/ImageUpload.js') }}"></script>
+<script>
+  setImageUploadListener('{{ path('upload_project_thumbnail', { 'id': program.id }) }}',
+    '#change-project-thumbnail-button', '#project-thumbnail-big',
+      {{ constant('App\\Catrobat\\StatusCode::OK') }},
+      {{ constant('App\\Catrobat\\StatusCode::UPLOAD_EXCEEDING_FILESIZE') }},
+      {{ constant('App\\Catrobat\\StatusCode::UPLOAD_UNSUPPORTED_MIME_TYPE') }}
+  )
+</script>

--- a/templates/UserManagement/Profile/avatarEdit.html.twig
+++ b/templates/UserManagement/Profile/avatarEdit.html.twig
@@ -1,25 +1,33 @@
-<div class="d-none error-message text-avatar-toolarge alert alert-danger">
+<div class="d-none error-message text-img-upload-too-large alert alert-danger">
   {{ 'profile.avatar.pictureTooLarge'|trans({}, 'catroweb') }}
 </div>
-<div class="d-none error-message text-avatar-uploadError alert alert-danger">
+<div class="d-none error-message text-img-upload-error alert alert-danger">
   {{ 'profile.avatar.uploadError'|trans({}, 'catroweb') }}
 </div>
-<div class="d-none error-message text-avatar-noImage alert alert-danger">
-  {{ 'profile.avatar.noImage'|trans({}, 'catroweb') }}
-</div>
-<div class="d-none error-message text-avatar-noSupport alert alert-danger">
+<div class="d-none error-message text-mime-type-not-supported alert alert-danger">
   {{ 'profile.avatar.noSupport'|trans({}, 'catroweb') }}
+</div>
+<div class="d-none error-message text-img-upload-success alert alert-success">
+  {{ 'success.imgUpload'|trans({}, 'catroweb') }}
 </div>
 
 <img alt="avatar" id="avatar-img"
      src="{% if app.user.avatar is not empty %}{{ app.user.avatar }}{% else %}{{ asset('images/default/avatar_default.png') }}{% endif %}">
 
-{% if not app.user.limited %}
-  <div id="avatar-upload">
-    <div>
-      <input type="file" name="file">
-      <a href="">{{ 'profile.changePicture'|trans({}, 'catroweb') }}</a>
-      <div class="button-show-ajax"><i class="fa fa-spinner fa-pulse fa-2x fa-fw" aria-hidden="true"></i></div>
-    </div>
+<div id="avatar-upload" class="upload-image">
+  <div>
+    <input type="file" name="file">
+    <a href="">{{ 'profile.changePicture'|trans({}, 'catroweb') }}</a>
+    <div class="button-show-ajax"><i class="fa fa-spinner fa-pulse fa-2x fa-fw" aria-hidden="true"></i></div>
   </div>
-{% endif %}
+</div>
+
+<script src="{{ asset('compiled/js/ImageUpload.js') }}"></script>
+<script>
+  setImageUploadListener('{{ path('profile_upload_avatar') }}',
+    '#avatar-upload', '#avatar-img',
+      {{ constant('App\\Catrobat\\StatusCode::OK') }},
+      {{ constant('App\\Catrobat\\StatusCode::UPLOAD_EXCEEDING_FILESIZE') }},
+      {{ constant('App\\Catrobat\\StatusCode::UPLOAD_UNSUPPORTED_MIME_TYPE') }}
+  )
+</script>

--- a/templates/UserManagement/Profile/myProfile.html.twig
+++ b/templates/UserManagement/Profile/myProfile.html.twig
@@ -64,16 +64,12 @@
         {{ constant('App\\Catrobat\\StatusCode::USER_PASSWORD_TOO_LONG') }},
         {{ constant('App\\Catrobat\\StatusCode::USER_PASSWORD_NOT_EQUAL_PASSWORD2') }},
         {{ constant('App\\Catrobat\\StatusCode::PASSWORD_INVALID') }},
-        {{ constant('App\\Catrobat\\StatusCode::UPLOAD_EXCEEDING_FILESIZE') }},
-        {{ constant('App\\Catrobat\\StatusCode::UPLOAD_UNSUPPORTED_MIME_TYPE') }},
-        {{ constant('App\\Catrobat\\Controller\\Web\\ProfileController::MAX_UPLOAD_SIZE') }},
         '{{ "success.text"|trans({}, "catroweb") }}',
         '{{ "myprofile.checkMail"|trans({}, "catroweb") }}',
         '{{ "myprofile.passwordUpdated"|trans({}, "catroweb") }}',
         '{{ "myprofile.notChangeVisibility"|trans({}, "catroweb") }}',
         '{{ "myprofile.notChangeVisibilityReason"|trans({}, "catroweb") }}'
       )
-      profile.init()
     {% else %}
       programs = new ProjectLoader('#user-programs', '{{ path('api_user_programs') }}')
     {% endif %}

--- a/tests/behat/features/bootstrap/WebFeatureContext.php
+++ b/tests/behat/features/bootstrap/WebFeatureContext.php
@@ -1179,6 +1179,50 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
     }
   }
 
+
+  /**
+   * @Then /^the project img tag should( [^"]*)? have the "([^"]*)" data url$/
+   * @param $not
+   * @param $name
+   */
+  public function theProjectImgTagShouldHaveTheDataUrl($not, $name)
+  {
+    $name = trim($name);
+    $not = trim($not);
+
+    $pre_source = $this->getSession()->getPage()->find('css', '#project-thumbnail-big');
+    $source = 0;
+    if (!is_null($pre_source))
+    {
+      $source = $pre_source->getAttribute('src');
+    }
+    else
+    {
+      Assert::assertTrue(false, "Couldn't find avatar in project-thumbnail-big");
+    }
+    $source = trim($source, '"');
+
+    switch ($name)
+    {
+      case 'logo.png':
+        throw new Exception($source);
+        $logoUrl = 'data:image/png;base64,' . base64_encode(file_get_contents(self::AVATAR_DIR . 'logo.png'));
+        $isSame = ($source === $logoUrl);
+        $not == 'not' ? Assert::assertFalse($isSame) : Assert::assertTrue($isSame);
+        break;
+
+      case 'fail.tif':
+        $failUrl = 'data:image/tiff;base64,' . base64_encode(file_get_contents(self::AVATAR_DIR . 'fail.tif'));
+        $isSame = ($source === $failUrl);
+        $not == 'not' ? Assert::assertFalse($isSame) : Assert::assertTrue($isSame);
+        break;
+
+      default:
+        Assert::assertTrue(false);
+    }
+  }
+
+
   /**
    * @Given /^the element "([^"]*)" should be visible$/
    * @param $element

--- a/tests/behat/features/web/change_project_image.feature
+++ b/tests/behat/features/web/change_project_image.feature
@@ -1,0 +1,39 @@
+@homepage
+Feature:
+  A user should be able to change his projects screenshot/thumbnail
+
+  Background:
+    Given there are users:
+      | name     | password | token      | email        | id |
+      | Catrobat | 123456   | cccccccccc | dev1@app.org |  1 |
+      | User1    | 654321   | cccccccccc | dev2@app.org |  2 |
+    And there are programs:
+      | id | name       | description | owned by |
+      | 1  | program 1  | p1          | Catrobat |
+      | 2  | program 2  |             | Catrobat |
+
+  Scenario: uploading new image should not work when not logged in
+    And I am on "/app/project/1"
+    And I should see "program 1"
+    Then the element "#change-project-thumbnail-button" should not exist
+
+  Scenario: uploading new a project image should not work when it is not my project
+    Given I log in as "User1" with the password "654321"
+    And I am on "/app/project/1"
+    And I should see "program 1"
+    Then the element "#change-project-thumbnail-button" should not exist
+
+  Scenario: uploading new image should work when I am logged in and it is my program
+    Given I log in as "Catrobat" with the password "123456"
+    And I am on "/app/project/1"
+    And I should see "program 1"
+    When I click "#change-project-thumbnail-button"
+    And I wait for the server response
+    When I attach the avatar "logo.png" to "file"
+    And I wait 250 milliseconds
+    Then I should see "Your image was uploaded successfully!"
+    And I click "#change-project-thumbnail-button"
+    And I wait for the server response
+    When I attach the avatar "galaxy.jpg" to "file"
+    And I wait 250 milliseconds
+    Then I should see "Your image was uploaded successfully!"

--- a/tests/behat/features/web/my_profile.feature
+++ b/tests/behat/features/web/my_profile.feature
@@ -215,6 +215,7 @@ Feature:
   Scenario: max. 5MB for avatar image
     When I click "#avatar-upload"
     And I attach the avatar "galaxy_big.png" to "file"
+    And I wait 500 milliseconds
     Then I should see "Your chosen picture is too large, please do not use images larger than 5mb."
 
   Scenario: deleting a program should work

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -626,6 +626,7 @@ success:
   registration: Registration successful!
   token: ok
   upload: Your project was uploaded successfully!
+  imgUpload: Your image was uploaded successfully!
   report: Your report was successfully sent!
 time:
   minutes.ago: '{0} < 1 minute ago |{1}1 minute ago |]1,Inf] %count% minutes ago'


### PR DESCRIPTION
A user can now change the screenshot/thumbnail of his projects similar to
the way he can change his profile avatar.
    
- created imageUtils.php and Imageupload.js to prevent duplicated code.
- the uploaded image gets checked and resized to the correct sizes (same like app upload)
- img gets refreshed instant on the html page, no need to refresh the page
- same error messaged like @myprofile avatar + 1 success message
