### PR TITLE
SHARE-118 Allow Webview Login using Cookies

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -64,6 +64,8 @@ security:
                 secure: false
                 httponly: false
             logout_on_user_change: true # remove when symfony 4
+            simple_preauth:
+                authenticator: webview_authenticator
 
         # disables authentication for assets and the profiler, adapt it according to your needs
         dev:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -79,6 +79,11 @@ services:
     public: true
   App\Catrobat\Security\ApiKeyAuthenticator: "@apikey_authenticator"
 
+  webview_authenticator:
+    class: App\Catrobat\Security\WebviewAuthenticator
+    public: true
+  App\Catrobat\Security\WebviewAuthenticator: "@webview_authenticator"
+
   user_authenticator:
     class: App\Catrobat\Security\UserAuthenticator
     arguments:

--- a/src/Resources/TwigBundle/views/Exception/error401.html.twig
+++ b/src/Resources/TwigBundle/views/Exception/error401.html.twig
@@ -1,0 +1,10 @@
+{% extends 'Default/base.html.twig' %}
+
+{% block body %}
+  <div id="error">
+    <h1>{{ "errors.authentication.title" | trans({}, "catroweb") }}</h1>
+    <i class="fas fa-exclamation-triangle fa-7x"></i>
+    <p>{{ exception.message | nl2br }}</p>
+  </div>
+
+{% endblock %}

--- a/templates/Default/sidebar.html.twig
+++ b/templates/Default/sidebar.html.twig
@@ -54,7 +54,7 @@
     </li>
 
     {# logout #}
-    {% if app.user %}
+    {% if app.user and app.session and not app.session.get('webview-auth') %}
       <li class="nav-item">
         <a class="nav-link" href="{{ url('logout') }}" id="btn-logout">
           <i class="fas fa-sign-out-alt mr-1"></i>

--- a/tests/behat/features/api/check_token.feature
+++ b/tests/behat/features/api/check_token.feature
@@ -43,7 +43,7 @@ Feature: Checking a user's token validity
     When I POST these parameters to "/app/api/checkToken/check.json"
     Then I should get the json object:
       """
-      {"statusCode":601,"answer":"There is no user with name \"doesnotexist\".", "preHeaderMessages":""}
+      {"statusCode":601,"answer":"This username does not exist.", "preHeaderMessages":""}
       """
     And the response code should be "401"
     

--- a/tests/behat/features/api/upload_program.feature
+++ b/tests/behat/features/api/upload_program.feature
@@ -38,7 +38,7 @@ Feature: Upload a program
     When I POST these parameters to "/app/api/upload/upload.json"
     Then I should get the json object:
       """
-      {"statusCode":601,"answer":"There is no user with name \"INVALID\".","preHeaderMessages":""}
+      {"statusCode":601,"answer":"This username does not exist.","preHeaderMessages":""}
       """
 
   Scenario: trying to upload with an invalid token should result in an error

--- a/tests/behat/features/bootstrap/WebFeatureContext.php
+++ b/tests/behat/features/bootstrap/WebFeatureContext.php
@@ -182,7 +182,7 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
    * @param $theme String
    */
   // @formatter:on
-  public function iUseTheUserAgentParameterized($lang_version, $flavor, $app_version, $build_type, $theme="pocketcode")
+  public function iUseTheUserAgentParameterized($lang_version, $flavor, $app_version, $build_type, $theme = "pocketcode")
   {
     // see org.catrobat.catroid.ui.WebViewActivity
     $platform = "Android";
@@ -209,7 +209,7 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
   {
     // see org.catrobat.catroid.ui.WebViewActivity
     $platform = "iPhone";
-    $user_agent =  " Platform/" . $platform;
+    $user_agent = " Platform/" . $platform;
     $this->getSession()->setRequestHeader("User-Agent", $user_agent);
   }
 
@@ -231,7 +231,7 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
    */
   public function theLogosSrcShouldBe($logo_src)
   {
-    $image = $this->getSession()->getPage()->findAll('css','#logo');
+    $image = $this->getSession()->getPage()->findAll('css', '#logo');
     $img_url = $image[0]->getAttribute('src');
     Assert::assertNotFalse(strpos($img_url, $logo_src));
   }
@@ -243,7 +243,7 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
    */
   public function theLogosSrcShouldNotBe($logo_src)
   {
-    $image = $this->getSession()->getPage()->findAll('css','#logo');
+    $image = $this->getSession()->getPage()->findAll('css', '#logo');
     $img_url = $image[0]->getAttribute('src');
     Assert::assertFalse(strpos($img_url, $logo_src));
   }
@@ -256,6 +256,20 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
   public function iWaitMilliseconds($milliseconds)
   {
     $this->getSession()->wait($milliseconds);
+  }
+
+  /**
+   * @Given /^I set the cookie "([^"]+)" to "([^"]*)"$/
+   * @param string $cookie_name
+   * @param string $cookie_value
+   */
+  public function iSetTheCookie($cookie_name, $cookie_value)
+  {
+    if ($cookie_value === "NULL")
+    {
+      $cookie_value = null;
+    }
+    $this->getSession()->setCookie($cookie_name, $cookie_value);
   }
 
   /**
@@ -639,11 +653,15 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
       $user->setAdditionalEmail('');
       $user->setPlainPassword($users[$i]['password']);
       $user->setEnabled(true);
-      $user->setUploadToken($users[$i]['token']);
+      if ($users[$i]['token'])
+      {
+        $user->setUploadToken($users[$i]['token']);
+      }
       $user->setCountry('at');
       $user_manager->updateUser($user, true);
 
-      if (array_key_exists('id', $users[$i])) {
+      if (array_key_exists('id', $users[$i]))
+      {
         $user->setId($users[$i]['id']);
         $em = $this->kernel->getContainer()->get('doctrine')->getManager();
         $em->flush();
@@ -806,7 +824,8 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
       $em->persist($program);
 
       // overwrite id if desired
-      if (array_key_exists('id', $programs[$i])) {
+      if (array_key_exists('id', $programs[$i]))
+      {
         $program->setId($programs[$i]['id']);
         $em->persist($program);
         $em->flush();
@@ -1617,7 +1636,8 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
       $em->persist($program);
 
       // overwrite id if desired
-      if (array_key_exists('id', $programs[$i])) {
+      if (array_key_exists('id', $programs[$i]))
+      {
         $program->setId($programs[$i]['id']);
         $em->persist($program);
         $em->flush();
@@ -3025,7 +3045,8 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
         $em->persist($program);
 
         // overwrite id if desired
-        if (array_key_exists('id', $programs[$i])) {
+        if (array_key_exists('id', $programs[$i]))
+        {
           $program->setId($programs[$i]['id']);
           $em->persist($program);
           $em->flush();

--- a/tests/behat/features/web/webview_authentication.feature
+++ b/tests/behat/features/web/webview_authentication.feature
@@ -1,0 +1,66 @@
+@homepage
+Feature: Users should be logged in automatically when they are logged in in the app
+
+  Background:
+    Given there are users:
+      | name     | password | token                            | email          | id |
+      | Catrobat | 123456   | cafe000000deadbeef1111affe227357 | dev1@catrob.at | 1  |
+      | User2    | 654321   | 112233445566778899aabbccddeeff00 | dev2@catrob.at | 2  |
+      | User3    | 654321   |                                  | dev3@catrob.at | 3  |
+      | User4    | 654321   | 99990bad099990bad099990bad099999 | dev4@catrob.at | 4  |
+
+  Scenario: Log in using Catrobat user and show profile
+    Given I set the cookie "CATRO_LOGIN_USER" to "Catrobat"
+    And I set the cookie "CATRO_LOGIN_TOKEN" to "cafe000000deadbeef1111affe227357"
+    And I am on "/app/user"
+    Then I should see "My Profile"
+    Then I should see "dev1@catrob.at"
+
+  Scenario: Log in using Catrobat user with wrong token
+    Given I set the cookie "CATRO_LOGIN_USER" to "Catrobat"
+    And I set the cookie "CATRO_LOGIN_TOKEN" to "deadbeef"
+    And I am on "/app/user"
+    Then I should not see "dev1@catrob.at"
+    And I should see "Your user credentials are wrong"
+
+  Scenario: Log in using unknown user
+    Given I set the cookie "CATRO_LOGIN_USER" to "Badguy"
+    And I set the cookie "CATRO_LOGIN_TOKEN" to "deadbeef"
+    And I am on "/app/user"
+    Then I should not see "My Profile"
+    And I should see "Your user credentials are wrong"
+
+  Scenario: Log in using empty token should be ignored
+    Given I set the cookie "CATRO_LOGIN_USER" to "User3"
+    And I set the cookie "CATRO_LOGIN_TOKEN" to ""
+    And I am on "/app/user"
+    Then I should not see "My Profile"
+    And I should be on "/app/login"
+    And I should see 1 "input#password"
+
+  Scenario: Log in without user cookie should be ignored
+    And I set the cookie "CATRO_LOGIN_TOKEN" to "99990bad099990bad099990bad099999"
+    And I am on "/app/user"
+    Then I should not see "My Profile"
+    And I should be on "/app/login"
+    And I should see 1 "input#password"
+
+  Scenario: Logout button should be hidden
+    Given I set the cookie "CATRO_LOGIN_USER" to "User2"
+    And I set the cookie "CATRO_LOGIN_TOKEN" to "112233445566778899aabbccddeeff00"
+    And I am on the homepage
+    And I open the menu
+    Then I should see 0 "#btn-logout"
+    Then I should see 0 "#btn-login"
+    Then I should see 1 "#btn-profile"
+
+  Scenario: Logout should not be possible
+    Given I set the cookie "CATRO_LOGIN_USER" to "User2"
+    And I set the cookie "CATRO_LOGIN_TOKEN" to "112233445566778899aabbccddeeff00"
+    And I am on the homepage
+    And I go to "/app/logout"
+    And I open the menu
+    Then I should see 1 "#btn-profile"
+    And I go to "/app/user"
+    Then I should see "My Profile"
+    Then I should see "dev2@catrob.at"

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -620,6 +620,11 @@ errors:
     tooold: 'Sorry, your project contains an old version of the Catrobat language! Are you using the latest version of Pocket Code?'
   programversion:
     tooold: 'Sorry, you are using an old version of Pocket Code. Please update to the latest version.'
+  authentication:
+    title: Authentication failed
+    webview: |
+      Your user credentials are wrong.
+      Please try to log in again in the app.
 
 success:
   text: Success


### PR DESCRIPTION
Allow to log in automatically inside the app by using a token.
Hide logout button if logged in using cookies.
Show advice to login again using the app if authentication fails.

To log in, set cookie `CATRO_LOGIN_USER` to the **URL-encoded username**
and cookie `CATRO_LOGIN_TOKEN` to the token returned by API login.

Fix static (not translated; exception not caught) error message
in `ApiKeyAuthenticator::authenticateToken`.