### PR TITLE
SHARE-158 Download several looks

### DIFF
--- a/assets/css/custom/medialib.scss
+++ b/assets/css/custom/medialib.scss
@@ -31,6 +31,27 @@ $tile-size-sm: 54px;
 $tile-size-lg: 191px;
 $border-spacing: 8px;
 
+#downloadbar
+{
+  position: fixed;
+  width:100%;
+  bottom: 10px;
+  left: 0px;
+  padding: 20px;
+  text-align: center;
+  background-color: white;
+  z-index: 100;
+  font-weight: bold;
+  font-size: 1.20rem;
+  border-top: 1px solid $primary;
+  border-bottom: 1px solid $primary;
+  visibility: hidden;
+}
+#downloadbar span
+{
+  color: $primary;
+}
+
 .category
 {
   margin-top: 1rem;
@@ -58,7 +79,13 @@ $border-spacing: 8px;
       border-radius: 5px;
       position: relative;
 
-      &:hover
+      /*&:hover
+      {
+        border-color: $primary;
+        text-decoration: none;
+      }*/
+
+      &.selected
       {
         border-color: $primary;
         text-decoration: none;

--- a/assets/js/custom/MediaLib.js
+++ b/assets/js/custom/MediaLib.js
@@ -15,6 +15,17 @@ function MediaLib(package_name, flavor, assetsDir)
   
   function getPackageFiles(package_name, flavor, assetsDir)
   {
+    var download_list = [];
+  
+    document.getElementById("start-downloads").onclick = function()
+    {
+      for (i = 0; i < download_list.length; i++)
+      {
+        medialib_downloadSelectedFile(download_list[i]);
+      }
+    };
+    
+    
     let url = Routing.generate('api_media_lib_package_bynameurl', {flavor: flavor, package: package_name}, false);
     $.get(url, {}, pkgFiles => {
       pkgFiles.forEach(file => {
@@ -24,10 +35,29 @@ function MediaLib(package_name, flavor, assetsDir)
         }
         
         const mediafileContainer = $('<a class="mediafile" id="mediafile-' + file.id + '"/>');
-        mediafileContainer.attr("href", file.download_url);
-        mediafileContainer.attr('data-extension', file.extension);
-        mediafileContainer.click(function() {
-          medialib_onDownload(this);
+        mediafileContainer.click(function()
+        {
+          mediafileContainer.toggleClass("selected");
+          var index_in_download_list = download_list.indexOf(file);
+          
+  
+          if (index_in_download_list == -1)
+          {
+            download_list.push(file);
+          }
+          else
+          {
+            download_list.splice(index_in_download_list, 1)
+          }
+
+          if (download_list.length > 0)
+          {
+            document.getElementById("downloadbar").style.visibility = "visible";
+          }
+          else
+          {
+            document.getElementById("downloadbar").style.visibility = "hidden";
+          }
         });
         
         if (flavor !== "pocketcode" && file.flavor === flavor)
@@ -289,18 +319,13 @@ function MediaLib(package_name, flavor, assetsDir)
   }
 }
 
-function medialib_onDownload(link)
+function medialib_downloadSelectedFile(file)
 {
-  if (link.href !== 'javascript:void(0)')
-  {
-    var download_href = link.href;
-    link.href = 'javascript:void(0)';
-    
-    setTimeout(function() {
-      link.href = download_href;
-    }, 5000);
-    
-    window.location = download_href;
-  }
+  var link = document.createElement('a');
+  link.href = file.download_url;
+  link.download = file.name;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
   return false;
 }

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -37,6 +37,9 @@ default:
                 default:
                     chrome:
                         api_url: "http://localhost:9222"
+                        download_behavior: allow
+                        download_path: /tmp/
+
 
         emuse\BehatHTMLFormatter\BehatHTMLFormatterExtension:
               name: html

--- a/templates/MediaLibrary/mediapackage.html.twig
+++ b/templates/MediaLibrary/mediapackage.html.twig
@@ -21,6 +21,9 @@
         <h1>{{ category.name }}</h1>
         <div class="files"></div>
       </div>
+      <div id="downloadbar">
+        <span class="fa-download fa">&nbsp;&nbsp;</span><a id="start-downloads" href="#">{{ "media-packages.download_these_files"|trans({}, "catroweb") }}</a>
+      </div>
     {% endfor %}
   </div>
 {% endblock %}

--- a/tests/behat/features/web/mediapackage.feature
+++ b/tests/behat/features/web/mediapackage.feature
@@ -1,4 +1,4 @@
-@web @media
+@homepage
 Feature:
   In order to speed up the creation of a pocketcode program
   As UX/Design team
@@ -29,19 +29,7 @@ Feature:
 
   Scenario: Viewing defined categories in a specific package
     Given I am on "/app/media-library/looks"
-    And I wait for the page to be loaded
     Then I should see "Animals"
-
-  Scenario: Download a media file
-    When I download "/app/download-media/1"
-    Then I should receive a "png" file
-    And I should receive a file named "Dog (-).png"
-    And the response code should be "200"
-
-  Scenario: The app needs the filename, so the media file link must provide the media file's name
-    When I am on "/app/media-library/looks"
-    And I wait for the page to be loaded
-    Then the media file "1" must have the download url "/pocketcode/download-media/1"
 
   Scenario: Viewing only media files for the pocketcode flavor
     Given I am on "/app/media-library/looks"
@@ -60,6 +48,25 @@ Feature:
     And I should see media file with id 7 in category "Luna & Cat Theme Special"
     And I should see 1 media file in category "Luna & Cat Theme Special"
     And I should see 1 media file in category "Bla"
+
+  Scenario: Selecting and deselecting media files for downloading
+    Given I am on "/app/media-library/looks"
+    And I wait for the page to be loaded
+    And I click "#mediafile-1"
+    And I click "#mediafile-5"
+    Then I should see "Download these files"
+    And I click "#mediafile-1"
+    And I click "#mediafile-5"
+    Then I should not see "Download these files"
+
+  Scenario: Downloading mutiple selected files
+    Given I am on "/app/media-library/looks"
+    And I wait for the page to be loaded
+    And I click "#mediafile-1"
+    And I click "#mediafile-5"
+    And I click "#start-downloads"
+    Then I should receive a file named "Dog (-).png"
+    Then I should receive a file named "SexyNULL.png"
 
   Scenario: When viewing a media package category the project navigation in the nav sidebar should be hidden
     Given I am on "/app/media-library/looks"

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -891,6 +891,7 @@ media-packages:
     md: medium
     lg: large
   theme-special: "%flavor% Theme Special"
+  download_these_files: Download these files
 
 flavor:
   pocketcode: Pocket Code


### PR DESCRIPTION
Implemented a function in the media-library to download multiple looks at once.

Created behat tests.

Modified behat.yml.dist to allow chrome headless to download files which is required for proper testing of this feature.