### PR TITLE
SHARE-168 Media Library Sidebar: Remove project navigation

### DIFF
--- a/assets/js/custom/MediaLib.js
+++ b/assets/js/custom/MediaLib.js
@@ -1,6 +1,10 @@
 function MediaLib(package_name, flavor, assetsDir)
 {
   $(function() {
+    // Removing the project navigation items and showing just the category menu items
+    var element = document.getElementById("project-navigation");
+    element.parentNode.removeChild(element);
+    
     getPackageFiles(package_name, flavor, assetsDir);
     let $content = $("#content");
     $content.find('#thumbsize-control input[type=radio]').change(function() {

--- a/templates/Default/sidebar.html.twig
+++ b/templates/Default/sidebar.html.twig
@@ -2,7 +2,7 @@
   <a class="logo" href="{{ path('index') }}"
      style="background-image:url('{{ asset('images/logo/catrobat_text.svg') }}')"><span
         class="sr-only">{{ "menu.home"|trans({}, "catroweb") }}</span></a>
-  <ul class="list-unstyled">
+  <ul class="list-unstyled" id="project-navigation">
     {% if theme() == 'pocketgalaxy' %}{# TODO maybe integrate in dynamic theming? #}
       <li class="nav-item">
         <a id="event-link" class="nav-link" href="http://www.galaxygamejam.com/AT/main.html">
@@ -149,11 +149,13 @@
         <span>{{ 'programs.random'|trans({}, "catroweb") }}</span>
       </a>
     </li>
-
+  </ul>
+  <ul class="list-unstyled">
     {% if sidebar_ul is not empty %}
       {{ sidebar_ul|raw }}
     {% endif %}
   </ul>
+
 </nav>
 <div id="sidebar-overlay"></div>
 

--- a/tests/behat/features/web/mediapackage.feature
+++ b/tests/behat/features/web/mediapackage.feature
@@ -56,3 +56,7 @@ Feature:
     And I should see media file with id 7 in category "Luna & Cat Theme Special"
     And I should see 1 media file in category "Luna & Cat Theme Special"
     And I should see 1 media file in category "Bla"
+
+  Scenario: When viewing a media package category the project navigation in the nav sidebar should be hidden
+    Given I am on "/app/media-library/looks"
+    And I should not see a "#project-navigation" element


### PR DESCRIPTION
When viewing a media library package, project navigation items in
sidebar are removed, leaving just the category navigation items.

Changed sidebar template, MediaLib.js and created behat scenario to test
this feature.