### PR TITLE
SHARE-169 Comments shown on remixed projects

### DIFF
--- a/src/Catrobat/Controller/Web/CommentsController.php
+++ b/src/Catrobat/Controller/Web/CommentsController.php
@@ -136,7 +136,6 @@ class CommentsController extends AbstractController
     $temp_comment->setUserId($id);
     $temp_comment->setText($_POST['Message']);
     $temp_comment->setProgram($program);
-    $temp_comment->setProgramId($program->getId());
     $temp_comment->setUploadDate(date_create());
     $temp_comment->setIsReported(false);
 

--- a/src/Catrobat/Controller/Web/ProgramController.php
+++ b/src/Catrobat/Controller/Web/ProgramController.php
@@ -759,7 +759,7 @@ class ProgramController extends AbstractController
     $program_comments = $this->getDoctrine()
       ->getRepository('App\Entity\UserComment')
       ->findBy(
-        ['programId' => $program->getId()], ['id' => 'DESC']);
+        ['program' => $program->getId()], ['id' => 'DESC']);
 
     return $program_comments;
   }

--- a/src/Entity/UserComment.php
+++ b/src/Entity/UserComment.php
@@ -19,13 +19,8 @@ class UserComment
   protected $id;
 
   /**
-   * @ORM\Column(type="integer")
-   */
-  protected $programId;
-
-  /**
    * @ORM\ManyToOne(targetEntity="\App\Entity\Program")
-   * @ORM\JoinColumn(name="programs", referencedColumnName="id", nullable=true)
+   * @ORM\JoinColumn(name="programId", referencedColumnName="id", nullable=true)
    */
   private $program;
 
@@ -84,22 +79,6 @@ class UserComment
   public function setId($id)
   {
     $this->id = $id;
-  }
-
-  /**
-   * @return mixed
-   */
-  public function getProgramId()
-  {
-    return $this->programId;
-  }
-
-  /**
-   * @param mixed $programId
-   */
-  public function setProgramId($programId)
-  {
-    $this->programId = $programId;
   }
 
   /**

--- a/src/Migrations/2020/Version20200116092044.php
+++ b/src/Migrations/2020/Version20200116092044.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200116092044 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE user_comment DROP FOREIGN KEY FK_CC794C66F1496545');
+        $this->addSql('DROP INDEX IDX_CC794C66F1496545 ON user_comment');
+        $this->addSql('ALTER TABLE user_comment DROP programs, CHANGE programId programId CHAR(36) DEFAULT NULL COMMENT \'(DC2Type:guid)\'');
+        $this->addSql('ALTER TABLE user_comment ADD CONSTRAINT FK_CC794C66BB3368CF FOREIGN KEY (programId) REFERENCES program (id)');
+        $this->addSql('CREATE INDEX IDX_CC794C66BB3368CF ON user_comment (programId)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE user_comment DROP FOREIGN KEY FK_CC794C66BB3368CF');
+        $this->addSql('DROP INDEX IDX_CC794C66BB3368CF ON user_comment');
+        $this->addSql('ALTER TABLE user_comment ADD programs CHAR(36) DEFAULT NULL COLLATE utf8mb4_unicode_ci COMMENT \'(DC2Type:guid)\', CHANGE programId programId INT NOT NULL');
+        $this->addSql('ALTER TABLE user_comment ADD CONSTRAINT FK_CC794C66F1496545 FOREIGN KEY (programs) REFERENCES program (id)');
+        $this->addSql('CREATE INDEX IDX_CC794C66F1496545 ON user_comment (programs)');
+    }
+}

--- a/tests/behat/features/bootstrap/WebFeatureContext.php
+++ b/tests/behat/features/bootstrap/WebFeatureContext.php
@@ -914,7 +914,6 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
 
       $new_comment->setUploadDate(new DateTime($comment['upload_date'], new DateTimeZone('UTC')));
       $new_comment->setProgram($program_manager->find($comment['program_id']));
-      $new_comment->setProgramId($comment['program_id']);
       $new_comment->setUserId($comment['user_id']);
       $new_comment->setUsername($comment['user_name']);
       $new_comment->setIsReported(false);
@@ -3237,7 +3236,6 @@ class WebFeatureContext extends MinkContext implements KernelAwareContext
             $temp_comment->setUserId($user->getId());
             $temp_comment->setText("This is a comment");
             $temp_comment->setProgram($program);
-            $temp_comment->setProgramId($program->getID());
             $temp_comment->setUploadDate(date_create());
             $temp_comment->setIsReported(false);
             $em->persist($temp_comment);

--- a/tests/behat/features/web/comments.feature
+++ b/tests/behat/features/web/comments.feature
@@ -73,6 +73,7 @@ Feature: As a visitor I want to write, see and report comments.
   Scenario: I should be able to see existing comments
     Given I am on "/app/project/1"
     Then I should see "c1"
+    Then I should not see "c2"
 
   Scenario: I should not see any comments when there are none
     Given I am on "/app/project/3"


### PR DESCRIPTION
For a program, random comments not belonging to it, were shown.

The reason was a column type mismatch (int <> guid) in the database
model / ORM. GUID was converted to INT resulting in wrong and random
relations between comments and programs.

- Fixed column types
- Fixed entity's setter and getter and corresponding code parts
calling them
- Created doctrine migration
- Extended behat scenario to test the changes