### PR TITLE
SHARE-120 Major Symfony Upgrade

### DIFF
--- a/.env
+++ b/.env
@@ -38,3 +38,16 @@ SLACK_WEBHOOK=xxxx
 #DEPLOY_WEBTEST_BRANCH=
 #DEPLOY_POREVIEW=
 #DEPLOY_POREVIEW_BRANCH=
+###> symfony/framework-bundle ###
+APP_ENV=dev
+APP_SECRET=93055246cfa39f62f5be97928084989a
+#TRUSTED_PROXIES=127.0.0.1,127.0.0.2
+#TRUSTED_HOSTS='^localhost|example\.com$'
+###< symfony/framework-bundle ###
+
+###> doctrine/doctrine-bundle ###
+# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
+# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
+# Configure your db driver and server_version in config/packages/doctrine.yaml
+DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name
+###< doctrine/doctrine-bundle ###

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,26 @@ vendor/
 ### root ###
 *.sh
 crowdin.yml
+###> symfony/framework-bundle ###
+/.env.local
+/.env.local.php
+/.env.*.local
+/public/bundles/
+/var/
+/vendor/
+###< symfony/framework-bundle ###
+
+###> behat/symfony2-extension ###
+behat.yml
+###< behat/symfony2-extension ###
+
+###> phpunit/phpunit ###
+/phpunit.xml
+.phpunit.result.cache
+###< phpunit/phpunit ###
+
+###> symfony/phpunit-bridge ###
+.phpunit
+.phpunit.result.cache
+/phpunit.xml
+###< symfony/phpunit-bridge ###

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -31,15 +31,12 @@ default:
         DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
 
         Behat\MinkExtension:
+            browser_name: chrome
             base_url: http://localhost/index_test.php/
             sessions:
                 default:
                     chrome:
                         api_url: "http://localhost:9222"
-
-        VIPSoft\DoctrineDataFixturesExtension\Extension:
-            lifetime:    scenario
-            autoload:    false
 
         emuse\BehatHTMLFormatter\BehatHTMLFormatterExtension:
               name: html

--- a/bin/var-dump-server
+++ b/bin/var-dump-server
@@ -1,0 +1,1 @@
+../vendor/symfony/var-dumper/Resources/bin/var-dump-server

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "doctrine/migrations": "^2.0",
         "doctrine/orm": "^2.6",
         "eightpoints/guzzle-bundle": "^7.3",
-        "facebook/graph-sdk": "^5.7",
-        "fr3d/ldap-bundle": "^3.0",
+        "fr3d/ldap-bundle": "^4.0",
         "friendsofsymfony/jsrouting-bundle": "^2.2",
         "friendsofsymfony/rest-bundle": "^2.4",
         "friendsofsymfony/user-bundle": "^2.1",
@@ -30,8 +29,8 @@
         "liip/theme-bundle": "dev-master",
         "php-http/guzzle6-adapter": "^2.0",
         "php-http/message": "^1.7",
-        "sensio/framework-extra-bundle": "^5.3",
-        "sonata-project/admin-bundle": "3.49.0",
+        "sensio/framework-extra-bundle": "*",
+        "sonata-project/admin-bundle": "3.49",
         "sonata-project/doctrine-orm-admin-bundle": "3.9.0",
         "sonata-project/user-bundle": "4.3.0",
         "symfony/acl-bundle": "*",
@@ -40,8 +39,8 @@
         "symfony/dotenv": "*",
         "symfony/flex": "^1.2",
         "symfony/framework-bundle": "*",
-        "symfony/maker-bundle": "*",
         "symfony/intl": "*",
+        "symfony/maker-bundle": "*",
         "symfony/monolog-bundle": "*",
         "symfony/polyfill-iconv": "*",
         "symfony/profiler-pack": "*",
@@ -51,13 +50,14 @@
     },
     "require-dev": {
         "behat/behat": "^3.5",
-        "behat/mink": "^1.7",
+        "behat/mink": "1.7",
         "behat/mink-extension": "^2.3",
         "behat/symfony2-extension": "^2.1",
         "bossa/phpspec2-expect": "^3.0",
         "deployer/deployer": "^6.4",
         "deployer/recipes": "^6.2",
-        "dmore/behat-chrome-extension": "^1.2",
+        "dmore/behat-chrome-extension": "^1.3",
+        "dmore/chrome-mink-driver": "^2.7",
         "emuse/behat-html-formatter": "@dev",
         "phpcheckstyle/phpcheckstyle": "^0.14.8",
         "phpspec/phpspec": "^5.1",
@@ -95,7 +95,8 @@
     "scripts": {
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
-            "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
+            "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd",
+            "assets:install %PUBLIC_DIR%": "symfony-cmd"
         },
 
         "post-install-cmd": [
@@ -108,8 +109,7 @@
 
     "extra": {
         "symfony": {
-            "allow-contrib": false,
-            "require": "3.4.*"
+            "allow-contrib": false
         },
         "symfony-app-dir": "app",
         "symfony-web-dir": "public",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e04109e6fd1acd214dd3f19e20786237",
+    "content-hash": "23472182453a2c4fa1d621d85002ff97",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -125,16 +125,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "v1.6.1",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "53120e0eb10355388d6ccbe462f1fea34ddadb24"
+                "reference": "fa4c4e861e809d6a1103bd620cce63ed91aedfeb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/53120e0eb10355388d6ccbe462f1fea34ddadb24",
-                "reference": "53120e0eb10355388d6ccbe462f1fea34ddadb24",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/fa4c4e861e809d6a1103bd620cce63ed91aedfeb",
+                "reference": "fa4c4e861e809d6a1103bd620cce63ed91aedfeb",
                 "shasum": ""
             },
             "require": {
@@ -143,12 +143,12 @@
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^7.5@dev"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -162,16 +162,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -189,7 +189,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2019-03-25T19:12:02+00:00"
+            "time": "2019-08-08T18:11:40+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -1067,28 +1067,30 @@
         },
         {
             "name": "doctrine/lexer",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8"
+                "reference": "e17f069ede36f7534b95adec71910ed1b49c74ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/1febd6c3ef84253d7c815bed85fc622ad207a9f8",
-                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/e17f069ede36f7534b95adec71910ed1b49c74ea",
+                "reference": "e17f069ede36f7534b95adec71910ed1b49c74ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5"
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -1102,12 +1104,12 @@
             ],
             "authors": [
                 {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
                     "name": "Guilherme Blanco",
                     "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Johannes Schmitt",
@@ -1123,20 +1125,20 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-06-08T11:03:04+00:00"
+            "time": "2019-07-30T19:33:28+00:00"
         },
         {
             "name": "doctrine/migrations",
-            "version": "v2.1.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "ebe6f891a4c61574f77fc4a06d913d29236b8466"
+                "reference": "a89fa87a192e90179163c1e863a145c13337f442"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/ebe6f891a4c61574f77fc4a06d913d29236b8466",
-                "reference": "ebe6f891a4c61574f77fc4a06d913d29236b8466",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/a89fa87a192e90179163c1e863a145c13337f442",
+                "reference": "a89fa87a192e90179163c1e863a145c13337f442",
                 "shasum": ""
             },
             "require": {
@@ -1205,7 +1207,7 @@
                 "migrations",
                 "php"
             ],
-            "time": "2019-06-06T15:47:41+00:00"
+            "time": "2019-07-30T18:51:47+00:00"
         },
         {
             "name": "doctrine/orm",
@@ -1448,16 +1450,16 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.10",
+            "version": "2.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "a6c8d7101b19a451c1707b1b79bbbc56e4bdb7ec"
+                "reference": "92dd169c32f6f55ba570c309d83f5209cefb5e23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/a6c8d7101b19a451c1707b1b79bbbc56e4bdb7ec",
-                "reference": "a6c8d7101b19a451c1707b1b79bbbc56e4bdb7ec",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/92dd169c32f6f55ba570c309d83f5209cefb5e23",
+                "reference": "92dd169c32f6f55ba570c309d83f5209cefb5e23",
                 "shasum": ""
             },
             "require": {
@@ -1476,7 +1478,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -1502,7 +1504,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2019-07-19T20:52:08+00:00"
+            "time": "2019-08-13T17:33:27+00:00"
         },
         {
             "name": "eightpoints/guzzle-bundle",
@@ -1568,64 +1570,6 @@
             "time": "2019-02-27T16:04:00+00:00"
         },
         {
-            "name": "facebook/graph-sdk",
-            "version": "5.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/facebook/php-graph-sdk.git",
-                "reference": "2d8250638b33d73e7a87add65f47fabf91f8ad9b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-graph-sdk/zipball/2d8250638b33d73e7a87add65f47fabf91f8ad9b",
-                "reference": "2d8250638b33d73e7a87add65f47fabf91f8ad9b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.4|^7.0"
-            },
-            "require-dev": {
-                "guzzlehttp/guzzle": "~5.0",
-                "mockery/mockery": "~0.8",
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "guzzlehttp/guzzle": "Allows for implementation of the Guzzle HTTP client",
-                "paragonie/random_compat": "Provides a better CSPRNG option in PHP 5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Facebook\\": "src/Facebook/"
-                },
-                "files": [
-                    "src/Facebook/polyfills.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Facebook Platform"
-            ],
-            "authors": [
-                {
-                    "name": "Facebook",
-                    "homepage": "https://github.com/facebook/php-graph-sdk/contributors"
-                }
-            ],
-            "description": "Facebook SDK for PHP",
-            "homepage": "https://github.com/facebook/php-graph-sdk",
-            "keywords": [
-                "facebook",
-                "sdk"
-            ],
-            "time": "2018-12-11T22:56:31+00:00"
-        },
-        {
             "name": "firebase/php-jwt",
             "version": "v5.0.0",
             "source": {
@@ -1673,35 +1617,33 @@
         },
         {
             "name": "fr3d/ldap-bundle",
-            "version": "v3.0.2",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Maks3w/FR3DLdapBundle.git",
-                "reference": "2309156974e02a8a1398fe491627e1a84da39e67"
+                "reference": "735b3e5fbc2ed743ec6e5866d4771e0f0b5d075f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Maks3w/FR3DLdapBundle/zipball/2309156974e02a8a1398fe491627e1a84da39e67",
-                "reference": "2309156974e02a8a1398fe491627e1a84da39e67",
+                "url": "https://api.github.com/repos/Maks3w/FR3DLdapBundle/zipball/735b3e5fbc2ed743ec6e5866d4771e0f0b5d075f",
+                "reference": "735b3e5fbc2ed743ec6e5866d4771e0f0b5d075f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": ">=7.1",
                 "psr/log": "~1.0",
-                "symfony/config": "2.3 - 3",
-                "symfony/dependency-injection": "2.3 - 3",
-                "symfony/polyfill-php56": "^1.1",
-                "symfony/security": "2.3 - 3",
-                "symfony/security-bundle": "2.3 - 3",
+                "symfony/config": "3.4 - 4",
+                "symfony/dependency-injection": "3.4 - 4",
+                "symfony/security": "3.4 - 4",
+                "symfony/security-bundle": "3.4 - 4",
                 "zendframework/zend-ldap": "2.5 - 3"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.11.*",
-                "fr3d/psr3-message-assertions": "0.1.*",
-                "friendsofsymfony/user-bundle": "~1.3",
-                "maks3w/phpunit-methods-trait": "^4.6",
-                "phpunit/phpunit": "^4.6",
-                "symfony/validator": "2.3 - 3"
+                "fr3d/psr3-message-assertions": "^0.3",
+                "friendsofphp/php-cs-fixer": "^2",
+                "friendsofsymfony/user-bundle": "^1.3||^2",
+                "phpunit/phpunit": "^7",
+                "symfony/validator": "3.4 - 4"
             },
             "suggest": {
                 "friendsofsymfony/user-bundle": "Integrate authentication and management for DB users, useful for unmanned LDAP servers",
@@ -1728,20 +1670,20 @@
                 "Authentication",
                 "ldap"
             ],
-            "time": "2019-03-20T09:22:45+00:00"
+            "time": "2019-05-23T09:19:40+00:00"
         },
         {
             "name": "friendsofsymfony/jsrouting-bundle",
-            "version": "2.3.1",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfSymfony/FOSJsRoutingBundle.git",
-                "reference": "f6c9ee6857bce5924fbd54d4c6176a4dfa9de5b4"
+                "reference": "e42ed450eac2b61d5fcba9cd834c294a429e9a40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSJsRoutingBundle/zipball/f6c9ee6857bce5924fbd54d4c6176a4dfa9de5b4",
-                "reference": "f6c9ee6857bce5924fbd54d4c6176a4dfa9de5b4",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSJsRoutingBundle/zipball/e42ed450eac2b61d5fcba9cd834c294a429e9a40",
+                "reference": "e42ed450eac2b61d5fcba9cd834c294a429e9a40",
                 "shasum": ""
             },
             "require": {
@@ -1775,12 +1717,12 @@
             ],
             "authors": [
                 {
-                    "name": "FriendsOfSymfony Community",
-                    "homepage": "https://github.com/friendsofsymfony/FOSJsRoutingBundle/contributors"
-                },
-                {
                     "name": "William Durand",
                     "email": "will+git@drnd.me"
+                },
+                {
+                    "name": "FriendsOfSymfony Community",
+                    "homepage": "https://github.com/friendsofsymfony/FOSJsRoutingBundle/contributors"
                 }
             ],
             "description": "A pretty nice way to expose your Symfony2 routing to client applications.",
@@ -1790,7 +1732,7 @@
                 "javascript",
                 "routing"
             ],
-            "time": "2019-06-17T18:22:41+00:00"
+            "time": "2019-08-10T15:40:05+00:00"
         },
         {
             "name": "friendsofsymfony/rest-bundle",
@@ -1973,16 +1915,16 @@
         },
         {
             "name": "google/apiclient",
-            "version": "v2.2.3",
+            "version": "v2.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client.git",
-                "reference": "4bfd3edc21cceaf45fc216a4196e1993cf7a89eb"
+                "reference": "d6c7563bdf88d6a0719ea63e21c74dc86032364e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/4bfd3edc21cceaf45fc216a4196e1993cf7a89eb",
-                "reference": "4bfd3edc21cceaf45fc216a4196e1993cf7a89eb",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/d6c7563bdf88d6a0719ea63e21c74dc86032364e",
+                "reference": "d6c7563bdf88d6a0719ea63e21c74dc86032364e",
                 "shasum": ""
             },
             "require": {
@@ -1997,6 +1939,8 @@
             },
             "require-dev": {
                 "cache/filesystem-adapter": "^0.3.2",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "phpcompatibility/php-compatibility": "^9.2",
                 "phpunit/phpunit": "~4.8.36",
                 "squizlabs/php_codesniffer": "~2.3",
                 "symfony/css-selector": "~2.1",
@@ -2028,20 +1972,20 @@
             "keywords": [
                 "google"
             ],
-            "time": "2019-05-21T18:06:55+00:00"
+            "time": "2019-08-19T18:09:46+00:00"
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.104",
+            "version": "v0.111",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "d41fea99f90d7935bd57cf654bf271072fe584f1"
+                "reference": "3bdb4e5be7fe49f8737f7b3a8a3a32ca68ff8f97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/d41fea99f90d7935bd57cf654bf271072fe584f1",
-                "reference": "d41fea99f90d7935bd57cf654bf271072fe584f1",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/3bdb4e5be7fe49f8737f7b3a8a3a32ca68ff8f97",
+                "reference": "3bdb4e5be7fe49f8737f7b3a8a3a32ca68ff8f97",
                 "shasum": ""
             },
             "require": {
@@ -2065,20 +2009,20 @@
             "keywords": [
                 "google"
             ],
-            "time": "2019-06-23T00:23:39+00:00"
+            "time": "2019-08-25T00:23:03+00:00"
         },
         {
             "name": "google/auth",
-            "version": "v1.5.1",
+            "version": "v1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "0f75e20e7392e863f5550ed2c2d3d50af21710fb"
+                "reference": "2ee962e5df3e9427fda859f1b0515d6d62c4afa5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/0f75e20e7392e863f5550ed2c2d3d50af21710fb",
-                "reference": "0f75e20e7392e863f5550ed2c2d3d50af21710fb",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/2ee962e5df3e9427fda859f1b0515d6d62c4afa5",
+                "reference": "2ee962e5df3e9427fda859f1b0515d6d62c4afa5",
                 "shasum": ""
             },
             "require": {
@@ -2116,7 +2060,7 @@
                 "google",
                 "oauth2"
             ],
-            "time": "2019-04-16T18:48:28+00:00"
+            "time": "2019-07-22T21:01:31+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -2474,27 +2418,30 @@
         },
         {
             "name": "knplabs/knp-menu",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/KnpMenu.git",
-                "reference": "655630a1db0b72108262d1a844de3b1ba0885be5"
+                "reference": "f22db6a9232f5118f4ae378bf5e6cfea32e9c5f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/KnpMenu/zipball/655630a1db0b72108262d1a844de3b1ba0885be5",
-                "reference": "655630a1db0b72108262d1a844de3b1ba0885be5",
+                "url": "https://api.github.com/repos/KnpLabs/KnpMenu/zipball/f22db6a9232f5118f4ae378bf5e6cfea32e9c5f5",
+                "reference": "f22db6a9232f5118f4ae378bf5e6cfea32e9c5f5",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.6.0"
+            },
+            "conflict": {
+                "twig/twig": "<1.40|>=2,<2.9"
             },
             "require-dev": {
                 "psr/container": "^1.0",
                 "symfony/http-foundation": "~2.4|~3.0|^4.0",
                 "symfony/phpunit-bridge": "~3.3|^4.0",
                 "symfony/routing": "~2.3|~3.0|^4.0",
-                "twig/twig": "~1.16|~2.0"
+                "twig/twig": "^1.40|^2.9"
             },
             "suggest": {
                 "twig/twig": "for the TwigRenderer and the integration with your templates"
@@ -2502,7 +2449,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2516,16 +2463,16 @@
             ],
             "authors": [
                 {
+                    "name": "KnpLabs",
+                    "homepage": "https://knplabs.com"
+                },
+                {
                     "name": "Christophe Coevoet",
                     "email": "stof@notk.org"
                 },
                 {
                     "name": "Symfony Community",
                     "homepage": "https://github.com/KnpLabs/KnpMenu/contributors"
-                },
-                {
-                    "name": "KnpLabs",
-                    "homepage": "https://knplabs.com"
                 }
             ],
             "description": "An object oriented menu library",
@@ -2534,7 +2481,7 @@
                 "menu",
                 "tree"
             ],
-            "time": "2017-11-18T20:49:26+00:00"
+            "time": "2019-08-23T08:46:21+00:00"
         },
         {
             "name": "knplabs/knp-menu-bundle",
@@ -2800,16 +2747,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.2.2",
+            "version": "v4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "1bd73cc04c3843ad8d6b0bfc0956026a151fc420"
+                "reference": "e612609022e935f3d0337c1295176505b41188c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bd73cc04c3843ad8d6b0bfc0956026a151fc420",
-                "reference": "1bd73cc04c3843ad8d6b0bfc0956026a151fc420",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/e612609022e935f3d0337c1295176505b41188c8",
+                "reference": "e612609022e935f3d0337c1295176505b41188c8",
                 "shasum": ""
             },
             "require": {
@@ -2817,7 +2764,7 @@
                 "php": ">=7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.5 || ^7.0"
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -2847,7 +2794,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-05-25T20:07:01+00:00"
+            "time": "2019-08-12T20:17:41+00:00"
         },
         {
             "name": "ocramius/package-versions",
@@ -2902,16 +2849,16 @@
         },
         {
             "name": "ocramius/proxy-manager",
-            "version": "2.2.2",
+            "version": "2.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/ProxyManager.git",
-                "reference": "14b137b06b0f911944132df9d51e445a35920ab1"
+                "reference": "4d154742e31c35137d5374c998e8f86b54db2e2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/14b137b06b0f911944132df9d51e445a35920ab1",
-                "reference": "14b137b06b0f911944132df9d51e445a35920ab1",
+                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/4d154742e31c35137d5374c998e8f86b54db2e2f",
+                "reference": "4d154742e31c35137d5374c998e8f86b54db2e2f",
                 "shasum": ""
             },
             "require": {
@@ -2968,7 +2915,7 @@
                 "proxy pattern",
                 "service proxies"
             ],
-            "time": "2018-09-27T13:45:01+00:00"
+            "time": "2019-08-10T08:37:15+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -3141,21 +3088,21 @@
         },
         {
             "name": "php-http/message",
-            "version": "1.7.2",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/message.git",
-                "reference": "b159ffe570dffd335e22ef0b91a946eacb182fa1"
+                "reference": "ce8f43ac1e294b54aabf5808515c3554a19c1e1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/message/zipball/b159ffe570dffd335e22ef0b91a946eacb182fa1",
-                "reference": "b159ffe570dffd335e22ef0b91a946eacb182fa1",
+                "url": "https://api.github.com/repos/php-http/message/zipball/ce8f43ac1e294b54aabf5808515c3554a19c1e1c",
+                "reference": "ce8f43ac1e294b54aabf5808515c3554a19c1e1c",
                 "shasum": ""
             },
             "require": {
                 "clue/stream-filter": "^1.4",
-                "php": "^5.4 || ^7.0",
+                "php": "^7.1",
                 "php-http/message-factory": "^1.0.2",
                 "psr/http-message": "^1.0"
             },
@@ -3181,7 +3128,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6-dev"
+                    "dev-master": "1.8-dev"
                 }
             },
             "autoload": {
@@ -3209,7 +3156,7 @@
                 "message",
                 "psr-7"
             ],
-            "time": "2018-11-01T09:32:41+00:00"
+            "time": "2019-08-05T06:55:08+00:00"
         },
         {
             "name": "php-http/message-factory",
@@ -3356,28 +3303,28 @@
             "authors": [
                 {
                     "name": "Jim Wigginton",
-                    "email": "terrafrost@php.net",
-                    "role": "Lead Developer"
+                    "role": "Lead Developer",
+                    "email": "terrafrost@php.net"
                 },
                 {
                     "name": "Patrick Monnerat",
-                    "email": "pm@datasphere.ch",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "pm@datasphere.ch"
                 },
                 {
                     "name": "Andreas Fischer",
-                    "email": "bantu@phpbb.com",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "bantu@phpbb.com"
                 },
                 {
                     "name": "Hans-Jürgen Petrich",
-                    "email": "petrich@tronic-media.com",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "petrich@tronic-media.com"
                 },
                 {
                     "name": "Graham Campbell",
-                    "email": "graham@alt-three.com",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "graham@alt-three.com"
                 }
             ],
             "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
@@ -3645,54 +3592,6 @@
             "time": "2018-11-20T15:27:04+00:00"
         },
         {
-            "name": "psr/simple-cache",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\SimpleCache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for simple caching",
-            "keywords": [
-                "cache",
-                "caching",
-                "psr",
-                "psr-16",
-                "simple-cache"
-            ],
-            "time": "2017-10-23T01:57:42+00:00"
-        },
-        {
             "name": "ralouphie/getallheaders",
             "version": "3.0.3",
             "source": {
@@ -3912,16 +3811,16 @@
         },
         {
             "name": "sonata-project/block-bundle",
-            "version": "3.15.0",
+            "version": "3.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sonata-project/SonataBlockBundle.git",
-                "reference": "d0a67fcd6873e234467cd58b35aa3feb5b54a6ff"
+                "reference": "38619fa25eda56d32361b6a50e2c5eb6b27b1891"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sonata-project/SonataBlockBundle/zipball/d0a67fcd6873e234467cd58b35aa3feb5b54a6ff",
-                "reference": "d0a67fcd6873e234467cd58b35aa3feb5b54a6ff",
+                "url": "https://api.github.com/repos/sonata-project/SonataBlockBundle/zipball/38619fa25eda56d32361b6a50e2c5eb6b27b1891",
+                "reference": "38619fa25eda56d32361b6a50e2c5eb6b27b1891",
                 "shasum": ""
             },
             "require": {
@@ -3980,13 +3879,13 @@
             ],
             "authors": [
                 {
-                    "name": "Sonata Community",
-                    "homepage": "https://github.com/sonata-project/SonataBlockBundle/contributors"
-                },
-                {
                     "name": "Thomas Rabaix",
                     "email": "thomas.rabaix@sonata-project.org",
                     "homepage": "https://sonata-project.org"
+                },
+                {
+                    "name": "Sonata Community",
+                    "homepage": "https://github.com/sonata-project/SonataBlockBundle/contributors"
                 }
             ],
             "description": "Symfony SonataBlockBundle",
@@ -3995,7 +3894,7 @@
                 "block",
                 "sonata"
             ],
-            "time": "2019-03-03T22:38:47+00:00"
+            "time": "2019-08-16T11:17:01+00:00"
         },
         {
             "name": "sonata-project/cache",
@@ -4716,24 +4615,24 @@
         },
         {
             "name": "symfony/asset",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/asset.git",
-                "reference": "0999874d3e72b3440f757797e60c3f48bb8a4482"
+                "reference": "3f97e57596884f7b9158d564a533112a0d19dbdd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/asset/zipball/0999874d3e72b3440f757797e60c3f48bb8a4482",
-                "reference": "0999874d3e72b3440f757797e60c3f48bb8a4482",
+                "url": "https://api.github.com/repos/symfony/asset/zipball/3f97e57596884f7b9158d564a533112a0d19dbdd",
+                "reference": "3f97e57596884f7b9158d564a533112a0d19dbdd",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3"
             },
             "require-dev": {
-                "symfony/http-foundation": "~2.8|~3.0|~4.0",
-                "symfony/http-kernel": "~2.8|~3.0|~4.0"
+                "symfony/http-foundation": "~3.4|~4.0",
+                "symfony/http-kernel": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/http-foundation": ""
@@ -4741,7 +4640,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -4768,29 +4667,31 @@
             ],
             "description": "Symfony Asset Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-30T15:47:52+00:00"
+            "time": "2019-08-03T21:50:52+00:00"
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "53266c9a1536e2dc673eb1efb6a6142ef84c6282"
+                "reference": "9e5dddb637b13db82e35695a8603fe6e118cc119"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/53266c9a1536e2dc673eb1efb6a6142ef84c6282",
-                "reference": "53266c9a1536e2dc673eb1efb6a6142ef84c6282",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/9e5dddb637b13db82e35695a8603fe6e118cc119",
+                "reference": "9e5dddb637b13db82e35695a8603fe6e118cc119",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/dom-crawler": "~2.8|~3.0|~4.0"
+                "php": "^7.1.3",
+                "symfony/dom-crawler": "~3.4|~4.0"
             },
             "require-dev": {
-                "symfony/css-selector": "~2.8|~3.0|~4.0",
-                "symfony/process": "~2.8|~3.0|~4.0"
+                "symfony/css-selector": "~3.4|~4.0",
+                "symfony/http-client": "^4.3",
+                "symfony/mime": "^4.3",
+                "symfony/process": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/process": ""
@@ -4798,7 +4699,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -4825,46 +4726,54 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-09T14:27:26+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/cache",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "8c6e162f0f7626771edbfa0a0e45b46623bbae1c"
+                "reference": "1d8f7fee990c586f275cde1a9fc883d6b1e2d43e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/8c6e162f0f7626771edbfa0a0e45b46623bbae1c",
-                "reference": "8c6e162f0f7626771edbfa0a0e45b46623bbae1c",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/1d8f7fee990c586f275cde1a9fc883d6b1e2d43e",
+                "reference": "1d8f7fee990c586f275cde1a9fc883d6b1e2d43e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "psr/cache": "~1.0",
                 "psr/log": "~1.0",
-                "psr/simple-cache": "^1.0",
-                "symfony/polyfill-apcu": "~1.1"
+                "symfony/cache-contracts": "^1.1",
+                "symfony/service-contracts": "^1.1",
+                "symfony/var-exporter": "^4.2"
             },
             "conflict": {
-                "symfony/var-dumper": "<3.3"
+                "doctrine/dbal": "<2.5",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/var-dumper": "<3.4"
             },
             "provide": {
                 "psr/cache-implementation": "1.0",
-                "psr/simple-cache-implementation": "1.0"
+                "psr/simple-cache-implementation": "1.0",
+                "symfony/cache-implementation": "1.0"
             },
             "require-dev": {
                 "cache/integration-tests": "dev-master",
                 "doctrine/cache": "~1.6",
-                "doctrine/dbal": "~2.4",
-                "predis/predis": "~1.0"
+                "doctrine/dbal": "~2.5",
+                "predis/predis": "~1.1",
+                "psr/simple-cache": "^1.0",
+                "symfony/config": "~4.2",
+                "symfony/dependency-injection": "~3.4|~4.1",
+                "symfony/var-dumper": "^4.1.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -4895,45 +4804,39 @@
                 "caching",
                 "psr6"
             ],
-            "time": "2019-06-17T17:26:15+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
-            "name": "symfony/class-loader",
-            "version": "v3.4.29",
+            "name": "symfony/cache-contracts",
+            "version": "v1.1.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/class-loader.git",
-                "reference": "4459eef5298dedfb69f771186a580062b8516497"
+                "url": "https://github.com/symfony/cache-contracts.git",
+                "reference": "ec5524b669744b5f1dc9c66d3c2b091eb7e7f0db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/class-loader/zipball/4459eef5298dedfb69f771186a580062b8516497",
-                "reference": "4459eef5298dedfb69f771186a580062b8516497",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/ec5524b669744b5f1dc9c66d3c2b091eb7e7f0db",
+                "reference": "ec5524b669744b5f1dc9c66d3c2b091eb7e7f0db",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "require-dev": {
-                "symfony/finder": "~2.8|~3.0|~4.0",
-                "symfony/polyfill-apcu": "~1.1"
+                "php": "^7.1.3",
+                "psr/cache": "^1.0"
             },
             "suggest": {
-                "symfony/polyfill-apcu": "For using ApcClassLoader on HHVM"
+                "symfony/cache-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Component\\ClassLoader\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
+                    "Symfony\\Contracts\\Cache\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4941,46 +4844,54 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
                 {
                     "name": "Symfony Community",
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony ClassLoader Component",
+            "description": "Generic abstractions related to caching",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T09:39:14+00:00"
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-06-13T11:15:36+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "29a33f66194fbe2ed4555981810f15fd8440e4a8"
+                "reference": "07d49c0f823e0bc367c6d84e35b61419188a5ece"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/29a33f66194fbe2ed4555981810f15fd8440e4a8",
-                "reference": "29a33f66194fbe2ed4555981810f15fd8440e4a8",
+                "url": "https://api.github.com/repos/symfony/config/zipball/07d49c0f823e0bc367c6d84e35b61419188a5ece",
+                "reference": "07d49c0f823e0bc367c6d84e35b61419188a5ece",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/filesystem": "~2.8|~3.0|~4.0",
+                "php": "^7.1.3",
+                "symfony/filesystem": "~3.4|~4.0",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.3",
-                "symfony/finder": "<3.3"
+                "symfony/finder": "<3.4"
             },
             "require-dev": {
-                "symfony/dependency-injection": "~3.3|~4.0",
-                "symfony/event-dispatcher": "~3.3|~4.0",
-                "symfony/finder": "~3.3|~4.0",
-                "symfony/yaml": "~3.0|~4.0"
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/finder": "~3.4|~4.0",
+                "symfony/messenger": "~4.1",
+                "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/yaml": "To use the yaml reference dumper"
@@ -4988,7 +4899,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5015,29 +4926,31 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-30T15:47:52+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c4d2f3529755ffc0be9fb823583b28d8744eeb3d"
+                "reference": "de63799239b3881b8a08f8481b22348f77ed7b36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c4d2f3529755ffc0be9fb823583b28d8744eeb3d",
-                "reference": "c4d2f3529755ffc0be9fb823583b28d8744eeb3d",
+                "url": "https://api.github.com/repos/symfony/console/zipball/de63799239b3881b8a08f8481b22348f77ed7b36",
+                "reference": "de63799239b3881b8a08f8481b22348f77ed7b36",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/debug": "~2.8|~3.0|~4.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": "^7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/service-contracts": "^1.1"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4",
+                "symfony/event-dispatcher": "<4.3",
                 "symfony/process": "<3.3"
             },
             "provide": {
@@ -5045,11 +4958,12 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.3|~4.0",
+                "symfony/config": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
+                "symfony/event-dispatcher": "^4.3",
                 "symfony/lock": "~3.4|~4.0",
-                "symfony/process": "~3.3|~4.0"
+                "symfony/process": "~3.4|~4.0",
+                "symfony/var-dumper": "^4.3"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -5060,7 +4974,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5087,20 +5001,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-05T11:33:52+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v4.3.2",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "d8f4fb38152e0eb6a433705e5f661d25b32c5fcd"
+                "reference": "afcdea44a2e399c1e4b52246ec8d54c715393ced"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/d8f4fb38152e0eb6a433705e5f661d25b32c5fcd",
-                "reference": "d8f4fb38152e0eb6a433705e5f661d25b32c5fcd",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/afcdea44a2e399c1e4b52246ec8d54c715393ced",
+                "reference": "afcdea44a2e399c1e4b52246ec8d54c715393ced",
                 "shasum": ""
             },
             "require": {
@@ -5143,38 +5057,40 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-19T15:27:09+00:00"
+            "time": "2019-08-20T14:27:59+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "76857ce235ba1866b66a1d5be34c6794c8895435"
+                "reference": "d3ad14b66ac773ba6123622eb9b5b010165fe3d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/76857ce235ba1866b66a1d5be34c6794c8895435",
-                "reference": "76857ce235ba1866b66a1d5be34c6794c8895435",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/d3ad14b66ac773ba6123622eb9b5b010165fe3d9",
+                "reference": "d3ad14b66ac773ba6123622eb9b5b010165fe3d9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "psr/container": "^1.0"
+                "php": "^7.1.3",
+                "psr/container": "^1.0",
+                "symfony/service-contracts": "^1.1.6"
             },
             "conflict": {
-                "symfony/config": "<3.3.7",
-                "symfony/finder": "<3.3",
+                "symfony/config": "<4.3",
+                "symfony/finder": "<3.4",
                 "symfony/proxy-manager-bridge": "<3.4",
                 "symfony/yaml": "<3.4"
             },
             "provide": {
-                "psr/container-implementation": "1.0"
+                "psr/container-implementation": "1.0",
+                "symfony/service-implementation": "1.0"
             },
             "require-dev": {
-                "symfony/config": "~3.3|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/config": "^4.3",
+                "symfony/expression-language": "~3.4|~4.0",
                 "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
@@ -5187,7 +5103,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5214,47 +5130,57 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-30T15:47:52+00:00"
+            "time": "2019-08-26T16:27:33+00:00"
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "47e2f56ecee35b7f18a21ffa44c86bc85bee75c6"
+                "reference": "d2967b2b43788bd3a7cddeb8bd4567e142b3821c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/47e2f56ecee35b7f18a21ffa44c86bc85bee75c6",
-                "reference": "47e2f56ecee35b7f18a21ffa44c86bc85bee75c6",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/d2967b2b43788bd3a7cddeb8bd4567e142b3821c",
+                "reference": "d2967b2b43788bd3a7cddeb8bd4567e142b3821c",
                 "shasum": ""
             },
             "require": {
-                "doctrine/common": "~2.4",
-                "php": "^5.5.9|>=7.0.8",
+                "doctrine/event-manager": "~1.0",
+                "doctrine/persistence": "~1.0",
+                "php": "^7.1.3",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.0"
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^1.1"
             },
             "conflict": {
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
-                "symfony/dependency-injection": "<3.4"
+                "symfony/dependency-injection": "<3.4",
+                "symfony/form": "<4.3",
+                "symfony/messenger": "<4.3"
             },
             "require-dev": {
+                "doctrine/annotations": "~1.7",
+                "doctrine/cache": "~1.6",
+                "doctrine/collections": "~1.0",
                 "doctrine/data-fixtures": "1.0.*",
                 "doctrine/dbal": "~2.4",
-                "doctrine/orm": "^2.4.5",
+                "doctrine/orm": "^2.6.3",
+                "doctrine/reflection": "~1.0",
+                "symfony/config": "^4.2",
                 "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/form": "^3.3.10|~4.0",
-                "symfony/http-kernel": "~2.8|~3.0|~4.0",
-                "symfony/property-access": "~2.8|~3.0|~4.0",
-                "symfony/property-info": "~2.8|3.0|~4.0",
-                "symfony/proxy-manager-bridge": "~2.8|~3.0|~4.0",
-                "symfony/security": "^2.8.31|^3.3.13|~4.0",
-                "symfony/stopwatch": "~2.8|~3.0|~4.0",
-                "symfony/translation": "~2.8|~3.0|~4.0",
-                "symfony/validator": "^3.2.5|~4.0"
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/form": "~4.3",
+                "symfony/http-kernel": "~3.4|~4.0",
+                "symfony/messenger": "~4.3",
+                "symfony/property-access": "~3.4|~4.0",
+                "symfony/property-info": "~3.4|~4.0",
+                "symfony/proxy-manager-bridge": "~3.4|~4.0",
+                "symfony/security-core": "~3.4|~4.0",
+                "symfony/stopwatch": "~3.4|~4.0",
+                "symfony/translation": "~3.4|~4.0",
+                "symfony/validator": "^3.4.31|^4.3.4"
             },
             "suggest": {
                 "doctrine/data-fixtures": "",
@@ -5267,7 +5193,7 @@
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5294,20 +5220,20 @@
             ],
             "description": "Symfony Doctrine Bridge",
             "homepage": "https://symfony.com",
-            "time": "2019-06-25T14:06:32+00:00"
+            "time": "2019-08-26T11:29:20+00:00"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v4.2.3",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "d8476760b04cdf7b499c8718aa437c20a9155103"
+                "reference": "cc686552948d627528c0e2e759186dff67c2610e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/d8476760b04cdf7b499c8718aa437c20a9155103",
-                "reference": "d8476760b04cdf7b499c8718aa437c20a9155103",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/cc686552948d627528c0e2e759186dff67c2610e",
+                "reference": "cc686552948d627528c0e2e759186dff67c2610e",
                 "shasum": ""
             },
             "require": {
@@ -5315,7 +5241,11 @@
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.0"
             },
+            "conflict": {
+                "masterminds/html5": "<2.6"
+            },
             "require-dev": {
+                "masterminds/html5": "^2.6",
                 "symfony/css-selector": "~3.4|~4.0"
             },
             "suggest": {
@@ -5324,7 +5254,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5351,32 +5281,32 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T20:35:37+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/dotenv",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
-                "reference": "3f4fdfb551bf36f2017d75cd2e6490fbe67f9d2d"
+                "reference": "1785b18148a016b8f4e6a612291188d568e1f9cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/3f4fdfb551bf36f2017d75cd2e6490fbe67f9d2d",
-                "reference": "3f4fdfb551bf36f2017d75cd2e6490fbe67f9d2d",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/1785b18148a016b8f4e6a612291188d568e1f9cd",
+                "reference": "1785b18148a016b8f4e6a612291188d568e1f9cd",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3"
             },
             "require-dev": {
-                "symfony/process": "~3.2|~4.0"
+                "symfony/process": "~3.4|~4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5408,34 +5338,41 @@
                 "env",
                 "environment"
             ],
-            "time": "2019-06-23T08:10:04+00:00"
+            "time": "2019-08-03T21:50:52+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f18fdd6cc7006441865e698420cee26bac94741f"
+                "reference": "429d0a1451d4c9c4abe1959b2986b88794b9b7d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f18fdd6cc7006441865e698420cee26bac94741f",
-                "reference": "f18fdd6cc7006441865e698420cee26bac94741f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/429d0a1451d4c9c4abe1959b2986b88794b9b7d2",
+                "reference": "429d0a1451d4c9c4abe1959b2986b88794b9b7d2",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3",
+                "symfony/event-dispatcher-contracts": "^1.1"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.3"
+                "symfony/dependency-injection": "<3.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "1.1"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "~3.3|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/stopwatch": "~2.8|~3.0|~4.0"
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/http-foundation": "^3.4|^4.0",
+                "symfony/service-contracts": "^1.1",
+                "symfony/stopwatch": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -5444,7 +5381,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5471,30 +5408,89 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-25T07:45:31+00:00"
+            "time": "2019-08-26T08:55:16+00:00"
         },
         {
-            "name": "symfony/expression-language",
-            "version": "v3.4.29",
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v1.1.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/expression-language.git",
-                "reference": "b050ccafec8ac5b14f2cb657ad4324b1015db0fe"
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "c61766f4440ca687de1084a5c00b08e167a2575c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/expression-language/zipball/b050ccafec8ac5b14f2cb657ad4324b1015db0fe",
-                "reference": "b050ccafec8ac5b14f2cb657ad4324b1015db0fe",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c61766f4440ca687de1084a5c00b08e167a2575c",
+                "reference": "c61766f4440ca687de1084a5c00b08e167a2575c",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/cache": "~3.1|~4.0"
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "psr/event-dispatcher": "",
+                "symfony/event-dispatcher-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-06-20T06:46:26+00:00"
+        },
+        {
+            "name": "symfony/expression-language",
+            "version": "v4.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/expression-language.git",
+                "reference": "c8b47d8820d3bf75f757eec8a2647584c14cf0c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/c8b47d8820d3bf75f757eec8a2647584c14cf0c6",
+                "reference": "c8b47d8820d3bf75f757eec8a2647584c14cf0c6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/cache": "~3.4|~4.0",
+                "symfony/service-contracts": "^1.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5521,30 +5517,30 @@
             ],
             "description": "Symfony ExpressionLanguage Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-30T15:47:52+00:00"
+            "time": "2019-08-08T09:29:19+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "70adda061ef83bb7def63a17953dc41f203308a7"
+                "reference": "9abbb7ef96a51f4d7e69627bc6f63307994e4263"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/70adda061ef83bb7def63a17953dc41f203308a7",
-                "reference": "70adda061ef83bb7def63a17953dc41f203308a7",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/9abbb7ef96a51f4d7e69627bc6f63307994e4263",
+                "reference": "9abbb7ef96a51f4d7e69627bc6f63307994e4263",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5571,29 +5567,29 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-23T09:29:17+00:00"
+            "time": "2019-08-20T14:07:54+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "5f80266a729e30bbcc37f8bf0e62c3d5a38c8208"
+                "reference": "86c1c929f0a4b24812e1eb109262fc3372c8e9f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/5f80266a729e30bbcc37f8bf0e62c3d5a38c8208",
-                "reference": "5f80266a729e30bbcc37f8bf0e62c3d5a38c8208",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/86c1c929f0a4b24812e1eb109262fc3372c8e9f2",
+                "reference": "86c1c929f0a4b24812e1eb109262fc3372c8e9f2",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5620,7 +5616,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-30T15:47:52+00:00"
+            "time": "2019-08-14T12:26:46+00:00"
         },
         {
             "name": "symfony/flex",
@@ -5673,49 +5669,52 @@
         },
         {
             "name": "symfony/form",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/form.git",
-                "reference": "141df08a2dc0aa5084c28163872d43c56e3a3335"
+                "reference": "eba11fd575e791d72030cb59215a9948791f1e74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/form/zipball/141df08a2dc0aa5084c28163872d43c56e3a3335",
-                "reference": "141df08a2dc0aa5084c28163872d43c56e3a3335",
+                "url": "https://api.github.com/repos/symfony/form/zipball/eba11fd575e791d72030cb59215a9948791f1e74",
+                "reference": "eba11fd575e791d72030cb59215a9948791f1e74",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-                "symfony/intl": "^2.8.18|^3.2.5|~4.0",
-                "symfony/options-resolver": "~3.4|~4.0",
+                "php": "^7.1.3",
+                "symfony/event-dispatcher": "^4.3",
+                "symfony/intl": "^4.3",
+                "symfony/options-resolver": "~4.3",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/property-access": "~2.8|~3.0|~4.0"
+                "symfony/property-access": "~3.4|~4.0",
+                "symfony/service-contracts": "~1.1"
             },
             "conflict": {
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
-                "symfony/dependency-injection": "<3.3",
-                "symfony/doctrine-bridge": "<2.7",
+                "symfony/console": "<4.3",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/doctrine-bridge": "<3.4",
                 "symfony/framework-bundle": "<3.4",
-                "symfony/http-kernel": "<3.3.5",
+                "symfony/http-kernel": "<4.3",
+                "symfony/intl": "<4.3",
+                "symfony/translation": "<4.2",
                 "symfony/twig-bridge": "<3.4.5|<4.0.5,>=4.0"
             },
             "require-dev": {
                 "doctrine/collections": "~1.0",
-                "symfony/config": "~2.7|~3.0|~4.0",
-                "symfony/console": "~3.4|~4.0",
-                "symfony/dependency-injection": "~3.3|~4.0",
-                "symfony/http-foundation": "~2.8|~3.0|~4.0",
-                "symfony/http-kernel": "^3.3.5|~4.0",
-                "symfony/security-csrf": "^2.8.31|^3.3.13|~4.0",
-                "symfony/translation": "~2.8|~3.0|~4.0",
-                "symfony/validator": "^3.2.5|~4.0",
-                "symfony/var-dumper": "~3.3.11|~3.4|~4.0"
+                "symfony/config": "~3.4|~4.0",
+                "symfony/console": "^4.3",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/http-foundation": "~3.4|~4.0",
+                "symfony/http-kernel": "~4.3",
+                "symfony/security-csrf": "~3.4|~4.0",
+                "symfony/translation": "~4.2",
+                "symfony/validator": "^3.4.31|^4.3.4",
+                "symfony/var-dumper": "^4.3"
             },
             "suggest": {
-                "symfony/framework-bundle": "For templating with PHP.",
                 "symfony/security-csrf": "For protecting forms against CSRF attacks.",
                 "symfony/twig-bridge": "For templating with Twig.",
                 "symfony/validator": "For form validation."
@@ -5723,7 +5722,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5750,79 +5749,88 @@
             ],
             "description": "Symfony Form Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-23T07:45:21+00:00"
+            "time": "2019-08-26T08:55:16+00:00"
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "ed26f0f9cef6ff47aa26766349272df653638f31"
+                "reference": "0fd8e354cef6b3da666e585d7ae75aeea2423833"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/ed26f0f9cef6ff47aa26766349272df653638f31",
-                "reference": "ed26f0f9cef6ff47aa26766349272df653638f31",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/0fd8e354cef6b3da666e585d7ae75aeea2423833",
+                "reference": "0fd8e354cef6b3da666e585d7ae75aeea2423833",
                 "shasum": ""
             },
             "require": {
                 "ext-xml": "*",
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/cache": "~3.4|~4.0",
-                "symfony/class-loader": "~3.2",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/dependency-injection": "^3.4.24|^4.2.5",
-                "symfony/event-dispatcher": "~3.4|~4.0",
-                "symfony/filesystem": "~2.8|~3.0|~4.0",
-                "symfony/finder": "~2.8|~3.0|~4.0",
-                "symfony/http-foundation": "^3.3.11|~4.0",
-                "symfony/http-kernel": "~3.4|~4.0",
+                "php": "^7.1.3",
+                "symfony/cache": "^4.3.4",
+                "symfony/config": "^4.3.4",
+                "symfony/debug": "~4.0",
+                "symfony/dependency-injection": "^4.3",
+                "symfony/filesystem": "~3.4|~4.0",
+                "symfony/finder": "~3.4|~4.0",
+                "symfony/http-foundation": "^4.3",
+                "symfony/http-kernel": "^4.3.4",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/routing": "^3.4.5|^4.0.5"
+                "symfony/routing": "^4.3"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<3.0",
                 "phpdocumentor/type-resolver": "<0.2.1",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
-                "symfony/asset": "<3.3",
-                "symfony/console": "<3.4",
-                "symfony/form": "<3.4",
-                "symfony/property-info": "<3.3",
-                "symfony/serializer": "<3.3",
+                "symfony/asset": "<3.4",
+                "symfony/browser-kit": "<4.3",
+                "symfony/console": "<4.3",
+                "symfony/dom-crawler": "<4.3",
+                "symfony/dotenv": "<4.2",
+                "symfony/form": "<4.3",
+                "symfony/messenger": "<4.3",
+                "symfony/property-info": "<3.4",
+                "symfony/serializer": "<4.2",
                 "symfony/stopwatch": "<3.4",
-                "symfony/translation": "<3.4",
-                "symfony/validator": "<3.4",
-                "symfony/workflow": "<3.3"
+                "symfony/translation": "<4.3",
+                "symfony/twig-bridge": "<4.1.1",
+                "symfony/validator": "<4.1",
+                "symfony/workflow": "<4.3"
             },
             "require-dev": {
-                "doctrine/annotations": "~1.0",
+                "doctrine/annotations": "~1.7",
                 "doctrine/cache": "~1.0",
                 "fig/link-util": "^1.0",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0",
-                "symfony/asset": "~3.3|~4.0",
-                "symfony/browser-kit": "~2.8|~3.0|~4.0",
-                "symfony/console": "~3.4|~4.0",
-                "symfony/css-selector": "~2.8|~3.0|~4.0",
-                "symfony/dom-crawler": "~2.8|~3.0|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/form": "^3.4.22|~4.1.11|^4.2.3",
+                "symfony/asset": "~3.4|~4.0",
+                "symfony/browser-kit": "^4.3",
+                "symfony/console": "^4.3.4",
+                "symfony/css-selector": "~3.4|~4.0",
+                "symfony/dom-crawler": "^4.3",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/form": "^4.3.4",
+                "symfony/http-client": "^4.3",
                 "symfony/lock": "~3.4|~4.0",
+                "symfony/mailer": "^4.3",
+                "symfony/messenger": "^4.3",
+                "symfony/mime": "^4.3",
                 "symfony/polyfill-intl-icu": "~1.0",
-                "symfony/process": "~2.8|~3.0|~4.0",
-                "symfony/property-info": "~3.3|~4.0",
-                "symfony/security-core": "~3.2|~4.0",
-                "symfony/security-csrf": "^2.8.31|^3.3.13|~4.0",
-                "symfony/serializer": "~3.3|~4.0",
+                "symfony/process": "~3.4|~4.0",
+                "symfony/property-info": "~3.4|~4.0",
+                "symfony/security-csrf": "~3.4|~4.0",
+                "symfony/security-http": "~3.4|~4.0",
+                "symfony/serializer": "^4.3",
                 "symfony/stopwatch": "~3.4|~4.0",
-                "symfony/templating": "~2.8|~3.0|~4.0",
-                "symfony/translation": "~3.4|~4.0",
-                "symfony/validator": "~3.4|~4.0",
-                "symfony/var-dumper": "~3.3|~4.0",
-                "symfony/web-link": "~3.3|~4.0",
-                "symfony/workflow": "~3.3|~4.0",
-                "symfony/yaml": "~3.2|~4.0",
-                "twig/twig": "~1.34|~2.4"
+                "symfony/templating": "~3.4|~4.0",
+                "symfony/translation": "~4.3",
+                "symfony/twig-bundle": "~2.8|~3.2|~4.0",
+                "symfony/validator": "^4.1",
+                "symfony/var-dumper": "^4.3",
+                "symfony/web-link": "~3.4|~4.0",
+                "symfony/workflow": "^4.3",
+                "symfony/yaml": "~3.4|~4.0",
+                "twig/twig": "~1.41|~2.10"
             },
             "suggest": {
                 "ext-apcu": "For best performance of the system caches",
@@ -5837,7 +5845,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5864,34 +5872,35 @@
             ],
             "description": "Symfony FrameworkBundle",
             "homepage": "https://symfony.com",
-            "time": "2019-06-25T15:43:39+00:00"
+            "time": "2019-08-26T08:55:16+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "8cfbf75bb3a72963b12c513a73e9247891df24f8"
+                "reference": "d804bea118ff340a12e22a79f9c7e7eb56b35adc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/8cfbf75bb3a72963b12c513a73e9247891df24f8",
-                "reference": "8cfbf75bb3a72963b12c513a73e9247891df24f8",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/d804bea118ff340a12e22a79f9c7e7eb56b35adc",
+                "reference": "d804bea118ff340a12e22a79f9c7e7eb56b35adc",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-mbstring": "~1.1",
-                "symfony/polyfill-php70": "~1.6"
+                "php": "^7.1.3",
+                "symfony/mime": "^4.3",
+                "symfony/polyfill-mbstring": "~1.1"
             },
             "require-dev": {
-                "symfony/expression-language": "~2.8|~3.0|~4.0"
+                "predis/predis": "~1.0",
+                "symfony/expression-language": "~3.4|~4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -5918,34 +5927,37 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-22T20:10:25+00:00"
+            "time": "2019-08-26T08:55:16+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "abbb38dbab652ddc40a86d0c3b0e14ca52d58ed2"
+                "reference": "5e0fc71be03d52cd00c423061cfd300bd6f92a52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/abbb38dbab652ddc40a86d0c3b0e14ca52d58ed2",
-                "reference": "abbb38dbab652ddc40a86d0c3b0e14ca52d58ed2",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/5e0fc71be03d52cd00c423061cfd300bd6f92a52",
+                "reference": "5e0fc71be03d52cd00c423061cfd300bd6f92a52",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "psr/log": "~1.0",
-                "symfony/debug": "^3.3.3|~4.0",
-                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-                "symfony/http-foundation": "~3.4.12|~4.0.12|^4.1.1",
-                "symfony/polyfill-ctype": "~1.8"
+                "symfony/debug": "~3.4|~4.0",
+                "symfony/event-dispatcher": "^4.3",
+                "symfony/http-foundation": "^4.1.1",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php73": "^1.9"
             },
             "conflict": {
-                "symfony/config": "<2.8",
-                "symfony/dependency-injection": "<3.4.10|<4.0.10,>=4",
-                "symfony/var-dumper": "<3.3",
+                "symfony/browser-kit": "<4.3",
+                "symfony/config": "<3.4",
+                "symfony/dependency-injection": "<4.3",
+                "symfony/translation": "<4.2",
+                "symfony/var-dumper": "<4.1.1",
                 "twig/twig": "<1.34|<2.4,>=2"
             },
             "provide": {
@@ -5953,34 +5965,34 @@
             },
             "require-dev": {
                 "psr/cache": "~1.0",
-                "symfony/browser-kit": "~2.8|~3.0|~4.0",
-                "symfony/class-loader": "~2.8|~3.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/console": "~2.8|~3.0|~4.0",
-                "symfony/css-selector": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "^3.4.10|^4.0.10",
-                "symfony/dom-crawler": "~2.8|~3.0|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/finder": "~2.8|~3.0|~4.0",
-                "symfony/process": "~2.8|~3.0|~4.0",
+                "symfony/browser-kit": "^4.3",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/console": "~3.4|~4.0",
+                "symfony/css-selector": "~3.4|~4.0",
+                "symfony/dependency-injection": "^4.3",
+                "symfony/dom-crawler": "~3.4|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/finder": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0",
                 "symfony/routing": "~3.4|~4.0",
-                "symfony/stopwatch": "~2.8|~3.0|~4.0",
-                "symfony/templating": "~2.8|~3.0|~4.0",
-                "symfony/translation": "~2.8|~3.0|~4.0",
-                "symfony/var-dumper": "~3.3|~4.0"
+                "symfony/stopwatch": "~3.4|~4.0",
+                "symfony/templating": "~3.4|~4.0",
+                "symfony/translation": "~4.2",
+                "symfony/translation-contracts": "^1.1",
+                "symfony/var-dumper": "^4.1.1",
+                "twig/twig": "^1.34|^2.4"
             },
             "suggest": {
                 "symfony/browser-kit": "",
                 "symfony/config": "",
                 "symfony/console": "",
                 "symfony/dependency-injection": "",
-                "symfony/finder": "",
                 "symfony/var-dumper": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -6007,30 +6019,30 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-26T13:56:39+00:00"
+            "time": "2019-08-26T16:47:42+00:00"
         },
         {
             "name": "symfony/inflector",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/inflector.git",
-                "reference": "4a7d5c4ad3edeba3fe4a27d26ece6a012eee46b1"
+                "reference": "b25a8dc15fada858432efa083c1ecd2cef5991a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/inflector/zipball/4a7d5c4ad3edeba3fe4a27d26ece6a012eee46b1",
-                "reference": "4a7d5c4ad3edeba3fe4a27d26ece6a012eee46b1",
+                "url": "https://api.github.com/repos/symfony/inflector/zipball/b25a8dc15fada858432efa083c1ecd2cef5991a7",
+                "reference": "b25a8dc15fada858432efa083c1ecd2cef5991a7",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -6065,28 +6077,28 @@
                 "symfony",
                 "words"
             ],
-            "time": "2019-01-16T13:27:11+00:00"
+            "time": "2019-08-06T18:44:23+00:00"
         },
         {
             "name": "symfony/intl",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/intl.git",
-                "reference": "acf561605727e2b6705c73d45d28f431d70397af"
+                "reference": "8db5505703c5bdb23d524fd994dad2f781966538"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/intl/zipball/acf561605727e2b6705c73d45d28f431d70397af",
-                "reference": "acf561605727e2b6705c73d45d28f431d70397af",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/8db5505703c5bdb23d524fd994dad2f781966538",
+                "reference": "8db5505703c5bdb23d524fd994dad2f781966538",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "symfony/polyfill-intl-icu": "~1.0"
             },
             "require-dev": {
-                "symfony/filesystem": "~2.8|~3.0|~4.0"
+                "symfony/filesystem": "~3.4|~4.0"
             },
             "suggest": {
                 "ext-intl": "to use the component with locales other than \"en\""
@@ -6094,7 +6106,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -6140,20 +6152,20 @@
                 "l10n",
                 "localization"
             ],
-            "time": "2019-06-13T15:39:17+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/maker-bundle",
-            "version": "v1.12.0",
+            "version": "v1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/maker-bundle.git",
-                "reference": "201d0e050dca336c44f93657ce1f34f3b3868432"
+                "reference": "c4388410e2fb6321e77c5dd6e3cb2dba821f9fe6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/maker-bundle/zipball/201d0e050dca336c44f93657ce1f34f3b3868432",
-                "reference": "201d0e050dca336c44f93657ce1f34f3b3868432",
+                "url": "https://api.github.com/repos/symfony/maker-bundle/zipball/c4388410e2fb6321e77c5dd6e3cb2dba821f9fe6",
+                "reference": "c4388410e2fb6321e77c5dd6e3cb2dba821f9fe6",
                 "shasum": ""
             },
             "require": {
@@ -6208,47 +6220,105 @@
                 "scaffold",
                 "scaffolding"
             ],
-            "time": "2019-07-09T22:19:18+00:00"
+            "time": "2019-08-18T17:34:03+00:00"
         },
         {
-            "name": "symfony/monolog-bridge",
-            "version": "v3.4.29",
+            "name": "symfony/mime",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/monolog-bridge.git",
-                "reference": "0ae5e7d0f633130ff55bd48f29f1ba9df7dc4442"
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "987a05df1c6ac259b34008b932551353f4f408df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/0ae5e7d0f633130ff55bd48f29f1ba9df7dc4442",
-                "reference": "0ae5e7d0f633130ff55bd48f29f1ba9df7dc4442",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/987a05df1c6ac259b34008b932551353f4f408df",
+                "reference": "987a05df1c6ac259b34008b932551353f4f408df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10",
+                "symfony/dependency-injection": "~3.4|^4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A library to manipulate MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "time": "2019-08-22T08:16:11+00:00"
+        },
+        {
+            "name": "symfony/monolog-bridge",
+            "version": "v4.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/monolog-bridge.git",
+                "reference": "8a491edacd54e0214f5e7fb254710d30682e7bc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/8a491edacd54e0214f5e7fb254710d30682e7bc1",
+                "reference": "8a491edacd54e0214f5e7fb254710d30682e7bc1",
                 "shasum": ""
             },
             "require": {
                 "monolog/monolog": "~1.19",
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/http-kernel": "~2.8|~3.0|~4.0"
+                "php": "^7.1.3",
+                "symfony/http-kernel": "^4.3",
+                "symfony/service-contracts": "^1.1"
             },
             "conflict": {
-                "symfony/console": "<2.8",
-                "symfony/http-foundation": "<3.3"
+                "symfony/console": "<3.4",
+                "symfony/http-foundation": "<3.4"
             },
             "require-dev": {
-                "symfony/console": "~2.8|~3.0|~4.0",
-                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-                "symfony/security-core": "~2.8|~3.0|~4.0",
-                "symfony/var-dumper": "~3.3|~4.0"
+                "symfony/console": "~3.4|~4.0",
+                "symfony/security-core": "~3.4|~4.0",
+                "symfony/var-dumper": "~3.4|~4.0"
             },
             "suggest": {
-                "symfony/console": "For the possibility to show log messages in console commands depending on verbosity settings. You need version ^2.8 of the console for it.",
-                "symfony/event-dispatcher": "Needed when using log messages in console commands.",
+                "symfony/console": "For the possibility to show log messages in console commands depending on verbosity settings.",
                 "symfony/http-kernel": "For using the debugging handlers together with the response life cycle of the HTTP kernel.",
                 "symfony/var-dumper": "For using the debugging handlers like the console handler or the log server handler."
             },
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -6275,7 +6345,7 @@
             ],
             "description": "Symfony Monolog Bridge",
             "homepage": "https://symfony.com",
-            "time": "2019-05-30T15:47:52+00:00"
+            "time": "2019-08-07T11:52:19+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -6342,25 +6412,25 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "ed3b397f9c07c8ca388b2a1ef744403b4d4ecc44"
+                "reference": "81c2e120522a42f623233968244baebd6b36cb6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/ed3b397f9c07c8ca388b2a1ef744403b4d4ecc44",
-                "reference": "ed3b397f9c07c8ca388b2a1ef744403b4d4ecc44",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/81c2e120522a42f623233968244baebd6b36cb6a",
+                "reference": "81c2e120522a42f623233968244baebd6b36cb6a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -6392,76 +6462,20 @@
                 "configuration",
                 "options"
             ],
-            "time": "2019-04-10T16:00:48+00:00"
-        },
-        {
-            "name": "symfony/polyfill-apcu",
-            "version": "v1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-apcu.git",
-                "reference": "a502face1da6a53289480166f24de2c3c68e5c3c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/a502face1da6a53289480166f24de2c3c68e5c3c",
-                "reference": "a502face1da6a53289480166f24de2c3c68e5c3c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.11-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Apcu\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting apcu_* functions to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "apcu",
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2019-08-08T09:29:19+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.11.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "82ebae02209c21113908c229e9883c419720738a"
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
-                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
                 "shasum": ""
             },
             "require": {
@@ -6473,7 +6487,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -6490,12 +6504,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Gert de Pagter",
                     "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -6506,20 +6520,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.11.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "f037ea22acfaee983e271dd9c3b8bb4150bd8ad7"
+                "reference": "685968b11e61a347c18bf25db32effa478be610f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/f037ea22acfaee983e271dd9c3b8bb4150bd8ad7",
-                "reference": "f037ea22acfaee983e271dd9c3b8bb4150bd8ad7",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/685968b11e61a347c18bf25db32effa478be610f",
+                "reference": "685968b11e61a347c18bf25db32effa478be610f",
                 "shasum": ""
             },
             "require": {
@@ -6531,7 +6545,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -6565,25 +6579,25 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-intl-icu",
-            "version": "v1.11.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-icu.git",
-                "reference": "999878a3a09d73cae157b0cf89bb6fb2cc073057"
+                "reference": "66810b9d6eb4af54d543867909d65ab9af654d7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/999878a3a09d73cae157b0cf89bb6fb2cc073057",
-                "reference": "999878a3a09d73cae157b0cf89bb6fb2cc073057",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/66810b9d6eb4af54d543867909d65ab9af654d7e",
+                "reference": "66810b9d6eb4af54d543867909d65ab9af654d7e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "symfony/intl": "~2.3|~3.0|~4.0"
+                "symfony/intl": "~2.3|~3.0|~4.0|~5.0"
             },
             "suggest": {
                 "ext-intl": "For best performance"
@@ -6591,7 +6605,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -6623,20 +6637,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-01-07T19:39:47+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.11.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "c766e95bec706cdd89903b1eda8afab7d7a6b7af"
+                "reference": "6af626ae6fa37d396dc90a399c0ff08e5cfc45b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/c766e95bec706cdd89903b1eda8afab7d7a6b7af",
-                "reference": "c766e95bec706cdd89903b1eda8afab7d7a6b7af",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/6af626ae6fa37d396dc90a399c0ff08e5cfc45b2",
+                "reference": "6af626ae6fa37d396dc90a399c0ff08e5cfc45b2",
                 "shasum": ""
             },
             "require": {
@@ -6650,7 +6664,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -6667,12 +6681,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Laurent Bassin",
                     "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
@@ -6685,20 +6699,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-03-04T13:44:35+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.11.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
+                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
-                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/b42a2f66e8f1b15ccf25652c3424265923eb4f17",
+                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17",
                 "shasum": ""
             },
             "require": {
@@ -6710,7 +6724,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -6744,135 +6758,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php56",
-            "version": "v1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php56.git",
-                "reference": "f4dddbc5c3471e1b700a147a20ae17cdb72dbe42"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/f4dddbc5c3471e1b700a147a20ae17cdb72dbe42",
-                "reference": "f4dddbc5c3471e1b700a147a20ae17cdb72dbe42",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "symfony/polyfill-util": "~1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.11-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php56\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 5.6+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2019-02-06T07:57:58+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php70",
-            "version": "v1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "bc4858fb611bda58719124ca079baff854149c89"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/bc4858fb611bda58719124ca079baff854149c89",
-                "reference": "bc4858fb611bda58719124ca079baff854149c89",
-                "shasum": ""
-            },
-            "require": {
-                "paragonie/random_compat": "~1.0|~2.0|~9.99",
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.11-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php70\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.11.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "ab50dcf166d5f577978419edd37aa2bb8eabce0c"
+                "reference": "04ce3335667451138df4307d6a9b61565560199e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/ab50dcf166d5f577978419edd37aa2bb8eabce0c",
-                "reference": "ab50dcf166d5f577978419edd37aa2bb8eabce0c",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/04ce3335667451138df4307d6a9b61565560199e",
+                "reference": "04ce3335667451138df4307d6a9b61565560199e",
                 "shasum": ""
             },
             "require": {
@@ -6881,7 +6780,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -6914,20 +6813,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
-            "name": "symfony/polyfill-util",
-            "version": "v1.11.0",
+            "name": "symfony/polyfill-php73",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-util.git",
-                "reference": "b46c6cae28a3106735323f00a0c38eccf2328897"
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/b46c6cae28a3106735323f00a0c38eccf2328897",
-                "reference": "b46c6cae28a3106735323f00a0c38eccf2328897",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/2ceb49eaccb9352bff54d22570276bb75ba4a188",
+                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188",
                 "shasum": ""
             },
             "require": {
@@ -6936,13 +6835,19 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Polyfill\\Util\\": ""
-                }
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6958,15 +6863,15 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony utilities for portability of PHP codes",
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
             "homepage": "https://symfony.com",
             "keywords": [
-                "compat",
                 "compatibility",
                 "polyfill",
+                "portable",
                 "shim"
             ],
-            "time": "2019-02-08T14:16:39+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/profiler-pack",
@@ -6998,25 +6903,24 @@
         },
         {
             "name": "symfony/property-access",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "27959b5664694ad57e095fdce9f4ef9f144e63ab"
+                "reference": "bb0c302375ffeef60c31e72a4539611b7f787565"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/27959b5664694ad57e095fdce9f4ef9f144e63ab",
-                "reference": "27959b5664694ad57e095fdce9f4ef9f144e63ab",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/bb0c302375ffeef60c31e72a4539611b7f787565",
+                "reference": "bb0c302375ffeef60c31e72a4539611b7f787565",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/inflector": "~3.1|~4.0",
-                "symfony/polyfill-php70": "~1.0"
+                "php": "^7.1.3",
+                "symfony/inflector": "~3.4|~4.0"
             },
             "require-dev": {
-                "symfony/cache": "~3.1|~4.0"
+                "symfony/cache": "~3.4|~4.0"
             },
             "suggest": {
                 "psr/cache-implementation": "To cache access methods."
@@ -7024,7 +6928,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -7062,37 +6966,37 @@
                 "property path",
                 "reflection"
             ],
-            "time": "2019-06-05T15:56:22+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "8d804d8a65a26dc9de1aaf2ff3a421e581d050e6"
+                "reference": "ff1049f6232dc5b6023b1ff1c6de56f82bcd264f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/8d804d8a65a26dc9de1aaf2ff3a421e581d050e6",
-                "reference": "8d804d8a65a26dc9de1aaf2ff3a421e581d050e6",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/ff1049f6232dc5b6023b1ff1c6de56f82bcd264f",
+                "reference": "ff1049f6232dc5b6023b1ff1c6de56f82bcd264f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3"
             },
             "conflict": {
-                "symfony/config": "<3.3.1",
-                "symfony/dependency-injection": "<3.3",
+                "symfony/config": "<4.2",
+                "symfony/dependency-injection": "<3.4",
                 "symfony/yaml": "<3.4"
             },
             "require-dev": {
-                "doctrine/annotations": "~1.0",
+                "doctrine/annotations": "~1.2",
                 "psr/log": "~1.0",
-                "symfony/config": "^3.3.1|~4.0",
-                "symfony/dependency-injection": "~3.3|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/http-foundation": "~2.8|~3.0|~4.0",
+                "symfony/config": "~4.2",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/http-foundation": "~3.4|~4.0",
                 "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
@@ -7105,7 +7009,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -7138,30 +7042,29 @@
                 "uri",
                 "url"
             ],
-            "time": "2019-06-26T11:14:13+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/security",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security.git",
-                "reference": "e5275701ce41d6ae9ffaa5a1ab8e412967186ff4"
+                "reference": "e4a121f421e97a9ce575f15eea0accd250c10abf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security/zipball/e5275701ce41d6ae9ffaa5a1ab8e412967186ff4",
-                "reference": "e5275701ce41d6ae9ffaa5a1ab8e412967186ff4",
+                "url": "https://api.github.com/repos/symfony/security/zipball/e4a121f421e97a9ce575f15eea0accd250c10abf",
+                "reference": "e4a121f421e97a9ce575f15eea0accd250c10abf",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-                "symfony/http-foundation": "^2.8.31|~3.3.13|~3.4|~4.0",
-                "symfony/http-kernel": "~3.3|~4.0",
-                "symfony/polyfill-php56": "~1.0",
-                "symfony/polyfill-php70": "~1.0",
-                "symfony/property-access": "~2.8|~3.0|~4.0"
+                "php": "^7.1.3",
+                "symfony/event-dispatcher-contracts": "^1.1",
+                "symfony/http-foundation": "~3.4|~4.0",
+                "symfony/http-kernel": "^4.3",
+                "symfony/property-access": "~3.4|~4.0",
+                "symfony/service-contracts": "^1.1"
             },
             "replace": {
                 "symfony/security-core": "self.version",
@@ -7172,13 +7075,13 @@
             "require-dev": {
                 "psr/container": "^1.0",
                 "psr/log": "~1.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/finder": "~2.8|~3.0|~4.0",
-                "symfony/ldap": "~3.1|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/finder": "~3.4|~4.0",
+                "symfony/ldap": "~3.4|~4.0",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-icu": "~1.0",
-                "symfony/routing": "~2.8|~3.0|~4.0",
-                "symfony/validator": "^3.2.5|~4.0"
+                "symfony/routing": "~3.4|~4.0",
+                "symfony/validator": "^3.4.31|^4.3.4"
             },
             "suggest": {
                 "psr/container-implementation": "To instantiate the Security class",
@@ -7191,7 +7094,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -7221,7 +7124,7 @@
             ],
             "description": "Symfony Security Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-25T12:22:47+00:00"
+            "time": "2019-08-26T08:55:16+00:00"
         },
         {
             "name": "symfony/security-acl",
@@ -7286,62 +7189,60 @@
         },
         {
             "name": "symfony/security-bundle",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-bundle.git",
-                "reference": "1803f2cfd74f6ac4aa07d3ad33e6035b7c93de3d"
+                "reference": "97ba8648e718999793e79ab4d1f1582c8d19be9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/1803f2cfd74f6ac4aa07d3ad33e6035b7c93de3d",
-                "reference": "1803f2cfd74f6ac4aa07d3ad33e6035b7c93de3d",
+                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/97ba8648e718999793e79ab4d1f1582c8d19be9d",
+                "reference": "97ba8648e718999793e79ab4d1f1582c8d19be9d",
                 "shasum": ""
             },
             "require": {
                 "ext-xml": "*",
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/dependency-injection": "^3.4.3|^4.0.3",
-                "symfony/http-kernel": "~3.4|~4.0",
-                "symfony/polyfill-php70": "~1.0",
-                "symfony/security": "~3.4.15|~4.0.15|^4.1.4"
+                "php": "^7.1.3",
+                "symfony/config": "^4.2",
+                "symfony/dependency-injection": "^4.2",
+                "symfony/http-kernel": "^4.3",
+                "symfony/security-core": "~4.3",
+                "symfony/security-csrf": "~4.2",
+                "symfony/security-guard": "~4.2",
+                "symfony/security-http": "^4.3"
             },
             "conflict": {
+                "symfony/browser-kit": "<4.2",
                 "symfony/console": "<3.4",
-                "symfony/event-dispatcher": "<3.4",
-                "symfony/framework-bundle": "<3.4",
-                "symfony/var-dumper": "<3.3"
+                "symfony/framework-bundle": "<4.3.4",
+                "symfony/twig-bundle": "<4.2",
+                "symfony/var-dumper": "<3.4"
             },
             "require-dev": {
                 "doctrine/doctrine-bundle": "~1.5",
-                "symfony/asset": "~2.8|~3.0|~4.0",
-                "symfony/browser-kit": "~2.8|~3.0|~4.0",
+                "symfony/asset": "~3.4|~4.0",
+                "symfony/browser-kit": "~4.2",
                 "symfony/console": "~3.4|~4.0",
-                "symfony/css-selector": "~2.8|~3.0|~4.0",
-                "symfony/dom-crawler": "~2.8|~3.0|~4.0",
-                "symfony/event-dispatcher": "~3.4|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/form": "^3.4|~4.0",
-                "symfony/framework-bundle": "~3.4|~4.0",
-                "symfony/http-foundation": "~3.3|~4.0",
-                "symfony/process": "~3.3|~4.0",
-                "symfony/security-acl": "~2.8|~3.0",
+                "symfony/css-selector": "~3.4|~4.0",
+                "symfony/dom-crawler": "~3.4|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/form": "~3.4|~4.0",
+                "symfony/framework-bundle": "^4.3.4",
+                "symfony/http-foundation": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0",
                 "symfony/translation": "~3.4|~4.0",
                 "symfony/twig-bridge": "~3.4|~4.0",
-                "symfony/twig-bundle": "~3.4|~4.0",
-                "symfony/validator": "^3.4|~4.0",
-                "symfony/var-dumper": "~3.3|~4.0",
+                "symfony/twig-bundle": "~4.2",
+                "symfony/validator": "~3.4|~4.0",
+                "symfony/var-dumper": "~3.4|~4.0",
                 "symfony/yaml": "~3.4|~4.0",
-                "twig/twig": "~1.34|~2.4"
-            },
-            "suggest": {
-                "symfony/security-acl": "For using the ACL functionality of this bundle"
+                "twig/twig": "~1.41|~2.10"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -7368,43 +7269,44 @@
             ],
             "description": "Symfony SecurityBundle",
             "homepage": "https://symfony.com",
-            "time": "2019-06-07T20:39:07+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "c060c0e0b97dc13b3c3fd8f981a68fa32a24371c"
+                "reference": "702900654e0ceed9ca7a9eccffb1d6ec69d7c8b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/c060c0e0b97dc13b3c3fd8f981a68fa32a24371c",
-                "reference": "c060c0e0b97dc13b3c3fd8f981a68fa32a24371c",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/702900654e0ceed9ca7a9eccffb1d6ec69d7c8b6",
+                "reference": "702900654e0ceed9ca7a9eccffb1d6ec69d7c8b6",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "phpdocumentor/type-resolver": "<0.2.1",
-                "symfony/dependency-injection": "<3.2",
-                "symfony/property-access": ">=3.0,<3.0.4|>=2.8,<2.8.4",
-                "symfony/property-info": "<3.1",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/property-access": "<3.4",
+                "symfony/property-info": "<3.4",
                 "symfony/yaml": "<3.4"
             },
             "require-dev": {
                 "doctrine/annotations": "~1.0",
                 "doctrine/cache": "~1.0",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0",
-                "symfony/cache": "~3.1|~4.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "~3.2|~4.0",
-                "symfony/http-foundation": "~2.8|~3.0|~4.0",
-                "symfony/property-access": "~2.8|~3.0|~4.0",
+                "symfony/cache": "~3.4|~4.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/http-foundation": "~3.4|~4.0",
+                "symfony/property-access": "~3.4|~4.0",
                 "symfony/property-info": "^3.4.13|~4.0",
+                "symfony/validator": "~3.4|~4.0",
                 "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
@@ -7420,7 +7322,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -7447,29 +7349,88 @@
             ],
             "description": "Symfony Serializer Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-14T05:50:06+00:00"
+            "time": "2019-08-26T08:55:16+00:00"
         },
         {
-            "name": "symfony/stopwatch",
-            "version": "v3.4.29",
+            "name": "symfony/service-contracts",
+            "version": "v1.1.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "2a651c2645c10bbedd21170771f122d935e0dd58"
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "ea7263d6b6d5f798b56a45a5b8d686725f2719a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/2a651c2645c10bbedd21170771f122d935e0dd58",
-                "reference": "2a651c2645c10bbedd21170771f122d935e0dd58",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ea7263d6b6d5f798b56a45a5b8d686725f2719a3",
+                "reference": "ea7263d6b6d5f798b56a45a5b8d686725f2719a3",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-08-20T14:44:19+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v4.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "1e4ff456bd625be5032fac9be4294e60442e9b71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/1e4ff456bd625be5032fac9be4294e60442e9b71",
+                "reference": "1e4ff456bd625be5032fac9be4294e60442e9b71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/service-contracts": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -7496,7 +7457,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T09:39:14+00:00"
+            "time": "2019-08-07T11:52:19+00:00"
         },
         {
             "name": "symfony/swiftmailer-bundle",
@@ -7565,20 +7526,20 @@
         },
         {
             "name": "symfony/templating",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/templating.git",
-                "reference": "558e53ae88afb9ba0ab7b5eac5771c8fdc639f81"
+                "reference": "15407776e1fe250ed3fa1c1a679482c60c2affe3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/templating/zipball/558e53ae88afb9ba0ab7b5eac5771c8fdc639f81",
-                "reference": "558e53ae88afb9ba0ab7b5eac5771c8fdc639f81",
+                "url": "https://api.github.com/repos/symfony/templating/zipball/15407776e1fe250ed3fa1c1a679482c60c2affe3",
+                "reference": "15407776e1fe250ed3fa1c1a679482c60c2affe3",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "require-dev": {
@@ -7590,7 +7551,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -7617,38 +7578,44 @@
             ],
             "description": "Symfony Templating Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-30T15:47:52+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "5c07632afb8cb14b422051b651213ed17bf7c249"
+                "reference": "28498169dd334095fa981827992f3a24d50fed0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/5c07632afb8cb14b422051b651213ed17bf7c249",
-                "reference": "5c07632afb8cb14b422051b651213ed17bf7c249",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/28498169dd334095fa981827992f3a24d50fed0f",
+                "reference": "28498169dd334095fa981827992f3a24d50fed0f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": "^7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^1.1.6"
             },
             "conflict": {
-                "symfony/config": "<2.8",
+                "symfony/config": "<3.4",
                 "symfony/dependency-injection": "<3.4",
                 "symfony/yaml": "<3.4"
             },
+            "provide": {
+                "symfony/translation-implementation": "1.0"
+            },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/console": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
                 "symfony/finder": "~2.8|~3.0|~4.0",
                 "symfony/http-kernel": "~3.4|~4.0",
-                "symfony/intl": "^2.8.18|^3.2.5|~4.0",
+                "symfony/intl": "~3.4|~4.0",
+                "symfony/service-contracts": "^1.1.2",
                 "symfony/var-dumper": "~3.4|~4.0",
                 "symfony/yaml": "~3.4|~4.0"
             },
@@ -7660,7 +7627,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -7687,50 +7654,116 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-13T10:34:15+00:00"
+            "time": "2019-08-26T08:55:16+00:00"
         },
         {
-            "name": "symfony/twig-bridge",
-            "version": "v3.4.29",
+            "name": "symfony/translation-contracts",
+            "version": "v1.1.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "c5cda7f836ccfa80a84c27aec10aa16591333829"
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "325b17c24f3ee23cbecfa63ba809c6d89b5fa04a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/c5cda7f836ccfa80a84c27aec10aa16591333829",
-                "reference": "c5cda7f836ccfa80a84c27aec10aa16591333829",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/325b17c24f3ee23cbecfa63ba809c6d89b5fa04a",
+                "reference": "325b17c24f3ee23cbecfa63ba809c6d89b5fa04a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "twig/twig": "^1.40|^2.9"
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "symfony/translation-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-08-02T12:15:04+00:00"
+        },
+        {
+            "name": "symfony/twig-bridge",
+            "version": "v4.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/twig-bridge.git",
+                "reference": "cd6c551dc5d62b520d1a973fb4cb2c46bfc00b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/cd6c551dc5d62b520d1a973fb4cb2c46bfc00b62",
+                "reference": "cd6c551dc5d62b520d1a973fb4cb2c46bfc00b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/translation-contracts": "^1.1",
+                "twig/twig": "^1.41|^2.10"
             },
             "conflict": {
                 "symfony/console": "<3.4",
-                "symfony/form": "<3.4.13|>=4.0,<4.0.13|>=4.1,<4.1.2"
+                "symfony/form": "<4.3.4",
+                "symfony/http-foundation": "<4.3",
+                "symfony/translation": "<4.2",
+                "symfony/workflow": "<4.3"
             },
             "require-dev": {
-                "symfony/asset": "~2.8|~3.0|~4.0",
+                "egulias/email-validator": "^2.1.10",
+                "fig/link-util": "^1.0",
+                "symfony/asset": "~3.4|~4.0",
                 "symfony/console": "~3.4|~4.0",
-                "symfony/dependency-injection": "~2.8|~3.0|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/finder": "~2.8|~3.0|~4.0",
-                "symfony/form": "^3.4.23|^4.2.4",
-                "symfony/http-foundation": "^3.3.11|~4.0",
-                "symfony/http-kernel": "~3.2|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/finder": "~3.4|~4.0",
+                "symfony/form": "^4.3.4",
+                "symfony/http-foundation": "~4.3",
+                "symfony/http-kernel": "~3.4|~4.0",
+                "symfony/mime": "~4.3",
                 "symfony/polyfill-intl-icu": "~1.0",
-                "symfony/routing": "~2.8|~3.0|~4.0",
-                "symfony/security": "^2.8.31|^3.3.13|~4.0",
+                "symfony/routing": "~3.4|~4.0",
                 "symfony/security-acl": "~2.8|~3.0",
-                "symfony/stopwatch": "~2.8|~3.0|~4.0",
-                "symfony/templating": "~2.8|~3.0|~4.0",
-                "symfony/translation": "~2.8|~3.0|~4.0",
-                "symfony/var-dumper": "~2.8.10|~3.1.4|~3.2|~4.0",
-                "symfony/web-link": "~3.3|~4.0",
-                "symfony/workflow": "~3.3|~4.0",
-                "symfony/yaml": "~2.8|~3.0|~4.0"
+                "symfony/security-core": "~3.0|~4.0",
+                "symfony/security-csrf": "~3.4|~4.0",
+                "symfony/security-http": "~3.4|~4.0",
+                "symfony/stopwatch": "~3.4|~4.0",
+                "symfony/templating": "~3.4|~4.0",
+                "symfony/translation": "^4.2.1",
+                "symfony/var-dumper": "~3.4|~4.0",
+                "symfony/web-link": "~3.4|~4.0",
+                "symfony/workflow": "~4.3",
+                "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/asset": "For using the AssetExtension",
@@ -7739,7 +7772,9 @@
                 "symfony/form": "For using the FormExtension",
                 "symfony/http-kernel": "For using the HttpKernelExtension",
                 "symfony/routing": "For using the RoutingExtension",
-                "symfony/security": "For using the SecurityExtension",
+                "symfony/security-core": "For using the SecurityExtension",
+                "symfony/security-csrf": "For using the CsrfExtension",
+                "symfony/security-http": "For using the LogoutUrlExtension",
                 "symfony/stopwatch": "For using the StopwatchExtension",
                 "symfony/templating": "For using the TwigEngine",
                 "symfony/translation": "For using the TranslationExtension",
@@ -7750,7 +7785,7 @@
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -7777,54 +7812,57 @@
             ],
             "description": "Symfony Twig Bridge",
             "homepage": "https://symfony.com",
-            "time": "2019-06-13T10:34:15+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/twig-bundle",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bundle.git",
-                "reference": "94c558cc915a6ac2e2de7d7f9a6b6e8a739a7c53"
+                "reference": "9528fdd8b9ba3f66c5570c22fb1a547e35abb23d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bundle/zipball/94c558cc915a6ac2e2de7d7f9a6b6e8a739a7c53",
-                "reference": "94c558cc915a6ac2e2de7d7f9a6b6e8a739a7c53",
+                "url": "https://api.github.com/repos/symfony/twig-bundle/zipball/9528fdd8b9ba3f66c5570c22fb1a547e35abb23d",
+                "reference": "9528fdd8b9ba3f66c5570c22fb1a547e35abb23d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/config": "~3.2|~4.0",
-                "symfony/http-foundation": "~2.8|~3.0|~4.0",
-                "symfony/http-kernel": "^3.3|~4.0",
+                "php": "^7.1.3",
+                "symfony/config": "~4.2",
+                "symfony/debug": "~4.0",
+                "symfony/http-foundation": "~4.3",
+                "symfony/http-kernel": "~4.1",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/twig-bridge": "^3.4.3|^4.0.3",
-                "twig/twig": "~1.40|~2.9"
+                "symfony/twig-bridge": "^4.3",
+                "twig/twig": "~1.41|~2.10"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.4",
-                "symfony/event-dispatcher": "<3.3.1"
+                "symfony/dependency-injection": "<4.1",
+                "symfony/framework-bundle": "<4.3",
+                "symfony/translation": "<4.2"
             },
             "require-dev": {
-                "doctrine/annotations": "~1.0",
+                "doctrine/annotations": "~1.7",
                 "doctrine/cache": "~1.0",
-                "symfony/asset": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "~3.4.24|^4.2.5",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/finder": "~2.8|~3.0|~4.0",
-                "symfony/form": "~2.8|~3.0|~4.0",
-                "symfony/framework-bundle": "^3.3.11|~4.0",
-                "symfony/routing": "~2.8|~3.0|~4.0",
-                "symfony/stopwatch": "~2.8|~3.0|~4.0",
-                "symfony/templating": "~2.8|~3.0|~4.0",
-                "symfony/web-link": "~3.3|~4.0",
-                "symfony/yaml": "~2.8|~3.0|~4.0"
+                "symfony/asset": "~3.4|~4.0",
+                "symfony/dependency-injection": "^4.2.5",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/finder": "~3.4|~4.0",
+                "symfony/form": "~3.4|~4.0",
+                "symfony/framework-bundle": "~4.3",
+                "symfony/routing": "~3.4|~4.0",
+                "symfony/stopwatch": "~3.4|~4.0",
+                "symfony/templating": "~3.4|~4.0",
+                "symfony/translation": "^4.2",
+                "symfony/web-link": "~3.4|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -7851,47 +7889,53 @@
             ],
             "description": "Symfony TwigBundle",
             "homepage": "https://symfony.com",
-            "time": "2019-05-30T15:47:52+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/validator",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "d6561bff343346be8ff3e93eb5c4344985bc538b"
+                "reference": "173b483999c2acad8e040633105733318dcc8a83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/d6561bff343346be8ff3e93eb5c4344985bc538b",
-                "reference": "d6561bff343346be8ff3e93eb5c4344985bc538b",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/173b483999c2acad8e040633105733318dcc8a83",
+                "reference": "173b483999c2acad8e040633105733318dcc8a83",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/translation": "~2.8|~3.0|~4.0"
+                "symfony/translation-contracts": "^1.1"
             },
             "conflict": {
+                "doctrine/lexer": "<1.0.2",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
-                "symfony/dependency-injection": "<3.3",
-                "symfony/http-kernel": "<3.3.5",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/http-kernel": "<3.4",
+                "symfony/intl": "<4.3",
+                "symfony/translation": "<4.2",
                 "symfony/yaml": "<3.4"
             },
             "require-dev": {
-                "doctrine/annotations": "~1.0",
+                "doctrine/annotations": "~1.7",
                 "doctrine/cache": "~1.0",
-                "egulias/email-validator": "^1.2.8|~2.0",
-                "symfony/cache": "~3.1|~4.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "~3.3|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/http-foundation": "~2.8|~3.0|~4.0",
-                "symfony/http-kernel": "^3.3.5|~4.0",
-                "symfony/intl": "^2.8.18|^3.2.5|~4.0",
-                "symfony/property-access": "~2.8|~3.0|~4.0",
-                "symfony/var-dumper": "~3.3|~4.0",
+                "egulias/email-validator": "^2.1.10",
+                "symfony/cache": "~3.4|~4.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/http-client": "^4.3",
+                "symfony/http-foundation": "~4.1",
+                "symfony/http-kernel": "~3.4|~4.0",
+                "symfony/intl": "^4.3",
+                "symfony/property-access": "~3.4|~4.0",
+                "symfony/property-info": "~3.4|~4.0",
+                "symfony/translation": "~4.2",
+                "symfony/var-dumper": "~3.4|~4.0",
                 "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
@@ -7904,12 +7948,14 @@
                 "symfony/http-foundation": "",
                 "symfony/intl": "",
                 "symfony/property-access": "For accessing properties within comparison constraints",
+                "symfony/property-info": "To automatically add NotNull and Type constraints",
+                "symfony/translation": "For translating validation errors.",
                 "symfony/yaml": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -7936,42 +7982,49 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-20T06:43:29+00:00"
+            "time": "2019-08-26T09:28:48+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "7b92618169c44af4bb226f69dbac42b56b1a7745"
+                "reference": "641043e0f3e615990a0f29479f9c117e8a6698c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/7b92618169c44af4bb226f69dbac42b56b1a7745",
-                "reference": "7b92618169c44af4bb226f69dbac42b56b1a7745",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/641043e0f3e615990a0f29479f9c117e8a6698c6",
+                "reference": "641043e0f3e615990a0f29479f9c117e8a6698c6",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": "^7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php72": "~1.5"
             },
             "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
+                "symfony/console": "<3.4"
             },
             "require-dev": {
                 "ext-iconv": "*",
+                "symfony/console": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0",
                 "twig/twig": "~1.34|~2.4"
             },
             "suggest": {
                 "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
                 "ext-intl": "To show region name in time zone dump",
-                "ext-symfony_debug": ""
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
             },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -8005,47 +8058,106 @@
                 "debug",
                 "dump"
             ],
-            "time": "2019-06-13T16:26:35+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
-            "name": "symfony/web-profiler-bundle",
-            "version": "v3.4.29",
+            "name": "symfony/var-exporter",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/web-profiler-bundle.git",
-                "reference": "6e835f66ca6052bf410a44a41449d1985c06aed3"
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "d5b4e2d334c1d80e42876c7d489896cfd37562f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/6e835f66ca6052bf410a44a41449d1985c06aed3",
-                "reference": "6e835f66ca6052bf410a44a41449d1985c06aed3",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/d5b4e2d334c1d80e42876c7d489896cfd37562f2",
+                "reference": "d5b4e2d334c1d80e42876c7d489896cfd37562f2",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/http-kernel": "~3.4.25|^4.2.6",
-                "symfony/polyfill-php70": "~1.0",
-                "symfony/routing": "~2.8|~3.0|~4.0",
-                "symfony/twig-bridge": "~2.8|~3.0|~4.0",
-                "symfony/var-dumper": "~3.3|~4.0",
-                "twig/twig": "~1.34|~2.4"
-            },
-            "conflict": {
-                "symfony/config": "<3.4",
-                "symfony/dependency-injection": "<3.4",
-                "symfony/event-dispatcher": "<3.3.1",
-                "symfony/var-dumper": "<3.3"
+                "php": "^7.1.3"
             },
             "require-dev": {
-                "symfony/config": "~3.4|~4.0",
-                "symfony/console": "~2.8|~3.0|~4.0",
+                "symfony/var-dumper": "^4.1.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A blend of var_export() + serialize() to turn any serializable data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "serialize"
+            ],
+            "time": "2019-08-22T07:33:08+00:00"
+        },
+        {
+            "name": "symfony/web-profiler-bundle",
+            "version": "v4.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/web-profiler-bundle.git",
+                "reference": "387c36fd133c08bb0d78d8de17c1121681b37a09"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/387c36fd133c08bb0d78d8de17c1121681b37a09",
+                "reference": "387c36fd133c08bb0d78d8de17c1121681b37a09",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/config": "^4.2",
+                "symfony/http-kernel": "^4.3",
+                "symfony/routing": "~3.4|~4.0",
+                "symfony/twig-bundle": "~4.2",
+                "symfony/var-dumper": "~3.4|~4.0",
+                "twig/twig": "^1.41|^2.10"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/form": "<4.3",
+                "symfony/messenger": "<4.2",
+                "symfony/var-dumper": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/stopwatch": "~2.8|~3.0|~4.0"
+                "symfony/stopwatch": "~3.4|~4.0"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -8072,24 +8184,24 @@
             ],
             "description": "Symfony WebProfilerBundle",
             "homepage": "https://symfony.com",
-            "time": "2019-06-09T16:36:33+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996"
+                "reference": "5a0b7c32dc3ec56fd4abae8a4a71b0cf05013686"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/212a27b731e5bfb735679d1ffaac82bd6a1dc996",
-                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/5a0b7c32dc3ec56fd4abae8a4a71b0cf05013686",
+                "reference": "5a0b7c32dc3ec56fd4abae8a4a71b0cf05013686",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
@@ -8104,7 +8216,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -8131,7 +8243,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-25T07:48:46+00:00"
+            "time": "2019-08-20T14:27:59+00:00"
         },
         {
             "name": "twbs/bootstrap",
@@ -8284,19 +8396,19 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
+                    "role": "Lead Developer",
                     "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "homepage": "http://fabien.potencier.org"
                 },
                 {
                     "name": "Armin Ronacher",
-                    "email": "armin.ronacher@active-4.com",
-                    "role": "Project Founder"
+                    "role": "Project Founder",
+                    "email": "armin.ronacher@active-4.com"
                 },
                 {
                     "name": "Twig Team",
-                    "homepage": "https://twig.symfony.com/contributors",
-                    "role": "Contributors"
+                    "role": "Contributors",
+                    "homepage": "https://twig.symfony.com/contributors"
                 }
             ],
             "description": "Twig, the flexible, fast, and secure template language for PHP",
@@ -8699,24 +8811,24 @@
         },
         {
             "name": "behat/mink",
-            "version": "v1.7.1",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/minkphp/Mink.git",
-                "reference": "e6930b9c74693dff7f4e58577e1b1743399f3ff9"
+                "reference": "6c129030ec2cc029905cf969a56ca8f087b2dfdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/minkphp/Mink/zipball/e6930b9c74693dff7f4e58577e1b1743399f3ff9",
-                "reference": "e6930b9c74693dff7f4e58577e1b1743399f3ff9",
+                "url": "https://api.github.com/repos/minkphp/Mink/zipball/6c129030ec2cc029905cf969a56ca8f087b2dfdf",
+                "reference": "6c129030ec2cc029905cf969a56ca8f087b2dfdf",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.1",
-                "symfony/css-selector": "~2.1|~3.0"
+                "symfony/css-selector": "~2.1"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "~2.7|~3.0"
+                "symfony/phpunit-bridge": "~2.7"
             },
             "suggest": {
                 "behat/mink-browserkit-driver": "extremely fast headless driver for Symfony\\Kernel-based apps (Sf2, Silex)",
@@ -8753,7 +8865,7 @@
                 "testing",
                 "web"
             ],
-            "time": "2016-03-05T08:26:18+00:00"
+            "time": "2015-09-20T20:24:03+00:00"
         },
         {
             "name": "behat/mink-extension",
@@ -9001,16 +9113,16 @@
         },
         {
             "name": "deployer/deployer",
-            "version": "v6.4.5",
+            "version": "v6.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/deployphp/deployer.git",
-                "reference": "be14a4f757cff060ebd3df661df12687e5fbc25e"
+                "reference": "427b83ea550a7063cfcd543ce3e9e37f11c49419"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/deployphp/deployer/zipball/be14a4f757cff060ebd3df661df12687e5fbc25e",
-                "reference": "be14a4f757cff060ebd3df661df12687e5fbc25e",
+                "url": "https://api.github.com/repos/deployphp/deployer/zipball/427b83ea550a7063cfcd543ce3e9e37f11c49419",
+                "reference": "427b83ea550a7063cfcd543ce3e9e37f11c49419",
                 "shasum": ""
             },
             "require": {
@@ -9049,7 +9161,7 @@
             ],
             "description": "Deployment Tool",
             "homepage": "https://deployer.org",
-            "time": "2019-07-01T13:14:52+00:00"
+            "time": "2019-08-12T18:28:24+00:00"
         },
         {
             "name": "deployer/phar-update",
@@ -9307,16 +9419,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.1",
+            "version": "1.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
+                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
-                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/007c053ae6f31bba39dfa19a7726f56e9763bbea",
+                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea",
                 "shasum": ""
             },
             "require": {
@@ -9351,7 +9463,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2019-04-07T13:18:21+00:00"
+            "time": "2019-08-09T12:45:53+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -9438,18 +9550,18 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "arne@blankerts.de"
                 },
                 {
                     "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "sebastian@phpeople.de"
                 },
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Library for handling version information and constraints",
@@ -9692,16 +9804,16 @@
         },
         {
             "name": "phpspec/phpspec",
-            "version": "5.1.0",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/phpspec.git",
-                "reference": "4badea737c34a6c8e2921fca0f6a1cbe4f724f2f"
+                "reference": "1bf4b5a7cf5fea43288e9283d340f7e1d5b69cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/phpspec/zipball/4badea737c34a6c8e2921fca0f6a1cbe4f724f2f",
-                "reference": "4badea737c34a6c8e2921fca0f6a1cbe4f724f2f",
+                "url": "https://api.github.com/repos/phpspec/phpspec/zipball/1bf4b5a7cf5fea43288e9283d340f7e1d5b69cae",
+                "reference": "1bf4b5a7cf5fea43288e9283d340f7e1d5b69cae",
                 "shasum": ""
             },
             "require": {
@@ -9758,7 +9870,7 @@
                     "homepage": "https://ciaranmcnulty.com/"
                 }
             ],
-            "description": "Specification-oriented BDD framework for PHP 5.6+",
+            "description": "Specification-oriented BDD framework for PHP 7.1+",
             "homepage": "http://phpspec.net/",
             "keywords": [
                 "BDD",
@@ -9769,7 +9881,7 @@
                 "testing",
                 "tests"
             ],
-            "time": "2018-10-29T08:12:52+00:00"
+            "time": "2019-08-05T10:24:38+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -9836,16 +9948,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "7.0.6",
+            "version": "7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "d471d0d2b529a67c6a722dd446c4ec90881ac315"
+                "reference": "7743bbcfff2a907e9ee4a25be13d0f8ec5e73800"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d471d0d2b529a67c6a722dd446c4ec90881ac315",
-                "reference": "d471d0d2b529a67c6a722dd446c4ec90881ac315",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7743bbcfff2a907e9ee4a25be13d0f8ec5e73800",
+                "reference": "7743bbcfff2a907e9ee4a25be13d0f8ec5e73800",
                 "shasum": ""
             },
             "require": {
@@ -9854,7 +9966,7 @@
                 "php": "^7.2",
                 "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0.2",
+                "phpunit/php-token-stream": "^3.1.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^4.2.2",
                 "sebastian/version": "^2.0.1",
@@ -9884,8 +9996,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -9895,7 +10007,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-07-08T05:29:42+00:00"
+            "time": "2019-07-25T05:31:54+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -9935,8 +10047,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "FilterIterator implementation that filters files based on a list of suffixes.",
@@ -9977,8 +10089,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Simple template engine.",
@@ -10026,8 +10138,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Utility class for timing",
@@ -10039,16 +10151,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.0.2",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "c4a66b97f040e3e20b3aa2a243230a1c3a9f7c8c"
+                "reference": "e899757bb3df5ff6e95089132f32cd59aac2220a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/c4a66b97f040e3e20b3aa2a243230a1c3a9f7c8c",
-                "reference": "c4a66b97f040e3e20b3aa2a243230a1c3a9f7c8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e899757bb3df5ff6e95089132f32cd59aac2220a",
+                "reference": "e899757bb3df5ff6e95089132f32cd59aac2220a",
                 "shasum": ""
             },
             "require": {
@@ -10061,7 +10173,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -10084,20 +10196,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2019-07-08T05:24:54+00:00"
+            "time": "2019-07-25T05:29:42+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.2.5",
+            "version": "8.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c1b8534b3730f20f58600124129197bf1183dc92"
+                "reference": "e31cce0cf4499c0ccdbbb211a3280d36ab341e36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c1b8534b3730f20f58600124129197bf1183dc92",
-                "reference": "c1b8534b3730f20f58600124129197bf1183dc92",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e31cce0cf4499c0ccdbbb211a3280d36ab341e36",
+                "reference": "e31cce0cf4499c0ccdbbb211a3280d36ab341e36",
                 "shasum": ""
             },
             "require": {
@@ -10113,7 +10225,7 @@
                 "phar-io/version": "^2.0.1",
                 "php": "^7.2",
                 "phpspec/prophecy": "^1.8.1",
-                "phpunit/php-code-coverage": "^7.0.5",
+                "phpunit/php-code-coverage": "^7.0.7",
                 "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^2.1.2",
@@ -10141,7 +10253,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "8.2-dev"
+                    "dev-master": "8.3-dev"
                 }
             },
             "autoload": {
@@ -10167,7 +10279,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-07-15T06:26:24+00:00"
+            "time": "2019-08-11T06:56:55+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -10439,16 +10551,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+                "reference": "06a9a5947f47b3029d76118eb5c22802e5869687"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/06a9a5947f47b3029d76118eb5c22802e5869687",
+                "reference": "06a9a5947f47b3029d76118eb5c22802e5869687",
                 "shasum": ""
             },
             "require": {
@@ -10476,6 +10588,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -10484,16 +10600,12 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -10502,7 +10614,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03T13:19:02+00:00"
+            "time": "2019-08-11T12:43:14+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -10783,8 +10895,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
@@ -10826,8 +10938,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
@@ -10835,26 +10947,82 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
-            "name": "symfony/css-selector",
-            "version": "v3.4.29",
+            "name": "symfony/class-loader",
+            "version": "v3.4.31",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/css-selector.git",
-                "reference": "8ca29297c29b64fb3a1a135e71cb25f67f9fdccf"
+                "url": "https://github.com/symfony/class-loader.git",
+                "reference": "e212b06996819a2bce026a63da03b7182d05a690"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/8ca29297c29b64fb3a1a135e71cb25f67f9fdccf",
-                "reference": "8ca29297c29b64fb3a1a135e71cb25f67f9fdccf",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/e212b06996819a2bce026a63da03b7182d05a690",
+                "reference": "e212b06996819a2bce026a63da03b7182d05a690",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.5.9|>=7.0.8"
             },
+            "require-dev": {
+                "symfony/finder": "~2.8|~3.0|~4.0",
+                "symfony/polyfill-apcu": "~1.1"
+            },
+            "suggest": {
+                "symfony/polyfill-apcu": "For using ApcClassLoader on HHVM"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
                     "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ClassLoader\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony ClassLoader Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-08-20T13:31:17+00:00"
+        },
+        {
+            "name": "symfony/css-selector",
+            "version": "v2.8.50",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "7b1692e418d7ccac24c373528453bc90e42797de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/7b1692e418d7ccac24c373528453bc90e42797de",
+                "reference": "7b1692e418d7ccac24c373528453bc90e42797de",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -10885,20 +11053,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T09:39:14+00:00"
+            "time": "2018-11-11T11:18:13+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v4.3.2",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "573b5c4a36a171b94cf031d8dc6cc568082190f1"
+                "reference": "3b1ab2e027d7c5af0e693c4a5b4ba5d407f1814d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/573b5c4a36a171b94cf031d8dc6cc568082190f1",
-                "reference": "573b5c4a36a171b94cf031d8dc6cc568082190f1",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/3b1ab2e027d7c5af0e693c4a5b4ba5d407f1814d",
+                "reference": "3b1ab2e027d7c5af0e693c4a5b4ba5d407f1814d",
                 "shasum": ""
             },
             "require": {
@@ -10950,29 +11118,29 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2019-06-26T12:14:14+00:00"
+            "time": "2019-08-20T14:27:59+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.29",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "d129c017e8602507688ef2c3007951a16c1a8407"
+                "reference": "e89969c00d762349f078db1128506f7f3dcc0d4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/d129c017e8602507688ef2c3007951a16c1a8407",
-                "reference": "d129c017e8602507688ef2c3007951a16c1a8407",
+                "url": "https://api.github.com/repos/symfony/process/zipball/e89969c00d762349f078db1128506f7f3dcc0d4a",
+                "reference": "e89969c00d762349f078db1128506f7f3dcc0d4a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -10999,7 +11167,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-30T15:47:52+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "textalk/websocket",
@@ -11147,19 +11315,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wapmorgan/PhpCodeFixer.git",
-                "reference": "cec59597eee2823b9054af9b273608bc6bc1e6e9"
+                "reference": "7ab62fa865305326d873654c4a919872a01ec5f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wapmorgan/PhpCodeFixer/zipball/cec59597eee2823b9054af9b273608bc6bc1e6e9",
-                "reference": "cec59597eee2823b9054af9b273608bc6bc1e6e9",
+                "url": "https://api.github.com/repos/wapmorgan/PhpCodeFixer/zipball/7ab62fa865305326d873654c4a919872a01ec5f1",
+                "reference": "7ab62fa865305326d873654c4a919872a01ec5f1",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=5.4",
-                "symfony/console": "^3.4"
+                "symfony/console": "^3.4|^4.0"
             },
             "suggest": {
                 "ext-json": "Adds ability to store report in JSON format"
@@ -11197,20 +11365,20 @@
                 "BSD-3-Clause"
             ],
             "description": "Analyzer of PHP code to search issues with deprecated functionality in newer interpreter versions.",
-            "time": "2019-07-18T21:08:13+00:00"
+            "time": "2019-08-17T13:24:48+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
                 "shasum": ""
             },
             "require": {
@@ -11218,8 +11386,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
             "extra": {
@@ -11248,7 +11415,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25T11:19:39+00:00"
+            "time": "2019-08-24T08:43:50+00:00"
         }
     ],
     "aliases": [],

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -4,48 +4,21 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
+
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
 if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
-    $_SERVER += $env;
-    $_ENV += $env;
+  foreach ($env as $k => $v) {
+    $_ENV[$k] = $_ENV[$k] ?? (isset($_SERVER[$k]) && 0 !== strpos($k, 'HTTP_') ? $_SERVER[$k] : $v);
+  }
 } elseif (!class_exists(Dotenv::class)) {
-    throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
+  throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
 } else {
-    $path = dirname(__DIR__).'/.env';
-    $dotenv = new Dotenv();
-
-    // load all the .env files
-    if (method_exists($dotenv, 'loadEnv')) {
-        $dotenv->loadEnv($path);
-    } else {
-        // fallback code in case your Dotenv component is not 4.2 or higher (when loadEnv() was added)
-
-        if (file_exists($path) || !file_exists($p = "$path.dist")) {
-            $dotenv->load($path);
-        } else {
-            $dotenv->load($p);
-        }
-
-        if (null === $env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) {
-            $dotenv->populate(array('APP_ENV' => $env = 'dev'));
-        }
-
-        if ('test' !== $env && file_exists($p = "$path.local")) {
-            $dotenv->load($p);
-            $env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env;
-        }
-
-        if (file_exists($p = "$path.$env")) {
-            $dotenv->load($p);
-        }
-
-        if (file_exists($p = "$path.$env.local")) {
-            $dotenv->load($p);
-        }
-    }
+  // load all the .env files
+  (new Dotenv(false))->loadEnv(dirname(__DIR__).'/.env');
 }
 
+$_SERVER += $_ENV;
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';

--- a/config/packages/fos_user.yaml
+++ b/config/packages/fos_user.yaml
@@ -8,7 +8,7 @@ fos_user:
     group_manager: sonata.user.orm.group_manager
 
   service:
-    user_manager: usermanager
+    user_manager: App\Entity\UserManager
     mailer: fos_user.mailer.twig_swift # allows usage of twig templates
 
   # Sends user an email to confirm their registration

--- a/config/packages/fr3d_ldap.yaml
+++ b/config/packages/fr3d_ldap.yaml
@@ -46,6 +46,6 @@ fr3d_ldap:
       - { ldap_attr: mail,  user_method: setEmail } # Default
 
   service:
-    user_hydrator: ldap.user_hydrator      # Overrides default user hydrator
-    ldap_manager: usermanager.ldap   # Overrides default ldap manager
+    user_hydrator: App\Catrobat\Ldap\UserHydrator      # Overrides default user hydrator
+    ldap_manager: App\Entity\UserLDAPManager   # Overrides default ldap manager
 #       ldap_driver: fr3d_ldap.ldap_driver.zend        # Overrides default ldap driver

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,7 +1,7 @@
 security:
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     encoders:
-        FOS\UserBundle\Model\UserInterface: bcrypt
+        FOS\UserBundle\Model\UserInterface: auto
 
     providers:
         chain_provider:
@@ -18,27 +18,27 @@ security:
             pattern: ^.*/api/checkToken/check.json
             stateless: true
             simple_preauth:
-                authenticator: apikey_authenticator
+                authenticator: App\Catrobat\Security\ApiKeyAuthenticator
 
         api_check_notifications:
             provider: chain_provider
             pattern: ^.*/api/notifications/get.json
             stateless: true
             simple_preauth:
-                authenticator: apikey_authenticator
+                authenticator: App\Catrobat\Security\ApiKeyAuthenticator
 
         api_upload:
             provider: chain_provider
             pattern: ^.*/api/upload/upload.json
             stateless: true
             simple_preauth:
-                authenticator: apikey_authenticator
+                authenticator: App\Catrobat\Security\ApiKeyAuthenticator
         api_submit:
             provider: chain_provider
             pattern: ^.*/api/gamejam/submit.json
             stateless: true
             simple_preauth:
-                authenticator: apikey_authenticator
+                authenticator: App\Catrobat\Security\ApiKeyAuthenticator
 
         debug:
             provider: chain_provider
@@ -63,7 +63,6 @@ security:
                 domain: ~ # Defaults to the current domain from $_SERVER
                 secure: false
                 httponly: false
-            logout_on_user_change: true # remove when symfony 4
             simple_preauth:
                 authenticator: webview_authenticator
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,35 +1,37 @@
 parameters:
-  catrobat.pubdir:                "%kernel.project_dir%/public/"
-  catrobat.resources.dir:         "%kernel.project_dir%/public/resources/"
-  catrobat.file.extract.dir:      "%kernel.project_dir%/public/resources/extract/"
-  catrobat.file.extract.path:     "resources/extract/"
-  catrobat.file.storage.dir:      "%kernel.project_dir%/public/resources/programs/"
-  catrobat.file.storage.path:     "resources/programs/"
-  catrobat.upload.temp.dir:       "%catrobat.pubdir%resources/tmp/uploads/"
-  catrobat.upload.temp.path:      "resources/tmp/uploads/"
-  catrobat.template.storage.dir:  "%kernel.project_dir%/public/resources/templates/"
-  catrobat.template.storage.path: "resources/templates/"
-  catrobat.screenshot.dir:        "%catrobat.pubdir%resources/screenshots/"
-  catrobat.screenshot.path:       "resources/screenshots/"
-  catrobat.template.dir:          "%catrobat.pubdir%resources/templates/"
-  catrobat.template.path:         "resources/templates/"
-  catrobat.template.screenshot.dir:        "%catrobat.pubdir%resources/templates/screenshots/"
-  catrobat.template.screenshot.path:       "resources/templates/screenshots/"
-  catrobat.thumbnail.dir:         "%catrobat.pubdir%resources/thumbnails/"
-  catrobat.thumbnail.path:        "resources/thumbnails/"
-  catrobat.template.thumbnail.dir:         "%catrobat.pubdir%resources/templates/thumbnails/"
-  catrobat.template.thumbnail.path:        "resources/templates/thumbnails/"
-  catrobat.featuredimage.dir:     "%catrobat.pubdir%resources/featured/"
-  catrobat.featuredimage.path:    "resources/featured/"
-  catrobat.mediapackage.dir:      "%catrobat.pubdir%resources/mediapackage/"
-  catrobat.mediapackage.path:     "resources/mediapackage/"
-  catrobat.apk.dir:               "%catrobat.pubdir%resources/apk/"
-  catrobat.backup.dir:            "%kernel.project_dir%/backups/"
-  catrobat.snapshot.dir:          "%catrobat.pubdir%resources/Snapshots"
-  catrobat.translations.dir:      "%kernel.project_dir%/translations"
-  catrobat.logs.dir:              "%kernel.project_dir%/var/log/"
-  catrobat.invalidupload.dir:     "%kernel.project_dir%/src/Catrobat/Commands/invisible_programs/"
+  catrobat.apk.dir:                     "%catrobat.pubdir%resources/apk/"
+  catrobat.backup.dir:                  "%kernel.project_dir%/backups/"
+  catrobat.featuredimage.dir:           "%catrobat.pubdir%resources/featured/"
+  catrobat.featuredimage.path:          "resources/featured/"
+  catrobat.file.extract.dir:            "%kernel.project_dir%/public/resources/extract/"
+  catrobat.file.extract.path:           "resources/extract/"
+  catrobat.file.storage.dir:            "%kernel.project_dir%/public/resources/programs/"
+  catrobat.file.storage.path:           "resources/programs/"
+  catrobat.invalidupload.dir:           "%kernel.project_dir%/src/Catrobat/Commands/invisible_programs/"
+  catrobat.logs.dir:                    "%kernel.project_dir%/var/log/"
   catrobat.max_description_upload_size: 10000 # also change in src/Catrobat/Listeners/DescriptionValidator.php
+  catrobat.mediapackage.dir:            "%catrobat.pubdir%resources/mediapackage/"
+  catrobat.mediapackage.path:           "resources/mediapackage/"
+  catrobat.pubdir:                      "%kernel.project_dir%/public/"
+  catrobat.resources.dir:               "%kernel.project_dir%/public/resources/"
+  catrobat.screenshot.dir:              "%catrobat.pubdir%resources/screenshots/"
+  catrobat.screenshot.path:             "resources/screenshots/"
+  catrobat.snapshot.dir:                "%catrobat.pubdir%resources/Snapshots"
+  catrobat.template.dir:                "%catrobat.pubdir%resources/templates/"
+  catrobat.template.path:               "resources/templates/"
+  catrobat.template.screenshot.dir:     "%catrobat.pubdir%resources/templates/screenshots/"
+  catrobat.template.screenshot.path:    "resources/templates/screenshots/"
+  catrobat.template.storage.dir:        "%kernel.project_dir%/public/resources/templates/"
+  catrobat.template.storage.path:       "resources/templates/"
+  catrobat.template.thumbnail.dir:      "%catrobat.pubdir%resources/templates/thumbnails/"
+  catrobat.template.thumbnail.path:     "resources/templates/thumbnails/"
+  catrobat.test.directory.source:       "%kernel.project_dir%/tests/testdata/DataFixtures/"
+  catrobat.test.directory.target:       "%kernel.project_dir%/tests/testdata/DataFixtures/GeneratedFixtures/"
+  catrobat.thumbnail.dir:               "%catrobat.pubdir%resources/thumbnails/"
+  catrobat.thumbnail.path:              "resources/thumbnails/"
+  catrobat.translations.dir:            "%kernel.project_dir%/translations"
+  catrobat.upload.temp.dir:             "%catrobat.pubdir%resources/tmp/uploads/"
+  catrobat.upload.temp.path:            "resources/tmp/uploads/"
 
   ldap_role_mappings:
     ROLE_MEDIAPACKAGE:  "Webserver-MediaPackageMaintainers"
@@ -41,9 +43,6 @@ parameters:
   #      This can drastically improve DX by reducing the time to load classes
   container.dumper.inline_class_loader: true
 
-  #      remove when updated to symfony > 4.0
-  container.autowiring.strict_mode: true
-
 services:
 
   security.acl.permission.map:
@@ -54,8 +53,8 @@ services:
     autowire: true      # Automatically injects dependencies in your services.
     autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
     public: false       # Allows optimizing the container by removing unused services; this also means
-    # fetching services directly from the container via $container->get() won't work.
-    # The best practice is to be explicit about your dependencies anyway.
+    #                    fetching services directly from the container via $container->get() won't work.
+    #                    The best practice is to be explicit about your dependencies anyway.
 
     #
     # setup special, global auto wiring rules:
@@ -67,31 +66,224 @@ services:
     #   It is also possible to inject the ParameterBagInterface with which one has easy access to all defined parameters
     #
     bind:
-      App\Catrobat\Services\ScreenshotRepository: '@screenshotrepository' # must be removed when merging with SHARE-120
+      App\Catrobat\Services\ScreenshotRepository: '@screenshot_repository'
+      $template_screenshot_repository: '@template_screenshot_repository'
 
+      $kernel_root_dir: "kernel.root_dir"
+      $catrobat_translation_dir: "%catrobat.translations.dir%"
+      $catrobat_upload_temp_dir: "%catrobat.upload.temp.dir%"
+      $catrobat_file_storage_dir: "%catrobat.file.storage.dir%"
+      $catrobat_file_storage_path: "%catrobat.file.extract.path%"
+      $catrobat_template_storage_dir: "%catrobat.template.storage.dir%"
+      $catrobat_template_storage_path: "%catrobat.template.storage.path%"
+      $snapshot_dir: "%catrobat.snapshot.dir%"
 
-  #  makes classes in src/Catrobat available to be used as services
-  #  this creates a service per class whose id is the fully-qualified class name
+  # ====================================================================================================================
+  #  Catrobat:
+  #              makes classes in src/Catrobat available to be used as services
+  #              this creates a service per class whose id is the fully-qualified class name
+  #
+  #              Repositories and Managers need to be public!
+  #
   App\Catrobat\:
     resource: '../src/Catrobat/*'
-    # you can exclude directories or files
-    # but if a service is unused, it's removed anyway -> removed them because there are errors if not
-    exclude: '../src/Catrobat/{Entity,Twig,Commands,Admin,CatrobatCode,Events,Exceptions,Features,Listeners,Requests,Responses,Services}'
 
-  # controllers are imported separately to make sure they're public
-  # and have a tag that allows actions to type-hint services
+  App\Entity\:
+    resource: '../src/Entity/*'
+
+  App\Repository\:
+    resource: '../src/Repository'
+    public: true
+
+  App\Entity\UserManager:
+    class: App\Entity\UserManager
+    public: true
+
+  App\Entity\ProgramManager:
+    class: App\Entity\ProgramManager
+    public: true
+
+  App\Entity\TemplateManager:
+    class: App\Entity\TemplateManager
+    public: true
+
+  App\Catrobat\Commands\Helpers\RemixManipulationProgramManager:
+    class: App\Catrobat\Commands\Helpers\RemixManipulationProgramManager
+    public: true
+
+  App\Entity\RemixManager:
+    class: App\Entity\RemixManager
+    public: true
+
+  App\Entity\MigrationManager:
+    class: App\Entity\MigrationManager
+    public: true
+
+  App\Catrobat\RemixGraph\RemixGraphManipulator:
+    class: App\Catrobat\RemixGraph\RemixGraphManipulator
+    public: true
+
+  App\Catrobat\RemixGraph\RemixSubgraphManipulator:
+    class: App\Catrobat\RemixGraph\RemixSubgraphManipulator
+    public: true
+
+  App\Catrobat\RecommenderSystem\RecommenderManager:
+    class: App\Catrobat\RecommenderSystem\RecommenderManager
+    public: true
+
+
+  # ====================================================================================================================
+  #   Controllers:
+  #                  controllers are imported separately to make sure they're public
+  #                  and have a tag that allows actions to type-hint services
+  #
   App\Catrobat\Controller\:
     resource: '../src/Catrobat/Controller'
     tags: ['controller.service_arguments']
     public: true
 
-  apikey_authenticator:
-    class: App\Catrobat\Security\ApiKeyAuthenticator
-    arguments:
-      - "@translator"
-    public: true
-  App\Catrobat\Security\ApiKeyAuthenticator: "@apikey_authenticator"
 
+  # ====================================================================================================================
+  #   Commands:
+  #               need a console tag; make sure all commands are in the correct folder and extend Command
+  #
+  App\Catrobat\Commands\:
+    resource: '../src/Catrobat/Commands'
+    exclude: '../src/Catrobat/Commands/Helpers'
+    tags:
+      - { name: console.command }
+
+
+  # ====================================================================================================================
+  #   Services:
+  #                most services need to be public (mainly for testing -> easy access in SymfonySupport.php)
+  #
+  App\Catrobat\Services\CatrobatFileSanitizer:
+    class: App\Catrobat\Services\CatrobatFileSanitizer
+    public: true
+
+  App\Catrobat\Services\TemplateService:
+    class: App\Catrobat\Services\TemplateService
+    public: true
+
+  App\Catrobat\Services\CatroNotificationService:
+    class: App\Catrobat\Services\CatroNotificationService
+    public: true
+
+  App\Catrobat\Services\CommunityStatisticsService:
+    class: App\Catrobat\Services\CommunityStatisticsService
+    public: true
+
+  App\Catrobat\Services\ProgramFileRepository:
+    class: App\Catrobat\Services\ProgramFileRepository
+    public: true
+
+  App\Catrobat\Services\ExtractedFileRepository:
+    class: App\Catrobat\Services\ExtractedFileRepository
+    public: true
+
+  App\Catrobat\Services\TemplateFileRepository:
+    class: App\Catrobat\Services\TemplateFileRepository
+    public: true
+
+  App\Catrobat\Services\FeaturedImageRepository:
+    class: App\Catrobat\Services\FeaturedImageRepository
+    public: true
+
+  App\Catrobat\Services\MediaPackageFileRepository:
+    class: App\Catrobat\Services\MediaPackageFileRepository
+    public: true
+
+  App\Catrobat\Services\ApkRepository:
+    class: App\Catrobat\Services\ApkRepository
+    public: true
+
+  App\Catrobat\Services\BackupFileRepository:
+    class: App\Catrobat\Services\BackupFileRepository
+    public: true
+
+  App\Catrobat\Services\ProgramDevicePermissionReader:
+    class: App\Catrobat\Services\ProgramDevicePermissionReader
+    public: true
+
+  App\Catrobat\Services\CatrobatFileCompressor:
+    class: App\Catrobat\Services\CatrobatFileCompressor
+    public: true
+
+  App\Catrobat\Services\TokenGenerator:
+    class: App\Catrobat\Services\TokenGenerator
+    public: true
+
+  App\Catrobat\Services\Time:
+    class: App\Catrobat\Services\Time
+    public: true
+
+  App\Catrobat\Services\CatrobatCodeParser\CatrobatCodeParser:
+    class: App\Catrobat\Services\CatrobatCodeParser\CatrobatCodeParser
+    public: true
+
+  App\Catrobat\Services\StatisticsService:
+    class: App\Catrobat\Services\StatisticsService
+    public: true
+    tags:
+      - { name: monolog.logger, channel: download_stats }
+
+  App\Catrobat\Requests\AppRequest:
+    class: App\Catrobat\Requests\AppRequest
+    public: true
+
+  App\Catrobat\Services\Formatter\ElapsedTimeStringFormatter:
+    class: App\Catrobat\Services\Formatter\ElapsedTimeStringFormatter
+    public: true
+
+  App\Catrobat\Services\Ci\JenkinsDispatcher:
+    class: App\Catrobat\Services\Ci\JenkinsDispatcher
+    arguments:
+      - "%jenkins%"
+
+  screenshot_repository:
+    class: App\Catrobat\Services\ScreenshotRepository
+    arguments:
+      - "%catrobat.screenshot.dir%"
+      - "%catrobat.screenshot.path%"
+      - "%catrobat.thumbnail.dir%"
+      - "%catrobat.thumbnail.path%"
+      - "%catrobat.upload.temp.dir%"
+      - "%catrobat.upload.temp.path%"
+    public: true
+
+  template_screenshot_repository:
+    class: App\Catrobat\Services\ScreenshotRepository
+    arguments:
+      - "%catrobat.template.screenshot.dir%"
+      - "%catrobat.template.screenshot.path%"
+      - "%catrobat.template.thumbnail.dir%"
+      - "%catrobat.template.thumbnail.path%"
+      - "%catrobat.upload.temp.dir%"
+      - "%catrobat.upload.temp.path%"
+    public: true
+
+  App\Catrobat\Services\AsyncHttpClient:
+    class: App\Catrobat\Services\AsyncHttpClient
+    arguments:
+      - timeout: 8.0
+      - max_number_of_total_requests: 12
+      - max_number_of_concurrent_requests: 4
+    public: true
+
+  # =============== Stuff that needs different parameters/services based on the environment
+
+  App\Catrobat\Services\CatrobatFileExtractor:
+    class: App\Catrobat\Services\CatrobatFileExtractor
+    arguments:
+      - "%catrobat.file.extract.dir%"
+      - "%catrobat.file.extract.path%"
+    public: true
+
+
+  # ====================================================================================================================
+  #   User Authentication
+  #
   webview_authenticator:
     class: App\Catrobat\Security\WebviewAuthenticator
     public: true
@@ -105,696 +297,182 @@ services:
     public: true
   App\Catrobat\Security\UserAuthenticator: "@user_authenticator"
 
-  template_service:
-    class: App\Catrobat\Services\TemplateService
-    arguments:
-      - "@templatemanager"
-    public: true
-  App\Catrobat\Services\TemplateService: "@template_service"
+  ldap_user_hydrator:
+    alias: App\Catrobat\Ldap\UserHydrator
 
-  catro_notification_service:
-    class: App\Catrobat\Services\CatroNotificationService
-    arguments:
-      - "@doctrine.orm.entity_manager"
-    public: true
-  App\Catrobat\Services\CatroNotificationService: "@catro_notification_service"
+  tokengenerator:
+    alias: App\Catrobat\Services\TokenGenerator
 
-  community_statistics_service:
-    class: App\Catrobat\Services\CommunityStatisticsService
-    arguments:
-      - "@doctrine.orm.entity_manager"
-    public: true
-  App\Catrobat\Services\CommunityStatisticsService: "@community_statistics_service"
-
-  # =========================== Repository ===========================
-
-  programrepository:
-    class: App\Repository\ProgramRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\Program
-    public: true
-  App\Repository\ProgramRepository: "@programrepository"
-
-  programlikerepository:
-    class: App\Repository\ProgramLikeRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\ProgramLike
-    public: true
-  App\Repository\ProgramLikeRepository: "@programlikerepository"
-
-  programremixrepository:
-    class: App\Repository\ProgramRemixRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\ProgramRemixRelation
-    public: true
-  App\Repository\ProgramRemixRepository: "@programremixrepository"
-
-  programremixbackwardrepository:
-    class: App\Repository\ProgramRemixBackwardRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\ProgramRemixBackwardRelation
-    public: true
-  App\Repository\ProgramRemixBackwardRepository: "@programremixbackwardrepository"
-
-  scratchprogramrepository:
-    class: App\Repository\ScratchProgramRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\ScratchProgram
-    public: true
-  App\Repository\ScratchProgramRepository: "@scratchprogramrepository"
-
-  scratchprogramremixrepository:
-    class: App\Repository\ScratchProgramRemixRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\ScratchProgramRemixRelation
-    public: true
-  App\Repository\ScratchProgramRemixRepository: "@scratchprogramremixrepository"
-
-  userlikesimilarityrelationrepository:
-    class: App\Repository\UserLikeSimilarityRelationRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\UserLikeSimilarityRelation
-    public: true
-  App\Repository\UserLikeSimilarityRelationRepository: "@userlikesimilarityrelationrepository"
-
-  userremixsimilarityrelationrepository:
-    class: App\Repository\UserRemixSimilarityRelationRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\UserRemixSimilarityRelation
-    public: true
-  App\Repository\UserRemixSimilarityRelationRepository: "@userremixsimilarityrelationrepository"
-
-  tagrepository:
-    class: App\Repository\TagRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\Tag
-    public: true
-  App\Repository\TagRepository: "@tagrepository"
-
-  extensionrepository:
-    class: App\Repository\ExtensionRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\Extension
-    public: true
-  App\Repository\ExtensionRepository: "@extensionrepository"
-
-  notificationrepository:
-    class: App\Repository\NotificationRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\Notification
-    public: true
-  App\Repository\NotificationRepository: "@notificationrepository"
-
-  rudewordrepository:
-    class: App\Repository\RudeWordsRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\RudeWord
-    public: true
-  App\Repository\RudeWordsRepository: "@rudewordrepository"
-
-  gamejamrepository:
-    class: App\Repository\GameJamRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\GameJam
-    public: true
-  App\Repository\GameJamRepository: "@gamejamrepository"
-
-  featuredrepository:
-    class: App\Repository\FeaturedRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\FeaturedProgram
-    public: true
-  App\Repository\FeaturedRepository: "@featuredrepository"
-
-  filerepository:
-    class: App\Catrobat\Services\ProgramFileRepository
-    arguments:
-      - "%catrobat.file.storage.dir%"
-      - "%catrobat.file.storage.path%"
-      - "@filecompressor"
-      - "%catrobat.upload.temp.dir%"
-    public: true
-  App\Catrobat\Services\ProgramFileRepository: "@filerepository"
-
-  extractedfilerepository:
-    class: App\Catrobat\Services\ExtractedFileRepository
-    arguments:
-      - "%catrobat.file.extract.dir%"
-      - "%catrobat.file.extract.path%"
-      - "%catrobat.file.storage.dir%"
-      - "@fileextractor"
-      - "@programmanager"
-      - "@filerepository"
-    public: true
-  App\Catrobat\Services\ExtractedFileRepository: "@extractedfilerepository"
-
-  screenshotrepository:
-    class: App\Catrobat\Services\ScreenshotRepository
-    arguments:
-      - "%catrobat.screenshot.dir%"
-      - "%catrobat.screenshot.path%"
-      - "%catrobat.thumbnail.dir%"
-      - "%catrobat.thumbnail.path%"
-      - "%catrobat.upload.temp.dir%"
-      - "%catrobat.upload.temp.path%"
-    public: true
-
-  templatescreenshotrepository:
-    class: App\Catrobat\Services\ScreenshotRepository
-    arguments:
-      - "%catrobat.template.screenshot.dir%"
-      - "%catrobat.template.screenshot.path%"
-      - "%catrobat.template.thumbnail.dir%"
-      - "%catrobat.template.thumbnail.path%"
-      - "%catrobat.upload.temp.dir%"
-      - "%catrobat.upload.temp.path%"
-    public: true
-
-  App\Catrobat\Services\FeaturedImageRepository: "@featuredimagerepository"
-  featuredimagerepository:
-    class: App\Catrobat\Services\FeaturedImageRepository
-    arguments:
-      - "%catrobat.featuredimage.dir%"
-      - "%catrobat.featuredimage.path%"
-    public: true
-
-  App\Catrobat\Services\MediaPackageFileRepository: "@mediapackagefilerepository"
-  mediapackagefilerepository:
-    class: App\Catrobat\Services\MediaPackageFileRepository
-    arguments:
-      - "%catrobat.mediapackage.dir%"
-      - "%catrobat.mediapackage.path%"
-    public: true
-
-
-  apkrepository:
-    class: App\Catrobat\Services\ApkRepository
-    arguments:
-      - "%catrobat.apk.dir%"
-    public: true
-  App\Catrobat\Services\ApkRepository: "@apkrepository"
-
-  backupfilerepository:
-    class: App\Catrobat\Services\BackupFileRepository
-    arguments:
-      - "%catrobat.backup.dir%"
-    public: true
-  App\Catrobat\Services\BackupFileRepository: "@backupfilerepository"
-
-  programdevicepermissionreader:
-    class: App\Catrobat\Services\ProgramDevicePermissionReader
-    public: true
-  App\Catrobat\Services\ProgramDevicePermissionReader: "@programdevicepermissionreader"
-
-  templaterepository:
-    class: App\Repository\TemplateRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\Template"
-    public: true
-  App\Repository\TemplateRepository: "@templaterepository"
-
-  templatefilerepository:
-    class: App\Catrobat\Services\TemplateFileRepository
-    arguments:
-      - catrobat.template.storage.dir%"
-      - "%catrobat.template.storage.path%"
-      - "@filecompressor"
-      - "%catrobat.upload.temp.dir%"
-    public: true
-  App\Catrobat\Services\TemplateFileRepository: "@templatefilerepository"
-
-  catro_notification_repository:
-    class: App\Repository\CatroNotificationRepository
-    factory: ['@doctrine.orm.entity_manager', getRepository]
-    arguments:
-      - App\Entity\CatroNotification
-    public: true
-  App\Repository\CatroNotificationRepository: "@catro_notification_repository"
-
-  # =========================== Manager & Stuff ===========================
-
-  programmanager:
-    class: App\Entity\ProgramManager
-    arguments:
-      - "@fileextractor"
-      - "@filerepository"
-      - "@screenshotrepository"
-      - "@doctrine.orm.entity_manager"
-      - "@programrepository"
-      - "@tagrepository"
-      - "@programlikerepository"
-      - "@event_dispatcher"
-      - "@logger"
-      - "@app_request"
-    public: true
-  App\Entity\ProgramManager: "@programmanager"
-
-  templatemanager:
-    class: App\Entity\TemplateManager
-    arguments:
-      - "@templatefilerepository"
-      - "@templatescreenshotrepository"
-      - "@doctrine.orm.entity_manager"
-      - "@templaterepository"
-    public: true
-  App\Entity\TemplateManager: "@templatemanager"
-
-  programmanager.remix_manipulation:
-    class: App\Catrobat\Commands\RemixManipulationProgramManager
-    arguments:
-      - "@fileextractor"
-      - "@filerepository"
-      - "@screenshotrepository"
-      - "@doctrine.orm.entity_manager"
-      - "@programrepository"
-      - "@tagrepository"
-      - "@programlikerepository"
-      - "@event_dispatcher"
-      - "@logger"
-    public: true
-  App\Catrobat\Commands\RemixManipulationProgramManager: "@programmanager.remix_manipulation"
-
-  remixmanager:
-    class: App\Entity\RemixManager
-    arguments:
-      - "@doctrine.orm.entity_manager"
-      - "@programrepository"
-      - "@scratchprogramrepository"
-      - "@programremixrepository"
-      - "@programremixbackwardrepository"
-      - "@scratchprogramremixrepository"
-      - "@remixgraphmanipulator"
-    public: true
-  App\Entity\RemixManager: "@remixmanager"
-
-  remixgraphmanipulator:
-    class: App\Catrobat\RemixGraph\RemixGraphManipulator
-    arguments:
-      - "@doctrine.orm.entity_manager"
-      - "@remixsubgraphmanipulator"
-      - "@programremixrepository"
-      - "@programremixbackwardrepository"
-      - "@scratchprogramremixrepository"
-    public: true
-  App\Catrobat\RemixGraph\RemixGraphManipulator: "@remixgraphmanipulator"
-
-  remixsubgraphmanipulator:
-    class: App\Catrobat\RemixGraph\RemixSubgraphManipulator
-    arguments:
-      - "@doctrine.orm.entity_manager"
-      - "@programrepository"
-      - "@programremixrepository"
-      - "@programremixbackwardrepository"
-    public: true
-  App\Catrobat\RemixGraph\RemixSubgraphManipulator: "@remixsubgraphmanipulator"
-
-  migrationmanager:
-    class: App\Entity\MigrationManager
-    arguments:
-      - "@doctrine.orm.entity_manager"
-    public: true
-  App\Entity\MigrationManager: "@migrationmanager"
-
-  recommendermanager:
-    class: App\Catrobat\RecommenderSystem\RecommenderManager
-    arguments:
-      - "@doctrine.orm.entity_manager"
-      - "@usermanager"
-      - "@userlikesimilarityrelationrepository"
-      - "@userremixsimilarityrelationrepository"
-      - "@programrepository"
-      - "@programlikerepository"
-      - "@programremixrepository"
-      - "@programremixbackwardrepository"
-      - "@app_request"
-    public: true
-  App\Catrobat\RecommenderSystem\RecommenderManager: "@recommendermanager"
-
-  rudewordfilter:
-    class: App\Catrobat\Services\RudeWordFilter
-    arguments:
-      - "@rudewordrepository"
-    public: true
-  App\Catrobat\Services\RudeWordFilter: "@rudewordfilter"
-
-  usermanager:
-    class: App\Entity\UserManager
-    arguments:
-      - "@fos_user.util.password_updater"
-      - "@fos_user.util.canonical_fields_updater"
-      - "@fos_user.object_manager"
-      - "%fos_user.model.user.class%"
-    public: true
-  App\Entity\UserManager: "@usermanager"
-
-  ldap.user_hydrator:
-    class: App\Catrobat\Ldap\UserHydrator
-    public: true
-  App\Catrobat\Ldap\UserHydrator: "@ldap.user_hydrator"
-
-  usermanager.ldap:
+  App\Entity\UserLDAPManager:
     class: App\Entity\UserLDAPManager
     arguments:
       - "@fr3d_ldap.ldap_driver"
-      - "@fr3d_ldap.user_hydrator"
+      - "@ldap_user_hydrator"
       - '%fr3d_ldap.ldap_manager.parameters%'
       - '%ldap_role_mappings%'
       - '%ldap_group_filter%'
       - "@tokengenerator"
-      - "@logger"
-    public: true
-  App\Entity\UserLDAPManager: "@usermanager.ldap"
-
-  App\Catrobat\Services\CatrobatFileSanitizer:
-    class: App\Catrobat\Services\CatrobatFileSanitizer
+      - "@monolog.logger"
     public: true
 
-  fileextractor:
-    class: App\Catrobat\Services\CatrobatFileExtractor
-    arguments:
-      - "%catrobat.file.extract.dir%"
-      - "%catrobat.file.extract.path%"
-    public: true
-  App\Catrobat\Services\CatrobatFileExtractor: "@fileextractor"
 
-  filecompressor:
-    class: App\Catrobat\Services\CatrobatFileCompressor
-    public: true
-  App\Catrobat\Services\CatrobatFileCompressor: "@filecompressor"
-
-  tokengenerator:
-    class: App\Catrobat\Services\TokenGenerator
-    public: true
-  App\Catrobat\Services\TokenGenerator: "@tokengenerator"
-
-  time:
-    class: App\Catrobat\Services\Time
-    public: true
-  App\Catrobat\Services\Time: "@time"
-
-  elapsedtime:
-    class: App\Catrobat\Services\Formatter\ElapsedTimeStringFormatter
-    arguments:
-      - "@translator"
-      - "@time"
-    public: true
-  App\Catrobat\Services\Formatter\ElapsedTimeStringFormatter: "@elapsedtime"
-
-  catrobat_code_parser:
-    class: App\Catrobat\Services\CatrobatCodeParser\CatrobatCodeParser
-    public: true
-  App\Catrobat\Services\CatrobatCodeParser\CatrobatCodeParser: "@catrobat_code_parser"
-
-  app_request:
-    class: App\Catrobat\Requests\AppRequest
-    arguments:
-      - "@request_stack"
-  App\Catrobat\Requests\AppRequest: "@app_request"
-
-  # =========================== Twig ===========================
-
-  app.twig_extension:
+  # ====================================================================================================================
+  #   Twig
+  #
+  App\Catrobat\Twig\AppExtension:
     class: App\Catrobat\Twig\AppExtension
-    arguments:
-      - "@request_stack"
-      - "@mediapackagefilerepository"
-      - "@gamejamrepository"
-      - "@liip_theme.active_theme"
-      - "%catrobat.translations.dir%"
-      - "@service_container"
     tags:
       - { name: twig.extension }
-  App\Catrobat\Twig\AppExtension: "@app.twig_extension"
 
-  # =========================== Jenkins ===========================
+  Liip\ThemeBundle\ActiveTheme: "@liip_theme.active_theme"
 
-  ci.jenkins.dispatcher:
-    class: App\Catrobat\Services\Ci\JenkinsDispatcher
-    arguments:
-      - "@router"
-      - "%jenkins%"
-    public: true
-  App\Catrobat\Services\Ci\JenkinsDispatcher: "@ci.jenkins.dispatcher"
 
-  # =========================== Controller ===========================
-
-  App\Catrobat\Controller\Api\UploadController:
-    autowire: false
-    arguments:
-      - "@usermanager"
-      - "@security.token_storage"
-      - "@programmanager"
-      - "@gamejamrepository"
-      - "@tokengenerator"
-      - "@translator"
-      - "@logger"
-      - "@catro_notification_service"
-    public: true
-    tags: ['controller.service_arguments']
-
-  # =========================== Controller ===========================
-
-  oauth_service:
-    class: App\Catrobat\Services\OAuthService
-    arguments:
-      - "@service_container"
-    public: true
-  App\Catrobat\Services\OAuthService: "@oauth_service"
-
-  # =========================== Download ===========================
-
-  statistics:
-    class: App\Catrobat\Services\StatisticsService
-    arguments:
-      - "@programmanager"
-      - "@doctrine.orm.entity_manager"
-      - "@logger"
-      - "@security.token_storage"
-    tags:
-      - { name: monolog.logger, channel: download_stats }
-    public: true
-  App\Catrobat\Services\StatisticsService: "@statistics"
-
-  # =========================== Async HTTP Client ===========================
-  async_http_client:
-    class: App\Catrobat\Services\AsyncHttpClient
-    arguments:
-      - { timeout: 8.0, max_number_of_total_requests: 12, max_number_of_concurrent_requests: 4 }
-    public: true
-  App\Catrobat\Services\AsyncHttpClient: "@async_http_client"
-
-  # =========================== FOS User bundle =============================
+  # ====================================================================================================================
+  #   Event Subscribers
+  #
   resetting_send_email_initialize:
     class: App\Catrobat\EventListener\ResettingSendEmailInitializeSubscriber
-    autowire: true
     tags:
       - { name: kernel.event_subscriber }
     public: true
   App\Catrobat\EventListener\ResettingSendEmailInitializeSubscriber: "@resetting_send_email_initialize"
 
-  # =========================== Debug =======================================
-  logger:
-    alias: 'monolog.logger'
-    public: true
 
-  # ============================ Commands ====================================
+  # ====================================================================================================================
+  #   Listeners:
+  #
 
-  catrowebadmin.filesystem:
-    class: Symfony\Component\Filesystem\Filesystem
-    public: false
+  # ======== System Validation ========
 
-  catrowebadmin.command.clean.oldapk:
-    class: App\Catrobat\Commands\CleanOldApkCommand
+  catrowebbundle.listener.language:
+    class: App\Catrobat\Listeners\LanguageListener
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 100 }
 
-  catrowebadmin.command.clean.apk:
-    class: App\Catrobat\Commands\CleanApkCommand
+  catrowebbundle.listener.flavor:
+    class: App\Catrobat\Listeners\FlavorListener
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 10  }
 
-  catrowebadmin.command.clean.backup:
-    class: App\Catrobat\Commands\CleanBackupsCommand
+  # ======== Upload Validation ========
+
+  catroweb.file.validator.name:
+    class: App\Catrobat\Listeners\NameValidator
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: catrobat.program.before, method: onProgramBeforeInsert }
 
-  catrowebadmin.command.clean.extracted:
-    class: App\Catrobat\Commands\CleanExtractedFileCommand
+  catroweb.file.validator.description:
+    class: App\Catrobat\Listeners\DescriptionValidator
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: catrobat.program.before, method: onProgramBeforeInsert }
 
-  catrowebadmin.command.clean.invalid:
-    class: App\Catrobat\Commands\InvalidFileUploadCleanupCommand
+  catroweb.file.validator.languageversion:
+    class: App\Catrobat\Listeners\VersionValidator
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: catrobat.program.before, method: onProgramBeforeInsert }
 
-  catrowebadmin.command.clean.invalid.revert:
-    class: App\Catrobat\Commands\InvalidFileUploadCleanupCommand
+  catroweb.file.validator.xmlheadervalidator:
+    class: App\Catrobat\Listeners\ProgramXmlHeaderValidator
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: catrobat.program.before, method: onProgramBeforeInsert }
 
-  catrowebadmin.command.clean.logs:
-    class: App\Catrobat\Commands\CleanLogsCommand
+  # ======== Upload Modification ========
+
+  catroweb.file.license.updater:
+    class: App\Catrobat\Listeners\LicenseUpdater
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: catrobat.program.before, method: onProgramBeforeInsert, priority: -1 }
 
-  catrowebadmin.command.init:
-    class: App\Catrobat\Commands\InitDirectoriesCommand
-    arguments:
-      - "@catrowebadmin.filesystem"
-      - "%catrobat.file.storage.dir%"
-    calls:
-      - [setProgramfileDirectory, ["%catrobat.file.storage.dir%"]]
-      - [setExtractDirectory, ["%catrobat.file.extract.dir%"]]
-      - [setScreenshotDirectory, ["%catrobat.screenshot.dir%"]]
-      - [setThumbnailDirectory, ["%catrobat.thumbnail.dir%"]]
-      - [setMediaPackageDirectory, ["%catrobat.mediapackage.dir%"]]
+  catroweb.file.remix.updater:
+    class: App\Catrobat\Listeners\RemixUpdater
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: catrobat.program.after.insert, method: onProgramAfterInsert }
 
-  catrowebadmin.command.import:
-    class: App\Catrobat\Commands\ProgramImportCommand
-    arguments:
-      - "@catrowebadmin.filesystem"
-      - "@usermanager"
-      - "@programmanager.remix_manipulation"
+  catroweb.flavor.check:
+    class: App\Catrobat\Listeners\ProgramFlavorListener
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: catrobat.program.before.persist, method: onEvent }
 
-  catrowebadmin.command.refresh:
-    class: App\Catrobat\Commands\RefreshCommand
-    arguments:
-      - "@catrowebadmin.filesystem"
+  catroweb.apk.cleanup:
+    class: App\Catrobat\Listeners\ApkCleanupListener
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: catrobat.program.before.persist, method: handleEvent }
 
-  catrowebadmin.command.drop.migration:
-    class: App\Catrobat\Commands\DropMigrationCommand
-    arguments:
-      - "@migrationmanager"
+  catroweb.extension.check:
+    class: App\Catrobat\Listeners\ProgramExtensionListener
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: catrobat.program.before.persist, method: onEvent }
 
-  command.reset:
-    class: App\Catrobat\Commands\ResetCommand
+  catroweb.gamejamtag.check:
+    class: App\Catrobat\Listeners\GameJamTagListener
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: catrobat.program.before.persist, method: onEvent }
 
-  command.import.webshare:
-    class: App\Catrobat\Commands\WebShareProgramImport
+  # ======== Snapshots =======
+
+  catrobat.upload.snapshotlistener:
+    class: App\Catrobat\Listeners\Upload\SaveProgramSnapshotListener
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: catrobat.program.after.insert, method: handleEvent }
 
-  command.purge:
-    class: App\Catrobat\Commands\PurgeCommand
+  # ======== Notifications =======
+
+  catrobat.core.services.uploadnotificator:
+    class: App\Catrobat\Listeners\UploadNotificator
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: catrobat.program.after.insert, method: onProgramInsertEvent }
 
-  command.backup.create:
-    class: App\Catrobat\Commands\CreateBackupCommand
+  catrobat.core.services.reportnotificator:
+    class: App\Catrobat\Listeners\ReportNotificator
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: catrobat.report.insert, method: onReportInsertEvent }
 
-  command.backup.restore:
-    class: App\Catrobat\Commands\RestoreBackupCommand
+  # ======== Logging ========
+
+  catrobat.core.services.invalidprogramuploadlogger:
+    class:  App\Catrobat\Listeners\InvalidProgramUploadLogger
     tags:
-      - { name: console.command }
+      - { name: monolog.logger, channel: upload }
+      - { name: kernel.event_listener, event: catrobat.program.invalid.upload, method: onInvalidProgramUploadedEvent }
 
-  catrowebadmin.command.checkcodestyle:
-    class: App\Catrobat\Commands\CheckCodeStyleCommand
+  # ======== Entity ========
+
+  catrobat.entity.featured.image_listener:
+    class: App\Catrobat\Listeners\Entity\FeaturedProgramImageListener
     tags:
-      - { name: console.command }
+      - { name: doctrine.orm.entity_listener }
 
-
-  catrowebadmin.command.import.legacy:
-    class: App\Catrobat\Commands\ImportLegacyCommand
-    arguments:
-      - "@catrowebadmin.filesystem"
-      - "@usermanager"
-      - "@programmanager"
-      - "@remixmanager"
-      - "@doctrine.orm.entity_manager"
+  # ======== Views ========
+  catrobat.view.uploadexception:
+    class: App\Catrobat\Listeners\View\UploadExceptionListener
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
 
-  catrowebadmin.create.constant.tags:
-    class: App\Catrobat\Commands\CreateConstantTagsCommand
-    arguments:
-      - "@doctrine.orm.entity_manager"
-      - "@translator"
+  catrobat.view.programlist:
+    class: App\Catrobat\Listeners\View\ProgramListSerializer
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
 
-  catrowebadmin.create.media-package-thumbnails:
-    class: App\Catrobat\Commands\CreateMissingMediaPackageThumbnailsCommand
+  catrobat.view.templatelist:
+    class:        App\Catrobat\Listeners\View\TemplateListSerializer
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
 
-  catrowebadmin.create.program.extensions:
-    class: App\Catrobat\Commands\CreateProgramExtensionsCommand
-    arguments:
-      - "@doctrine.orm.entity_manager"
-      - "%catrobat.file.storage.dir%"
-      - "@programrepository"
+  # ======== Download ========
+
+  catrobat.download.stats:
+    class: App\Catrobat\Listeners\DownloadStatisticsListener
     tags:
-      - { name: console.command }
+      - { name: kernel.event_listener, event: kernel.terminate, method: onTerminateEvent }
 
-  command.remixgraph.migrate:
-    class: App\Catrobat\Commands\MigrateRemixGraphsCommand
-    arguments:
-      - "@catrowebadmin.filesystem"
-      - "@usermanager"
-      - "@programmanager"
-      - "@remixmanager"
-      - "@doctrine.orm.entity_manager"
-      - "%kernel.root_dir%"
-    tags:
-      - { name: console.command }
 
-  command.recommender.compute:
-    class: App\Catrobat\Commands\RecommenderUserSimilaritiesCommand
-    arguments:
-      - "@usermanager"
-      - "@recommendermanager"
-      - "@doctrine.orm.entity_manager"
-      - "%kernel.root_dir%"
-    tags:
-      - { name: console.command }
+  # ====================================================================================================================
+  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  # ====================================================================================================================
 
-  command.recommender.export:
-    class: App\Catrobat\Commands\CSVUserSimilaritiesCommand
-    arguments:
-      - "@programremixrepository"
-      - "@programlikerepository"
-      - "@doctrine.orm.entity_manager"
-      - "%kernel.root_dir%"
-    tags:
-      - { name: console.command }
-
-  catrowebadmin.reflavor.extension:
-    class: App\Catrobat\Commands\ReflavorExtensionCommand
-    arguments:
-      - "@doctrine.orm.entity_manager"
-      - "@programrepository"
-    tags:
-      - { name: console.command }
-
-  # =========================== Sonata Admin Blocks ================================================
+  # ====================================================================================================================
+  #  Sonata Admin Blocks
+  #
 
   # ===== Projects
 
@@ -1031,6 +709,7 @@ services:
     public: true
 
   # ===== Extensions
+
   catrowebadmin.block.extensions.all:
     class: App\Admin\AllExtensionsAdmin
     tags:
@@ -1059,7 +738,7 @@ services:
       - { name: sonata.block, label: Cleanup }
     arguments:
       - "catrowebadmin.block.tools.statistic"
-      - "@templating"
+      - "@twig"
       - "%catrobat.file.extract.dir%"
       - "%catrobat.apk.dir%"
     public: true
@@ -1077,7 +756,7 @@ services:
   catrowebadmin.block.statistics.clicks:
     class: App\Admin\ClickStatisticsAdmin
     tags:
-      - { name: sonata.admin, manager_type: orm, label: "Click Statistics" }
+      - { name: sonata.admin, manager_type: orm, label: "Click DFStatistics" }
     arguments:
       - ~
       - App\Entity\ClickStatistic
@@ -1108,7 +787,6 @@ services:
       - App\Catrobat\Controller\Admin\GameJamSubmittedProgramsController
     public: true
 
-  # TODO change 2nd parameter
   catrowebadmin.block.program.snapshots:
     class: App\Admin\SnapshotAdmin
     tags:
@@ -1119,158 +797,3 @@ services:
       - App\Entity\Group
       - App\Catrobat\Controller\Admin\SnapshotController
     public: true
-
-  #====================== Listeners
-  # ======== System Validation ========
-
-  catrowebbundle.listener.language:
-    class: App\Catrobat\Listeners\LanguageListener
-    tags:
-      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 100 }
-
-  catrowebbundle.listener.flavor:
-    arguments:
-      - "@service_container"
-      - "@router"
-      - "@liip_theme.active_theme"
-      - "@app_request"
-    class: App\Catrobat\Listeners\FlavorListener
-    tags:
-      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 10  }
-
-  # ======== Upload Validation ========
-
-  catroweb.file.validator.name:
-    class: App\Catrobat\Listeners\NameValidator
-    arguments:    ["@rudewordfilter"]
-    tags:
-      - { name: kernel.event_listener, event: catrobat.program.before, method: onProgramBeforeInsert }
-
-  catroweb.file.validator.description:
-    class: App\Catrobat\Listeners\DescriptionValidator
-    autowire: true
-    tags:
-      - { name: kernel.event_listener, event: catrobat.program.before, method: onProgramBeforeInsert }
-
-  catroweb.file.validator.languageversion:
-    class: App\Catrobat\Listeners\VersionValidator
-    tags:
-      - { name: kernel.event_listener, event: catrobat.program.before, method: onProgramBeforeInsert }
-
-  #      catroweb.file.validator.filestructure:
-  #            class: App\Catrobat\Listeners\FileStructureValidator
-  #            tags:
-  #            - { name: kernel.event_listener, event: catrobat.program.before, method: onProgramBeforeInsert, priority: 250 }
-
-  #      catroweb.file.validator.definedimages:
-  #            class: App\Catrobat\Listeners\OnlyDefinedImagesValidator
-  #            tags:
-  #            - { name: kernel.event_listener, event: catrobat.program.before, method: onProgramBeforeInsert }
-
-  catroweb.file.validator.xmlheadervalidator:
-    class: App\Catrobat\Listeners\ProgramXmlHeaderValidator
-    tags:
-      - { name: kernel.event_listener, event: catrobat.program.before, method: onProgramBeforeInsert }
-
-  # ======== Upload Modification ========
-
-  catroweb.file.license.updater:
-    class: App\Catrobat\Listeners\LicenseUpdater
-    tags:
-      - { name: kernel.event_listener, event: catrobat.program.before, method: onProgramBeforeInsert, priority: -1 }
-
-  catroweb.file.remix.updater:
-    class: App\Catrobat\Listeners\RemixUpdater
-    arguments: ["@remixmanager","@async_http_client","@router","%kernel.root_dir%"]
-    tags:
-      - { name: kernel.event_listener, event: catrobat.program.after.insert, method: onProgramAfterInsert }
-
-  catroweb.flavor.check:
-    class: App\Catrobat\Listeners\ProgramFlavorListener
-    arguments:
-      - "@request_stack"
-    tags:
-      - { name: kernel.event_listener, event: catrobat.program.before.persist, method: onEvent }
-
-  catroweb.apk.cleanup:
-    class: App\Catrobat\Listeners\ApkCleanupListener
-    arguments: ["@apkrepository"]
-    tags:
-      - { name: kernel.event_listener, event: catrobat.program.before.persist, method: handleEvent }
-
-  catroweb.extension.check:
-    class: App\Catrobat\Listeners\ProgramExtensionListener
-    arguments: ["@extensionrepository"]
-    tags:
-      - { name: kernel.event_listener, event: catrobat.program.before.persist, method: onEvent }
-
-  catroweb.gamejamtag.check:
-    class: App\Catrobat\Listeners\GameJamTagListener
-    tags:
-      - { name: kernel.event_listener, event: catrobat.program.before.persist, method: onEvent }
-
-  # ======== Snapshots =======
-
-  catrobat.upload.snapshotlistener:
-    class:        App\Catrobat\Listeners\Upload\SaveProgramSnapshotListener
-    arguments:    ["@time","@filerepository", "%catrobat.snapshot.dir%"]
-    tags:
-      - { name: kernel.event_listener, event: catrobat.program.after.insert, method: handleEvent }
-
-  # ======== Notifications =======
-
-  catrobat.core.services.uploadnotificator:
-    class:        App\Catrobat\Listeners\UploadNotificator
-    arguments:    ["@mailer","@notificationrepository"]
-    tags:
-      - { name: kernel.event_listener, event: catrobat.program.after.insert, method: onProgramInsertEvent }
-
-  catrobat.core.services.reportnotificator:
-    class:        App\Catrobat\Listeners\ReportNotificator
-    arguments:    ["@mailer","@notificationrepository"]
-    tags:
-      - { name: kernel.event_listener, event: catrobat.report.insert, method: onReportInsertEvent }
-
-  # ======== Logging ========
-
-  catrobat.core.services.invalidprogramuploadlogger:
-    class:        App\Catrobat\Listeners\InvalidProgramUploadLogger
-    arguments:    ["@logger"]
-    tags:
-      - { name: monolog.logger, channel: upload }
-      - { name: kernel.event_listener, event: catrobat.program.invalid.upload, method: onInvalidProgramUploadedEvent }
-
-  # ======== Entity ========
-
-  catrobat.entity.featured.image_listener:
-    class: App\Catrobat\Listeners\Entity\FeaturedProgramImageListener
-    arguments: ["@featuredimagerepository"]
-    tags:
-      - { name: doctrine.orm.entity_listener }
-
-  # ======== Views ========
-  catrobat.view.uploadexception:
-    class:        App\Catrobat\Listeners\View\UploadExceptionListener
-    arguments: ["@translator"]
-    tags:
-      - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
-
-  catrobat.view.programlist:
-    class:        App\Catrobat\Listeners\View\ProgramListSerializer
-    arguments: ["@request_stack","@router","@screenshotrepository","@elapsedtime"]
-    tags:
-      - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
-  catrobat.view.templatelist:
-    class:        App\Catrobat\Listeners\View\TemplateListSerializer
-    arguments: ["@request_stack","%catrobat.template.storage.path%","@templatescreenshotrepository","@elapsedtime"]
-    tags:
-      - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
-
-
-  # =========================== Download ===========================
-
-  catrobat.download.stats:
-    class: App\Catrobat\Listeners\DownloadStatisticsListener
-    arguments: ["@statistics", "@security.token_storage"]
-    tags:
-      - { name: kernel.event_listener, event: kernel.terminate, method: onTerminateEvent }

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -1,6 +1,7 @@
+# In this file we can overwrite services an parameters defined in services.yml
+# Services and parameters defined in this file will only be used in the 'test' environment.
+
 parameters:
-  catrobat.test.directory.source: "%kernel.project_dir%/tests/testdata/DataFixtures/"
-  catrobat.test.directory.target: "%kernel.project_dir%/tests/testdata/DataFixtures/GeneratedFixtures/"
   catrobat.file.extract.dir:   "%catrobat.pubdir%resources_test/extract/"
   catrobat.file.storage.dir:   "%catrobat.pubdir%resources_test/projects/"
   catrobat.screenshot.dir:     "%catrobat.pubdir%resources_test/screenshots/"
@@ -25,79 +26,78 @@ parameters:
     uploadtoken: "UPLOADTOKEN"
 
 services:
-  catrobat.test.command.generatetestdata:
-    class: App\Catrobat\Commands\GenerateTestDataCommand
-    arguments:
-    - "@catrobat.test.filesystem"
-    - "@catrobat.test.extractor"
-    - "@catrobat.test.compressor"
-    - "%catrobat.test.directory.source%"
-    - "%catrobat.test.directory.target%"
-    tags:
-    - { name: console.command }
 
-  catrobat.test.filesystem:
-    class: Symfony\Component\Filesystem\Filesystem
-    public: false
+  # default configuration for services in *this* file
+  _defaults:
+    autowire: true       # Automatically injects dependencies in your services.
+    autoconfigure: false # Automatically registers your services as commands, event subscribers, etc.
+    public: true         # Since we are overriding only public services
 
-  catrobat.test.extractor:
-    class: App\Catrobat\Services\CatrobatFileExtractor
-    arguments:
-    - "%catrobat.test.directory.target%"
-    - "%catrobat.file.extract.path%"
+  #
+  #  How To overwrite services?
+  #
+  #  When Overwriting a service make sure the new <service>.php class extends the real service
+  #  This allows easy dependency injections. When the real service is needed in the test service
+  #  you need to define it as <service>.inner and hand it over as first argument. This way all other
+  #  arguments can still be auto wired and circles are avoided.
+  #
 
-  catrobat.test.compressor:
-    class: App\Catrobat\Services\CatrobatFileCompressor
-
-  tokengenerator.inner:
+  # ======== Overwriting the token generator
+  token_generator.inner:
     class: App\Catrobat\Services\TokenGenerator
 
-  tokengenerator:
+  App\Catrobat\Services\TokenGenerator:
     class: App\Catrobat\Services\TestEnv\ProxyTokenGenerator
+    autowire: false
     arguments:
-    - "@tokengenerator.inner"
+      - '@token_generator.inner'
+
+  # ======== Overwriting the oauth service
+
+  oauth_service.inner:
+    class: App\Catrobat\Services\OAuthService
+
+  App\Catrobat\Services\OAuthService:
+    class: App\Catrobat\Services\TestEnv\FakeOAuthService
+    arguments:
+      - '@oauth_service.inner'
+
+  # ======== Overwriting the statistics service
+
+  statistics.inner:
+    class: App\Catrobat\Services\StatisticsService
+
+  App\Catrobat\Services\StatisticsService:
+    class: App\Catrobat\Services\TestEnv\FakeStatisticsService
+    arguments:
+      - "@statistics.inner"
+
+  # ======== Overwriting the time service
 
   time.inner:
     class: App\Catrobat\Services\Time
 
-  time:
-    class: App\Catrobat\Services\TestEnv\ProxyTime
+  App\Catrobat\Services\Time:
     arguments:
-    - "@time.inner"
+      - '@time.inner'
+    class: App\Catrobat\Services\TestEnv\ProxyTime
 
-  ci.jenkins.dispatcher:
+  # ======== Overwriting the jenkins dispatcher
+
+  App\Catrobat\Services\Ci\JenkinsDispatcher:
     class: App\Catrobat\Services\TestEnv\FakeJenkinsDispatcher
     arguments:
-    - "@router"
-    - "%jenkins%"
+      - "%jenkins%"
+
+  # ======== Overwriting the ldap driver
 
   fr3d_ldap.ldap_driver:
     class: App\Catrobat\Services\TestEnv\LdapTestDriver
-    arguments:
-    - "%ldap_base_dn%"
 
-  real_oauth_service:
-    class: App\Catrobat\Services\OAuthService
-    arguments:
-      - "@service_container"
+  # ========
 
-  oauth_service:
-    class: App\Catrobat\Services\TestEnv\FakeOAuthService
+  App\Catrobat\Services\CatrobatFileExtractor:
+    class: App\Catrobat\Services\CatrobatFileExtractor
     arguments:
-      - "@real_oauth_service"
-      - "@service_container"
-
-  statistics:
-    class: App\Catrobat\Services\TestEnv\FakeStatisticsService
-    arguments:
-    - "@real_statistics"
-
-  real_statistics:
-    class: App\Catrobat\Services\StatisticsService
-    arguments:
-    - "@programmanager"
-    - "@doctrine.orm.entity_manager"
-    - "@logger"
-    - "@security.token_storage"
-    tags:
-    - { name: monolog.logger, channel: download_stats }
+      - "%catrobat.test.directory.target%"
+      - "%catrobat.file.extract.path%"

--- a/public/index.php
+++ b/public/index.php
@@ -4,23 +4,24 @@ use App\Kernel;
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
-require dirname(__DIR__).'/config/bootstrap.php';
-
-if ($_SERVER['APP_DEBUG']) {
+require dirname(__DIR__) . '/config/bootstrap.php';
+if ($_SERVER['APP_DEBUG'])
+{
   umask(0000);
-
   Debug::enable();
 }
 
-if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false) {
+if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false)
+{
   Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
 }
 
-if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false) {
+if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false)
+{
   Request::setTrustedHosts([$trustedHosts]);
 }
 
-$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool)$_SERVER['APP_DEBUG']);
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();

--- a/public/index_test.php
+++ b/public/index_test.php
@@ -11,19 +11,22 @@ use App\Kernel;
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
-require dirname(__DIR__).'/config/bootstrap.php';
+require dirname(__DIR__) . '/config/bootstrap.php';
 
-if ($_SERVER['APP_DEBUG']) {
+if ($_SERVER['APP_DEBUG'])
+{
   umask(0000);
 
   Debug::enable();
 }
 
-if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false) {
+if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false)
+{
   Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
 }
 
-if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false) {
+if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false)
+{
   Request::setTrustedHosts([$trustedHosts]);
 }
 

--- a/src/Admin/AllProgramsAdmin.php
+++ b/src/Admin/AllProgramsAdmin.php
@@ -2,6 +2,7 @@
 
 namespace App\Admin;
 
+use App\Catrobat\Services\ScreenshotRepository;
 use App\Entity\Program;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -40,6 +41,26 @@ class AllProgramsAdmin extends AbstractAdmin
     '_sort_by'    => 'id',
     '_sort_order' => 'DESC',
   ];
+
+  /**
+   * @var ScreenshotRepository
+   */
+  private $screenshot_repository;
+
+  /**
+   * AllProgramsAdmin constructor.
+   *
+   * @param $code
+   * @param $class
+   * @param $baseControllerName
+   * @param ScreenshotRepository $screenshot_repository
+   */
+  public function __construct($code, $class, $baseControllerName, ScreenshotRepository $screenshot_repository)
+  {
+    parent::__construct($code, $class, $baseControllerName);
+
+    $this->screenshot_repository = $screenshot_repository;
+  }
 
 
   /**
@@ -175,7 +196,7 @@ class AllProgramsAdmin extends AbstractAdmin
     /**
      * @var $object object
      */
-    return '/' . $this->getConfigurationPool()->getContainer()->get('screenshotrepository')->getThumbnailWebPath($object->getId());
+    return '/' . $this->screenshot_repository->getThumbnailWebPath($object->getId());
   }
 
   /**

--- a/src/Admin/ApkListAdmin.php
+++ b/src/Admin/ApkListAdmin.php
@@ -2,6 +2,7 @@
 
 namespace App\Admin;
 
+use App\Catrobat\Services\ScreenshotRepository;
 use Doctrine\ORM\QueryBuilder;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -33,6 +34,25 @@ class ApkListAdmin extends AbstractAdmin
   protected $datagridValues = [
     '_sort_by' => 'apk_request_time',
   ];
+
+  /**
+   * @var ScreenshotRepository
+   */
+  private $screenshot_repository;
+
+  /**
+   * ApkListAdmin constructor.
+   *
+   * @param $code
+   * @param $class
+   * @param $baseControllerName
+   * @param ScreenshotRepository $screenshot_repository
+   */
+  public function __construct($code, $class, $baseControllerName, ScreenshotRepository $screenshot_repository)
+  {
+    parent::__construct($code, $class, $baseControllerName);
+    $this->screenshot_repository = $screenshot_repository;
+  }
 
 
   /**
@@ -127,7 +147,6 @@ class ApkListAdmin extends AbstractAdmin
     /**
      * @var $object Program
      */
-    return '/' . $this->getConfigurationPool()->getContainer()->get('screenshotrepository')
-        ->getThumbnailWebPath($object->getId());
+    return '/' . $this->screenshot_repository->getThumbnailWebPath($object->getId());
   }
 }

--- a/src/Admin/ApproveProgramsAdmin.php
+++ b/src/Admin/ApproveProgramsAdmin.php
@@ -2,6 +2,7 @@
 
 namespace App\Admin;
 
+use App\Catrobat\Services\ScreenshotRepository;
 use App\Entity\Program;
 use App\Entity\ProgramManager;
 use App\Entity\User;
@@ -40,6 +41,39 @@ class ApproveProgramsAdmin extends AbstractAdmin
    */
   private $extractedProgram = null;
 
+  /**
+   * @var ScreenshotRepository
+   */
+  private $screenshot_repository;
+
+  /**
+   * @var ProgramManager
+   */
+  private $program_manager;
+
+  /**
+   * @var ExtractedFileRepository
+   */
+  private $extracted_file_repository;
+
+  /**
+   * ApproveProgramsAdmin constructor.
+   *
+   * @param $code
+   * @param $class
+   * @param $baseControllerName
+   * @param ScreenshotRepository $screenshot_repository
+   * @param ProgramManager $program_manager
+   * @param ExtractedFileRepository $extracted_file_repository
+   */
+  public function __construct($code, $class, $baseControllerName, ScreenshotRepository $screenshot_repository,
+                              ProgramManager $program_manager, ExtractedFileRepository $extracted_file_repository)
+  {
+    parent::__construct($code, $class, $baseControllerName);
+    $this->screenshot_repository = $screenshot_repository;
+    $this->program_manager = $program_manager;
+    $this->extracted_file_repository = $extracted_file_repository;
+  }
 
   /**
    * @param string $context
@@ -173,8 +207,7 @@ class ApproveProgramsAdmin extends AbstractAdmin
      * @var $object Program
      */
 
-    return '/' . $this->getConfigurationPool()->getContainer()->get('screenshotrepository')
-        ->getThumbnailWebPath($object->getId());
+    return '/' . $this->screenshot_repository->getThumbnailWebPath($object->getId());
   }
 
 
@@ -189,16 +222,15 @@ class ApproveProgramsAdmin extends AbstractAdmin
   {
     /**
      * @var $extractedFileRepository ExtractedFileRepository
-     * @var $progManager ProgramManager
+     * @var $program_manager ProgramManager
      * @var $object Program
      */
 
     if ($this->extractedProgram == null)
     {
-      $extractedFileRepository = $this->getConfigurationPool()->getContainer()->get('extractedfilerepository');
-      $progManager = $this->getConfigurationPool()->getContainer()->get('programmanager');
-      $this->extractedProgram = $extractedFileRepository
-        ->loadProgramExtractedFile($progManager->find($object->getId()));
+      $this->extractedProgram = $this->extracted_file_repository->loadProgramExtractedFile(
+        $this->program_manager->find($object->getId())
+      );
     }
 
     $image_paths = $this->extractedProgram->getContainingImagePaths();
@@ -239,10 +271,9 @@ class ApproveProgramsAdmin extends AbstractAdmin
 
     if ($this->extractedProgram == null)
     {
-      $extractedFileRepository = $this->getConfigurationPool()->getContainer()->get('extractedfilerepository');
-      $progManager = $this->getConfigurationPool()->getContainer()->get('programmanager');
-      $this->extractedProgram = $extractedFileRepository
-        ->loadProgramExtractedFile($progManager->find($object->getId()));
+      $this->extractedProgram = $this->extracted_file_repository->loadProgramExtractedFile(
+        $this->program_manager->find($object->getId())
+      );
     }
 
     return $this->encodeFileNameOfPathsArray($this->extractedProgram->getContainingSoundPaths());
@@ -264,10 +295,9 @@ class ApproveProgramsAdmin extends AbstractAdmin
 
     if ($this->extractedProgram == null)
     {
-      $extractedFileRepository = $this->getConfigurationPool()->getContainer()->get('extractedfilerepository');
-      $progManager = $this->getConfigurationPool()->getContainer()->get('programmanager');
-      $this->extractedProgram = $extractedFileRepository
-        ->loadProgramExtractedFile($progManager->find($object->getId()));
+      $this->extractedProgram = $this->extracted_file_repository->loadProgramExtractedFile(
+        $this->program_manager->find($object->getId())
+      );
     }
 
     return $this->extractedProgram->getContainingStrings();
@@ -288,10 +318,9 @@ class ApproveProgramsAdmin extends AbstractAdmin
 
     if ($this->extractedProgram == null)
     {
-      $extractedFileRepository = $this->getConfigurationPool()->getContainer()->get('extractedfilerepository');
-      $progManager = $this->getConfigurationPool()->getContainer()->get('programmanager');
-      $this->extractedProgram = $extractedFileRepository
-        ->loadProgramExtractedFile($progManager->find($object->getId()));
+      $this->extractedProgram = $this->extracted_file_repository->loadProgramExtractedFile(
+        $this->program_manager->find($object->getId())
+      );
     }
 
     if ($this->extractedProgram->hasScenes())

--- a/src/Admin/FeaturedUrlAdmin.php
+++ b/src/Admin/FeaturedUrlAdmin.php
@@ -2,6 +2,7 @@
 
 namespace App\Admin;
 
+use App\Catrobat\Services\FeaturedImageRepository;
 use App\Entity\FeaturedProgram;
 use Doctrine\DBAL\Types\IntegerType;
 use Doctrine\DBAL\Types\StringType;
@@ -12,6 +13,7 @@ use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use App\Catrobat\Forms\FeaturedImageConstraint;
 use Sonata\BlockBundle\Meta\Metadata;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -33,6 +35,23 @@ class FeaturedUrlAdmin extends AbstractAdmin
    */
   protected $baseRoutePattern = 'featured_url';
 
+  /**
+   * @var FeaturedImageRepository
+   */
+  private $featured_image_repository;
+
+  /**
+   * @var ParameterBagInterface
+   */
+  private $parameter_bag;
+
+  public function __construct($code, $class, $baseControllerName, FeaturedImageRepository $featured_image_repository,
+                              ParameterBagInterface $parameter_bag)
+  {
+    parent::__construct($code, $class, $baseControllerName);
+    $this->featured_image_repository = $featured_image_repository;
+    $this->parameter_bag = $parameter_bag;
+  }
 
   /**
    * @param string $context
@@ -128,8 +147,7 @@ class FeaturedUrlAdmin extends AbstractAdmin
      * @var $object FeaturedProgram
      */
 
-    return '../../' . $this->getConfigurationPool()->getContainer()->get('featuredimagerepository')
-        ->getWebPath($object->getId(), $object->getImageType());
+    return '../../' . $this->featured_image_repository->getWebPath($object->getId(), $object->getImageType());
   }
 
 
@@ -172,7 +190,7 @@ class FeaturedUrlAdmin extends AbstractAdmin
   private function checkFlavor()
   {
     $flavor = $this->getForm()->get('flavor')->getData();
-    $flavor_options =  $this->getConfigurationPool()->getContainer()->getParameter('themes');
+    $flavor_options =  $this->parameter_bag->get('themes');
 
     if (!in_array($flavor, $flavor_options)) {
       throw new NotFoundHttpException(

--- a/src/Admin/MediaPackageFileAdmin.php
+++ b/src/Admin/MediaPackageFileAdmin.php
@@ -2,12 +2,14 @@
 
 namespace App\Admin;
 
+use App\Catrobat\Services\MediaPackageFileRepository;
 use App\Entity\MediaPackageCategory;
 use App\Entity\MediaPackageFile;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\File\File;
@@ -31,6 +33,33 @@ class MediaPackageFileAdmin extends AbstractAdmin
    */
   protected $baseRoutePattern = 'media_package_file';
 
+  /**
+   * @var MediaPackageFileRepository
+   */
+  private $media_package_file_repository;
+
+  /**
+   * @var ParameterBagInterface
+   */
+  private $parameter_bag;
+
+  /**
+   * MediaPackageFileAdmin constructor.
+   *
+   * @param $code
+   * @param $class
+   * @param $baseControllerName
+   * @param MediaPackageFileRepository $media_package_file_repository
+   * @param ParameterBagInterface $parameter_bag
+   */
+  public function __construct($code, $class, $baseControllerName,
+                              MediaPackageFileRepository $media_package_file_repository,
+                              ParameterBagInterface $parameter_bag)
+  {
+    parent::__construct($code, $class, $baseControllerName);
+    $this->media_package_file_repository = $media_package_file_repository;
+    $this->parameter_bag = $parameter_bag;
+  }
 
   /**
    * @param FormMapper $formMapper
@@ -114,8 +143,7 @@ class MediaPackageFileAdmin extends AbstractAdmin
     {
       return;
     }
-    $this->getConfigurationPool()->getContainer()->get('mediapackagefilerepository')
-      ->save($file, $object->getId(), $object->getExtension());
+    $this->media_package_file_repository->save($file, $object->getId(), $object->getExtension());
   }
 
 
@@ -155,8 +183,7 @@ class MediaPackageFileAdmin extends AbstractAdmin
     {
       return;
     }
-    $this->getConfigurationPool()->getContainer()->get('mediapackagefilerepository')
-      ->save($file, $object->getId(), $object->getExtension());
+    $this->media_package_file_repository->save($file, $object->getId(), $object->getExtension());
   }
 
 
@@ -174,8 +201,7 @@ class MediaPackageFileAdmin extends AbstractAdmin
    */
   public function postRemove($object)
   {
-    $this->getConfigurationPool()->getContainer()->get('mediapackagefilerepository')
-      ->remove($object->removed_id, $object->getExtension());
+    $this->media_package_file_repository->remove($object->removed_id, $object->getExtension());
   }
 
   /**
@@ -184,7 +210,7 @@ class MediaPackageFileAdmin extends AbstractAdmin
   private function checkFlavor()
   {
     $flavor = $this->getForm()->get('flavor')->getData();
-    $flavor_options =  $this->getConfigurationPool()->getContainer()->getParameter('themes');
+    $flavor_options =  $this->parameter_bag->get('themes');
 
     if (!in_array($flavor, $flavor_options)) {
       throw new NotFoundHttpException(

--- a/src/Admin/PendingApkRequestsAdmin.php
+++ b/src/Admin/PendingApkRequestsAdmin.php
@@ -2,6 +2,7 @@
 
 namespace App\Admin;
 
+use App\Catrobat\Services\ScreenshotRepository;
 use Doctrine\ORM\QueryBuilder;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -35,6 +36,24 @@ class PendingApkRequestsAdmin extends AbstractAdmin
     '_sort_by' => 'apk_request_time',
   ];
 
+  /**
+   * @var ScreenshotRepository
+   */
+  private $screenshot_repository;
+
+  /**
+   * PendingApkRequestsAdmin constructor.
+   *
+   * @param $code
+   * @param $class
+   * @param $baseControllerName
+   * @param ScreenshotRepository $screenshot_repository
+   */
+  public function __construct($code, $class, $baseControllerName, ScreenshotRepository $screenshot_repository)
+  {
+    parent::__construct($code, $class, $baseControllerName);
+    $this->screenshot_repository = $screenshot_repository;
+  }
 
   /**
    * @param string $context
@@ -130,7 +149,6 @@ class PendingApkRequestsAdmin extends AbstractAdmin
    */
   public function getThumbnailImageUrl($object)
   {
-    return '/' . $this->getConfigurationPool()->getContainer()->get('screenshotrepository')
-      ->getThumbnailWebPath($object->getId());
+    return '/' . $this->screenshot_repository->getThumbnailWebPath($object->getId());
   }
 }

--- a/src/Admin/TemplateAdmin.php
+++ b/src/Admin/TemplateAdmin.php
@@ -116,7 +116,7 @@ class TemplateAdmin extends AbstractAdmin
    */
   public function getThumbnailImageUrl($object)
   {
-    return '/' . $this->getConfigurationPool()->getContainer()->get('templatescreenshotrepository')
+    return '/' . $this->getConfigurationPool()->getContainer()->get('template_screenshot_repository')
         ->getThumbnailWebPath($object->getId());
   }
 

--- a/src/Catrobat/Commands/CSVUserSimilaritiesCommand.php
+++ b/src/Catrobat/Commands/CSVUserSimilaritiesCommand.php
@@ -5,10 +5,12 @@ namespace App\Catrobat\Commands;
 use App\Entity\ProgramLike;
 use App\Repository\ProgramLikeRepository;
 use App\Repository\ProgramRemixRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\EntityManager;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 
 /**
@@ -42,19 +44,20 @@ class CSVUserSimilaritiesCommand extends ContainerAwareCommand
    * CSVUserSimilaritiesCommand constructor.
    *
    * @param ProgramRemixRepository $program_remix_repository
-   * @param ProgramLikeRepository  $program_like_repository
-   * @param EntityManager          $entity_manager
-   * @param                        $app_root_dir
+   * @param ProgramLikeRepository $program_like_repository
+   * @param EntityManagerInterface $entity_manager
+   * @param $kernel_root_dir
    */
   public function __construct(ProgramRemixRepository $program_remix_repository,
                               ProgramLikeRepository $program_like_repository,
-                                 EntityManager $entity_manager, $app_root_dir)
+                              EntityManagerInterface $entity_manager,
+                              $kernel_root_dir)
   {
     parent::__construct();
     $this->program_remix_repository = $program_remix_repository;
     $this->program_like_repository = $program_like_repository;
     $this->entity_manager = $entity_manager;
-    $this->app_root_dir = $app_root_dir;
+    $this->app_root_dir = $kernel_root_dir;
   }
 
   /**

--- a/src/Catrobat/Commands/CleanApkCommand.php
+++ b/src/Catrobat/Commands/CleanApkCommand.php
@@ -3,6 +3,7 @@
 namespace App\Catrobat\Commands;
 
 use App\Entity\Program;
+use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -43,8 +44,8 @@ class CleanApkCommand extends ContainerAwareCommand
     $this->output->writeln('Deleting APKs');
     CommandHelper::emptyDirectory($this->getContainer()->getParameter('catrobat.apk.dir'), 'Emptying apk directory', $output);
 
-    /* @var $em \Doctrine\ORM\EntityManager */
-    $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+    /* @var $em EntityManager */
+    $em = $this->getContainer()->get('doctrine')->getManager();
     $query = $em->createQuery("UPDATE App\Entity\Program p SET p.apk_status = :status WHERE p.apk_status != :status");
     $query->setParameter('status', Program::APK_NONE);
     $result = $query->getSingleScalarResult();

--- a/src/Catrobat/Commands/CleanExtractedFileCommand.php
+++ b/src/Catrobat/Commands/CleanExtractedFileCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Catrobat\Commands;
 
+use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -42,8 +43,8 @@ class CleanExtractedFileCommand extends ContainerAwareCommand
     $this->output->writeln('Deleting Extracted Catrobat Files');
     CommandHelper::emptyDirectory($this->getContainer()->getParameter('catrobat.file.extract.dir'), 'Emptying extracted directory', $output);
 
-    /* @var $em \Doctrine\ORM\EntityManager */
-    $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+    /* @var $em EntityManager */
+    $em = $this->getContainer()->get('doctrine')->getManager();
     $query = $em->createQuery("UPDATE App\Entity\Program p SET p.directory_hash = :hash WHERE p.directory_hash != :hash");
     $query->setParameter('hash', "null");
     $result = $query->getSingleScalarResult();

--- a/src/Catrobat/Commands/CleanOldApkCommand.php
+++ b/src/Catrobat/Commands/CleanOldApkCommand.php
@@ -112,7 +112,7 @@ class CleanOldApkCommand extends ContainerAwareCommand
       $id_query_part = ' AND (' . $id_query_part . ')';
     }
 
-    $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+    $em = $this->getContainer()->get('doctrine')->getManager();
     $query = $em->createQuery("UPDATE App\Entity\Program p 
                       SET p.apk_status = :status WHERE p.apk_status != :status" . $id_query_part);
     $query->setParameter('status', Program::APK_NONE);

--- a/src/Catrobat/Commands/CreateConstantTagsCommand.php
+++ b/src/Catrobat/Commands/CreateConstantTagsCommand.php
@@ -2,26 +2,13 @@
 
 namespace App\Catrobat\Commands;
 
-use App\Catrobat\Services\CatrobatFileExtractor;
-use Symfony\Component\Console\Input\InputArgument;
+use App\Repository\TagRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Finder\Finder;
-use App\Entity\ProgramManager;
-use App\Entity\UserManager;
 use App\Entity\Tag;
-use Symfony\Component\HttpFoundation\File\File;
-use Doctrine\ORM\EntityManager;
-use Symfony\Component\Process\Process;
-use App\Entity\Program;
-use App\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-use App\Entity\FeaturedProgram;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Translation\TranslatorInterface;
-use App\Repository\TagRepository;
 
 /**
  * Class CreateConstantTagsCommand
@@ -44,17 +31,17 @@ class CreateConstantTagsCommand extends ContainerAwareCommand
   private $tag_repository;
 
   /**
-   * @var EntityManager
+   * @var EntityManagerInterface
    */
   private $em;
 
   /**
    * CreateConstantTagsCommand constructor.
    *
-   * @param EntityManager       $em
+   * @param EntityManagerInterface       $em
    * @param TranslatorInterface $translator
    */
-  public function __construct(EntityManager $em, TranslatorInterface $translator)
+  public function __construct(EntityManagerInterface $em, TranslatorInterface $translator)
   {
     parent::__construct();
     $this->em = $em;
@@ -81,7 +68,7 @@ class CreateConstantTagsCommand extends ContainerAwareCommand
   protected function execute(InputInterface $input, OutputInterface $output)
   {
     $this->output = $output;
-    $this->tag_repository = $this->getContainer()->get('tagrepository');
+    $this->tag_repository = $this->getContainer()->get(TagRepository::class);
     $metadata = $this->em->getClassMetadata('App\Entity\Tag')->getFieldNames();
 
     $number_of_tags = 7; // uses the tag names defined in the translation files!

--- a/src/Catrobat/Commands/CreateMissingMediaPackageThumbnailsCommand.php
+++ b/src/Catrobat/Commands/CreateMissingMediaPackageThumbnailsCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Catrobat\Commands;
 
+use App\Catrobat\Services\MediaPackageFileRepository;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -46,7 +47,7 @@ class CreateMissingMediaPackageThumbnailsCommand extends ContainerAwareCommand
         "(e.g. sudo -u www-data bin/console ...) or run with --force.");
     }
 
-    $this->getContainer()->get('mediapackagefilerepository')->createMissingThumbnails();
+    $this->getContainer()->get(MediaPackageFileRepository::class)->createMissingThumbnails();
 
     return null;
   }

--- a/src/Catrobat/Commands/CreateProgramExtensionsCommand.php
+++ b/src/Catrobat/Commands/CreateProgramExtensionsCommand.php
@@ -2,9 +2,12 @@
 
 namespace App\Catrobat\Commands;
 
+use App\Catrobat\Services\ProgramFileRepository;
 use App\Entity\Extension;
+use App\Repository\ExtensionRepository;
 use App\Repository\ProgramRepository;
 use App\Catrobat\Exceptions\Upload\InvalidXmlException;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
@@ -24,12 +27,12 @@ class CreateProgramExtensionsCommand extends ContainerAwareCommand
   private $output;
 
   /**
-   * @var EntityManager
+   * @var EntityManagerInterface
    */
   private $em;
 
   /**
-   * @var
+   * @var ProgramFileRepository
    */
   private $programfile_directory;
 
@@ -42,11 +45,12 @@ class CreateProgramExtensionsCommand extends ContainerAwareCommand
   /**
    * CreateProgramExtensionsCommand constructor.
    *
-   * @param EntityManager     $em
-   * @param string            $programfile_directory
+   * @param EntityManagerInterface $em
+   * @param ProgramFileRepository $programfile_directory
    * @param ProgramRepository $program_repo
    */
-  public function __construct(EntityManager $em, $programfile_directory, $program_repo)
+  public function __construct(EntityManagerInterface $em, ProgramFileRepository $programfile_directory,
+                              ProgramRepository $program_repo)
   {
     parent::__construct();
     $this->em = $em;
@@ -84,7 +88,7 @@ class CreateProgramExtensionsCommand extends ContainerAwareCommand
 
     $this->writeln("Deleting all linked extensions");
 
-    $extension_repository = $this->getContainer()->get('extensionrepository');
+    $extension_repository = $this->getContainer()->get(ExtensionRepository::class);
     $extensions = $extension_repository->findAll();
 
     foreach ($extensions as $extension)

--- a/src/Catrobat/Commands/GenerateTestDataCommand.php
+++ b/src/Catrobat/Commands/GenerateTestDataCommand.php
@@ -4,6 +4,7 @@ namespace App\Catrobat\Commands;
 
 use App\Catrobat\Services\CatrobatFileCompressor;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -56,12 +57,12 @@ class GenerateTestDataCommand extends Command
    * @param                        $source_extensions
    */
   public function __construct(Filesystem $filesystem, CatrobatFileExtractor $extractor,
-                              CatrobatFileCompressor $compressor, $source, $target_directory)
+                              CatrobatFileCompressor $compressor, ParameterBagInterface $parameter_bag)
   {
     parent::__construct();
     $this->filesystem = $filesystem;
-    $this->source = $source;
-    $this->target_directory = realpath($target_directory) . '/';
+    $this->source = $parameter_bag->get('catrobat.test.directory.source');
+    $this->target_directory = realpath($parameter_bag->get('catrobat.test.directory.target')) . '/';
     $this->extractor = $extractor;
     $this->compressor = $compressor;
   }

--- a/src/Catrobat/Commands/Helpers/CronjobProgressWriter.php
+++ b/src/Catrobat/Commands/Helpers/CronjobProgressWriter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Catrobat\Commands;
+namespace App\Catrobat\Commands\Helpers;
 
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/Catrobat/Commands/Helpers/MigrationFileLock.php
+++ b/src/Catrobat/Commands/Helpers/MigrationFileLock.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Catrobat\Commands;
+namespace App\Catrobat\Commands\Helpers;
 
 use App\Catrobat\Listeners\RemixUpdater;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Catrobat/Commands/Helpers/RecommenderFileLock.php
+++ b/src/Catrobat/Commands/Helpers/RecommenderFileLock.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Catrobat\Commands;
+namespace App\Catrobat\Commands\Helpers;
 
 use App\Catrobat\RecommenderSystem\RecommenderManager;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Catrobat/Commands/Helpers/RemixManipulationCatrobatFileExtractor.php
+++ b/src/Catrobat/Commands/Helpers/RemixManipulationCatrobatFileExtractor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Catrobat\Commands;
+namespace App\Catrobat\Commands\Helpers;
 
 use App\Catrobat\Services\CatrobatFileExtractor;
 use App\Catrobat\Services\RemixUrlIndicator;

--- a/src/Catrobat/Commands/Helpers/RemixManipulationProgramManager.php
+++ b/src/Catrobat/Commands/Helpers/RemixManipulationProgramManager.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Catrobat\Commands;
+namespace App\Catrobat\Commands\Helpers;
 
 use App\Entity\ProgramManager;
 use App\Catrobat\Services\CatrobatFileExtractor;

--- a/src/Catrobat/Commands/ImportLegacyCommand.php
+++ b/src/Catrobat/Commands/ImportLegacyCommand.php
@@ -2,10 +2,13 @@
 
 namespace App\Catrobat\Commands;
 
+use App\Catrobat\Services\ProgramFileRepository;
+use App\Catrobat\Services\ScreenshotRepository;
 use App\Entity\RemixManager;
 use App\Catrobat\Listeners\RemixUpdater;
 use App\Catrobat\Services\AsyncHttpClient;
 use App\Catrobat\Services\CatrobatFileExtractor;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\Output;
@@ -98,6 +101,7 @@ class ImportLegacyCommand extends ContainerAwareCommand
    * @var
    */
   private $screenshot_repository;
+
   /**
    * @var
    */
@@ -110,10 +114,10 @@ class ImportLegacyCommand extends ContainerAwareCommand
    * @param UserManager    $user_manager
    * @param ProgramManager $program_manager
    * @param RemixManager   $remix_manager
-   * @param EntityManager  $em
+   * @param EntityManagerInterface  $em
    */
   public function __construct(Filesystem $filesystem, UserManager $user_manager, ProgramManager $program_manager,
-                                 RemixManager $remix_manager, EntityManager $em)
+                                 RemixManager $remix_manager, EntityManagerInterface $em)
   {
     parent::__construct();
     $this->fileystem = $filesystem;
@@ -146,8 +150,8 @@ class ImportLegacyCommand extends ContainerAwareCommand
     $this->output = $output;
     $this->filesystem = new Filesystem();
     $this->finder = new Finder();
-    $this->screenshot_repository = $this->getContainer()->get('screenshotrepository');
-    $this->catrobat_file_repository = $this->getContainer()->get('filerepository');
+    $this->screenshot_repository = $this->getContainer()->get(ScreenshotRepository::class);
+    $this->catrobat_file_repository = $this->getContainer()->get(ProgramFileRepository::class);
 
     CommandHelper::executeSymfonyCommand('catrobat:purge', $this->getApplication(), ['--force' => true], $output);
 
@@ -440,7 +444,7 @@ class ImportLegacyCommand extends ContainerAwareCommand
       /**
        * @var $fileextractor CatrobatFileExtractor
        */
-      $fileextractor = $this->getContainer()->get('fileextractor');
+      $fileextractor = $this->getContainer()->get('App\Catrobat\Services\CatrobatFileExtractor');
       $router = $this->getContainer()->get('router');
       $extracted_catrobat_file = $fileextractor->extract(new File($filepath));
 

--- a/src/Catrobat/Commands/InitDirectoriesCommand.php
+++ b/src/Catrobat/Commands/InitDirectoriesCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Catrobat\Commands;
 
+use App\Catrobat\Services\ProgramFileRepository;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -45,7 +46,7 @@ class InitDirectoriesCommand extends Command
    * @param Filesystem $filesystem
    * @param            $programfile_directory
    */
-  public function __construct(Filesystem $filesystem, $programfile_directory)
+  public function __construct(Filesystem $filesystem, ProgramFileRepository $programfile_directory)
   {
     parent::__construct();
     $this->fileystem = $filesystem;

--- a/src/Catrobat/Commands/InvalidFileUploadCleanupCommand.php
+++ b/src/Catrobat/Commands/InvalidFileUploadCleanupCommand.php
@@ -53,11 +53,11 @@ class InvalidFileUploadCleanupCommand extends ContainerAwareCommand
     $ids = explode(",\n", $content);
 
     /** @var ProgramRepository $pr */
-    $pr = $this->getContainer()->get('programrepository');
+    $pr = $this->getContainer()->get(ProgramRepository::class);
 
     $fs = new Filesystem();
     /** @var EntityManager $em */
-    $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+    $em = $this->getContainer()->get('doctrine')->getManager();
 
     foreach ($ids as $id)
     {

--- a/src/Catrobat/Commands/InvalidFileUploadCleanupRevertCommand.php
+++ b/src/Catrobat/Commands/InvalidFileUploadCleanupRevertCommand.php
@@ -57,11 +57,11 @@ class InvalidFileUploadCleanupRevertCommand extends ContainerAwareCommand
     $ids = explode(",\n", $content);
 
     /** @var ProgramRepository $pr */
-    $pr = $this->getContainer()->get('programrepository');
+    $pr = $this->getContainer()->get(ProgramRepository::class);
 
     $fs = new Filesystem();
     /** @var EntityManager $em */
-    $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+    $em = $this->getContainer()->get('doctrine')->getManager();
 
     foreach ($ids as $id)
     {

--- a/src/Catrobat/Commands/MigrateRemixGraphsCommand.php
+++ b/src/Catrobat/Commands/MigrateRemixGraphsCommand.php
@@ -2,17 +2,20 @@
 
 namespace App\Catrobat\Commands;
 
+use App\Catrobat\Commands\Helpers\MigrationFileLock;
 use App\Entity\RemixManager;
 use App\Entity\User;
 use App\Catrobat\Services\CatrobatFileExtractor;
 use App\Catrobat\Services\RemixData;
 use App\Entity\Program;
 use App\Catrobat\Services\AsyncHttpClient;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use App\Entity\ProgramManager;
@@ -55,7 +58,7 @@ class MigrateRemixGraphsCommand extends ContainerAwareCommand
   private $remix_manager;
 
   /**
-   * @var EntityManager
+   * @var EntityManagerInterface
    */
   private $entity_manager;
 
@@ -77,16 +80,16 @@ class MigrateRemixGraphsCommand extends ContainerAwareCommand
   /**
    * MigrateRemixGraphsCommand constructor.
    *
-   * @param Filesystem     $filesystem
-   * @param UserManager    $user_manager
+   * @param Filesystem $filesystem
+   * @param UserManager $user_manager
    * @param ProgramManager $program_manager
-   * @param RemixManager   $remix_manager
-   * @param EntityManager  $entity_manager
-   * @param                $app_root_dir
+   * @param RemixManager $remix_manager
+   * @param EntityManagerInterface $entity_manager
+   * @param $kernel_root_dir
    */
   public function __construct(Filesystem $filesystem, UserManager $user_manager,
                                  ProgramManager $program_manager, RemixManager $remix_manager,
-                                 EntityManager $entity_manager, $app_root_dir)
+                                 EntityManagerInterface $entity_manager, $kernel_root_dir)
   {
     parent::__construct();
     $this->file_system = $filesystem;
@@ -95,7 +98,7 @@ class MigrateRemixGraphsCommand extends ContainerAwareCommand
     $this->program_manager = $program_manager;
     $this->remix_manager = $remix_manager;
     $this->entity_manager = $entity_manager;
-    $this->app_root_dir = $app_root_dir;
+    $this->app_root_dir = $kernel_root_dir;
     $this->output = null;
     $this->migration_file_lock = null;
   }
@@ -353,7 +356,7 @@ class MigrateRemixGraphsCommand extends ContainerAwareCommand
   private function extractRemixData($program_file_path, $program_id, $program_name, OutputInterface $output, ProgressBar $progress_bar)
   {
     /** @var CatrobatFileExtractor $file_extractor */
-    $file_extractor = $this->getContainer()->get('fileextractor');
+    $file_extractor = $this->getContainer()->get('App\Catrobat\Services\CatrobatFileExtractor');
     $extracted_file = null;
 
     $progress_bar->setMessage('Extracting XML of program #' . $program_id . ' "' . $program_name . '"');
@@ -502,7 +505,7 @@ class MigrateRemixGraphsCommand extends ContainerAwareCommand
        * @var CatrobatFileExtractor $fileextractor
        * @var $user User
        */
-      $fileextractor = $this->getContainer()->get('fileextractor');
+      $fileextractor = $this->getContainer()->get('App\Catrobat\Services\CatrobatFileExtractor');
       $program_file = new File($program_file_path);
       $extracted_file = $fileextractor->extract($program_file);
 

--- a/src/Catrobat/Commands/ProgramImportCommand.php
+++ b/src/Catrobat/Commands/ProgramImportCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Catrobat\Commands;
 
+use App\Catrobat\Commands\Helpers\RemixManipulationProgramManager;
 use App\Catrobat\RemixGraph\RemixGraphLayout;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/Catrobat/Commands/RecommenderUserSimilaritiesCommand.php
+++ b/src/Catrobat/Commands/RecommenderUserSimilaritiesCommand.php
@@ -2,7 +2,10 @@
 
 namespace App\Catrobat\Commands;
 
+use App\Catrobat\Commands\Helpers\CronjobProgressWriter;
+use App\Catrobat\Commands\Helpers\RecommenderFileLock;
 use App\Catrobat\RecommenderSystem\RecommenderManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -10,6 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use App\Entity\UserManager;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 
 /**
@@ -29,7 +33,7 @@ class RecommenderUserSimilaritiesCommand extends ContainerAwareCommand
   private $recommender_manager;
 
   /**
-   * @var EntityManager
+   * @var EntityManagerInterface
    */
   private $entity_manager;
 
@@ -51,19 +55,19 @@ class RecommenderUserSimilaritiesCommand extends ContainerAwareCommand
   /**
    * RecommenderUserSimilaritiesCommand constructor.
    *
-   * @param UserManager        $user_manager
+   * @param UserManager $user_manager
    * @param RecommenderManager $recommender_manager
-   * @param EntityManager      $entity_manager
-   * @param                    $app_root_dir
+   * @param EntityManagerInterface $entity_manager
+   * @param ParameterBagInterface $parameter_bag
    */
   public function __construct(UserManager $user_manager, RecommenderManager $recommender_manager,
-                              EntityManager $entity_manager, $app_root_dir)
+                              EntityManagerInterface $entity_manager, $kernel_root_dir)
   {
     parent::__construct();
     $this->user_manager = $user_manager;
     $this->recommender_manager = $recommender_manager;
     $this->entity_manager = $entity_manager;
-    $this->app_root_dir = $app_root_dir;
+    $this->app_root_dir = $kernel_root_dir;
     $this->output = null;
     $this->migration_file_lock = null;
   }

--- a/src/Catrobat/Commands/ReflavorExtensionCommand.php
+++ b/src/Catrobat/Commands/ReflavorExtensionCommand.php
@@ -7,6 +7,7 @@ use App\Catrobat\Requests\AppRequest;
 use App\Entity\Program;
 use App\Repository\ProgramRepository;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ReflavorExtensionCommand extends ContainerAwareCommand
 {
   /**
-   * @var EntityManager
+   * @var EntityManagerInterface
    */
   private $em;
   /**
@@ -35,11 +36,11 @@ class ReflavorExtensionCommand extends ContainerAwareCommand
   /**
    * ReflavorExtensionCommand constructor.
    *
-   * @param EntityManager $em
+   * @param EntityManagerInterface $em
    * @param               $program_repo
    * @param AppRequest    $app_request
    */
-  public function __construct(EntityManager $em, ProgramRepository $program_repo, AppRequest $app_request)
+  public function __construct(EntityManagerInterface $em, ProgramRepository $program_repo, AppRequest $app_request)
   {
     parent::__construct();
     $this->em = $em;

--- a/src/Catrobat/Commands/RestoreBackupCommand.php
+++ b/src/Catrobat/Commands/RestoreBackupCommand.php
@@ -83,7 +83,7 @@ class RestoreBackupCommand extends ContainerAwareCommand
       @unlink($local_resource_directory . 'database.sql');
 
       /* @var $em \Doctrine\ORM\EntityManager */
-      $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+      $em = $this->getContainer()->get('doctrine')->getManager();
       $query = $em->createQuery("UPDATE App\Entity\Program p SET p.apk_status = :status WHERE p.apk_status != :status");
       $query->setParameter('status', Program::APK_NONE);
       $result = $query->getSingleScalarResult();

--- a/src/Catrobat/Controller/Admin/ApkController.php
+++ b/src/Catrobat/Controller/Admin/ApkController.php
@@ -55,7 +55,7 @@ class ApkController extends CRUDController
       throw new NotFoundHttpException();
     }
 
-    $dispatcher = $this->container->get('ci.jenkins.dispatcher');
+    $dispatcher = $this->container->get('App\Catrobat\Services\Ci\JenkinsDispatcher');
     $dispatcher->sendBuildRequest($object->getId());
 
     $object->setApkRequestTime(new \DateTime());
@@ -112,7 +112,7 @@ class ApkController extends CRUDController
     $datagrid = $this->admin->getDatagrid();
 
     $objects = $datagrid->getResults();
-    $dispatcher = $this->container->get('ci.jenkins.dispatcher');
+    $dispatcher = $this->container->get('App\Catrobat\Services\Ci\JenkinsDispatcher');
 
     foreach ($objects as $program)
     {

--- a/src/Catrobat/Controller/Admin/EmailUserMessageController.php
+++ b/src/Catrobat/Controller/Admin/EmailUserMessageController.php
@@ -27,19 +27,18 @@ class EmailUserMessageController extends CRUDController
   }
 
   /**
+   * @param Request $request
    * @param \Swift_Mailer $mailer
-   * @param Request       $request
+   * @param UserManager $user_manager
    *
    * @return Response
    */
-  public function sendAction(\Swift_Mailer $mailer, Request $request)
+  public function sendAction(Request $request, \Swift_Mailer $mailer, UserManager $user_manager)
   {
     /**
-     * @var $userManager UserManager
      * @var $user        User
      */
-    $userManager = $this->get('usermanager');
-    $user = $userManager->findUserByUsername($request->get('username'));
+    $user = $user_manager->findUserByUsername($request->get('username'));
     if (!$user)
     {
       return new Response("User does not exist");

--- a/src/Catrobat/Controller/Admin/ExtensionController.php
+++ b/src/Catrobat/Controller/Admin/ExtensionController.php
@@ -2,20 +2,14 @@
 
 namespace App\Catrobat\Controller\Admin;
 
-use App\Catrobat\Commands\CleanApkCommand;
-use App\Catrobat\Commands\CleanExtractedFileCommand;
-use App\Catrobat\Commands\CleanBackupsCommand;
-use App\Catrobat\Commands\CreateBackupCommand;
 use App\Catrobat\Commands\CreateProgramExtensionsCommand;
 use App\Repository\ProgramRepository;
 use Doctrine\ORM\EntityManager;
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Process\Process;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 
@@ -28,7 +22,7 @@ class ExtensionController extends Controller
 
   /**
    * @return RedirectResponse
-   * @throws \Exception
+   * @throws \Symfony\Component\Console\Exception\ExceptionInterface
    */
   public function extensionsAction()
   {
@@ -44,7 +38,7 @@ class ExtensionController extends Controller
 
     $em = $this->getDoctrine()->getManager();
     $program_file_dir = $this->get('kernel')->getRootDir() . "/../public/resources/programs/";
-    $program_repo = $this->container->get('programrepository');
+    $program_repo = $this->container->get(ProgramRepository::class);
 
     $command = new CreateProgramExtensionsCommand($em, $program_file_dir, $program_repo);
     $command->setContainer($this->container);

--- a/src/Catrobat/Controller/Admin/TemplateController.php
+++ b/src/Catrobat/Controller/Admin/TemplateController.php
@@ -4,6 +4,7 @@
 namespace App\Catrobat\Controller\Admin;
 
 use App\Catrobat\Services\TemplateService;
+use App\Entity\Template;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -17,8 +18,16 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class TemplateController extends CRUDController
 {
 
+  private $template_service;
+
+  public function __construct(TemplateService $template_service)
+  {
+    $this->template_service = $template_service;
+  }
+
   /**
-   * @return \Symfony\Component\HttpFoundation\Response
+   * @return Response
+   * @throws \ImagickException
    */
   public function createAction()
   {
@@ -44,9 +53,10 @@ class TemplateController extends CRUDController
 
 
   /**
-   * @param int|null $id
+   * @param null $id
    *
    * @return RedirectResponse|Response
+   * @throws \ImagickException
    */
   public function editAction($id = null)
   {
@@ -58,13 +68,13 @@ class TemplateController extends CRUDController
 
 
   /**
-   *
+   * @throws \ImagickException
    */
   private function saveFiles()
   {
     /**
      * @var $templateService TemplateService
-     * @var $template \App\Entity\Template
+     * @var $template Template
      */
     $template = $this->getTemplate();
     if ($template->getId() != null)
@@ -80,7 +90,7 @@ class TemplateController extends CRUDController
    */
   private function getTemplateService()
   {
-    return $this->get("template_service");
+    return $this->template_service;
   }
 
 

--- a/src/Catrobat/Controller/Api/FeaturedController.php
+++ b/src/Catrobat/Controller/Api/FeaturedController.php
@@ -4,10 +4,10 @@ namespace App\Catrobat\Controller\Api;
 
 use App\Entity\FeaturedProgram;
 use Doctrine\ORM\NonUniqueResultException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use App\Repository\FeaturedRepository;
 use App\Catrobat\Services\FeaturedImageRepository;
 
@@ -16,7 +16,7 @@ use App\Catrobat\Services\FeaturedImageRepository;
  * Class FeaturedController
  * @package App\Catrobat\Controller\Api
  */
-class FeaturedController extends Controller
+class FeaturedController extends AbstractController
 {
 
   /**
@@ -24,13 +24,16 @@ class FeaturedController extends Controller
    *   defaults={"_format": "json"}, methods={"GET"})
    *
    * @param Request $request
+   * @param FeaturedImageRepository $image_repository
+   * @param FeaturedRepository $repository
    *
    * @return JsonResponse
    * @throws NonUniqueResultException
    */
-  public function getFeaturedProgramsAction(Request $request)
+  public function getFeaturedProgramsAction(Request $request, FeaturedImageRepository $image_repository,
+                                            FeaturedRepository $repository)
   {
-    return $this->getFeaturedPrograms($request, false);
+    return $this->getFeaturedPrograms($request, false, $image_repository, $repository);
   }
 
 
@@ -39,33 +42,36 @@ class FeaturedController extends Controller
    *   defaults={"_format": "json"}, methods={"GET"})
    *
    * @param Request $request
+   * @param FeaturedImageRepository $image_repository
+   * @param FeaturedRepository $repository
    *
    * @return JsonResponse
    * @throws NonUniqueResultException
    */
-  public function getFeaturedIOSProgramsAction(Request $request)
+  public function getFeaturedIOSProgramsAction(Request $request, FeaturedImageRepository $image_repository,
+                                               FeaturedRepository $repository)
   {
-    return $this->getFeaturedPrograms($request, true);
+    return $this->getFeaturedPrograms($request, true, $image_repository, $repository);
   }
 
 
   /**
    * @param Request $request
-   * @param         $ios_only
+   * @param $ios_only
+   * @param FeaturedImageRepository $image_repository
+   * @param FeaturedRepository $repository
    *
    * @return JsonResponse
    * @throws NonUniqueResultException
    */
-  private function getFeaturedPrograms(Request $request, $ios_only)
+  private function getFeaturedPrograms(Request $request, $ios_only, FeaturedImageRepository $image_repository,
+                                       FeaturedRepository $repository)
   {
     /**
      * @var $image_repository FeaturedImageRepository
      * @var $repository FeaturedRepository
      * @var $featured_program FeaturedProgram
      */
-
-    $image_repository = $this->get('featuredimagerepository');
-    $repository = $this->get('featuredrepository');
 
     $flavor = $request->get('flavor');
 

--- a/src/Catrobat/Controller/Api/ListProgramsController.php
+++ b/src/Catrobat/Controller/Api/ListProgramsController.php
@@ -5,8 +5,8 @@ namespace App\Catrobat\Controller\Api;
 use App\Entity\ProgramManager;
 use Doctrine\DBAL\Types\GuidType;
 use Doctrine\ORM\NonUniqueResultException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Routing\Annotation\Route;
 use App\Catrobat\Responses\ProgramListResponse;
 
@@ -15,8 +15,18 @@ use App\Catrobat\Responses\ProgramListResponse;
  * Class ListProgramsController
  * @package App\Catrobat\Controller\Api
  */
-class ListProgramsController extends Controller
+class ListProgramsController extends AbstractController
 {
+
+  /**
+   * @var ProgramManager
+   */
+  private $program_manager;
+
+  public function __construct(ProgramManager $program_manager)
+  {
+    $this->program_manager = $program_manager;
+  }
 
   /**
    * @Route("/api/projects/recent.json", name="api_recent_programs",
@@ -177,38 +187,36 @@ class ListProgramsController extends Controller
     }
 
     /**
-     * @var ProgramManager $program_manager
      * @var GuidType $user_id
      */
-    $program_manager = $this->get('programmanager');
     $limit = intval($request->get('limit', 20));
     $offset = intval($request->get('offset', 0));
     $user_id = $request->get('user_id', 0);
 
     if ($sortBy == 'downloads')
     {
-      $programs = $program_manager->getMostDownloadedPrograms($flavor, $limit, $offset);
+      $programs = $this->program_manager->getMostDownloadedPrograms($flavor, $limit, $offset);
 
       $count = count($programs);
       if ($count != $limit && $flavor)
       {
-        $flavor_count = $program_manager->getTotalPrograms($flavor);
+        $flavor_count = $this->program_manager->getTotalPrograms($flavor);
         $new_offset = max($offset - $flavor_count + $count, 0);
-        $programs = array_merge($programs, $program_manager->getMostDownloadedPrograms(
+        $programs = array_merge($programs, $this->program_manager->getMostDownloadedPrograms(
           '!' . $flavor, $limit - $count, $new_offset
         ));
       }
     }
     elseif ($sortBy == 'views')
     {
-      $programs = $program_manager->getMostViewedPrograms($flavor, $limit, $offset);
+      $programs = $this->program_manager->getMostViewedPrograms($flavor, $limit, $offset);
 
       $count = count($programs);
       if ($count != $limit && $flavor)
       {
-        $flavor_count = $program_manager->getTotalPrograms($flavor);
+        $flavor_count = $this->program_manager->getTotalPrograms($flavor);
         $new_offset = max($offset - $flavor_count + $count, 0);
-        $programs = array_merge($programs, $program_manager->getMostViewedPrograms(
+        $programs = array_merge($programs, $this->program_manager->getMostViewedPrograms(
           '!' . $flavor, $limit - $count, $new_offset
         ));
       }
@@ -216,36 +224,36 @@ class ListProgramsController extends Controller
     elseif ($sortBy == 'user')
     {
       if ($this->getUser() !== null && $this->getUser()->getId() === $user_id) {
-        $programs = $program_manager->getUserPrograms($user_id);
+        $programs = $this->program_manager->getUserPrograms($user_id);
       }
       else {
-        $programs = $program_manager->getPublicUserPrograms($user_id);
+        $programs = $this->program_manager->getPublicUserPrograms($user_id);
       }
     }
     elseif ($sortBy == 'random')
     {
-      $programs = $program_manager->getRandomPrograms($flavor, $limit, $offset);
+      $programs = $this->program_manager->getRandomPrograms($flavor, $limit, $offset);
 
       $count = count($programs);
       if ($count != $limit && $flavor)
       {
-        $flavor_count = $program_manager->getTotalPrograms($flavor);
+        $flavor_count = $this->program_manager->getTotalPrograms($flavor);
         $new_offset = max($offset - $flavor_count + $count, 0);
-        $programs = array_merge($programs, $program_manager->getRandomPrograms(
+        $programs = array_merge($programs, $this->program_manager->getRandomPrograms(
           '!' . $flavor, $limit - $count, $new_offset
         ));
       }
     }
     else
     {
-      $programs = $program_manager->getRecentPrograms($flavor, $limit, $offset);
+      $programs = $this->program_manager->getRecentPrograms($flavor, $limit, $offset);
 
       $count = count($programs);
       if ($count != $limit && $flavor)
       {
-        $flavor_count = $program_manager->getTotalPrograms($flavor);
+        $flavor_count = $this->program_manager->getTotalPrograms($flavor);
         $new_offset = max($offset - $flavor_count + $count, 0);
-        $programs = array_merge($programs, $program_manager->getRecentPrograms(
+        $programs = array_merge($programs, $this->program_manager->getRecentPrograms(
           '!' . $flavor, $limit - $count, $new_offset
         ));
       }
@@ -257,11 +265,11 @@ class ListProgramsController extends Controller
     }
     else
     {
-      $numbOfTotalProjects = $program_manager->getTotalPrograms($flavor);
+      $numbOfTotalProjects = $this->program_manager->getTotalPrograms($flavor);
 
       if ($flavor)
       {
-        $numbOfTotalProjects += $program_manager->getTotalPrograms('!' . $flavor);
+        $numbOfTotalProjects += $this->program_manager->getTotalPrograms('!' . $flavor);
       }
     }
 

--- a/src/Catrobat/Controller/Api/MediaPackageController.php
+++ b/src/Catrobat/Controller/Api/MediaPackageController.php
@@ -6,7 +6,7 @@ use App\Entity\MediaPackage;
 use App\Entity\MediaPackageCategory;
 use App\Entity\MediaPackageFile;
 use App\Catrobat\StatusCode;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  * Class MediaPackageController
  * @package App\Catrobat\Controller\Api
  */
-class MediaPackageController extends Controller
+class MediaPackageController extends AbstractController
 {
 
   /**

--- a/src/Catrobat/Controller/Api/ProgramController.php
+++ b/src/Catrobat/Controller/Api/ProgramController.php
@@ -4,7 +4,7 @@ namespace App\Catrobat\Controller\Api;
 
 use App\Catrobat\Responses\ProgramListResponse;
 use App\Entity\ProgramManager;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -14,20 +14,20 @@ use Symfony\Component\Routing\Annotation\Route;
  * Class ProgramController
  * @package App\Catrobat\Controller\Api
  */
-class ProgramController extends Controller
+class ProgramController extends AbstractController
 {
   /**
    * @Route("/api/projects/getInfoById.json", name="api_info_by_id", defaults={"_format": "json"}, methods={"GET"})
    *
    * @param Request $request
+   * @param ProgramManager $program_manager
    *
    * @return ProgramListResponse|JsonResponse
    */
-  public function showProgramAction(Request $request)
+  public function showProgramAction(Request $request, ProgramManager $program_manager)
   {
     /** @var ProgramManager $program_manager */
     $id = $request->get('id', 0);
-    $program_manager = $this->get('programmanager');
 
     $programs = [];
     $program = $program_manager->find($id);

--- a/src/Catrobat/Controller/Api/RecommenderController.php
+++ b/src/Catrobat/Controller/Api/RecommenderController.php
@@ -5,22 +5,24 @@ namespace App\Catrobat\Controller\Api;
 use App\Catrobat\RecommenderSystem\RecommenderManager;
 use App\Catrobat\Responses\ProgramListResponse;
 use App\Catrobat\StatusCode;
+use App\Entity\UserManager;
 use Doctrine\DBAL\Types\GuidType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use App\Entity\Program;
 use App\Entity\ProgramManager;
 use App\Entity\UserTestGroup;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpKernel\HttpKernel;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Class RecommenderController
  * @package App\Catrobat\Controller\Api
  */
-class RecommenderController extends Controller
+class RecommenderController extends AbstractController
 {
-
   /**
    * @var int
    */
@@ -31,23 +33,20 @@ class RecommenderController extends Controller
    */
   private $DEFAULT_OFFSET = 0;
 
-
   /**
-   * @Route("/api/projects/recsys.json", name="api_recsys_programs", defaults={"_format": "json"},
-   *   methods={"GET"})
+   *  @Route("/api/projects/recsys.json", name="api_recsys_programs", defaults={"_format": "json"}, methods={"GET"})
    *
    * @param Request $request
+   * @param ProgramManager $program_manager
    *
    * @return ProgramListResponse
    */
-  public function listRecsysProgramAction(Request $request)
+  public function listRecsysProgramAction(Request $request, ProgramManager $program_manager)
   {
     $limit = intval($request->query->get('limit', $this->DEFAULT_LIMIT));
     $offset = intval($request->query->get('offset', $this->DEFAULT_OFFSET));
     $program_id = $request->query->get('program_id');
 
-    /** @var ProgramManager $program_manager */
-    $program_manager = $this->get('programmanager');
     $flavor = $request->get('flavor');
 
     $programs_count = $program_manager->getRecommendedProgramsCount($program_id, $flavor);
@@ -58,22 +57,21 @@ class RecommenderController extends Controller
 
 
   /**
-   * @Route("/api/projects/recsys_specific_projects/{id}.json", name="api_recsys_specific_projects",
+   *  @Route("/api/projects/recsys_specific_projects/{id}.json", name="api_recsys_specific_projects",
    *   defaults={"_format": "json"},  methods={"GET"})
    *
    * @param Request $request
-   * @param GuidType $id
+   * @param $id
+   * @param ProgramManager $program_manager
    *
    * @return ProgramListResponse|JsonResponse
    */
-  public function listRecsysSpecificProgramsAction(Request $request, $id)
+  public function listRecsysSpecificProgramsAction(Request $request, $id, ProgramManager $program_manager)
   {
-    $is_test_environment = ($this->get('kernel')->getEnvironment() == 'test');
+    $is_test_environment = ($this->getParameter('kernel.environment') == 'test');
     $limit = intval($request->query->get('limit', $this->DEFAULT_LIMIT));
     $offset = intval($request->query->get('offset', $this->DEFAULT_OFFSET));
 
-    /** @var ProgramManager $program_manager */
-    $program_manager = $this->get('programmanager');
     $flavor = $request->get('flavor');
 
     /** @var Program $program */
@@ -96,12 +94,14 @@ class RecommenderController extends Controller
    *   defaults={"_format":"json"}, methods={"GET"})
    *
    * @param Request $request
+   * @param UserManager $user_manager
+   * @param RecommenderManager $recommender_manager
    *
    * @return ProgramListResponse
    */
-  public function listRecsysGeneralProgramsAction(Request $request)
+  public function listRecsysGeneralProgramsAction(Request $request, UserManager $user_manager, RecommenderManager $recommender_manager)
   {
-    $is_test_environment = ($this->get('kernel')->getEnvironment() == 'test');
+    $is_test_environment = ( $this->getParameter('kernel.environment') == 'test');
     $test_user_id_for_like_recommendation = $is_test_environment ?
       $request->query->get('test_user_id_for_like_recommendation', 0) : "";
     $limit = intval($request->query->get('limit', $this->DEFAULT_LIMIT));
@@ -114,10 +114,8 @@ class RecommenderController extends Controller
     $is_user_specific_recommendation = false;
 
     $user = ($test_user_id_for_like_recommendation == "") ?
-      $this->getUser() : $this->get('usermanager')->find($test_user_id_for_like_recommendation);
+      $this->getUser() : $user_manager->find($test_user_id_for_like_recommendation);
 
-    /** @var RecommenderManager $recommender_manager */
-    $recommender_manager = $this->get('recommendermanager');
 
     /*
      * This part of the Recommender Controller is currently modified due to an online

--- a/src/Catrobat/Controller/Api/ReportController.php
+++ b/src/Catrobat/Controller/Api/ReportController.php
@@ -5,20 +5,22 @@ namespace App\Catrobat\Controller\Api;
 use App\Entity\Program;
 use App\Entity\User;
 use App\Catrobat\Events\ReportInsertEvent;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use App\Entity\ProgramManager;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use App\Catrobat\StatusCode;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use App\Entity\ProgramInappropriateReport;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 
 /**
  * Class ReportController
  * @package App\Catrobat\Controller\Api
  */
-class ReportController extends Controller
+class ReportController extends AbstractController
 {
 
   /**
@@ -26,24 +28,26 @@ class ReportController extends Controller
    *   defaults={"_format": "json"}, methods={"POST", "GET"})
    *
    * @param Request $request
+   * @param ProgramManager $program_manager
+   * @param TranslatorInterface $translator
+   * @param EventDispatcherInterface $event_dispatcher
    *
    * @return JsonResponse
    */
-  public function reportProgramAction(Request $request)
+  public function reportProgramAction(Request $request, ProgramManager $program_manager,
+                                      TranslatorInterface $translator, EventDispatcherInterface $event_dispatcher)
   {
     /* @var $program_manager ProgramManager */
     /* @var $program Program */
     /* @var $user User */
 
-    $program_manager = $this->get('programmanager');
     $entity_manager = $this->getDoctrine()->getManager();
-    $event_dispatcher = $this->get('event_dispatcher');
 
     $response = [];
     if (!$request->get('program') || !$request->get('category') || !$request->get('note'))
     {
       $response['statusCode'] = StatusCode::MISSING_POST_DATA;
-      $response['answer'] = $this->trans('errors.post-data');
+      $response['answer'] = $translator->trans('errors.post-data', [], 'catroweb');
       $response['preHeaderMessages'] = '';
 
       return JsonResponse::create($response);
@@ -53,7 +57,7 @@ class ReportController extends Controller
     if ($program == null)
     {
       $response['statusCode'] = StatusCode::INVALID_PROGRAM;
-      $response['answer'] = $this->trans('errors.program.invalid');
+      $response['answer'] = $translator->trans('errors.program.invalid', [], 'catroweb');
       $response['preHeaderMessages'] = '';
 
       return JsonResponse::create($response);
@@ -83,20 +87,9 @@ class ReportController extends Controller
       new ReportInsertEvent($request->get('category'), $request->get('note'), $report));
 
     $response = [];
-    $response['answer'] = $this->trans('success.report');
+    $response['answer'] = $translator->trans('success.report', [], 'catroweb');
     $response['statusCode'] = StatusCode::OK;
 
     return JsonResponse::create($response);
-  }
-
-  /**
-   * @param       $message
-   * @param array $parameters
-   *
-   * @return string
-   */
-  private function trans($message, $parameters = [])
-  {
-    return $this->get('translator')->trans($message, $parameters, 'catroweb');
   }
 }

--- a/src/Catrobat/Controller/Api/SearchController.php
+++ b/src/Catrobat/Controller/Api/SearchController.php
@@ -4,7 +4,7 @@ namespace App\Catrobat\Controller\Api;
 
 use App\Catrobat\Responses\ProgramListResponse;
 use App\Entity\ProgramManager;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\Annotation\Route;
  * Class SearchController
  * @package App\Catrobat\Controller\Api
  */
-class SearchController extends Controller
+class SearchController extends AbstractController
 {
 
   /**
@@ -32,13 +32,12 @@ class SearchController extends Controller
    *    methods={"GET"})
    *
    * @param Request $request
+   * @param ProgramManager $program_manager
    *
    * @return ProgramListResponse
    */
-  public function searchProgramsAction(Request $request)
+  public function searchProgramsAction(Request $request, ProgramManager $program_manager)
   {
-    /** @var ProgramManager $program_manager */
-    $program_manager = $this->get('programmanager');
     $query = $request->query->get('q');
 
     $query = str_replace("yahoo", "", $query);
@@ -64,13 +63,12 @@ class SearchController extends Controller
    *   defaults={"_format":"json"}, methods={"GET"})
    *
    * @param Request $request
+   * @param ProgramManager $program_manager
    *
    * @return ProgramListResponse
    */
-  public function tagSearchProgramsAction(Request $request)
+  public function tagSearchProgramsAction(Request $request, ProgramManager $program_manager)
   {
-    /** @var ProgramManager $program_manager */
-    $program_manager = $this->get('programmanager');
     $query = $request->query->get('q');
     $limit = intval($request->query->get('limit', $this->DEFAULT_LIMIT));
     $offset = intval($request->query->get('offset', $this->DEFAULT_OFFSET));
@@ -87,13 +85,11 @@ class SearchController extends Controller
    *                                                       defaults={"_format": "json"},
    *                                                       methods={"GET"})
    * @param Request $request
-   *
+   * @param ProgramManager $program_manager
    * @return ProgramListResponse
    */
-  public function extensionSearchProgramsAction(Request $request)
+  public function extensionSearchProgramsAction(Request $request, ProgramManager $program_manager)
   {
-    /** @var ProgramManager $program_manager */
-    $program_manager = $this->get('programmanager');
     $query = $request->query->get('q');
     $limit = intval($request->query->get('limit', $this->DEFAULT_LIMIT));
     $offset = intval($request->query->get('offset', $this->DEFAULT_OFFSET));

--- a/src/Catrobat/Controller/Api/SecurityController.php
+++ b/src/Catrobat/Controller/Api/SecurityController.php
@@ -4,38 +4,60 @@ namespace App\Catrobat\Controller\Api;
 
 use App\Catrobat\Services\OAuthService;
 use App\Catrobat\Services\TestEnv\FakeOAuthService;
+use App\Catrobat\Services\TokenGenerator;
 use App\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Request;
 use App\Entity\UserManager;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use App\Catrobat\StatusCode;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use App\Catrobat\Requests\LoginUserRequest;
 use App\Catrobat\Requests\CreateUserRequest;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use App\Catrobat\Security\UserAuthenticator;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 
 /**
  * Class SecurityController
  * @package App\Catrobat\Controller\Api
  */
-class SecurityController extends Controller
+class SecurityController extends AbstractController
 {
+
+  /**
+   * @var OAuthService|FakeOAuthService
+   */
+  private $oauth_service;
+
+  /**
+   * SecurityController constructor.
+   *
+   * @param OAuthService $oauth_service
+   */
+  public function __construct(OAuthService $oauth_service)
+  {
+    $this->oauth_service = $oauth_service;
+  }
 
   /**
    * @Route("/api/checkToken/check.json", name="catrobat_api_check_token", defaults={"_format": "json"},
    *                                      methods={"POST"})
+   * 
+   * @param TranslatorInterface $translator
    *
    * @return JsonResponse
    */
-  public function checkTokenAction()
+  public function checkTokenAction(TranslatorInterface $translator)
   {
     return JsonResponse::create([
       'statusCode'        => StatusCode::OK,
-      'answer'            => $this->trans('success.token'),
+      'answer'            => $translator->trans('success.token', [], 'catroweb'),
       'preHeaderMessages' => "  \n",
     ]);
   }
@@ -46,24 +68,25 @@ class SecurityController extends Controller
    *
    * @Route("/api/loginOrRegister/loginOrRegister.json", name="catrobat_api_login_or_register", defaults={"_format":
    *                                                     "json"}, methods={"POST"})
-   *
    * @param Request $request
+   * @param UserManager $user_manager
+   * @param TokenGenerator $token_generator
+   * @param TranslatorInterface $translator
+   * @param UserAuthenticator $user_authenticator
+   * @param ValidatorInterface $validator
    *
    * @return JsonResponse
    */
-  public function loginOrRegisterAction(Request $request)
+  public function loginOrRegisterAction(Request $request, UserManager $user_manager, TokenGenerator $token_generator,
+                                        TranslatorInterface $translator, UserAuthenticator $user_authenticator,
+                                        ValidatorInterface $validator)
   {
     /**
-     * @var $userManager UserManager
      * @var $user        User
      */
-    $userManager = $this->get('usermanager');
-    $tokenGenerator = $this->get("tokengenerator");
-    $validator = $this->get('validator');
-
     $retArray = [];
 
-    $this->signInLdapUser($request, $retArray);
+    $this->signInLdapUser($request, $retArray, $user_authenticator, $translator);
     if (array_key_exists('statusCode', $retArray) && ($retArray['statusCode'] === StatusCode::OK || $retArray['statusCode'] === StatusCode::LOGIN_ERROR))
     {
       return JsonResponse::create($retArray);
@@ -84,38 +107,39 @@ class SecurityController extends Controller
           $retArray['statusCode'] = StatusCode::USER_EMAIL_INVALID;
           break;
       }
-      $retArray['answer'] = $this->trans($violation->getMessageTemplate(), $violation->getParameters());
+      $retArray['answer'] = $translator->trans($violation->getMessageTemplate(), $violation->getParameters(), 'catroweb');
+
       break;
     }
 
     if (count($violations) == 0)
     {
-      if ($userManager->findUserByEmail($create_request->mail) != null)
+      if ($user_manager->findUserByEmail($create_request->mail) != null)
       {
         $retArray['statusCode'] = StatusCode::USER_ADD_EMAIL_EXISTS;
-        $retArray['answer'] = $this->trans('errors.email.exists');
+        $retArray['answer'] = $translator->trans('errors.email.exists', [], 'catroweb');
       }
       else
       {
-        $user = $userManager->createUser();
+        $user = $user_manager->createUser();
         $user->setUsername($create_request->username);
         $user->setEmail($create_request->mail);
         $user->setPlainPassword($create_request->password);
         $user->setEnabled(true);
-        $user->setUploadToken($tokenGenerator->generateToken());
+        $user->setUploadToken($token_generator->generateToken());
         $user->setCountry($create_request->country);
 
         $violations = $validator->validate($user);
         if (count($violations) > 0)
         {
           $retArray['statusCode'] = StatusCode::LOGIN_ERROR;
-          $retArray['answer'] = $this->trans('errors.login');
+          $retArray['answer'] = $translator->trans('errors.login', [], 'catroweb');
         }
         else
         {
-          $userManager->updateUser($user);
+          $user_manager->updateUser($user);
           $retArray['statusCode'] = 201;
-          $retArray['answer'] = $this->trans('success.registration');
+          $retArray['answer'] = $translator->trans('success.registration', [], 'catroweb');
           $retArray['token'] = $user->getUploadToken();
         }
       }
@@ -131,19 +155,19 @@ class SecurityController extends Controller
    *                                       "json"}, methods={"POST"})
    *
    * @param Request $request
+   * @param UserManager $user_manager
+   * @param TokenGenerator $token_generator
+   * @param TranslatorInterface $translator
+   * @param ValidatorInterface $validator
    *
    * @return JsonResponse
    */
-  public function registerNativeUser(Request $request)
+  public function registerNativeUser(Request $request, UserManager $user_manager, TokenGenerator $token_generator,
+                                     TranslatorInterface $translator, ValidatorInterface $validator)
   {
     /**
-     * @var $userManager UserManager
      * @var $user        User
      */
-    $userManager = $this->get("usermanager");
-    $tokenGenerator = $this->get("tokengenerator");
-    $validator = $this->get("validator");
-
     $retArray = [];
 
     $create_request = new CreateUserRequest($request);
@@ -160,37 +184,37 @@ class SecurityController extends Controller
           $retArray['statusCode'] = StatusCode::USER_EMAIL_INVALID;
           break;
       }
-      $retArray['answer'] = $this->trans($violation->getMessageTemplate(), $violation->getParameters());
+      $retArray['answer'] = $translator->trans($violation->getMessageTemplate(), $violation->getParameters(), 'catroweb');
       break;
     }
 
     if (count($violations) == 0)
     {
-      if ($userManager->findUserByEmail($create_request->mail) != null)
+      if ($user_manager->findUserByEmail($create_request->mail) != null)
       {
         $retArray['statusCode'] = StatusCode::USER_ADD_EMAIL_EXISTS;
-        $retArray['answer'] = $this->trans("errors.email.exists");
+        $retArray['answer'] = $translator->trans('errors.email.exists', [], 'catroweb');
       }
       else
       {
-        if ($userManager->findUserByUsername($create_request->username) != null)
+        if ($user_manager->findUserByUsername($create_request->username) != null)
         {
           $retArray['statusCode'] = StatusCode::USER_ADD_USERNAME_EXISTS;
-          $retArray['answer'] = $this->trans("errors.username.exists");
+          $retArray['answer'] = $translator->trans('errors.username.exists', [], 'catroweb');
         }
         else
         {
-          $user = $userManager->createUser();
+          $user = $user_manager->createUser();
           $user->setUsername($create_request->username);
           $user->setEmail($create_request->mail);
           $user->setPlainPassword($create_request->password);
           $user->setEnabled(true);
-          $user->setUploadToken($tokenGenerator->generateToken());
+          $user->setUploadToken($token_generator->generateToken());
           $user->setCountry($create_request->country);
 
-          $userManager->updateUser($user);
+          $user_manager->updateUser($user);
           $retArray['statusCode'] = 201;
-          $retArray['answer'] = $this->trans("success.registration");
+          $retArray['answer'] = $translator->trans('success.registration', [], 'catroweb');
           $retArray['token'] = $user->getUploadToken();
         }
       }
@@ -203,21 +227,23 @@ class SecurityController extends Controller
   /**
    * @Route("/api/login/Login.json", name="catrobat_api_login", options={"expose"=true}, defaults={"_format": "json"},
    *                                 methods={"POST"})
-   *
    * @param Request $request
+   * @param UserManager $user_manager
+   * @param TokenGenerator $token_generator
+   * @param TranslatorInterface $translator
+   * @param UserAuthenticator $user_authenticator
+   * @param ValidatorInterface $validator
+   * @param EncoderFactoryInterface $factory
    *
    * @return JsonResponse
    */
-  public function loginNativeUser(Request $request)
+  public function loginNativeUser(Request $request, UserManager $user_manager, TokenGenerator $token_generator,
+                                  TranslatorInterface $translator, UserAuthenticator $user_authenticator,
+                                  ValidatorInterface $validator, EncoderFactoryInterface $factory)
   {
     /**
-     * @var $userManager UserManager
      * @var $user        User
      */
-
-    $userManager = $this->get("usermanager");
-    $tokenGenerator = $this->get("tokengenerator");
-    $validator = $this->get("validator");
     $retArray = [];
 
     $login_request = new LoginUserRequest($request);
@@ -234,7 +260,7 @@ class SecurityController extends Controller
           $retArray['statusCode'] = StatusCode::USER_EMAIL_INVALID;
           break;
       }
-      $retArray['answer'] = $this->trans($violation->getMessageTemplate(), $violation->getParameters());
+      $retArray['answer'] = $translator->trans($violation->getMessageTemplate(), $violation->getParameters(), 'catroweb');
       break;
     }
 
@@ -250,41 +276,44 @@ class SecurityController extends Controller
       $username = $request->request->get('registrationUsername');
       $password = $request->request->get('registrationPassword');
 
-      $user = $userManager->findUserByUsername($username);
+      $user = $user_manager->findUserByUsername($username);
 
       if (!$user)
       {
-        $this->signInLdapUser($request, $retArray);
-        if (array_key_exists('statusCode', $retArray) && ($retArray['statusCode'] === StatusCode::OK || $retArray['statusCode'] === StatusCode::LOGIN_ERROR))
+        $this->signInLdapUser($request, $retArray, $user_authenticator, $translator);
+        if (array_key_exists('statusCode', $retArray) &&
+          ($retArray['statusCode'] === StatusCode::OK
+            || $retArray['statusCode'] === StatusCode::LOGIN_ERROR
+            || $retArray['statusCode'] === StatusCode::USERNAME_NOT_FOUND
+          ))
         {
           return JsonResponse::create($retArray);
         }
         $retArray['statusCode'] = StatusCode::USER_USERNAME_INVALID;
-        $retArray['answer'] = $this->trans('errors.username.not_exists');
+        $retArray['answer'] = $translator->trans('errors.username.exists', [], 'catroweb');
       }
       else
       {
-        $factory = $this->get('security.encoder_factory');
         $encoder = $factory->getEncoder($user);
-        $correct_pass = $userManager->isPasswordValid($user, $password, $encoder);
+        $correct_pass = $user_manager->isPasswordValid($user, $password, $encoder);
         $dd = null;
         if ($correct_pass)
         {
           $retArray['statusCode'] = StatusCode::OK;
-          $user->setUploadToken($tokenGenerator->generateToken());
+          $user->setUploadToken($token_generator->generateToken());
           $retArray['token'] = $user->getUploadToken();
           $retArray['email'] = $user->getEmail();
-          $userManager->updateUser($user);
+          $user_manager->updateUser($user);
         }
         else
         {
-          $this->signInLdapUser($request, $retArray);
+          $this->signInLdapUser($request, $retArray, $user_authenticator, $translator);
           if (array_key_exists('statusCode', $retArray) && ($retArray['statusCode'] === StatusCode::OK || $retArray['statusCode'] === StatusCode::LOGIN_ERROR))
           {
             return JsonResponse::create($retArray);
           }
           $retArray['statusCode'] = StatusCode::LOGIN_ERROR;
-          $retArray['answer'] = $this->trans("errors.login");
+          $retArray['answer'] = $translator->trans('errors.login', [], 'catroweb');
         }
       }
     }
@@ -298,15 +327,13 @@ class SecurityController extends Controller
   /**
    * @param $request
    * @param $retArray
+   * @param UserAuthenticator $authenticator
+   * @param TranslatorInterface $translator
    *
    * @return JsonResponse
    */
-  private function signInLdapUser($request, &$retArray)
+  private function signInLdapUser($request, &$retArray, UserAuthenticator $authenticator, TranslatorInterface $translator)
   {
-    /**
-     * @var $authenticator UserAuthenticator
-     */
-    $authenticator = $this->get('user_authenticator');
     $token = null;
     $username = $request->request->get('registrationUsername');
 
@@ -317,16 +344,18 @@ class SecurityController extends Controller
       $retArray['token'] = $token->getUser()->getUploadToken();
       $retArray['preHeaderMessages'] = '';
 
-      return JsonResponse::create($retArray);
     } catch (UsernameNotFoundException $exception)
     {
-      $user = null;
+      $retArray['statusCode'] = StatusCode::USERNAME_NOT_FOUND;
+      $retArray['answer'] = $translator->trans('errors.username.not_exists', [], 'catroweb');
+      $retArray['preHeaderMessages'] = '';
+      return JsonResponse::create($retArray);
+
     } catch (AuthenticationException $exception)
     {
       $retArray['statusCode'] = StatusCode::LOGIN_ERROR;
-      $retArray['answer'] = $this->trans('errors.login');
+      $retArray['answer'] = $translator->trans('errors.login', [], 'catroweb');
       $retArray['preHeaderMessages'] = '';
-
       return JsonResponse::create($retArray);
     }
 
@@ -464,7 +493,7 @@ class SecurityController extends Controller
   public function getGoogleAppId()
   {
     $retArray = [];
-    $retArray['gplus_appid'] = $this->container->getParameter('google_app_id');
+    $retArray['gplus_appid'] = $this->getParameter('google_app_id');
 
     return JsonResponse::create($retArray);
   }
@@ -504,18 +533,7 @@ class SecurityController extends Controller
    */
   private function getOAuthService()
   {
-    return $this->get("oauth_service");
+    return $this->oauth_service;
   }
-
-
-  /**
-   * @param       $message
-   * @param array $parameters
-   *
-   * @return string
-   */
-  private function trans($message, $parameters = [])
-  {
-    return $this->get('translator')->trans($message, $parameters, 'catroweb');
-  }
+  
 }

--- a/src/Catrobat/Controller/Api/TaggingController.php
+++ b/src/Catrobat/Controller/Api/TaggingController.php
@@ -2,7 +2,8 @@
 
 namespace App\Catrobat\Controller\Api;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use App\Repository\TagRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -12,7 +13,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  * Class TaggingController
  * @package App\Catrobat\Controller\Api
  */
-class TaggingController extends Controller
+class TaggingController extends AbstractController
 {
 
   /**
@@ -22,10 +23,8 @@ class TaggingController extends Controller
    *
    * @return JsonResponse
    */
-  public function taggingAction(Request $request)
+  public function taggingAction(Request $request, TagRepository $tags_repo)
   {
-    $tags_repo = $this->get('tagrepository');
-
     $em = $this->getDoctrine()->getManager();
     $metadata = $em->getClassMetadata('App\Entity\Tag')->getFieldNames();
 

--- a/src/Catrobat/Controller/Api/TemplatesListController.php
+++ b/src/Catrobat/Controller/Api/TemplatesListController.php
@@ -3,8 +3,9 @@
 namespace App\Catrobat\Controller\Api;
 
 use App\Catrobat\Responses\TemplateListResponse;
+use App\Entity\TemplateManager;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Routing\Annotation\Route;
 
 
@@ -12,7 +13,7 @@ use Symfony\Component\Routing\Annotation\Route;
  * Class TemplatesListController
  * @package App\Catrobat\Controller\Api
  */
-class TemplatesListController extends Controller
+class TemplatesListController extends AbstractController
 {
 
   /**
@@ -22,10 +23,8 @@ class TemplatesListController extends Controller
    *
    * @return TemplateListResponse
    */
-  public function listTemplatesAction(Request $request)
+  public function listTemplatesAction(Request $request, TemplateManager $template_manager)
   {
-    $template_manager = $this->get('templatemanager');
-
     $templates = $template_manager->findAllActive();
 
     return new TemplateListResponse($templates);

--- a/src/Catrobat/Controller/Api/UploadController.php
+++ b/src/Catrobat/Controller/Api/UploadController.php
@@ -21,6 +21,7 @@ use App\Catrobat\Exceptions\Upload\MissingChecksumException;
 use App\Catrobat\Exceptions\Upload\InvalidChecksumException;
 use App\Catrobat\Exceptions\Upload\MissingPostDataException;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use App\Repository\GameJamRepository;
 use App\Catrobat\Exceptions\Upload\NoGameJamException;
@@ -72,20 +73,20 @@ class UploadController
    */
   private $logger;
 
+
   /**
    * UploadController constructor.
    *
-   * @param UserManager         $usermanager
-   * @param TokenStorage        $tokenstorage
-   * @param ProgramManager      $programmanager
-   * @param GameJamRepository   $gamejamrepository
-   * @param TokenGenerator      $tokengenerator
-   * @param TranslatorInterface $translator
-   * @param LoggerInterface     $logger
+   * @param UserManager           $usermanager
+   * @param TokenStorageInterface $tokenstorage
+   * @param ProgramManager        $programmanager
+   * @param GameJamRepository     $gamejamrepository
+   * @param TokenGenerator        $tokengenerator
+   * @param TranslatorInterface   $translator
+   * @param LoggerInterface       $logger
    * @param CatroNotificationService $catroNotificationService
    */
-
-  public function __construct(UserManager $usermanager, TokenStorage $tokenstorage, ProgramManager $programmanager,
+  public function __construct(UserManager $usermanager, TokenStorageInterface $tokenstorage, ProgramManager $programmanager,
                               GameJamRepository $gamejamrepository, TokenGenerator $tokengenerator,
                               TranslatorInterface $translator, LoggerInterface $logger,
                               CatroNotificationService $catroNotificationService)

--- a/src/Catrobat/Controller/Ci/ApkStatusController.php
+++ b/src/Catrobat/Controller/Ci/ApkStatusController.php
@@ -2,28 +2,30 @@
 
 namespace App\Catrobat\Controller\Ci;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 use App\Entity\Program;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 
 /**
  * Class ApkStatusController
  * @package App\Catrobat\Controller\Ci
  */
-class ApkStatusController extends Controller
+class ApkStatusController extends AbstractController
 {
 
   /**
    * @Route("/ci/status/{id}", name="ci_status", defaults={"_format": "json"}, methods={"GET"})
    *
    * @param Program $program
+   * @param TranslatorInterface $translator
    *
    * @return JsonResponse
    */
-  public function getApkStatusAction(Program $program)
+  public function getApkStatusAction(Program $program, TranslatorInterface $translator)
   {
     $result = [];
     switch ($program->getApkStatus())
@@ -32,14 +34,14 @@ class ApkStatusController extends Controller
         $result['status'] = 'ready';
         $result['url'] = $this->generateUrl('ci_download',
           ['id' => $program->getId(), 'fname' => $program->getName()], UrlGeneratorInterface::ABSOLUTE_URL);
-        $result['label'] = $this->get('translator')->trans('ci.download', [], 'catroweb');
+        $result['label'] = $translator->trans('ci.download', [], 'catroweb');
         break;
       case Program::APK_PENDING:
         $result['status'] = 'pending';
-        $result['label'] = $this->get('translator')->trans('ci.pending', [], 'catroweb');
+        $result['label'] = $translator->trans('ci.pending', [], 'catroweb');
         break;
       default:
-        $result['label'] = $this->get('translator')->trans('ci.generate', [], 'catroweb');
+        $result['label'] = $translator->trans('ci.generate', [], 'catroweb');
         $result['status'] = 'none';
     }
 

--- a/src/Catrobat/Controller/Ci/DownloadApkController.php
+++ b/src/Catrobat/Controller/Ci/DownloadApkController.php
@@ -3,7 +3,10 @@
 namespace App\Catrobat\Controller\Ci;
 
 use App\Catrobat\Services\ApkRepository;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use App\Entity\ProgramManager;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use App\Entity\Program;
@@ -16,7 +19,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
  * Class DownloadApkController
  * @package App\Catrobat\Controller\Ci
  */
-class DownloadApkController extends Controller
+class DownloadApkController extends AbstractController
 {
 
   /**
@@ -24,15 +27,16 @@ class DownloadApkController extends Controller
    *
    * @param Request $request
    * @param Program $program
+   * @param ApkRepository $apk_repository
+   * @param ProgramManager $programManager
    *
    * @return BinaryFileResponse
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
-  public function downloadApkAction(Request $request, Program $program)
+  public function downloadApkAction(Request $request, Program $program, ApkRepository $apk_repository,
+                                    ProgramManager $programManager)
   {
-    /* @var $apkrepository ApkRepository */
-
     if (!$program->isVisible())
     {
       throw new NotFoundHttpException();
@@ -42,11 +46,9 @@ class DownloadApkController extends Controller
       throw new NotFoundHttpException();
     }
 
-    $apkrepository = $this->get('apkrepository');
-
     try
     {
-      $file = $apkrepository->getProgramFile($program->getId());
+      $file = $apk_repository->getProgramFile($program->getId());
     } catch (\Exception $e)
     {
       throw new NotFoundHttpException();
@@ -57,7 +59,7 @@ class DownloadApkController extends Controller
       $downloaded = $request->getSession()->get('apk_downloaded', []);
       if (!in_array($program->getId(), $downloaded))
       {
-        $this->get('programmanager')->increaseApkDownloads($program);
+        $programManager->increaseApkDownloads($program);
         $downloaded[] = $program->getId();
         $request->getSession()->set('apk_downloaded', $downloaded);
       }

--- a/src/Catrobat/Controller/DownloadBackupController.php
+++ b/src/Catrobat/Controller/DownloadBackupController.php
@@ -2,7 +2,8 @@
 
 namespace App\Catrobat\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use App\Catrobat\Services\BackupFileRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -10,22 +11,19 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 
-class DownloadBackupController extends Controller
+class DownloadBackupController extends AbstractController
 {
   /**
    * @Route("/download-backup/{backupFile}", name="backup_download", methods={"GET"})
    *
    * @param Request $request
-   * @param         $backupFile
+   * @param $backupFile
+   * @param BackupFileRepository $backupFileRepository
    *
    * @return BinaryFileResponse
    */
-  public function downloadBackupAction(Request $request, $backupFile)
+  public function downloadBackupAction(Request $request, $backupFile, BackupFileRepository $backupFileRepository)
   {
-    /**
-     * @var $backupFileRepository \App\Catrobat\Services\BackupFileRepository
-     */
-    $backupFileRepository = $this->get('backupfilerepository');
 
     $file = $backupFileRepository->getBackupFile($backupFile);
     if ($file->isFile())

--- a/src/Catrobat/Controller/DownloadMediaPackageController.php
+++ b/src/Catrobat/Controller/DownloadMediaPackageController.php
@@ -2,12 +2,13 @@
 
 namespace App\Catrobat\Controller;
 
+use App\Catrobat\Services\MediaPackageFileRepository;
 use App\Entity\MediaPackageFile;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 
@@ -15,25 +16,23 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
  * Class DownloadMediaPackageController
  * @package App\Catrobat\Controller
  */
-class DownloadMediaPackageController extends Controller
+class DownloadMediaPackageController extends AbstractController
 {
 
   /**
    * @Route("/download-media/{id}", name="download_media", defaults={"_format": "json"}, methods={"GET"})
    *
    * @param Request $request
-   * @param         $id
+   * @param $id
+   * @param MediaPackageFileRepository $file_repository
    *
    * @return BinaryFileResponse
    */
-  public function downloadMediaPackageAction(Request $request, $id)
+  public function downloadMediaPackageAction(Request $request, $id, MediaPackageFileRepository $file_repository)
   {
     /**
-     * @var $file_repository \App\Catrobat\Services\MediaPackageFileRepository
-     * @var $media_file      \App\Entity\MediaPackageFile
+     * @var $media_file  MediaPackageFile
      */
-
-    $file_repository = $this->get('mediapackagefilerepository');
 
     $em = $this->getDoctrine()->getManager();
     $media_file = $em->getRepository(MediaPackageFile::class)->findOneBy(['id' => $id]);

--- a/src/Catrobat/Controller/Resetting/ResettingController.php
+++ b/src/Catrobat/Controller/Resetting/ResettingController.php
@@ -2,7 +2,8 @@
 
 namespace App\Catrobat\Controller\Resetting;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 
@@ -10,13 +11,13 @@ use Symfony\Component\Routing\Annotation\Route;
  * Class ResettingController
  * @package App\Catrobat\Controller\Resetting
  */
-class ResettingController extends Controller
+class ResettingController extends AbstractController
 {
 
   /**
    * @Route("/reset/invalid", name="reset_invalid")
    *
-   * @return \Symfony\Component\HttpFoundation\Response
+   * @return Response
    */
   public function handleInvalidUsernameOrEmail()
   {
@@ -29,7 +30,7 @@ class ResettingController extends Controller
   /**
    * @Route("/reset/already_requested", name="reset_already_requested")
    *
-   * @return \Symfony\Component\HttpFoundation\Response
+   * @return Response
    */
   public function handlePasswordAlreadyRequested()
   {

--- a/src/Catrobat/Controller/Security/LogoutController.php
+++ b/src/Catrobat/Controller/Security/LogoutController.php
@@ -2,18 +2,19 @@
 
 namespace App\Catrobat\Controller\Security;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 
 /**
  * Class LogoutController
  * @package App\Catrobat\Controller\Security
  */
-class LogoutController extends Controller
+class LogoutController extends AbstractController
 {
 
   /**
-   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   * @return RedirectResponse
    */
   public function logoutAction()
   {

--- a/src/Catrobat/Controller/Security/TokenLoginController.php
+++ b/src/Catrobat/Controller/Security/TokenLoginController.php
@@ -3,35 +3,38 @@
 namespace App\Catrobat\Controller\Security;
 
 use App\Entity\User;
+use App\Entity\UserManager;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 
 /**
  * Class TokenLoginController
  * @package App\Catrobat\Controller\Security
  */
-class TokenLoginController extends Controller
+class TokenLoginController extends AbstractController
 {
 
   /**
    * @Route("/tokenlogin", name="token_login", methods={"GET"})
    *
    * @param Request $request
+   * @param UserManager $user_manager
    *
-   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   * @return RedirectResponse
    */
-  public function tokenloginAction(Request $request)
+  public function tokenloginAction(Request $request, UserManager $user_manager)
   {
     /**
      * @var $user User
      */
     $username = $request->query->get('username');
     $token = $request->query->get('token');
-    $user = $this->get('usermanager')->findUserByUsername($username);
+    $user = $user_manager->findUserByUsername($username);
 
     if ($user == null)
     {
@@ -53,7 +56,7 @@ class TokenLoginController extends Controller
 
 
   /**
-   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   * @return RedirectResponse
    */
   private function logout()
   {

--- a/src/Catrobat/Controller/Web/CodeViewController.php
+++ b/src/Catrobat/Controller/Web/CodeViewController.php
@@ -2,33 +2,40 @@
 
 namespace App\Catrobat\Controller\Web;
 
-use App\Catrobat\Services\CatrobatCodeParser\ParsedSceneProgram;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use App\Catrobat\Services\ExtractedFileRepository;
+use App\Entity\Program;
+use App\Entity\ProgramManager;
+use App\Catrobat\Services\CatrobatCodeParser\CatrobatCodeParser;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 
 /**
  * Class CodeViewController
  * @package App\Catrobat\Controller\Web
  */
-class CodeViewController extends Controller
+class CodeViewController extends AbstractController
 {
 
   /**
    * @param $id
+   * @param ProgramManager $programManager
+   * @param ExtractedFileRepository $extractedFileRepository
+   * @param CatrobatCodeParser $catrobatCodeParser
    *
-   * @var $parsed_program ParsedSceneProgram
-   *
-   * @return \Symfony\Component\HttpFoundation\Response
-   * @throws \Twig\Error\Error
+   * @return mixed
    */
-  public function viewCodeAction($id)
+  public function viewCodeAction($id, ProgramManager $programManager, ExtractedFileRepository $extractedFileRepository,
+                                 CatrobatCodeParser $catrobatCodeParser)
   {
+    /**
+     * @var $program Program
+     */
     try
     {
-      $program = $this->get('programmanager')->find($id);
-      $extracted_program = $this->get('extractedfilerepository')->loadProgramExtractedFile($program);
+      $program = $programManager->find($id);
+      $extracted_program = $extractedFileRepository->loadProgramExtractedFile($program);
 
-      $parsed_program = $this->get('catrobat_code_parser')->parse($extracted_program);
+      $parsed_program = $catrobatCodeParser->parse($extracted_program);
 
       $web_path = $extracted_program->getWebPath();
     } catch (\Exception $e)

--- a/src/Catrobat/Controller/Web/CommentsController.php
+++ b/src/Catrobat/Controller/Web/CommentsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Catrobat\Controller\Web;
 
+use App\Catrobat\Services\CatroNotificationService;
 use App\Catrobat\StatusCode;
 use App\Entity\CommentNotification;
 use App\Entity\Program;
@@ -9,7 +10,9 @@ use App\Entity\ProgramInappropriateReport;
 use App\Entity\ProgramManager;
 use App\Entity\User;
 use App\Entity\UserComment;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -18,7 +21,7 @@ use Symfony\Component\Routing\Annotation\Route;
  * Class CommentsController
  * @package App\Catrobat\Controller\Web
  */
-class CommentsController extends Controller
+class CommentsController extends AbstractController
 {
 
   /**
@@ -101,10 +104,14 @@ class CommentsController extends Controller
   /**
    * @Route("/comment", name="comment", methods={"POST"})
    *
-   * @throws \Exception
+   * @param CatroNotificationService $notification_service
+   * @param ProgramManager $program_manager
+   *
    * @return Response
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
-  public function postCommentAction()
+  public function postCommentAction(CatroNotificationService $notification_service, ProgramManager $program_manager)
   {
     /**
      * @var $user             User
@@ -119,12 +126,9 @@ class CommentsController extends Controller
       return new Response(StatusCode::NOT_LOGGED_IN);
     }
 
-    $notification_service = $this->get("catro_notification_service");
-
     $user = $this->get("security.token_storage")->getToken()->getUser();
     $id = $user->getId();
 
-    $program_manager = $this->get("programmanager");
     $program = $program_manager->find($_POST['ProgramId']);
 
     $temp_comment = new UserComment();

--- a/src/Catrobat/Controller/Web/GameJamController.php
+++ b/src/Catrobat/Controller/Web/GameJamController.php
@@ -3,30 +3,36 @@
 namespace App\Catrobat\Controller\Web;
 
 use App\Entity\GameJam;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use App\Repository\GameJamRepository;
+use Doctrine\ORM\NonUniqueResultException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Twig\Error\Error;
 
 /**
  * Class GameJamController
  * @package App\Catrobat\Controller\Web
  */
-class GameJamController extends Controller
+class GameJamController extends AbstractController
 {
 
   /**
    * @Route("/gamejame/submit-your-own", name="gamejam_submit_own", methods={"GET"})
    *
-   * @return \Symfony\Component\HttpFoundation\Response
-   * @throws \Doctrine\ORM\NonUniqueResultException
-   * @throws \Twig\Error\Error
+   * @param GameJamRepository $game_jam_repository
+   *
+   * @return Response
+   * @throws NonUniqueResultException
+   * @throws Error
    */
-  public function gamejamSubmitOwnAction()
+  public function gamejamSubmitOwnAction(GameJamRepository $game_jam_repository)
   {
     /**
      * @var $gamejam GameJam
      */
     $jam = null;
-    $gamejam = $this->get('gamejamrepository')->getCurrentGameJam();
+    $gamejam = $game_jam_repository->getCurrentGameJam();
 
     if ($gamejam)
     {
@@ -34,7 +40,7 @@ class GameJamController extends Controller
 
       if ($gamejam_flavor != null)
       {
-        $config = $this->container->getParameter('gamejam');
+        $config = $this->getParameter('gamejam');
         $gamejam_config = $config[$gamejam_flavor];
         $jam = $this->configureSubmitYourOwn($gamejam_config, $gamejam);
       }
@@ -52,8 +58,8 @@ class GameJamController extends Controller
    *
    * @param $page
    *
-   * @return \Symfony\Component\HttpFoundation\Response
-   * @throws \Twig\Error\Error
+   * @return Response
+   * @throws Error
    */
   public function tutorialcardsAction($page)
   {

--- a/src/Catrobat/Controller/Web/ProgramController.php
+++ b/src/Catrobat/Controller/Web/ProgramController.php
@@ -7,10 +7,11 @@ use App\Catrobat\RecommenderSystem\RecommendedPageId;
 use App\Catrobat\Requests\AppRequest;
 use App\Catrobat\Services\CatroNotificationService;
 use App\Catrobat\Services\Formatter\ElapsedTimeStringFormatter;
+use App\Catrobat\Services\RudeWordFilter;
 use App\Catrobat\Services\ScreenshotRepository;
+use App\Catrobat\Services\StatisticsService;
+use App\Catrobat\Services\TestEnv\FakeStatisticsService;
 use App\Catrobat\StatusCode;
-use App\Entity\CatroNotification;
-use App\Entity\GameJam;
 use App\Entity\LikeNotification;
 use App\Entity\Program;
 use App\Entity\ProgramInappropriateReport;
@@ -19,6 +20,9 @@ use App\Entity\ProgramManager;
 use App\Entity\RemixManager;
 use App\Entity\User;
 use App\Entity\UserComment;
+use App\Repository\CatroNotificationRepository;
+use App\Repository\FeaturedRepository;
+use App\Repository\GameJamRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\Types\GuidType;
@@ -27,13 +31,14 @@ use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Exception;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use ImagickException;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Error\Error;
 
 
@@ -41,26 +46,40 @@ use Twig\Error\Error;
  * Class ProgramController
  * @package App\Catrobat\Controller\Web
  */
-class ProgramController extends Controller
+class ProgramController extends AbstractController
 {
+
+  /**
+   * @var StatisticsService|FakeStatisticsService $statistics
+   */
+  private $statistics;
+
+  /**
+   * ProgramController constructor.
+   *
+   * @param StatisticsService $statistics_service
+   */
+  public function __construct(StatisticsService $statistics_service)
+  {
+    $this->statistics = $statistics_service;
+  }
 
   /**
    * @Route("/project/remixgraph/{id}", name="program_remix_graph", methods={"GET"})
    *
    * @param Request $request
-   * @param GuidType $id
+   * @param $id
+   * @param RemixManager $remix_manager
+   * @param ScreenshotRepository $screenshot_repository
    *
    * @return JsonResponse
    * @throws ORMException
    * @throws OptimisticLockException
    */
-  public function programRemixGraphAction(Request $request, $id)
+  public function programRemixGraphAction(Request $request, $id, RemixManager $remix_manager,
+                                          ScreenshotRepository $screenshot_repository)
   {
-    /** @var RemixManager $remix_manager */
-    $remix_manager = $this->get('remixmanager');
     $remix_graph_data = $remix_manager->getFullRemixGraph($id);
-    /** @var ScreenshotRepository $screenshot_repository */
-    $screenshot_repository = $this->get('screenshotrepository');
 
     $catrobat_program_thumbnails = [];
     foreach ($remix_graph_data['catrobatNodes'] as $node_id)
@@ -74,10 +93,9 @@ class ProgramController extends Controller
           ->getThumbnailWebPath($node_id);
     }
 
-    $statistics = $this->get('statistics');
     $locale = strtolower($request->getLocale());
     $referrer = $request->headers->get('referer');
-    $statistics->createClickStatistics($request, 'show_remix_graph', 0, $id, null,
+    $this->statistics->createClickStatistics($request, 'show_remix_graph', 0, $id, null,
       null, $referrer, $locale, false, false);
 
     return new JsonResponse([
@@ -93,29 +111,34 @@ class ProgramController extends Controller
    * @Route("/details/{id}", name="catrobat_web_detail", methods={"GET"})
    *
    * @param Request $request
-   * @param GuidType $id
+   * @param $id
+   * @param ProgramManager $program_manager
+   * @param FeaturedRepository $featured_repository
+   * @param ScreenshotRepository $screenshot_repository
+   * @param ElapsedTimeStringFormatter $elapsed_time
+   * @param AppRequest $app_request
+   * @param RemixManager $remix_manager
+   * @param GameJamRepository $game_jam_repository
    *
-   * @return JsonResponse
+   * @return Response
    * @throws Error
    * @throws NonUniqueResultException
    * @throws ORMException
    * @throws OptimisticLockException
    */
-  public function programAction(Request $request, $id)
+  public function programAction(Request $request, $id, ProgramManager $program_manager,
+                                FeaturedRepository $featured_repository, ScreenshotRepository $screenshot_repository,
+                                ElapsedTimeStringFormatter $elapsed_time, AppRequest $app_request,
+                                RemixManager $remix_manager, GameJamRepository $game_jam_repository)
   {
     /**
      * @var $user             User
      * @var $program          Program
      * @var $reported_program ProgramInappropriateReport
      * @var $like             ProgramLike
-     * @var $program_manager  ProgramManager
      */
-    $program_manager = $this->get('programmanager');
     $program = $program_manager->find($id);
-    $featured_repository = $this->get('featuredrepository');
-    $screenshot_repository = $this->get('screenshotrepository');
     $router = $this->get('router');
-    $elapsed_time = $this->get('elapsedtime');
 
     if (!$program || !$program->isVisible())
     {
@@ -133,8 +156,6 @@ class ProgramController extends Controller
 
     if ($program->isDebugBuild())
     {
-      /** @var AppRequest $app_request */
-      $app_request = $this->get('app_request');
       if (!$app_request->isDebugBuildRequest())
       {
         throw $this->createNotFoundException('Unable to find Project entity.');
@@ -142,7 +163,7 @@ class ProgramController extends Controller
     }
 
     $viewed = $request->getSession()->get('viewed', []);
-    $this->checkAndAddViewed($request, $program, $viewed);
+    $this->checkAndAddViewed($request, $program, $viewed, $program_manager);
     $referrer = $request->headers->get('referer');
     $request->getSession()->set('referer', $referrer);
 
@@ -168,7 +189,7 @@ class ProgramController extends Controller
     $program_comments = $this->findCommentsById($program);
     $program_details = $this->createProgramDetailsArray($screenshot_repository, $program,
       $like_type, $like_type_count, $total_like_count, $elapsed_time, $referrer,
-      $program_comments, $request);
+      $program_comments, $request,$remix_manager);
 
     $user_programs = $this->findUserPrograms($user, $program);
 
@@ -179,11 +200,9 @@ class ProgramController extends Controller
     $share_text = trim($program->getName() . ' on ' . $program_url . ' ' .
       $program->getDescription());
 
-    $jam = $this->extractGameJamConfig();
+    $jam = $this->extractGameJamConfig($game_jam_repository);
 
-    $max_description_size = $this->container->get('kernel')->getContainer()
-      ->getParameter("catrobat.max_description_upload_size");
-
+    $max_description_size = $this->getParameter("catrobat.max_description_upload_size");
 
     $my_program = false;
     if ($user_programs && count($user_programs) > 0)
@@ -212,18 +231,19 @@ class ProgramController extends Controller
    *
    * @param Request $request
    * @param GuidType $id
+   * @param ProgramManager $program_manager
+   * @param CatroNotificationRepository $notification_repo
+   * @param CatroNotificationService $notification_service
    *
    * @return JsonResponse|RedirectResponse
    * @throws Exception
    */
-  public function programLikeAction(Request $request, $id)
+  public function programLikeAction(Request $request, $id, ProgramManager $program_manager,
+                                    CatroNotificationRepository $notification_repo,
+                                    CatroNotificationService  $notification_service )
   {
     /**
-     * @var ProgramManager           $program_manager
      * @var User                     $user
-     * @var Program                  $program
-     * @var CatroNotification        $notification
-     * @var CatroNotificationService $notification_service
      * @var Program                  $program
      */
 
@@ -242,7 +262,6 @@ class ProgramController extends Controller
         throw $this->createAccessDeniedException('Invalid like-type for program given!');
       }
     }
-    $program_manager = $this->get('programmanager');
     $program = $program_manager->find($id);
     if ($program === null)
     {
@@ -281,7 +300,6 @@ class ProgramController extends Controller
     {
       $program_notification_exists = false;
 
-      $notification_repo = $this->get("catro_notification_repository");
       $notifications = $notification_repo->findByUser($program->getUser());
 
       foreach ($notifications as $notification)
@@ -297,7 +315,6 @@ class ProgramController extends Controller
         }
       }
 
-      $notification_service = $this->get("catro_notification_service");
       if ($new_type === ProgramLike::TYPE_THUMBS_UP
         || $new_type === ProgramLike::TYPE_SMILE
         || $new_type === ProgramLike::TYPE_LOVE
@@ -452,23 +469,23 @@ class ProgramController extends Controller
    *
    * @param GuidType $id
    * @param string  $newDescription
+   * @param RudeWordFilter  $rude_word_filter
+   * @param ProgramManager  $program_manager
+   * @param TranslatorInterface  $translator
    *
    * @return Response
    * @throws Exception
    *
    */
-  public function editProgramDescription($id, $newDescription)
+  public function editProgramDescription($id, $newDescription, RudeWordFilter $rude_word_filter,
+                                         ProgramManager $program_manager, TranslatorInterface $translator)
   {
     /**
      * @var User           $user
      * @var Program        $program
-     * @var ProgramManager $program_manager
      */
 
-    $rude_word_filter = $this->get('rudewordfilter');
-    $max_description_size = $this->container->get('kernel')->getContainer()
-      ->getParameter("catrobat.max_description_upload_size");
-    $translator = $this->get('translator');
+    $max_description_size = $this->getParameter("catrobat.max_description_upload_size");
 
     if (strlen($newDescription) > $max_description_size)
     {
@@ -490,7 +507,6 @@ class ProgramController extends Controller
       return $this->redirectToRoute('fos_user_security_login');
     }
 
-    $program_manager = $this->get('programmanager');
     $program = $program_manager->find($id);
     if (!$program)
     {
@@ -513,21 +529,23 @@ class ProgramController extends Controller
 
 
   /**
-   * @return array
+   * @param GameJamRepository $game_jam_repository
+   *
+   * @return array|null
    * @throws NonUniqueResultException
    */
-  private function extractGameJamConfig()
+  private function extractGameJamConfig(GameJamRepository $game_jam_repository)
   {
     $jam = null;
-    /** @var GameJam $gamejam */
-    $gamejam = $this->get('gamejamrepository')->getCurrentGameJam();
+
+    $gamejam = $game_jam_repository->getCurrentGameJam();
 
     if ($gamejam)
     {
       $gamejam_flavor = $gamejam->getFlavor();
       if ($gamejam_flavor !== null)
       {
-        $config = $this->container->getParameter('gamejam');
+        $config = $this->getParameter('gamejam');
         $gamejam_config = $config[$gamejam_flavor];
         if ($gamejam_config)
         {
@@ -551,15 +569,16 @@ class ProgramController extends Controller
    * @param Request $request
    * @param Program $program
    * @param         $viewed
+   * @param ProgramManager $program_manager
    *
    * @throws ORMException
    * @throws OptimisticLockException
    */
-  private function checkAndAddViewed(Request $request, $program, $viewed)
+  private function checkAndAddViewed(Request $request, $program, $viewed, ProgramManager $program_manager)
   {
     if (!in_array($program->getId(), $viewed))
     {
-      $this->get('programmanager')->increaseViews($program);
+      $program_manager->increaseViews($program);
       $viewed[] = $program->getId();
       $request->getSession()->set('viewed', $viewed);
     }
@@ -576,12 +595,13 @@ class ProgramController extends Controller
    * @param $total_like_count
    * @param $program_comments
    * @param $request                    Request
+   * @param $remix_manager              RemixManager
    *
    * @return array
    */
   private function createProgramDetailsArray($screenshot_repository, $program, $like_type,
                                              $like_type_count, $total_like_count, $elapsed_time,
-                                             $referrer, $program_comments, $request)
+                                             $referrer, $program_comments, $request, $remix_manager)
   {
     $rec_by_page_id = intval($request->query->get('rec_by_page_id', RecommendedPageId::INVALID_PAGE));
     $rec_by_program_id = intval($request->query->get('rec_by_program_id', 0));
@@ -615,8 +635,7 @@ class ProgramController extends Controller
       else
       {
         // case: NO recommendation
-        $url = $this->generateUrl('download', ['id'    => $program->getId(),
-                                               'fname' => $program->getName()]);
+        $url = $this->generateUrl('download', ['id' => $program->getId(), 'fname' => $program->getName()]);
       }
     }
 
@@ -640,9 +659,6 @@ class ProgramController extends Controller
         }
       }
     }
-
-    /** @var RemixManager $remix_manager */
-    $remix_manager = $this->get('remixmanager');
 
     $program_details = [
       'screenshotBig'   => $screenshot_repository->getScreenshotWebPath($program->getId()),

--- a/src/Catrobat/Controller/Web/TagExtensionController.php
+++ b/src/Catrobat/Controller/Web/TagExtensionController.php
@@ -2,15 +2,17 @@
 
 namespace App\Catrobat\Controller\Web;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Twig\Error\Error;
 
 
 /**
  * Class TagExtensionController
  * @package App\Catrobat\Controller\Web
  */
-class TagExtensionController extends Controller
+class TagExtensionController extends AbstractController
 {
 
   /**
@@ -18,8 +20,8 @@ class TagExtensionController extends Controller
    *
    * @param $q
    *
-   * @return \Symfony\Component\HttpFoundation\Response
-   * @throws \Twig\Error\Error
+   * @return Response
+   * @throws Error
    */
   public function tagSearchAction($q)
   {
@@ -30,8 +32,8 @@ class TagExtensionController extends Controller
   /**
    * @Route("/tag/search/", name="empty_tag_search", methods={"GET"})
    *
-   * @return \Symfony\Component\HttpFoundation\Response
-   * @throws \Twig\Error\Error
+   * @return Response
+   * @throws Error
    */
   public function tagSearchNothingAction()
   {
@@ -44,8 +46,8 @@ class TagExtensionController extends Controller
    *
    * @param $q
    *
-   * @return \Symfony\Component\HttpFoundation\Response
-   * @throws \Twig\Error\Error
+   * @return Response
+   * @throws Error
    */
   public function extensionSearchAction($q)
   {
@@ -56,8 +58,8 @@ class TagExtensionController extends Controller
   /**
    * @Route("/extension/search/", name="empty_extension_search", methods={"GET"})
    *
-   * @return \Symfony\Component\HttpFoundation\Response
-   * @throws \Twig\Error\Error
+   * @return Response
+   * @throws Error
    */
   public function extensionSearchNothingAction()
   {

--- a/src/Catrobat/Controller/Web/TranslationController.php
+++ b/src/Catrobat/Controller/Web/TranslationController.php
@@ -2,7 +2,7 @@
 
 namespace App\Catrobat\Controller\Web;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  * Class TranslationController
  * @package App\Catrobat\Controller\Web
  */
-class TranslationController extends Controller
+class TranslationController extends AbstractController
 {
 
   /**
@@ -39,8 +39,8 @@ class TranslationController extends Controller
 
 
   /**
-   * @Route("/transChoice/{word}/{count}/{array}/{domain}", name = "translate_choice", defaults={"array" = "", "domain" =
-   *                                              "catroweb"})
+   * @Route("/transChoice/{word}/{count}/{array}/{domain}", name = "translate_choice",
+   *   defaults={"array" = "", "domain" = "catroweb"})
    *
    * @param TranslatorInterface $translator
    * @param                     $word

--- a/src/Catrobat/Controller/Web/TutorialController.php
+++ b/src/Catrobat/Controller/Web/TutorialController.php
@@ -6,8 +6,9 @@ use App\Entity\Program;
 use App\Entity\StarterCategory;
 use App\Catrobat\Services\ScreenshotRepository;
 use Doctrine\DBAL\Types\GuidType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Twig\Error\Error;
@@ -17,7 +18,7 @@ use Twig\Error\Error;
  * Class TutorialController
  * @package App\Catrobat\Controller\Web
  */
-class TutorialController extends Controller
+class TutorialController extends AbstractController
 {
 
   /**
@@ -111,10 +112,11 @@ class TutorialController extends Controller
    *
    * @param Request $request
    * @param GuidType  $id
+   * @param ScreenshotRepository  $screenshot_repository
    *
    * @return JsonResponse
    */
-  public function categoryProgramsAction(Request $request, $id)
+  public function categoryProgramsAction(Request $request, $id, ScreenshotRepository $screenshot_repository)
   {
     /**
     * @var $program Program
@@ -122,8 +124,6 @@ class TutorialController extends Controller
 
     $em = $this->getDoctrine()->getManager();
     $programs = $em->getRepository('App\Entity\Program')->findBy(['category' => $id]);
-
-    $screenshot_repository = $this->get('screenshotrepository');
 
     $retArray = $this->receiveCategoryPrograms($request, $programs, $screenshot_repository);
 

--- a/src/Catrobat/Ldap/UserHydrator.php
+++ b/src/Catrobat/Ldap/UserHydrator.php
@@ -22,7 +22,7 @@ class UserHydrator implements HydratorInterface
    *
    * @return UserInterface
    */
-  public function hydrate(array $ldapEntry)
+  public function hydrate(array $ldapEntry): UserInterface
   {
     $user = new User();
     $user->setUsername($ldapEntry['cn'][0]);

--- a/src/Catrobat/Listeners/DownloadStatisticsListener.php
+++ b/src/Catrobat/Listeners/DownloadStatisticsListener.php
@@ -4,7 +4,10 @@ namespace App\Catrobat\Listeners;
 
 use App\Catrobat\RecommenderSystem\RecommendedPageId;
 use App\Catrobat\Services\StatisticsService;
+use App\Catrobat\Services\TestEnv\FakeStatisticsService;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
 
 
 /**
@@ -25,10 +28,10 @@ class DownloadStatisticsListener
   /**
    * DownloadStatisticsListener constructor.
    *
-   * @param $statistics_service
-   * @param $security_token_storage
+   * @param StatisticsService $statistics_service
+   * @param TokenStorageInterface $security_token_storage
    */
-  public function __construct($statistics_service, $security_token_storage)
+  public function __construct(StatisticsService $statistics_service, TokenStorageInterface$security_token_storage)
   {
     $this->statistics_service = $statistics_service;
     $this->security_token_storage = $security_token_storage;
@@ -36,6 +39,8 @@ class DownloadStatisticsListener
 
   /**
    * @param PostResponseEvent $event
+   *
+   * @throws \Exception
    */
   public function onTerminateEvent(PostResponseEvent $event)
   {
@@ -91,6 +96,8 @@ class DownloadStatisticsListener
    * @param $rec_by_program_id
    * @param $locale
    * @param $is_user_specific_recommendation
+   *
+   * @throws \Exception
    */
   public function createProgramDownloadStatistics($request, $program_id, $referrer, $rec_tag_by_program_id,
                                                   $rec_by_page_id, $rec_by_program_id, $locale,

--- a/src/Catrobat/Listeners/FlavorListener.php
+++ b/src/Catrobat/Listeners/FlavorListener.php
@@ -3,7 +3,10 @@
 namespace App\Catrobat\Listeners;
 
 use App\Catrobat\Requests\AppRequest;
+use Doctrine\ORM\Query\Parameter;
 use Liip\ThemeBundle\ActiveTheme;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\RouterInterface;
@@ -17,9 +20,9 @@ use Symfony\Component\DependencyInjection\Container;
 class FlavorListener
 {
   /**
-   * @var Container
+   * @var ParameterBag
    */
-  private $container;
+  private $parameter_bag;
 
   /**
    * @var RouterInterface
@@ -39,14 +42,15 @@ class FlavorListener
   /**
    * FlavorListener constructor.
    *
-   * @param Container $container
+   * @param ParameterBagInterface $parameter_bag
    * @param RouterInterface $router
-   * @param $theme
+   * @param ActiveTheme $theme
    * @param AppRequest $app_request
    */
-  public function __construct(Container $container, RouterInterface $router, $theme, AppRequest $app_request)
+  public function __construct(ParameterBagInterface $parameter_bag, RouterInterface $router, ActiveTheme $theme,
+                              AppRequest $app_request)
   {
-    $this->container = $container;
+    $this->parameter_bag = $parameter_bag;
     $this->router = $router;
     $this->theme = $theme;
     $this->app_request = $app_request;
@@ -124,7 +128,7 @@ class FlavorListener
 
   public function checkFlavor($flavor): bool
   {
-    $flavor_options = $this->container->getParameter('themes');
+    $flavor_options = $this->parameter_bag->get('themes');
 
     return in_array($flavor, $flavor_options);
   }

--- a/src/Catrobat/Listeners/InvalidProgramUploadLogger.php
+++ b/src/Catrobat/Listeners/InvalidProgramUploadLogger.php
@@ -3,7 +3,7 @@
 namespace App\Catrobat\Listeners;
 
 use App\Catrobat\Events\InvalidProgramUploadedEvent;
-use Monolog\Logger;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class InvalidProgramUploadLogger
@@ -13,16 +13,16 @@ class InvalidProgramUploadLogger
 {
 
   /**
-   * @var Logger
+   * @var LoggerInterface
    */
   private $logger;
 
   /**
    * InvalidProgramUploadLogger constructor.
    *
-   * @param Logger $logger
+   * @param LoggerInterface $logger
    */
-  public function __construct(Logger $logger)
+  public function __construct(LoggerInterface $logger)
   {
     $this->logger = $logger;
   }

--- a/src/Catrobat/Listeners/LanguageListener.php
+++ b/src/Catrobat/Listeners/LanguageListener.php
@@ -21,6 +21,9 @@ class LanguageListener
     {
       $pref_language = $event->getRequest()->getPreferredLanguage();
     }
+    if ($pref_language === null) {
+      $pref_language = "en";
+    }
     $event->getRequest()->setLocale($pref_language);
   }
 }

--- a/src/Catrobat/Listeners/RemixUpdater.php
+++ b/src/Catrobat/Listeners/RemixUpdater.php
@@ -8,7 +8,8 @@ use App\Catrobat\Events\ProgramAfterInsertEvent;
 use App\Catrobat\Services\ExtractedCatrobatFile;
 use App\Catrobat\Services\AsyncHttpClient;
 use App\Catrobat\Services\RemixData;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 
 /**
@@ -29,21 +30,30 @@ class RemixUpdater
   private $async_http_client;
 
   /**
-   * @var Router The router.
+   * @var RouterInterface The router.
    */
   private $router;
 
   /**
-   * @param RemixManager    $remix_manager
-   * @param AsyncHttpClient $async_http_client
-   * @param Router          $router
-   * @param string          $app_root_dir
+   * @var string
    */
-  public function __construct(RemixManager $remix_manager, AsyncHttpClient $async_http_client, Router $router, $app_root_dir)
+  private $migration_lock_file_path;
+
+  /**
+   * RemixUpdater constructor.
+   *
+   * @param RemixManager $remix_manager
+   * @param AsyncHttpClient $async_http_client
+   * @param RouterInterface $router
+   * @param $kernel_root_dir
+   */
+  public function __construct(RemixManager $remix_manager, AsyncHttpClient $async_http_client, RouterInterface $router,
+                              $kernel_root_dir)
   {
     $this->remix_manager = $remix_manager;
     $this->async_http_client = $async_http_client;
     $this->router = $router;
+    $app_root_dir = $kernel_root_dir;
     $this->migration_lock_file_path = $app_root_dir . '/' . self::MIGRATION_LOCK_FILE_NAME;
   }
 

--- a/src/Catrobat/Listeners/ReportNotificator.php
+++ b/src/Catrobat/Listeners/ReportNotificator.php
@@ -3,6 +3,8 @@
 namespace App\Catrobat\Listeners;
 
 use App\Catrobat\Events\ReportInsertEvent;
+use App\Entity\Notification;
+use App\Repository\NotificationRepository;
 
 /**
  * Class ReportNotificator
@@ -15,7 +17,7 @@ class ReportNotificator
    */
   private $mailer;
   /**
-   * @var \App\Repository\NotificationRepository
+   * @var NotificationRepository
    */
   private $notification_repo;
 
@@ -23,9 +25,9 @@ class ReportNotificator
    * ReportNotificator constructor.
    *
    * @param \Swift_Mailer                                     $mailer
-   * @param \App\Repository\NotificationRepository $repository
+   * @param NotificationRepository $repository
    */
-  public function __construct(\Swift_Mailer $mailer, \App\Repository\NotificationRepository $repository)
+  public function __construct(\Swift_Mailer $mailer, NotificationRepository $repository)
   {
     $this->mailer = $mailer;
     $this->notification_repo = $repository;
@@ -36,7 +38,7 @@ class ReportNotificator
    */
   public function onReportInsertEvent(ReportInsertEvent $event)
   {
-    /* @var $notification_repo \App\Repository\NotificationRepository */
+    /* @var $notification_repo NotificationRepository */
 
     $notification_repo = $this->notification_repo;
     $all_users = $notification_repo->findAll();
@@ -45,7 +47,7 @@ class ReportNotificator
 
     foreach ($all_users as $user)
     {
-      /* @var $user \App\Entity\Notification */
+      /* @var $user Notification */
       if (!$user->getReport())
       {
         continue;

--- a/src/Catrobat/Listeners/UploadNotificator.php
+++ b/src/Catrobat/Listeners/UploadNotificator.php
@@ -3,6 +3,7 @@
 namespace App\Catrobat\Listeners;
 
 use App\Catrobat\Events\ProgramAfterInsertEvent;
+use App\Repository\NotificationRepository;
 
 /**
  * Class UploadNotificator
@@ -15,7 +16,7 @@ class UploadNotificator
    */
   private $mailer;
   /**
-   * @var \App\Repository\NotificationRepository
+   * @var NotificationRepository
    */
   private $notification_repo;
 
@@ -23,9 +24,9 @@ class UploadNotificator
    * UploadNotificator constructor.
    *
    * @param \Swift_Mailer                                     $mailer
-   * @param \App\Repository\NotificationRepository $repository
+   * @param NotificationRepository $repository
    */
-  public function __construct(\Swift_Mailer $mailer, \App\Repository\NotificationRepository $repository)
+  public function __construct(\Swift_Mailer $mailer, NotificationRepository $repository)
   {
     $this->mailer = $mailer;
     $this->notification_repo = $repository;

--- a/src/Catrobat/Listeners/View/ProgramListSerializer.php
+++ b/src/Catrobat/Listeners/View/ProgramListSerializer.php
@@ -10,6 +10,7 @@ use App\Catrobat\Services\Formatter\ElapsedTimeStringFormatter;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Class ProgramListSerializer
@@ -37,12 +38,13 @@ class ProgramListSerializer
   /**
    * ProgramListSerializer constructor.
    *
-   * @param RequestStack               $request_stack
-   * @param Router                     $router
-   * @param ScreenshotRepository       $screenshot_repository
+   * @param ScreenshotRepository $screenshot_repository
+   * @param RequestStack $request_stack
+   * @param Router $router
    * @param ElapsedTimeStringFormatter $time_formatter
    */
-  public function __construct(RequestStack $request_stack, Router $router, ScreenshotRepository $screenshot_repository, ElapsedTimeStringFormatter $time_formatter)
+  public function __construct(ScreenshotRepository $screenshot_repository, RequestStack $request_stack,
+                              RouterInterface $router, ElapsedTimeStringFormatter $time_formatter)
   {
     $this->request_stack = $request_stack;
     $this->router = $router;

--- a/src/Catrobat/Listeners/View/TemplateListSerializer.php
+++ b/src/Catrobat/Listeners/View/TemplateListSerializer.php
@@ -38,18 +38,17 @@ class TemplateListSerializer
   /**
    * TemplateListSerializer constructor.
    *
-   * @param RequestStack               $request_stack
-   * @param                            $template_path
-   * @param ScreenshotRepository       $screenshot_repository
+   * @param $template_screenshot_repository
+   * @param RequestStack $request_stack
+   * @param $catrobat_template_storage_path
    * @param ElapsedTimeStringFormatter $time_formatter
    */
-  public function __construct(RequestStack $request_stack, $template_path,
-                              ScreenshotRepository $screenshot_repository,
-                              ElapsedTimeStringFormatter $time_formatter)
+  public function __construct($template_screenshot_repository, RequestStack $request_stack,
+                              $catrobat_template_storage_path, ElapsedTimeStringFormatter $time_formatter)
   {
     $this->request_stack = $request_stack;
-    $this->template_path = $template_path;
-    $this->screenshot_repository = $screenshot_repository;
+    $this->template_path = $catrobat_template_storage_path;
+    $this->screenshot_repository = $template_screenshot_repository;
     $this->time_formatter = $time_formatter;
   }
 

--- a/src/Catrobat/RecommenderSystem/RecommenderManager.php
+++ b/src/Catrobat/RecommenderSystem/RecommenderManager.php
@@ -16,6 +16,7 @@ use App\Repository\UserLikeSimilarityRelationRepository;
 use App\Repository\UserRemixSimilarityRelationRepository;
 use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -29,7 +30,7 @@ class RecommenderManager
 {
   const RECOMMENDER_LOCK_FILE_NAME = 'CatrobatRecommender.lock';
   /**
-   * @var EntityManager The entity manager.
+   * @var EntityManagerInterface The entity manager.
    */
   private $entity_manager;
 
@@ -77,7 +78,7 @@ class RecommenderManager
   /**
    * RecommenderManager constructor.
    *
-   * @param EntityManager                         $entity_manager
+   * @param EntityManagerInterface                         $entity_manager
    * @param UserManager                           $user_manager
    * @param UserLikeSimilarityRelationRepository  $user_like_similarity_relation_repository
    * @param UserRemixSimilarityRelationRepository $user_remix_similarity_relation_repository
@@ -87,7 +88,7 @@ class RecommenderManager
    * @param ProgramRemixBackwardRepository        $program_remix_backward_repository
    * @param AppRequest                            $app_request
    */
-  public function __construct(EntityManager $entity_manager, UserManager $user_manager,
+  public function __construct(EntityManagerInterface $entity_manager, UserManager $user_manager,
                               UserLikeSimilarityRelationRepository $user_like_similarity_relation_repository,
                               UserRemixSimilarityRelationRepository $user_remix_similarity_relation_repository,
                               ProgramRepository $program_repository,

--- a/src/Catrobat/RemixGraph/RemixGraphManipulator.php
+++ b/src/Catrobat/RemixGraph/RemixGraphManipulator.php
@@ -8,6 +8,9 @@ use App\Entity\ScratchProgramRemixRelation;
 use App\Repository\ProgramRemixRepository;
 use App\Repository\ProgramRemixBackwardRepository;
 use App\Repository\ScratchProgramRemixRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
 
 
 /**
@@ -44,14 +47,17 @@ class RemixGraphManipulator
   /**
    * RemixManager constructor.
    *
-   * @param EntityManager                  $entity_manager
+   * @param EntityManagerInterface                  $entity_manager
    * @param RemixSubgraphManipulator       $remix_subgraph_manipulator
    * @param ProgramRemixRepository         $program_remix_repository
    * @param ProgramRemixBackwardRepository $program_remix_backward_repository
    * @param ScratchProgramRemixRepository  $scratch_program_remix_repository
    */
-  public function __construct($entity_manager, $remix_subgraph_manipulator, $program_remix_repository,
-                              $program_remix_backward_repository, $scratch_program_remix_repository)
+  public function __construct(EntityManagerInterface $entity_manager,
+                              RemixSubgraphManipulator $remix_subgraph_manipulator,
+                              ProgramRemixRepository $program_remix_repository,
+                              ProgramRemixBackwardRepository $program_remix_backward_repository,
+                              ScratchProgramRemixRepository $scratch_program_remix_repository)
   {
     $this->entity_manager = $entity_manager;
     $this->remix_subgraph_manipulator = $remix_subgraph_manipulator;
@@ -64,8 +70,8 @@ class RemixGraphManipulator
    * @param Program $program
    * @param array   $removed_forward_parent_ids
    *
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function convertBackwardParentsHavingNoForwardAncestor(Program $program, array $removed_forward_parent_ids)
   {
@@ -172,8 +178,8 @@ class RemixGraphManipulator
    * @param Program $program
    * @param         $scratch_parent_ids_to_be_added
    *
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function linkToScratchParents(Program $program, $scratch_parent_ids_to_be_added)
   {
@@ -191,8 +197,8 @@ class RemixGraphManipulator
    * @param int[]   $ids_of_new_parents
    * @param array   $preserved_creation_date_mapping
    * @param array   $preserved_seen_date_mapping
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function appendRemixSubgraphToCatrobatParents(Program $program, array $ids_of_new_parents,
                                                        array $preserved_creation_date_mapping,

--- a/src/Catrobat/RemixGraph/RemixSubgraphManipulator.php
+++ b/src/Catrobat/RemixGraph/RemixSubgraphManipulator.php
@@ -9,6 +9,7 @@ use App\Entity\ProgramRemixBackwardRelation;
 use App\Repository\ProgramRepository;
 use App\Repository\ProgramRemixRepository;
 use App\Repository\ProgramRemixBackwardRepository;
+use Doctrine\ORM\EntityManagerInterface;
 
 
 /**
@@ -20,7 +21,7 @@ class RemixSubgraphManipulator
   const COMMON_TIMESTAMP = 'common_timestamp';
 
   /**
-   * @var EntityManager The entity manager.
+   * @var EntityManagerInterface The entity manager.
    */
   private $entity_manager;
 
@@ -42,13 +43,15 @@ class RemixSubgraphManipulator
   /**
    * RemixManager constructor.
    *
-   * @param EntityManager                  $entity_manager
+   * @param EntityManagerInterface         $entity_manager
    * @param ProgramRepository              $program_repository
    * @param ProgramRemixRepository         $program_remix_repository
    * @param ProgramRemixBackwardRepository $program_remix_backward_repository
    */
-  public function __construct($entity_manager, $program_repository, $program_remix_repository,
-                              $program_remix_backward_repository)
+  public function __construct(EntityManagerInterface $entity_manager,
+                              ProgramRepository $program_repository,
+                              ProgramRemixRepository $program_remix_repository,
+                              ProgramRemixBackwardRepository $program_remix_backward_repository)
   {
     $this->entity_manager = $entity_manager;
     $this->program_repository = $program_repository;

--- a/src/Catrobat/Services/ApkRepository.php
+++ b/src/Catrobat/Services/ApkRepository.php
@@ -3,6 +3,7 @@
 namespace App\Catrobat\Services;
 
 use App\Catrobat\Exceptions\InvalidStorageDirectoryException;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\File\File;
 
 /**
@@ -19,11 +20,12 @@ class ApkRepository
   /**
    * ApkRepository constructor.
    *
-   * @param $dir
+   * @param ParameterBagInterface $parameter_bag
    */
-  public function __construct($dir)
+  public function __construct(ParameterBagInterface $parameter_bag)
   {
-    $dir = preg_replace('/([^\/]+)$/', '$1/', $dir);
+    $apk_dir = $parameter_bag->get('catrobat.apk.dir');
+    $dir = preg_replace('/([^\/]+)$/', '$1/', $apk_dir);
 
     if (!is_dir($dir))
     {

--- a/src/Catrobat/Services/BackupFileRepository.php
+++ b/src/Catrobat/Services/BackupFileRepository.php
@@ -4,6 +4,7 @@ namespace App\Catrobat\Services;
 
 
 use App\Catrobat\Exceptions\InvalidStorageDirectoryException;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\File\File;
 
 /**
@@ -20,10 +21,11 @@ class BackupFileRepository
   /**
    * BackupFileRepository constructor.
    *
-   * @param $directory
+   * @param ParameterBagInterface $parameter_bag
    */
-  public function __construct($directory)
+  public function __construct(ParameterBagInterface $parameter_bag)
   {
+    $directory = $parameter_bag->get('catrobat.backup.dir');
     if (!is_dir($directory))
     {
       throw new InvalidStorageDirectoryException($directory . ' is not a valid directory');

--- a/src/Catrobat/Services/CatroNotificationService.php
+++ b/src/Catrobat/Services/CatroNotificationService.php
@@ -29,8 +29,8 @@
 
 namespace App\Catrobat\Services;
 
-use App\Entity\CatroNotification;
-use Doctrine\ORM\EntityManager;
+
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Class CatroNotificationService
@@ -44,16 +44,16 @@ class CatroNotificationService
   const DEFAULT_NOTIFICATION = 0;
 
   /**
-   * @var EntityManager
+   * @var EntityManagerInterface
    */
   private $em;
 
   /**
    * CatroNotificationService constructor.
    *
-   * @param EntityManager $em
+   * @param EntityManagerInterface $em
    */
-  public function __construct(EntityManager $em)
+  public function __construct(EntityManagerInterface $em)
   {
     $this->em = $em;
   }
@@ -68,9 +68,6 @@ class CatroNotificationService
 
   /**
    * @param $notification
-   *
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
    */
   public function addNotification($notification)
   {
@@ -79,10 +76,7 @@ class CatroNotificationService
   }
 
   /**
-   * @param \Generator $notifications
-   *
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @param $notifications
    */
   public function addNotifications($notifications)
   {
@@ -95,9 +89,6 @@ class CatroNotificationService
 
   /**
    * @param $notification
-   *
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
    */
   public function removeNotification($notification)
   {
@@ -106,12 +97,7 @@ class CatroNotificationService
   }
 
   /**
-   * @param array CatroNotification $notifications
-   *
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
-   *
-   * @desc Deletes all given notifications
+   * @param $notifications
    */
   public function deleteNotifications($notifications)
   {

--- a/src/Catrobat/Services/CatrobatCodeParser/CatrobatCodeParser.php
+++ b/src/Catrobat/Services/CatrobatCodeParser/CatrobatCodeParser.php
@@ -4,6 +4,7 @@ namespace App\Catrobat\Services\CatrobatCodeParser;
 
 use App\Catrobat\Services\ExtractedCatrobatFile;
 
+
 /**
  * Class CatrobatCodeParser
  * @package App\Catrobat\Services\CatrobatCodeParser

--- a/src/Catrobat/Services/CatrobatFileCompressor.php
+++ b/src/Catrobat/Services/CatrobatFileCompressor.php
@@ -12,13 +12,6 @@ use Symfony\Component\Finder\Finder;
 class CatrobatFileCompressor
 {
   /**
-   * CatrobatFileCompressor constructor.
-   */
-  public function __construct()
-  {
-  }
-
-  /**
    * @param $source
    * @param $destination
    * @param $archive_name

--- a/src/Catrobat/Services/Ci/JenkinsDispatcher.php
+++ b/src/Catrobat/Services/Ci/JenkinsDispatcher.php
@@ -2,7 +2,9 @@
 
 namespace App\Catrobat\Services\Ci;
 
-use Symfony\Component\Routing\Router;
+
+
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Class JenkinsDispatcher
@@ -11,7 +13,7 @@ use Symfony\Component\Routing\Router;
 class JenkinsDispatcher
 {
   /**
-   * @var Router
+   * @var RouterInterface
    */
   protected $router;
   /**
@@ -27,7 +29,7 @@ class JenkinsDispatcher
    *
    * @throws \Exception
    */
-  public function __construct($router, $config)
+  public function __construct($config, RouterInterface $router)
   {
     if (!isset($config['url']))
     {

--- a/src/Catrobat/Services/CommunityStatisticsService.php
+++ b/src/Catrobat/Services/CommunityStatisticsService.php
@@ -4,6 +4,7 @@ namespace App\Catrobat\Services;
 
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Class CommunityStatisticsService
@@ -20,9 +21,9 @@ class CommunityStatisticsService
   /**
    * CommunityStatisticsService constructor.
    *
-   * @param EntityManager $em
+   * @param EntityManagerInterface $em
    */
-  public function __construct(EntityManager $em)
+  public function __construct(EntityManagerInterface $em)
   {
     $this->em = $em;
   }

--- a/src/Catrobat/Services/ExtractedCatrobatFile.php
+++ b/src/Catrobat/Services/ExtractedCatrobatFile.php
@@ -6,6 +6,7 @@ use App\Catrobat\CatrobatCode\CodeObject;
 use App\Catrobat\CatrobatCode\StatementFactory;
 use App\Catrobat\Exceptions\Upload\InvalidXmlException;
 use App\Catrobat\Exceptions\Upload\MissingXmlException;
+use Doctrine\DBAL\Types\GuidType;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\File\File;
 
@@ -325,7 +326,7 @@ class ExtractedCatrobatFile
   /**
    * based on: http://stackoverflow.com/a/27295688
    *
-   * @param int     $program_id
+   * @param GuidType     $program_id
    * @param boolean $is_initial_version
    * @param bool    $migration_mode
    *

--- a/src/Catrobat/Services/ExtractedFileRepository.php
+++ b/src/Catrobat/Services/ExtractedFileRepository.php
@@ -7,7 +7,9 @@ use App\Catrobat\Exceptions\InvalidStorageDirectoryException;
 use App\Catrobat\Exceptions\InvalidCatrobatFileException;
 use App\Entity\ProgramManager;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpFoundation\ParameterBag;
 
 
 /**
@@ -48,19 +50,21 @@ class ExtractedFileRepository
   /**
    * ExtractedFileRepository constructor.
    *
-   * @param                       $local_extracted_path
-   * @param                       $web_extracted_path
-   * @param                       $local_storage_path
+   * @param ParameterBagInterface $parameter_bag
    * @param CatrobatFileExtractor $file_extractor
-   * @param ProgramManager        $program_manager
+   * @param ProgramManager $program_manager
    * @param ProgramFileRepository $prog_file_rep
-   * @param LoggerInterface       $l
+   * @param LoggerInterface $l
    */
-  public function __construct($local_extracted_path, $web_extracted_path, $local_storage_path,
-                                 CatrobatFileExtractor $file_extractor,
-                                 ProgramManager $program_manager,
-                                 ProgramFileRepository $prog_file_rep, LoggerInterface $l)
+  public function __construct(ParameterBagInterface $parameter_bag, CatrobatFileExtractor $file_extractor,
+                              ProgramManager $program_manager, ProgramFileRepository $prog_file_rep,
+                              LoggerInterface $l)
   {
+
+    $local_extracted_path = $parameter_bag->get('catrobat.file.extract.dir');
+    $web_extracted_path = $parameter_bag->get('catrobat.file.extract.path');
+    $local_storage_path = $parameter_bag->get('catrobat.file.storage.dir');
+
     if (!is_dir($local_extracted_path))
     {
       throw new InvalidStorageDirectoryException($local_extracted_path . ' is not a valid directory');

--- a/src/Catrobat/Services/FeaturedImageRepository.php
+++ b/src/Catrobat/Services/FeaturedImageRepository.php
@@ -3,6 +3,7 @@
 namespace App\Catrobat\Services;
 
 use App\Catrobat\Exceptions\InvalidStorageDirectoryException;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\File\File;
 
 
@@ -24,11 +25,12 @@ class FeaturedImageRepository
   /**
    * FeaturedImageRepository constructor.
    *
-   * @param $dir
-   * @param $path
+   * @param ParameterBagInterface $parameter_bag
    */
-  public function __construct($dir, $path)
+  public function __construct(ParameterBagInterface $parameter_bag)
   {
+    $dir = $parameter_bag->get('catrobat.featuredimage.dir');
+    $path = $parameter_bag->get('catrobat.featuredimage.path');
     $dir = preg_replace('/([^\/]+)$/', '$1/', $dir);
     $path = preg_replace('/([^\/]+)$/', '$1/', $path);
 

--- a/src/Catrobat/Services/MediaPackageFileRepository.php
+++ b/src/Catrobat/Services/MediaPackageFileRepository.php
@@ -3,6 +3,7 @@
 namespace App\Catrobat\Services;
 
 use App\Catrobat\Exceptions\InvalidStorageDirectoryException;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\File\File;
@@ -21,13 +22,16 @@ class MediaPackageFileRepository
   /**
    * MediaPackageFileRepository constructor.
    *
-   * @param string $dir  Directory where media package files are stored
-   * @param string $path Path where files in $dir can be accessed via web
-   *
-   * @throws InvalidStorageDirectoryException
+   * @param ParameterBagInterface $parameter_bag
    */
-  public function __construct($dir, $path)
+  public function __construct(ParameterBagInterface $parameter_bag)
   {
+    /**
+     * @var string $dir  Directory where media package files are stored
+     * @var string $path Path where files in $dir can be accessed via web
+     */
+    $dir = $parameter_bag->get('catrobat.mediapackage.dir');
+    $path = $parameter_bag->get('catrobat.mediapackage.path');
     $dir = preg_replace('/([^\/]+)$/', '$1/', $dir);
     $path = preg_replace('/([^\/]+)$/', '$1/', $path);
     $thumb_dir = $dir . 'thumbs/';

--- a/src/Catrobat/Services/ProgramFileRepository.php
+++ b/src/Catrobat/Services/ProgramFileRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Catrobat\Services;
 
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\File;
 use App\Catrobat\Exceptions\InvalidStorageDirectoryException;
@@ -16,7 +17,7 @@ class ProgramFileRepository
   /**
    * @var
    */
-  private $directory;
+  protected $directory;
   /**
    * @var Filesystem
    */
@@ -24,33 +25,43 @@ class ProgramFileRepository
   /**
    * @var
    */
-  private $webpath;
+  protected $webpath;
   /**
    * @var CatrobatFileCompressor
    */
   private $file_compressor;
 
   /**
+   * @var
+   */
+  private $tmp_dir;
+
+  /**
    * ProgramFileRepository constructor.
    *
-   * @param                        $directory
-   * @param                        $webpath
+   * @param $catrobat_file_storage_dir
+   * @param $catrobat_file_storage_path
    * @param CatrobatFileCompressor $file_compressor
-   * @param                        $tmp_dir
+   * @param $catrobat_upload_temp_dir
    */
-  public function __construct($directory, $webpath, CatrobatFileCompressor $file_compressor, $tmp_dir)
+  public function __construct($catrobat_file_storage_dir, $catrobat_file_storage_path,
+                              CatrobatFileCompressor $file_compressor, $catrobat_upload_temp_dir)
   {
+    $directory = $catrobat_file_storage_dir;
+    $tmp_dir = $catrobat_upload_temp_dir;
+
     if (!is_dir($directory))
     {
       throw new InvalidStorageDirectoryException($directory . ' is not a valid directory');
     }
+
     if ($tmp_dir && !is_dir($tmp_dir))
     {
       throw new InvalidStorageDirectoryException($tmp_dir . ' is not a valid directory');
     }
 
     $this->directory = $directory;
-    $this->webpath = $webpath;
+    $this->webpath = $catrobat_file_storage_path;
     $this->tmp_dir = $tmp_dir;
     $this->filesystem = new Filesystem();
     $this->file_compressor = $file_compressor;

--- a/src/Catrobat/Services/RudeWordFilter.php
+++ b/src/Catrobat/Services/RudeWordFilter.php
@@ -2,6 +2,9 @@
 
 namespace App\Catrobat\Services;
 
+use App\Repository\RudeWordsRepository;
+use Doctrine\ORM\NonUniqueResultException;
+
 /**
  * Class RudeWordFilter
  * @package App\Catrobat\Services
@@ -9,16 +12,16 @@ namespace App\Catrobat\Services;
 class RudeWordFilter
 {
   /**
-   * @var \App\Repository\RudeWordsRepository
+   * @var RudeWordsRepository
    */
   private $repository;
 
   /**
    * RudeWordFilter constructor.
    *
-   * @param \App\Repository\RudeWordsRepository $repository
+   * @param RudeWordsRepository $repository
    */
-  public function __construct(\App\Repository\RudeWordsRepository $repository)
+  public function __construct(RudeWordsRepository $repository)
   {
     $this->repository = $repository;
   }
@@ -27,7 +30,7 @@ class RudeWordFilter
    * @param $string
    *
    * @return bool
-   * @throws \Doctrine\ORM\NonUniqueResultException
+   * @throws NonUniqueResultException
    */
   public function containsRudeWord($string)
   {

--- a/src/Catrobat/Services/ScreenshotRepository.php
+++ b/src/Catrobat/Services/ScreenshotRepository.php
@@ -3,7 +3,6 @@
 namespace App\Catrobat\Services;
 
 use App\Catrobat\Exceptions\InvalidStorageDirectoryException;
-use mysql_xdevapi\Exception;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;

--- a/src/Catrobat/Services/StatisticsService.php
+++ b/src/Catrobat/Services/StatisticsService.php
@@ -8,12 +8,15 @@ use App\Entity\Program;
 use App\Entity\ProgramDownloads;
 use App\Catrobat\RecommenderSystem\RecommendedPageId;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
+use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Monolog\Logger;
 use App\Entity\ProgramManager;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 
 /**
@@ -31,7 +34,7 @@ class StatisticsService
    */
   private $entity_manager;
   /**
-   * @var Logger
+   * @var LoggerInterface
    */
   private $logger;
   /**
@@ -42,15 +45,15 @@ class StatisticsService
   /**
    * StatisticsService constructor.
    *
-   * @param ProgramManager $programmanager
-   * @param                $entity_manager
-   * @param Logger         $logger
-   * @param                $security_token_storage
+   * @param ProgramManager  $program_manager
+   * @param                 $entity_manager
+   * @param LoggerInterface $logger
+   * @param                 $security_token_storage
    */
-  public function __construct(ProgramManager $programmanager, $entity_manager,
-                              Logger $logger, $security_token_storage)
+  public function __construct(ProgramManager $program_manager, EntityManagerInterface $entity_manager,
+                              LoggerInterface $logger, TokenStorageInterface $security_token_storage)
   {
-    $this->programmanager = $programmanager;
+    $this->programmanager = $program_manager;
     $this->entity_manager = $entity_manager;
     $this->logger = $logger;
     $this->security_token_storage = $security_token_storage;
@@ -85,15 +88,15 @@ class StatisticsService
       $user = $session_user;
     }
 
-    $this->logger->addDebug('create download stats for program id: ' . $program_id . ', ip: ' . $ip .
+    $this->logger->debug('create download stats for program id: ' . $program_id . ', ip: ' . $ip .
       ', user agent: ' . $user_agent . ', referrer: ' . $referrer);
     if ($user !== null)
     {
-      $this->logger->addDebug('user: ' . $user->getUsername());
+      $this->logger->debug('user: ' . $user->getUsername());
     }
     else
     {
-      $this->logger->addDebug('user: anon.');
+      $this->logger->debug('user: anon.');
     }
 
     // geocoder disabled, license needed
@@ -150,7 +153,7 @@ class StatisticsService
       $this->entity_manager->flush();
     } catch (\Exception $e)
     {
-      $this->logger->addError($e->getMessage());
+      $this->logger->error($e->getMessage());
 
       return false;
     }
@@ -193,7 +196,7 @@ class StatisticsService
   /**
    * @return Logger
    */
-  public function getLogger(): Logger
+  public function getLogger(): LoggerInterface
   {
     return $this->logger;
   }
@@ -256,15 +259,15 @@ class StatisticsService
       $user = $session_user;
     }
 
-    $this->logger->addDebug('create download stats for project id: ' . $rec_from_id . ', ip: ' . $ip .
+    $this->logger->debug('create download stats for project id: ' . $rec_from_id . ', ip: ' . $ip .
       ', user agent: ' . $user_agent . ', referrer: ' . $referrer);
     if ($user !== null)
     {
-      $this->logger->addDebug('user: ' . $user->getUsername());
+      $this->logger->debug('user: ' . $user->getUsername());
     }
     else
     {
-      $this->logger->addDebug('user: anon.');
+      $this->logger->debug('user: anon.');
     }
 
     // geocoder disabled, license needed
@@ -395,15 +398,15 @@ class StatisticsService
       $user = $session_user;
     }
 
-    $this->logger->addDebug('create click stats for program id: ' . $program_id . ', ip: ' . $ip .
+    $this->logger->debug('create click stats for program id: ' . $program_id . ', ip: ' . $ip .
       ', user agent: ' . $user_agent . ', referrer: ' . $referrer);
     if ($user !== null)
     {
-      $this->logger->addDebug('user: ' . $user->getUsername());
+      $this->logger->debug('user: ' . $user->getUsername());
     }
     else
     {
-      $this->logger->addDebug('user: anon.');
+      $this->logger->debug('user: anon.');
     }
 
     $homepage_click_statistics = new HomepageClickStatistic();

--- a/src/Catrobat/Services/TemplateFileRepository.php
+++ b/src/Catrobat/Services/TemplateFileRepository.php
@@ -14,14 +14,16 @@ class TemplateFileRepository extends ProgramFileRepository
   /**
    * TemplateFileRepository constructor.
    *
-   * @param                        $directory
-   * @param                        $webpath
+   * @param $catrobat_template_storage_dir
+   * @param $catrobat_template_storage_path
    * @param CatrobatFileCompressor $file_compressor
-   * @param                        $tmp_dir
+   * @param $catrobat_upload_temp_dir
    */
-  public function __construct($directory, $webpath, CatrobatFileCompressor $file_compressor, $tmp_dir)
+  public function __construct($catrobat_template_storage_dir, $catrobat_template_storage_path,
+                              CatrobatFileCompressor $file_compressor, $catrobat_upload_temp_dir)
   {
-    parent::__construct($directory, $webpath, $file_compressor, $tmp_dir);
+    parent::__construct($catrobat_template_storage_dir, $catrobat_template_storage_path, $file_compressor,
+      $catrobat_upload_temp_dir);
   }
 
   /**

--- a/src/Catrobat/Services/TemplateService.php
+++ b/src/Catrobat/Services/TemplateService.php
@@ -13,7 +13,9 @@ use App\Entity\TemplateManager;
 class TemplateService
 {
 
-  /* @var $templateManager \App\Entity\TemplateManager */
+  /**
+   * @var $templateManager TemplateManager
+   */
   private $templateManager;
 
   /**

--- a/src/Catrobat/Services/TestEnv/FakeStatisticsService.php
+++ b/src/Catrobat/Services/TestEnv/FakeStatisticsService.php
@@ -3,12 +3,16 @@
 namespace App\Catrobat\Services\TestEnv;
 
 use App\Catrobat\Services\StatisticsService;
+use App\Entity\ProgramManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Class FakeStatisticsService
  * @package App\Catrobat\Features\Helpers
  */
-class FakeStatisticsService
+class FakeStatisticsService extends StatisticsService
 {
   /**
    * @var StatisticsService
@@ -23,9 +27,16 @@ class FakeStatisticsService
    * FakeStatisticsService constructor.
    *
    * @param StatisticsService $geocoder_service
+   * @param ProgramManager $program_manager
+   * @param EntityManagerInterface $entity_manager
+   * @param LoggerInterface $logger
+   * @param TokenStorageInterface $security_token_storage
    */
-  public function __construct(StatisticsService $geocoder_service)
+  public function __construct(StatisticsService $geocoder_service, ProgramManager $program_manager,
+                              EntityManagerInterface $entity_manager, LoggerInterface $logger,
+                              TokenStorageInterface $security_token_storage)
   {
+    parent::__construct($program_manager, $entity_manager, $logger, $security_token_storage);
     $this->geocoder_service = $geocoder_service;
   }
 
@@ -37,14 +48,18 @@ class FakeStatisticsService
    * @param $rec_by_page_id
    * @param $rec_by_program_id
    * @param $locale
+   * @param bool $not_needed
    *
    * @return bool
+   * @throws \Exception
    */
-  public function createProgramDownloadStatistics($event, $program_id, $referrer, $rec_tag_by_program_id, $rec_by_page_id, $rec_by_program_id, $locale)
+  public function createProgramDownloadStatistics($event, $program_id, $referrer, $rec_tag_by_program_id,
+                                                  $rec_by_page_id, $rec_by_program_id, $locale, $not_needed = false)
   {
     if ($this->use_real_service)
     {
-      return $this->geocoder_service->createProgramDownloadStatistics($event, $program_id, $referrer, $rec_tag_by_program_id, $rec_by_page_id, $rec_by_program_id, $locale);
+      return $this->geocoder_service->createProgramDownloadStatistics($event, $program_id, $referrer,
+        $rec_tag_by_program_id, $rec_by_page_id, $rec_by_program_id, $locale);
     }
 
     return true;
@@ -58,14 +73,21 @@ class FakeStatisticsService
    * @param $tag_id
    * @param $extension_name
    * @param $referrer
+   * @param bool $not_needed
+   * @param bool $not_needed2
+   * @param bool $not_needed3
+   * @param bool $not_needed4
    *
    * @return bool
    * @throws \Doctrine\ORM\ORMException
    * @throws \Doctrine\ORM\OptimisticLockException
    */
-  public function createClickStatistics($request, $type, $rec_from_id, $rec_program_id, $tag_id, $extension_name, $referrer)
+  public function createClickStatistics($request, $type, $rec_from_id, $rec_program_id, $tag_id, $extension_name,
+                                        $referrer, $not_needed = false, $not_needed2 = false, $not_needed3 = false,
+                                        $not_needed4 = false)
   {
-    return $this->geocoder_service->createClickStatistics($request, $type, $rec_from_id, $rec_program_id, $tag_id, $extension_name, $referrer);
+    return $this->geocoder_service->createClickStatistics($request, $type, $rec_from_id, $rec_program_id,
+      $tag_id, $extension_name, $referrer);
   }
 
   /**

--- a/src/Catrobat/Services/TestEnv/LdapTestDriver.php
+++ b/src/Catrobat/Services/TestEnv/LdapTestDriver.php
@@ -5,6 +5,7 @@ namespace App\Catrobat\Services\TestEnv;
 use FR3D\LdapBundle\Driver\LdapDriverException;
 use FR3D\LdapBundle\Driver\LdapDriverInterface;
 use FR3D\LdapBundle\Model\LdapUserInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 
@@ -38,11 +39,11 @@ class LdapTestDriver implements LdapDriverInterface
   /**
    * LdapTestDriver constructor.
    *
-   * @param $baseDN
+   * @param ParameterBagInterface $parameter_bag
    */
-  public function __construct($baseDN)
+  public function __construct(ParameterBagInterface $parameter_bag)
   {
-    $this->baseDN = $baseDN;
+    $this->baseDN = $parameter_bag->get('ldap_base_dn');
     $this->throw_expection_on_search = false;
   }
 
@@ -56,7 +57,7 @@ class LdapTestDriver implements LdapDriverInterface
    *
    * @return bool true on success or false on failure
    */
-  public function bind(UserInterface $user, $password)
+  public function bind(UserInterface $user, $password): bool
   {
     $this->loadFixtures();
     if ($user instanceof LdapUserInterface)

--- a/src/Catrobat/Services/TestEnv/SymfonySupport.php
+++ b/src/Catrobat/Services/TestEnv/SymfonySupport.php
@@ -2,19 +2,34 @@
 
 namespace App\Catrobat\Services\TestEnv;
 
+use App\Catrobat\Services\ExtractedFileRepository;
+use App\Catrobat\Services\MediaPackageFileRepository;
+use App\Catrobat\Services\ProgramFileRepository;
 use App\Entity\Extension;
 use App\Entity\ProgramDownloads;
 use App\Entity\ProgramLike;
+use App\Entity\ProgramManager;
 use App\Entity\ProgramRemixBackwardRelation;
 use App\Entity\ProgramRemixRelation;
 use App\Entity\ScratchProgramRemixRelation;
 use App\Entity\User;
 use App\Entity\UserLikeSimilarityRelation;
+use App\Entity\UserManager;
+use App\Repository\ExtensionRepository;
+use App\Repository\ProgramRemixBackwardRepository;
+use App\Repository\ProgramRemixRepository;
+use App\Repository\ScratchProgramRemixRepository;
+use App\Repository\ScratchProgramRepository;
+use App\Repository\TagRepository;
 use App\Repository\UserLikeSimilarityRelationRepository;
 use App\Entity\UserRemixSimilarityRelation;
 use App\Catrobat\RecommenderSystem\RecommenderManager;
+use App\Repository\UserRemixSimilarityRelationRepository;
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -26,6 +41,8 @@ use App\Catrobat\Services\CatrobatFileCompressor;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use App\Entity\GameJam;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Symfony\Component\Routing\Router;
 use Symfony\Component\Validator\Constraints\DateTime;
 use PHPUnit\Framework\Assert;
 
@@ -81,7 +98,7 @@ class SymfonySupport
   }
 
   /**
-   * @return \Symfony\Bundle\FrameworkBundle\Client
+   * @return Client
    */
   public function getClient()
   {
@@ -94,91 +111,91 @@ class SymfonySupport
   }
 
   /**
-   * @return \App\Entity\UserManager
+   * @return UserManager
    */
   public function getUserManager()
   {
-    return $this->kernel->getContainer()->get('usermanager');
+    return $this->kernel->getContainer()->get(UserManager::class);
   }
 
   /**
-   * @return \App\Entity\ProgramManager
+   * @return ProgramManager
    */
   public function getProgramManager()
   {
-    return $this->kernel->getContainer()->get('programmanager');
+    return $this->kernel->getContainer()->get(ProgramManager::class);
   }
 
   /**
-   * @return \App\Repository\TagRepository
+   * @return TagRepository
    */
   public function getTagRepository()
   {
-    return $this->kernel->getContainer()->get('tagrepository');
+    return $this->kernel->getContainer()->get(TagRepository::class);
   }
 
   /**
-   * @return \App\Repository\ExtensionRepository
+   * @return ExtensionRepository
    */
   public function getExtensionRepository()
   {
-    return $this->kernel->getContainer()->get('extensionrepository');
+    return $this->kernel->getContainer()->get(ExtensionRepository::class);
   }
 
   /**
-   * @return \App\Repository\ProgramRemixRepository
+   * @return ProgramRemixRepository
    */
   public function getProgramRemixForwardRepository()
   {
-    return $this->kernel->getContainer()->get('programremixrepository');
+    return $this->kernel->getContainer()->get(ProgramRemixRepository::class);
   }
 
   /**
-   * @return \App\Repository\ProgramRemixBackwardRepository
+   * @return ProgramRemixBackwardRepository
    */
   public function getProgramRemixBackwardRepository()
   {
-    return $this->kernel->getContainer()->get('programremixbackwardrepository');
+    return $this->kernel->getContainer()->get(ProgramRemixBackwardRepository::class);
   }
 
   /**
-   * @return \App\Repository\ScratchProgramRepository
+   * @return ScratchProgramRepository
    */
   public function getScratchProgramRepository()
   {
-    return $this->kernel->getContainer()->get('scratchprogramrepository');
+    return $this->kernel->getContainer()->get(ScratchProgramRepository::class);
   }
 
   /**
-   * @return \App\Repository\ScratchProgramRemixRepository
+   * @return ScratchProgramRemixRepository
    */
   public function getScratchProgramRemixRepository()
   {
-    return $this->kernel->getContainer()->get('scratchprogramremixrepository');
+    return $this->kernel->getContainer()->get(ScratchProgramRemixRepository::class);
   }
 
   /**
-   * @return \App\Catrobat\Services\ProgramFileRepository
+   * @return ProgramFileRepository
    */
   public function getFileRepository()
   {
-    return $this->kernel->getContainer()->get('filerepository');
+    return $this->kernel->getContainer()->get(ProgramFileRepository::class);
   }
 
   /**
-   * @return \App\Catrobat\Services\ExtractedFileRepository
+   * @return ExtractedFileRepository
    */
   public function getExtractedFileRepository()
   {
-    return $this->kernel->getContainer()->get('extractedfilerepository');
+    return $this->kernel->getContainer()->get(ExtractedFileRepository::class);
   }
 
   /**
-   * @return \App\Catrobat\Services\MediaPackageFileRepository
+   * @return MediaPackageFileRepository
    */
   public function getMediaPackageFileRepository()
   {
-    return $this->kernel->getContainer()->get('mediapackagefilerepository');
+    return $this->kernel->getContainer()->get(MediaPackageFileRepository::class);
   }
 
   /**
@@ -186,7 +203,7 @@ class SymfonySupport
    */
   public function getRecommenderManager()
   {
-    return $this->kernel->getContainer()->get('recommendermanager');
+    return $this->kernel->getContainer()->get(RecommenderManager::class);
   }
 
   /**
@@ -194,19 +211,19 @@ class SymfonySupport
    */
   public function getUserLikeSimilarityRelationRepository()
   {
-    return $this->kernel->getContainer()->get('userlikesimilarityrelationrepository');
+    return $this->kernel->getContainer()->get(UserLikeSimilarityRelationRepository::class);
   }
 
   /**
-   * @return \App\Repository\UserRemixSimilarityRelationRepository
+   * @return UserRemixSimilarityRelationRepository
    */
   public function getUserRemixSimilarityRelationRepository()
   {
-    return $this->kernel->getContainer()->get('userremixsimilarityrelationrepository');
+    return $this->kernel->getContainer()->get(UserRemixSimilarityRelationRepository::class);
   }
 
   /**
-   * @return \Doctrine\ORM\EntityManager
+   * @return EntityManager
    */
   public function getManager()
   {
@@ -214,7 +231,7 @@ class SymfonySupport
   }
 
   /**
-   * @return \Symfony\Component\Routing\Router
+   * @return Router
    */
   public function getRouter()
   {
@@ -243,7 +260,7 @@ class SymfonySupport
   }
 
   /**
-   * @return false|\Symfony\Component\HttpKernel\Profiler\Profiler
+   * @return false | Profiler
    */
   public function getSymfonyProfile()
   {
@@ -261,7 +278,9 @@ class SymfonySupport
   }
 
   /**
-   * @return \App\Entity\User
+   * @return User|object|null
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function getDefaultUser()
   {
@@ -320,8 +339,8 @@ class SymfonySupport
    * @param array $config
    *
    * @return GameJam
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    * @throws \Exception
    */
   public function insertDefaultGamejam($config = [])
@@ -351,7 +370,9 @@ class SymfonySupport
   /**
    * @param array $config
    *
-   * @return \FOS\UserBundle\Model\UserInterface|mixed
+   * @return object|null
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function insertUser($config = [])
   {
@@ -383,7 +404,7 @@ class SymfonySupport
   }
 
   /**
-   *
+   * 
    */
   public function computeAllLikeSimilaritiesBetweenUsers()
   {
@@ -431,8 +452,8 @@ class SymfonySupport
   /**
    * @param array $config
    *
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function insertUserLikeSimilarity($config = [])
   {
@@ -451,8 +472,8 @@ class SymfonySupport
   /**
    * @param array $config
    *
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function insertUserRemixSimilarity($config = [])
   {
@@ -471,9 +492,8 @@ class SymfonySupport
   /**
    * @param array $config
    *
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
-   * @throws \Exception
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function insertProgramLike($config = [])
   {
@@ -497,8 +517,8 @@ class SymfonySupport
   /**
    * @param $config
    *
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function insertTag($config)
   {
@@ -516,8 +536,8 @@ class SymfonySupport
   /**
    * @param $config
    *
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function insertExtension($config)
   {
@@ -535,8 +555,8 @@ class SymfonySupport
   /**
    * @param $config
    *
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function insertForwardRemixRelation($config)
   {
@@ -556,8 +576,8 @@ class SymfonySupport
   /**
    * @param $config
    *
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function insertBackwardRemixRelation($config)
   {
@@ -577,8 +597,8 @@ class SymfonySupport
   /**
    * @param $config
    *
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    */
   public function insertScratchRemixRelation($config)
   {
@@ -698,8 +718,8 @@ class SymfonySupport
    * @param $config
    *
    * @return ProgramDownloads
-   * @throws \Doctrine\ORM\ORMException
-   * @throws \Doctrine\ORM\OptimisticLockException
+   * @throws ORMException
+   * @throws OptimisticLockException
    * @throws \Exception
    */
   public function insertProgramDownloadStatistics($program, $config)
@@ -720,12 +740,12 @@ class SymfonySupport
 
     if (isset($config['username']))
     {
-      $userManager = $this->getUserManager();
-      $user = $userManager->createUser();
+      $user_manager = $this->getUserManager();
+      $user = $user_manager->createUser();
       $user->setUsername($config['username']);
       $user->setEmail('dog@robat.at');
       $user->setPassword('test');
-      $userManager->updateUser($user);
+      $user_manager->updateUser($user);
       $program_statistics->setUser($user);
     }
 
@@ -804,7 +824,7 @@ class SymfonySupport
    * @param string $flavor
    * @param null $request_param
    *
-   * @return \Symfony\Component\HttpFoundation\Response|null
+   * @return Response | null
    * @throws ORMException
    * @throws OptimisticLockException
    */

--- a/src/Catrobat/StatusCode.php
+++ b/src/Catrobat/StatusCode.php
@@ -74,6 +74,7 @@ class StatusCode
   const USERNAME_MISSING = 800;
   const USERNAME_ALREADY_EXISTS = 801;
   const USERNAME_INVALID = 802;
+  const USERNAME_NOT_FOUND = 803;
 
   const NO_GAME_JAM = 900;
 }

--- a/src/Catrobat/Twig/AppExtension.php
+++ b/src/Catrobat/Twig/AppExtension.php
@@ -2,9 +2,11 @@
 
 namespace App\Catrobat\Twig;
 
+use App\Catrobat\Services\CommunityStatisticsService;
 use App\Entity\MediaPackageFile;
 use App\Catrobat\Services\MediaPackageFileRepository;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\RequestStack;
 use App\Repository\GameJamRepository;
@@ -48,30 +50,30 @@ class AppExtension extends AbstractExtension
   private $translationPath;
 
   /**
-   * @var Container
+   * @var ParameterBagInterface
    */
-  private $container;
+  private $parameter_bag;
 
   /**
    * AppExtension constructor.
    *
-   * @param RequestStack               $request_stack
+   * @param RequestStack $request_stack
    * @param MediaPackageFileRepository $mediapackage_file_repo
-   * @param GameJamRepository          $gamejamrepository
-   * @param ActiveTheme                $theme
-   * @param                            $translationPath
-   * @param Container                  $container
+   * @param GameJamRepository $gamejamrepository
+   * @param ActiveTheme $theme
+   * @param ParameterBagInterface $parameter_bag
+   * @param $catrobat_translation_dir
    */
-  public function __construct(RequestStack $request_stack, MediaPackageFileRepository
-  $mediapackage_file_repo, GameJamRepository $gamejamrepository, ActiveTheme $theme,
-                              $translationPath, Container $container)
+  public function __construct(RequestStack $request_stack, MediaPackageFileRepository $mediapackage_file_repo,
+                              GameJamRepository $gamejamrepository, ActiveTheme $theme,
+                              ParameterBagInterface $parameter_bag, $catrobat_translation_dir)
   {
-    $this->translationPath = $translationPath;
+    $this->translationPath = $catrobat_translation_dir;
+    $this->parameter_bag = $parameter_bag;
     $this->request_stack = $request_stack;
     $this->mediapackage_file_repository = $mediapackage_file_repo;
     $this->gamejamrepository = $gamejamrepository;
     $this->theme = $theme;
-    $this->container = $container;
   }
 
   /**
@@ -385,7 +387,7 @@ class AppExtension extends AbstractExtension
    */
   public function getJavascriptPath($jsFile)
   {
-    $jsPath = $this->container->getParameter('jspath');
+    $jsPath = $this->parameter_bag->get('jspath');
     $jsPath .= $jsFile;
     $jsPath = str_replace("//", "/", $jsPath);
 
@@ -396,15 +398,15 @@ class AppExtension extends AbstractExtension
    * Twig extension to provide a function to retrieve the community statistics in any view.
    * Needed to render the footer.
    *
-   * See the fetchStatistics implementation of Services\CommunityStatisticsService.php
-   *                                           for details.
+   * See the fetchStatistics implementation of Services\CommunityStatisticsService.php for details.
+   *
+   * @param CommunityStatisticsService $communityStatisticsService
    *
    * @return array|mixed
-   * @throws \Exception
    */
-  public function getCommunityStats()
+  public function getCommunityStats(CommunityStatisticsService $communityStatisticsService)
   {
-    $cms_s = $this->container->get("community_statistics_service");
+    $cms_s = $communityStatisticsService;
     $stats = $cms_s->fetchStatistics();
 
     /* Numberformatter could be used to apply the locale. However this requires the intl extension to be fully working.

--- a/src/Entity/MigrationManager.php
+++ b/src/Entity/MigrationManager.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Class MigrationManager
@@ -13,7 +14,7 @@ use Doctrine\ORM\EntityManager;
 class MigrationManager
 {
   /**
-   * @var EntityManager
+   * @var EntityManagerInterface
    */
   protected $entity_manager;
   /**
@@ -24,9 +25,9 @@ class MigrationManager
   /**
    * MigrationManager constructor.
    *
-   * @param $entity_manager
+   * @param $entity_manager EntityManagerInterface
    */
-  public function __construct($entity_manager)
+  public function __construct(EntityManagerInterface $entity_manager)
   {
     $this->entity_manager = $entity_manager;
     $this->connection = $this->entity_manager->getConnection();

--- a/src/Entity/Program.php
+++ b/src/Entity/Program.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\GuidType;
 use Doctrine\ORM\Mapping as ORM;
 
 
@@ -373,7 +374,7 @@ class Program
   /**
    * Get id.
    *
-   * @return int
+   * @return GuidType
    */
   public function getId()
   {

--- a/src/Entity/ProgramManager.php
+++ b/src/Entity/ProgramManager.php
@@ -23,6 +23,7 @@ use App\Repository\TagRepository;
 use DateTime;
 use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
@@ -65,7 +66,7 @@ class ProgramManager
   protected $event_dispatcher;
 
   /**
-   * @var EntityManager
+   * @var EntityManagerInterface
    */
   protected $entity_manager;
 
@@ -102,13 +103,13 @@ class ProgramManager
   /**
    * ProgramManager constructor.
    *
-   * @param CatrobatFileExtractor $file_extractor
-   * @param ProgramFileRepository $file_repository
-   * @param ScreenshotRepository $screenshot_repository
-   * @param EntityManager $entity_manager
-   * @param ProgramRepository $program_repository
-   * @param TagRepository $tag_repository
-   * @param ProgramLikeRepository $program_like_repository
+   * @param CatrobatFileExtractor    $file_extractor
+   * @param ProgramFileRepository    $file_repository
+   * @param ScreenshotRepository     $screenshot_repository
+   * @param EntityManagerInterface            $entity_manager
+   * @param ProgramRepository        $program_repository
+   * @param TagRepository            $tag_repository
+   * @param ProgramLikeRepository    $program_like_repository
    * @param EventDispatcherInterface $event_dispatcher
    * @param LoggerInterface $logger
    * @param AppRequest $app_request
@@ -116,7 +117,7 @@ class ProgramManager
    * @param CatrobatFileSanitizer $file_sanitizer
    */
   public function __construct(CatrobatFileExtractor $file_extractor, ProgramFileRepository $file_repository,
-                              ScreenshotRepository $screenshot_repository, EntityManager $entity_manager,
+                              ScreenshotRepository $screenshot_repository, EntityManagerInterface $entity_manager,
                               ProgramRepository $program_repository, TagRepository $tag_repository,
                               ProgramLikeRepository $program_like_repository,
                               EventDispatcherInterface $event_dispatcher,
@@ -241,7 +242,7 @@ class ProgramManager
       $this->file_repository->saveProgramTemp($extracted_file, $program->getId());
     } catch (Exception $e)
     {
-      $this->logger->error("UploadError -> saveProgramAssetsTemp failed!", ["exception" => $e]);
+      $this->logger->error("UploadError -> saveProgramAssetsTemp failed!", ["exception" => $e->getMessage()]);
       $program_id = $program->getId();
       $this->entity_manager->remove($program);
       $this->entity_manager->flush();

--- a/src/Entity/RemixManager.php
+++ b/src/Entity/RemixManager.php
@@ -12,7 +12,7 @@ use App\Repository\ScratchProgramRemixRepository;
 use App\Repository\ScratchProgramRepository;
 use DateTime;
 use Doctrine\DBAL\Types\GuidType;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Exception;
@@ -24,7 +24,7 @@ use Exception;
 class RemixManager
 {
   /**
-   * @var EntityManager The entity manager.
+   * @var EntityManagerInterface The entity manager.
    */
   private $entity_manager;
 
@@ -64,7 +64,7 @@ class RemixManager
   protected $app_request;
 
   /**
-   * @param EntityManager                  $entity_manager
+   * @param EntityManagerInterface                  $entity_manager
    * @param ProgramRepository              $program_repository
    * @param ScratchProgramRepository       $scratch_program_repository
    * @param ProgramRemixRepository         $program_remix_repository
@@ -73,7 +73,7 @@ class RemixManager
    * @param RemixGraphManipulator          $remix_graph_manipulator
    * @param AppRequest                     $app_request
    */
-  public function __construct(EntityManager $entity_manager, ProgramRepository $program_repository,
+  public function __construct(EntityManagerInterface $entity_manager, ProgramRepository $program_repository,
                               ScratchProgramRepository $scratch_program_repository,
                               ProgramRemixRepository $program_remix_repository,
                               ProgramRemixBackwardRepository $program_remix_backward_repository,

--- a/src/Entity/TemplateManager.php
+++ b/src/Entity/TemplateManager.php
@@ -7,6 +7,7 @@ use App\Repository\TemplateRepository;
 use App\Catrobat\Services\ScreenshotRepository;
 use App\Catrobat\Services\TemplateFileRepository;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Class TemplateManager
@@ -29,7 +30,7 @@ class TemplateManager
   protected $screenshot_repository;
 
   /**
-   * @var EntityManager
+   * @var EntityManagerInterface
    */
   protected $entity_manager;
 
@@ -44,11 +45,11 @@ class TemplateManager
    *
    * @param TemplateFileRepository $file_repository
    * @param ScreenshotRepository  $screenshot_repository
-   * @param EntityManager         $entity_manager
+   * @param EntityManagerInterface         $entity_manager
    * @param TemplateRepository    $template_repository
    */
   public function __construct(TemplateFileRepository $file_repository, ScreenshotRepository $screenshot_repository,
-                              EntityManager $entity_manager, TemplateRepository $template_repository)
+                              EntityManagerInterface $entity_manager, TemplateRepository $template_repository)
   {
     $this->file_repository = $file_repository;
     $this->screenshot_repository = $screenshot_repository;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\GuidType;
 use FR3D\LdapBundle\Model\LdapUserInterface;
 use Sonata\UserBundle\Entity\BaseUser as BaseUser;
 use Doctrine\ORM\Mapping as ORM;
@@ -208,7 +209,7 @@ class User extends BaseUser implements LdapUserInterface
   /**
    * Get id.
    *
-   * @return int
+   * @return GuidType
    */
   public function getId()
   {
@@ -347,9 +348,9 @@ class User extends BaseUser implements LdapUserInterface
    *
    * @return string Distinguished Name
    */
-  public function getDn()
+  public function getDn(): string
   {
-    return $this->dn;
+    return $this->dn !== null ? $this->dn : '';
   }
 
   /**

--- a/src/Entity/UserLDAPManager.php
+++ b/src/Entity/UserLDAPManager.php
@@ -41,14 +41,14 @@ class UserLDAPManager extends LdapManager
    * UserLDAPManager constructor.
    *
    * @param LdapDriverInterface $driver
-   * @param UserHydrator        $userManager
+   * @param UserHydrator        $user_manager
    * @param array               $params
    * @param                     $role_mappings
    * @param                     $group_filter
    * @param                     $tokengenerator
    * @param Logger              $logger
    */
-  public function __construct(LdapDriverInterface $driver, UserHydrator $userManager,
+  public function __construct(LdapDriverInterface $driver, UserHydrator $user_manager,
                               array $params, $role_mappings, $group_filter, $tokengenerator, Logger $logger)
   {
     $this->role_mappings = $role_mappings;
@@ -56,7 +56,7 @@ class UserLDAPManager extends LdapManager
     $this->logger = $logger;
     $this->tokengenerator = $tokengenerator;
 
-    parent::__construct($driver, $userManager, $params);
+    parent::__construct($driver, $user_manager, $params);
   }
 
   /**
@@ -65,7 +65,7 @@ class UserLDAPManager extends LdapManager
    * @return bool|\FOS\UserBundle\Model\UserInterface|object|UserInterface|null
    * @throws \Exception
    */
-  public function findUserBy(array $criteria)
+  public function findUserBy(array $criteria): ?UserInterface
   {
     try
     {
@@ -78,14 +78,14 @@ class UserLDAPManager extends LdapManager
 
       if ($entries['count'] == 0)
       {
-        return false;
+        return null;
       }
 
       // same Email-Address already in system?
       /**
        * @var UserManager $usermanager
        */
-      $usermanager = $this->userManager;
+      $usermanager = $this->user_manager;
       $sameEmailUser = $usermanager->findOneBy([
         "email" => $entries[0]['mail'],
       ]);
@@ -100,7 +100,7 @@ class UserLDAPManager extends LdapManager
         return $sameEmailUser;
       }
 
-      $user = $this->userManager->createUser();
+      $user = $this->user_manager->createUser();
       $this->hydrate($user, $entries[0]);
 
       return $user;
@@ -108,7 +108,7 @@ class UserLDAPManager extends LdapManager
     {
       $this->logger->addError("LDAP-Server not reachable?: " . $e->getMessage());
 
-      return false;
+      return null;
     }
   }
 
@@ -118,7 +118,7 @@ class UserLDAPManager extends LdapManager
    *
    * @return bool
    */
-  public function bind(UserInterface $user, $password)
+  public function bind(UserInterface $user, $password): bool
   {
     try
     {

--- a/src/Entity/UserManager.php
+++ b/src/Entity/UserManager.php
@@ -18,13 +18,12 @@ class UserManager extends \Sonata\UserBundle\Entity\UserManager
    * @param PasswordUpdaterInterface $passwordUpdater
    * @param CanonicalFieldsUpdater   $canonicalFieldsUpdater
    * @param ObjectManager            $om
-   * @param                          $class
    */
   public function __construct(PasswordUpdaterInterface $passwordUpdater,
                                  CanonicalFieldsUpdater $canonicalFieldsUpdater,
-                                 ObjectManager $om, $class)
+                                 ObjectManager $om)
   {
-    parent::__construct($passwordUpdater, $canonicalFieldsUpdater, $om, $class);
+    parent::__construct($passwordUpdater, $canonicalFieldsUpdater, $om, User::class);
   }
 
   /**

--- a/src/Entity/UserTestGroup.php
+++ b/src/Entity/UserTestGroup.php
@@ -51,7 +51,7 @@ class UserTestGroup
 {
   /**
    * @ORM\Id
-   * @ORM\Column(type="integer", unique=true, nullable=false)
+   * @ORM\Column(type="guid", unique=true, nullable=false)
    */
   protected $user_id;
 

--- a/src/Repository/CatroNotificationRepository.php
+++ b/src/Repository/CatroNotificationRepository.php
@@ -2,12 +2,21 @@
 
 namespace App\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use App\Entity\CatroNotification;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * Class CatroNotificationRepository
  * @package App\Entity
  */
-class CatroNotificationRepository extends EntityRepository
+class CatroNotificationRepository extends ServiceEntityRepository
 {
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, CatroNotification::class);
+  }
 }

--- a/src/Repository/ExtensionRepository.php
+++ b/src/Repository/ExtensionRepository.php
@@ -2,15 +2,25 @@
 
 namespace App\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use App\Entity\Extension;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 
 /**
  * Class ExtensionRepository
  * @package App\Repository
  */
-class ExtensionRepository extends EntityRepository
+class ExtensionRepository extends ServiceEntityRepository
 {
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, Extension::class);
+  }
+
   /**
    * @return mixed
    */

--- a/src/Repository/FeaturedRepository.php
+++ b/src/Repository/FeaturedRepository.php
@@ -2,14 +2,26 @@
 
 namespace App\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use App\Entity\FeaturedProgram;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
+
 
 /**
  * Class FeaturedRepository
  * @package App\Entity
  */
-class FeaturedRepository extends EntityRepository
+class FeaturedRepository extends ServiceEntityRepository
 {
+
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, FeaturedProgram::class);
+  }
+
   /**
    * @param      $flavor
    * @param int  $limit

--- a/src/Repository/GameJamRepository.php
+++ b/src/Repository/GameJamRepository.php
@@ -2,15 +2,26 @@
 
 namespace App\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use App\Entity\GameJam;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Query;
+use Doctrine\Common\Persistence\ManagerRegistry;
+
 
 /**
  * Class GameJamRepository
  * @package App\Repository
  */
-class GameJamRepository extends EntityRepository
+class GameJamRepository extends ServiceEntityRepository
 {
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, GameJam::class);
+  }
+
   /**
    * @return mixed
    * @throws \Doctrine\ORM\NonUniqueResultException

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -2,12 +2,21 @@
 
 namespace App\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use App\Entity\Notification;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * Class NotificationRepository
  * @package App\Entity
  */
-class NotificationRepository extends EntityRepository
+class NotificationRepository extends ServiceEntityRepository
 {
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, Notification::class);
+  }
 }

--- a/src/Repository/ProgramInappropriateReportRepository.php
+++ b/src/Repository/ProgramInappropriateReportRepository.php
@@ -2,12 +2,21 @@
 
 namespace App\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use App\Entity\ProgramInappropriateReport;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * Class ProgramInappropriateReportRepository
  * @package App\Repository
  */
-class ProgramInappropriateReportRepository extends EntityRepository
+class ProgramInappropriateReportRepository extends ServiceEntityRepository
 {
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, ProgramInappropriateReport::class);
+  }
 }

--- a/src/Repository/ProgramLikeRepository.php
+++ b/src/Repository/ProgramLikeRepository.php
@@ -3,16 +3,26 @@
 namespace App\Repository;
 
 use App\Entity\ProgramLike;
-use Doctrine\ORM\EntityRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 
 /**
  * Class ProgramLikeRepository
  * @package App\Repository
  */
-class ProgramLikeRepository extends EntityRepository
+class ProgramLikeRepository extends ServiceEntityRepository
 {
+
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, ProgramLike::class);
+  }
+
   /**
    * @param int $program_id
    * @param int $type

--- a/src/Repository/ProgramRemixBackwardRepository.php
+++ b/src/Repository/ProgramRemixBackwardRepository.php
@@ -4,15 +4,25 @@ namespace App\Repository;
 
 use App\Entity\ProgramRemixBackwardRelation;
 use App\Entity\User;
-use Doctrine\ORM\EntityRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\DBAL\Types\GuidType;
 
 
 /**
  * Class ProgramRemixBackwardRepository
  * @package App\Repository
  */
-class ProgramRemixBackwardRepository extends EntityRepository
+class ProgramRemixBackwardRepository extends ServiceEntityRepository
 {
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, ProgramRemixBackwardRelation::class);
+  }
+
   /**
    * @param int[] $program_ids
    *
@@ -53,7 +63,7 @@ class ProgramRemixBackwardRepository extends EntityRepository
   }
 
   /**
-   * @param int   $program_id
+   * @param GuidType  $program_id
    * @param int[] $parent_program_ids
    */
   public function removeParentRelations($program_id, array $parent_program_ids)

--- a/src/Repository/ProgramRemixRepository.php
+++ b/src/Repository/ProgramRemixRepository.php
@@ -2,19 +2,29 @@
 
 namespace App\Repository;
 
+use App\Entity\Extension;
 use App\Entity\ProgramRemixRelation;
 use App\Entity\User;
 use DateTime;
-use Doctrine\ORM\EntityRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 
 /**
  * Class ProgramRemixRepository
  * @package App\Repository
  */
-class ProgramRemixRepository extends EntityRepository
+class ProgramRemixRepository extends ServiceEntityRepository
 {
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, ProgramRemixRelation::class);
+  }
+
   /**
    * @param int[] $descendant_program_ids
    *

--- a/src/Repository/ProgramRepository.php
+++ b/src/Repository/ProgramRepository.php
@@ -4,19 +4,28 @@ namespace App\Repository;
 
 use App\Entity\Program;
 use Doctrine\DBAL\DBALException;
-use Doctrine\ORM\EntityRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 
 /**
  * Class ProgramRepository
  * @package App\Repository
  */
-class ProgramRepository extends EntityRepository
+class ProgramRepository extends ServiceEntityRepository
 {
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, Program::class);
+  }
+
   /**
    * @var array
    */

--- a/src/Repository/RudeWordsRepository.php
+++ b/src/Repository/RudeWordsRepository.php
@@ -2,19 +2,30 @@
 
 namespace App\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use App\Entity\RudeWord;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * Class RudeWordsRepository
  * @package App\Repository
  */
-class RudeWordsRepository extends EntityRepository
+class RudeWordsRepository extends ServiceEntityRepository
 {
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, RudeWord::class);
+  }
+
   /**
    * @param $array
    *
    * @return bool
-   * @throws \Doctrine\ORM\NonUniqueResultException
+   * @throws NonUniqueResultException
    */
   public function contains($array)
   {

--- a/src/Repository/ScratchProgramRemixRepository.php
+++ b/src/Repository/ScratchProgramRemixRepository.php
@@ -2,14 +2,26 @@
 
 namespace App\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use App\Entity\ScratchProgramRemixRelation;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\DBAL\Types\GuidType;
 
 /**
  * Class ScratchProgramRemixRepository
  * @package App\Repository
  */
-class ScratchProgramRemixRepository extends EntityRepository
+class ScratchProgramRemixRepository extends ServiceEntityRepository
 {
+
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, ScratchProgramRemixRelation::class);
+  }
+
   /**
    * @param int[] $program_ids
    *
@@ -29,7 +41,7 @@ class ScratchProgramRemixRepository extends EntityRepository
   }
 
   /**
-   * @param int   $program_id
+   * @param GuidType   $program_id
    * @param int[] $scratch_parent_program_ids
    */
   public function removeParentRelations($program_id, array $scratch_parent_program_ids)

--- a/src/Repository/ScratchProgramRepository.php
+++ b/src/Repository/ScratchProgramRepository.php
@@ -2,14 +2,24 @@
 
 namespace App\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use App\Entity\ScratchProgram;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * Class ScratchProgramRepository
  * @package App\Repository
  */
-class ScratchProgramRepository extends EntityRepository
+class ScratchProgramRepository extends ServiceEntityRepository
 {
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, ScratchProgram::class);
+  }
+
   /**
    * @param int[] $scratch_program_ids
    *

--- a/src/Repository/StarterCategoryRepository.php
+++ b/src/Repository/StarterCategoryRepository.php
@@ -2,12 +2,21 @@
 
 namespace App\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use App\Entity\StarterCategory;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * Class StarterCategoryRepository
  * @package App\Repository
  */
-class StarterCategoryRepository extends EntityRepository
+class StarterCategoryRepository extends ServiceEntityRepository
 {
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, StarterCategory::class);
+  }
 }

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -2,14 +2,24 @@
 
 namespace App\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use App\Entity\Tag;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * Class TagRepository
  * @package App\Repository
  */
-class TagRepository extends EntityRepository
+class TagRepository extends ServiceEntityRepository
 {
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, Tag::class);
+  }
+
   /**
    * @param $language
    *

--- a/src/Repository/TemplateRepository.php
+++ b/src/Repository/TemplateRepository.php
@@ -2,15 +2,23 @@
 
 namespace App\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use App\Entity\Template;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * Class TemplateRepository
  * @package App\Repository
  */
-class TemplateRepository extends EntityRepository
+class TemplateRepository extends ServiceEntityRepository
 {
-
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, Template::class);
+  }
   /**
    * @param $active
    *

--- a/src/Repository/UserCommentRepository.php
+++ b/src/Repository/UserCommentRepository.php
@@ -2,13 +2,21 @@
 
 namespace App\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use App\Entity\UserComment;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 /**
  * Class UserCommentRepository
  * @package App\Repository
  */
-class UserCommentRepository extends EntityRepository
+class UserCommentRepository extends ServiceEntityRepository
 {
-
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, UserComment::class);
+  }
 }

--- a/src/Repository/UserLikeSimilarityRelationRepository.php
+++ b/src/Repository/UserLikeSimilarityRelationRepository.php
@@ -4,15 +4,24 @@ namespace App\Repository;
 
 use App\Entity\User;
 use App\Entity\UserLikeSimilarityRelation;
-use Doctrine\ORM\EntityRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 
 /**
  * Class UserLikeSimilarityRelationRepository
  * @package App\Repository
  */
-class UserLikeSimilarityRelationRepository extends EntityRepository
+class UserLikeSimilarityRelationRepository extends ServiceEntityRepository
 {
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, UserLikeSimilarityRelation::class);
+  }
+
   /**
    *
    */

--- a/src/Repository/UserRemixSimilarityRelationRepository.php
+++ b/src/Repository/UserRemixSimilarityRelationRepository.php
@@ -6,16 +6,25 @@ use App\Entity\User;
 use App\Entity\UserRemixSimilarityRelation;
 use DateTime;
 use Doctrine\DBAL\DBALException;
-use Doctrine\ORM\EntityRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Exception;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 
 /**
  * Class UserRemixSimilarityRelationRepository
  * @package App\Repository
  */
-class UserRemixSimilarityRelationRepository extends EntityRepository
+class UserRemixSimilarityRelationRepository extends ServiceEntityRepository
 {
+  /**
+   * @param ManagerRegistry $managerRegistry
+   */
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, UserRemixSimilarityRelation::class);
+  }
+
   /**
    *
    */

--- a/symfony.lock
+++ b/symfony.lock
@@ -169,9 +169,6 @@
     "emuse/behat-html-formatter": {
         "version": "0.1.x-dev"
     },
-    "facebook/graph-sdk": {
-        "version": "5.7.0"
-    },
     "firebase/php-jwt": {
         "version": "v5.0.0"
     },
@@ -376,9 +373,6 @@
     "psr/log": {
         "version": "1.1.0"
     },
-    "psr/simple-cache": {
-        "version": "1.0.1"
-    },
     "ralouphie/getallheaders": {
         "version": "2.0.5"
     },
@@ -495,6 +489,9 @@
     "symfony/cache": {
         "version": "v3.4.22"
     },
+    "symfony/cache-contracts": {
+        "version": "v1.1.5"
+    },
     "symfony/class-loader": {
         "version": "v3.4.22"
     },
@@ -534,6 +531,9 @@
     },
     "symfony/event-dispatcher": {
         "version": "v3.4.22"
+    },
+    "symfony/event-dispatcher-contracts": {
+        "version": "v1.1.5"
     },
     "symfony/expression-language": {
         "version": "v3.4.22"
@@ -599,6 +599,9 @@
             "ref": "fadbfe33303a76e25cb63401050439aa9b1a9c7f"
         }
     },
+    "symfony/mime": {
+        "version": "v4.3.4"
+    },
     "symfony/monolog-bridge": {
         "version": "v3.4.22"
     },
@@ -635,9 +638,6 @@
             "tests/.gitignore"
         ]
     },
-    "symfony/polyfill-apcu": {
-        "version": "v1.10.0"
-    },
     "symfony/polyfill-ctype": {
         "version": "v1.10.0"
     },
@@ -653,17 +653,11 @@
     "symfony/polyfill-mbstring": {
         "version": "v1.10.0"
     },
-    "symfony/polyfill-php56": {
-        "version": "v1.10.0"
-    },
-    "symfony/polyfill-php70": {
-        "version": "v1.10.0"
-    },
     "symfony/polyfill-php72": {
         "version": "v1.10.0"
     },
-    "symfony/polyfill-util": {
-        "version": "v1.10.0"
+    "symfony/polyfill-php73": {
+        "version": "v1.12.0"
     },
     "symfony/process": {
         "version": "v3.4.22"
@@ -710,6 +704,9 @@
     "symfony/serializer": {
         "version": "v3.4.22"
     },
+    "symfony/service-contracts": {
+        "version": "v1.1.6"
+    },
     "symfony/stopwatch": {
         "version": "v3.4.22"
     },
@@ -743,6 +740,9 @@
             "translations/.gitignore"
         ]
     },
+    "symfony/translation-contracts": {
+        "version": "v1.1.6"
+    },
     "symfony/twig-bridge": {
         "version": "v3.4.22"
     },
@@ -765,6 +765,9 @@
     },
     "symfony/var-dumper": {
         "version": "v3.4.22"
+    },
+    "symfony/var-exporter": {
+        "version": "v4.3.4"
     },
     "symfony/web-profiler-bundle": {
         "version": "3.3",

--- a/tests/PhpSpec/spec/App/Catrobat/Requests/AddProgramRequestSpec.php
+++ b/tests/PhpSpec/spec/App/Catrobat/Requests/AddProgramRequestSpec.php
@@ -8,9 +8,13 @@ use Symfony\Component\HttpFoundation\File\File;
 
 class AddProgramRequestSpec extends ObjectBehavior
 {
-  public function let(User $user, File $file)
+  private $file;
+
+  public function let(User $user)
   {
-    $this->beConstructedWith($user, $file);
+    fopen('/tmp/phpSpecTest', 'w');
+    $this->file = new File('/tmp/phpSpecTest');
+    $this->beConstructedWith($user, $this->file);
   }
 
   public function it_is_initializable()
@@ -26,9 +30,11 @@ class AddProgramRequestSpec extends ObjectBehavior
     $this->getUser()->shouldReturn($new_user);
   }
 
-  public function it_holds_a_file(File $file, File $new_file)
+  public function it_holds_a_file()
   {
-    $this->getProgramfile()->shouldReturn($file);
+    $new_file = $this->file;
+
+    $this->getProgramfile()->shouldReturn($this->file);
     $this->setProgramfile($new_file);
     $this->getProgramfile()->shouldReturn($new_file);
   }

--- a/tests/PhpSpec/spec/App/Entity/ProgramManagerSpec.php
+++ b/tests/PhpSpec/spec/App/Entity/ProgramManagerSpec.php
@@ -18,6 +18,7 @@ use App\Repository\ProgramLikeRepository;
 use App\Repository\ProgramRepository;
 use App\Repository\TagRepository;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
@@ -44,7 +45,6 @@ class ProgramManagerSpec extends ObjectBehavior
    * @param ProgramRepository $program_repository
    * @param EventDispatcherInterface $event_dispatcher
    * @param AddProgramRequest $request
-   * @param File $file
    * @param User $user
    * @param ExtractedCatrobatFile $extracted_file
    * @param Program $inserted_program
@@ -58,7 +58,7 @@ class ProgramManagerSpec extends ObjectBehavior
   public function let(CatrobatFileExtractor $file_extractor, ProgramFileRepository $file_repository,
                       ScreenshotRepository $screenshot_repository, EntityManager $entity_manager,
                       ProgramRepository $program_repository, EventDispatcherInterface $event_dispatcher,
-                      AddProgramRequest $request, File $file, User $user, ExtractedCatrobatFile $extracted_file,
+                      AddProgramRequest $request, User $user, ExtractedCatrobatFile $extracted_file,
                       Program $inserted_program, TagRepository $tag_repository,
                       ProgramLikeRepository $program_like_repository, LoggerInterface $logger,
                       AppRequest $app_request,
@@ -67,6 +67,10 @@ class ProgramManagerSpec extends ObjectBehavior
     $this->beConstructedWith($file_extractor, $file_repository, $screenshot_repository,
       $entity_manager, $program_repository, $tag_repository, $program_like_repository,
       $event_dispatcher, $logger, $app_request, $extension_repository, $catrobat_file_sanitizer);
+
+    fopen('/tmp/phpSpecTest', 'w');
+    $file = new File('/tmp/phpSpecTest');
+
     $request->getProgramfile()->willReturn($file);
     $request->getUser()->willReturn($user);
     $request->getIp()->willReturn('127.0.0.1');

--- a/tests/PhpSpec/spec/App/Entity/UserManagerSpec.php
+++ b/tests/PhpSpec/spec/App/Entity/UserManagerSpec.php
@@ -4,6 +4,7 @@ namespace tests\PhpSpec\spec\App\Entity;
 
 use App\Entity\User;
 use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use FOS\UserBundle\Util\CanonicalFieldsUpdater;

--- a/tests/behat/features/admin/server_maintenance.feature
+++ b/tests/behat/features/admin/server_maintenance.feature
@@ -81,4 +81,4 @@ Feature: Admin Server Maintenance
     When I GET "/admin/maintain/list"
     Then the client response should contain "a_backup.tar.gz"
     When I GET "/app/download-backup/a_backup.tar.gz"
-    Then the response Header should contain the key "Content-Disposition" with the value 'attachment; filename="a_backup.tar.gz"'
+    Then the response Header should contain the key "Content-Disposition" with the value 'attachment; filename=a_backup.tar.gz'

--- a/tests/behat/features/api/authentication.feature
+++ b/tests/behat/features/api/authentication.feature
@@ -27,8 +27,8 @@ Feature: Authenticate to the system
           {
             "statusCode": 201,
             "answer": "Registration successful!",
-            "token": "rrrrrrrrrrr",
-            "preHeaderMessages": ""
+            "preHeaderMessages": "",
+            "token": "rrrrrrrrrrr"
           }
           """
 

--- a/tests/behat/features/api/register_and_login.feature
+++ b/tests/behat/features/api/register_and_login.feature
@@ -72,7 +72,7 @@ Feature: Login with an existing account or register a new one
     When I POST these parameters to "/app/api/login/Login.json"
     Then I should get the json object:
       """
-      {"statusCode":764, "answer":"This username does not exist.","preHeaderMessages":""}
+      {"statusCode":803,"answer":"This username does not exist.","preHeaderMessages":""}
       """
 
   Scenario: Log in user wrong password

--- a/tests/behat/features/bootstrap/BaseContext.php
+++ b/tests/behat/features/bootstrap/BaseContext.php
@@ -257,7 +257,9 @@ class BaseContext implements KernelAwareContext
   /**
    * @param array $config
    *
-   * @return \FOS\UserBundle\Model\UserInterface|mixed
+   * @return object|null
+   * @throws \Doctrine\ORM\ORMException
+   * @throws \Doctrine\ORM\OptimisticLockException
    */
   public function insertUser($config = [])
   {

--- a/tests/behat/features/bootstrap/FlavorFeatureContext.php
+++ b/tests/behat/features/bootstrap/FlavorFeatureContext.php
@@ -11,6 +11,25 @@ use PHPUnit\Framework\Assert;
 class FlavorFeatureContext extends BaseContext
 {
 
+  private $old_metadata_hash = "";
+
+  /**
+   * @BeforeScenario
+   */
+  public function clearData()
+  {
+    $em = $this->getManager();
+    $metaData = $em->getMetadataFactory()->getAllMetadata();
+    $new_metadata_hash = md5(json_encode($metaData));
+    if ($this->old_metadata_hash === $new_metadata_hash) {
+      return;
+    };
+    $this->old_metadata_hash = $new_metadata_hash;
+    $tool = new \Doctrine\ORM\Tools\SchemaTool($em);
+    $tool->dropSchema($metaData);
+    $tool->createSchema($metaData);
+  }
+
   /**
    * FeatureContext constructor.
    *

--- a/tests/behat/features/bootstrap/GamejamFeatureContext.php
+++ b/tests/behat/features/bootstrap/GamejamFeatureContext.php
@@ -34,6 +34,25 @@ class GamejamFeatureContext extends BaseContext
     $this->setErrorDirectory($error_directory);
   }
 
+  private $old_metadata_hash = "";
+
+  /**
+   * @BeforeScenario
+   */
+  public function clearData()
+  {
+    $em = $this->getManager();
+    $metaData = $em->getMetadataFactory()->getAllMetadata();
+    $new_metadata_hash = md5(json_encode($metaData));
+    if ($this->old_metadata_hash === $new_metadata_hash) {
+      return;
+    };
+    $this->old_metadata_hash = $new_metadata_hash;
+    $tool = new \Doctrine\ORM\Tools\SchemaTool($em);
+    $tool->dropSchema($metaData);
+    $tool->createSchema($metaData);
+  }
+
   /**
    * @return string
    */
@@ -309,7 +328,7 @@ class GamejamFeatureContext extends BaseContext
       }
       else
       {
-        $gamejam = $this->getSymfonySupport()->getSymfonyService('gamejamrepository')->findOneByName($gamejam);
+        $gamejam = $this->getSymfonySupport()->getSymfonyService(App\Repository\GameJamRepository::class)->findOneByName($gamejam);
       }
 
       @$config = [

--- a/tests/behat/features/bootstrap/GamejamJavascriptContext.php
+++ b/tests/behat/features/bootstrap/GamejamJavascriptContext.php
@@ -36,6 +36,25 @@ class GamejamJavascriptContext extends MinkContext implements KernelAwareContext
     $this->symfony_support = new SymfonySupport(self::FIXTUREDIR);
   }
 
+  private $old_metadata_hash = "";
+
+  /**
+   * @BeforeScenario
+   */
+  public function clearData()
+  {
+    $em = $this->symfony_support->getManager();
+    $metaData = $em->getMetadataFactory()->getAllMetadata();
+    $new_metadata_hash = md5(json_encode($metaData));
+    if ($this->old_metadata_hash === $new_metadata_hash) {
+      return;
+    };
+    $this->old_metadata_hash = $new_metadata_hash;
+    $tool = new \Doctrine\ORM\Tools\SchemaTool($em);
+    $tool->dropSchema($metaData);
+    $tool->createSchema($metaData);
+  }
+
   /*
    * (non-PHPdoc)
    * @see \Behat\Symfony2Extension\Context\KernelAwareContext::setKernel()

--- a/tests/behat/features/bootstrap/GamejamWebContext.php
+++ b/tests/behat/features/bootstrap/GamejamWebContext.php
@@ -46,6 +46,25 @@ class GamejamWebContext extends BaseContext
     $this->setErrorDirectory($error_directory);
   }
 
+  private $old_metadata_hash = "";
+
+  /**
+   * @BeforeScenario
+   */
+  public function clearData()
+  {
+    $em = $this->getManager();
+    $metaData = $em->getMetadataFactory()->getAllMetadata();
+    $new_metadata_hash = md5(json_encode($metaData));
+    if ($this->old_metadata_hash === $new_metadata_hash) {
+      return;
+    };
+    $this->old_metadata_hash = $new_metadata_hash;
+    $tool = new \Doctrine\ORM\Tools\SchemaTool($em);
+    $tool->dropSchema($metaData);
+    $tool->createSchema($metaData);
+  }
+
   /**
    * @Given There is an ongoing game jam
    *

--- a/tests/behat/features/gamejam/limited_accounts.feature
+++ b/tests/behat/features/gamejam/limited_accounts.feature
@@ -27,4 +27,3 @@ Feature: Limited Accounts
     And I wait 100 milliseconds
     Then I see the program "Pink Pony"
     But I do not see a delete button
-     

--- a/tests/phpUnit/AppExtensionTest.php
+++ b/tests/phpUnit/AppExtensionTest.php
@@ -6,7 +6,7 @@ use App\Catrobat\Twig\AppExtension;
 use Prophecy\Prophet;
 
 
-class AppExtentionTest extends \PHPUnit\Framework\TestCase
+class AppExtensionTest extends \PHPUnit\Framework\TestCase
 {
   private $prophet;
 
@@ -84,9 +84,9 @@ class AppExtentionTest extends \PHPUnit\Framework\TestCase
     return $requestStack;
   }
 
-  private function mockContainer()
+  private function mockParameterBag()
   {
-    $container = $this->prophet->prophesize('Symfony\Component\DependencyInjection\Container');
+    $container = $this->prophet->prophesize('Symfony\Component\DependencyInjection\ParameterBag\ParameterBag');
 
     return $container;
   }
@@ -97,9 +97,10 @@ class AppExtentionTest extends \PHPUnit\Framework\TestCase
     $requestStack = $this->mockRequestStack($locale);
     $gamejamRepository = $this->prophet->prophesize('App\Repository\GameJamRepository');
     $theme = $this->prophet->prophesize('Liip\ThemeBundle\ActiveTheme');
-    $container = $this->mockContainer();
+    $parameter_bag = $this->mockParameterBag();
 
-    return new AppExtension($requestStack->reveal(), $repo->reveal(), $gamejamRepository->reveal(), $theme->reveal(), $this->translationPath, $container->reveal());
+    return new AppExtension($requestStack->reveal(), $repo->reveal(), $gamejamRepository->reveal(),
+      $theme->reveal(), $parameter_bag->reveal(), $this->translationPath);
   }
 
   private function mockMediaPackageFileRepository()

--- a/tests/phpUnit/CatrobatCodeParserTests/CatrobatCodeParserTest.php
+++ b/tests/phpUnit/CatrobatCodeParserTests/CatrobatCodeParserTest.php
@@ -2,8 +2,8 @@
 
 namespace tests\CatrobatCodeParserTests;
 
-use App\Catrobat\Services\CatrobatCodeParser\CatrobatCodeParser;
 use App\Catrobat\Services\ExtractedCatrobatFile;
+use App\Catrobat\Services\CatrobatCodeParser\CatrobatCodeParser;
 
 class CatrobatCodeParserTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
- fixed all remaining deprecations to upgrade from Symfony 3.4 to 4.1
- fixed all remaining deprecations to upgrade from Symfony 4.1 to 4.2
- fixed all remaining deprecations to upgrade from Symfony 4.2 to 4.3

** Upgraded from symfony 3.4 to 4.3 **

- fixed a handful of deprecations to upgrade from Symfony 4.3 to 5

- upgraded and fixed all deprecations for most of our packages;
  finally upgraded from fr3d_ldap bundle 3 to 4!

- locked phpUnit to 8.2 -> 8.3 is buggy and fix is only in dev version

- added dmore/behat-chrome-extension (since we are using chrome headless for our tests)

- had to remove vipsoft/doctrine-data-fixtures-extension since the repo is inactive and
  not compatible with symfony 4.3. This packages reset our assets/database between every
  Behat Scenario. The same functionality (just very basic) was added to the Context files.
  (clearData() ~  @beforeScenario) This should be improved or be replaced by a different
  package in the future to reduce the runtime of the tests.

___________________

**Major change caused by the upgrade impacting commits in the future**:

Controllers are now AbstractControllers and can not access the container.
Therefore we now use (as we should have anyway) Dependency Injection.
We also use dependency injection for parameters or at least use only
the ParameterbagInterface. For more details look into the services(_test).yml
files wich are almost completly rewritten with this commit. (also with explanations :)

___________________

-- fixed minor ldap login bug (gives now the correct message if the username is not found)