### PR TITLE
SHARE-167 Behat Tests HTTPS and APP_ENV

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -25,7 +25,7 @@ default:
 
         Behat\Symfony2Extension:
             kernel:
-                bootstrap: config/bootstrap.php
+                bootstrap: config/bootstrap_test.php
                 class: App\Kernel
 
         DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~

--- a/config/bootstrap_test.php
+++ b/config/bootstrap_test.php
@@ -1,0 +1,4 @@
+<?php
+
+$_SERVER["APP_ENV"] = "test";
+require dirname(__DIR__) . '/config/bootstrap.php';

--- a/tests/behat/features/api/search.feature
+++ b/tests/behat/features/api/search.feature
@@ -58,7 +58,7 @@ Feature: Search programs
         "completeTerm": "",
         "preHeaderMessages": "",
         "CatrobatInformation": {
-          "BaseUrl": "https:\/\/pocketcode.org\/",
+          "BaseUrl": "http:\/\/pocketcode.org\/",
           "TotalProjects": 1,
           "ProjectsExtension": ".catrobat"
         }
@@ -75,7 +75,7 @@ Feature: Search programs
         "completeTerm":"",
         "preHeaderMessages":"",
         "CatrobatInformation": {
-          "BaseUrl":"https://pocketcode.org/",
+          "BaseUrl":"http://pocketcode.org/",
           "TotalProjects":0,
           "ProjectsExtension":".catrobat"
         }

--- a/tests/behat/features/bootstrap/ApiFeatureContext.php
+++ b/tests/behat/features/bootstrap/ApiFeatureContext.php
@@ -107,7 +107,7 @@ class ApiFeatureContext extends BaseContext
   /**
    * @var array
    */
-  private $server_parameters = ['HTTP_HOST' => 'pocketcode.org', 'HTTPS' => true];
+  private $server_parameters = ['HTTP_HOST' => 'pocketcode.org', 'HTTPS' => false];
 
   /**
    * @var array
@@ -182,8 +182,10 @@ class ApiFeatureContext extends BaseContext
    */
   public function iInvokeTheRequest()
   {
-    $this->getClient()->request($this->method, 'https://' . $this->server_parameters['HTTP_HOST'] . $this->url .
-      '?' . http_build_query($this->get_parameters), $this->post_parameters, $this->files, $this->server_parameters);
+    $uri = $this->server_parameters['HTTPS'] === true ? "https://" : "http://";
+    $uri .= $this->server_parameters['HTTP_HOST'] . $this->url . '?' . http_build_query($this->get_parameters);
+
+    $this->getClient()->request($this->method, $uri , $this->post_parameters, $this->files, $this->server_parameters);
   }
 
   /**


### PR DESCRIPTION
API Behat tests using iInvokeTheRequest() were using https always.
Use protocol based on $this->server_parameters.
Fix tests that assume https.

Behat tests using Symfony2Extensions accessed Symfony directly,
using APP_ENV=dev. Therefore, loading .env.dev instead of .env.test
Fix this by using a separate bootstrap_test.php file.