### PR TITLE
HOTFIX Content-Disposition Header of Project Download

### DIFF
--- a/src/Catrobat/Controller/DownloadProgramController.php
+++ b/src/Catrobat/Controller/DownloadProgramController.php
@@ -101,11 +101,13 @@ class DownloadProgramController extends AbstractController
       }
 
       $response = new BinaryFileResponse($file);
-      $d = $response->headers->makeDisposition(
-        ResponseHeaderBag::DISPOSITION_ATTACHMENT,
-        $program->getId() . '.catrobat'
+
+      // can be changed back to $response->setContentDisposition
+      // after https://github.com/symfony/symfony/issues/34099 has been fixed
+      $response->headers->set(
+        'Content-Disposition',
+        'attachment; filename="' . $program->getId() . '.catrobat"'
       );
-      $response->headers->set('Content-Disposition', $d);
 
       return $response;
     }


### PR DESCRIPTION
The filename in the Content-Disposition header
needs to be a quoted string according to RFC 2616.

Symfony has a bug (https://github.com/symfony/symfony/issues/34099),
it quotes the string just if there are special characters inside.

Circumvent the bug by generating the header manually.