### PR TITLE
SHARE-143 Search Behat test fails (cons.searches ...)

### DIFF
--- a/assets/js/analytics/analytics.js
+++ b/assets/js/analytics/analytics.js
@@ -1294,8 +1294,8 @@ else
         'BaseSelector': 'nav button#btn-search-header',
         'Category'    : 'engagement',
         'Action'      : 'search',
-        'Label'       : function (e) { return e.previousElementSibling.value },
-        'search_term' : function (e) { return e.previousElementSibling.value },
+        'Label'       : function (e) { return e.parentElement.previousElementSibling.value },
+        'search_term' : function (e) { return e.parentElement.previousElementSibling.value },
       })
       
       AnalyticsTracker.registerElementsForClickTracking(searchButton)


### PR DESCRIPTION
Reason of failed test: Search button did not work due to Javascript error.

Fixed Javascript null error caused due to a wrong reference to the search input field in analytics.js