### PR TITLE
SHARE-128 Reactions (likes) redesign

### DIFF
--- a/assets/css/base/_sidebar.scss
+++ b/assets/css/base/_sidebar.scss
@@ -75,6 +75,10 @@ $sidebar-width: 250px;
   body.new-nav .container {
     padding-left: 15px + $sidebar-width;
   }
+
+  body.new-nav.modal-open .modal {
+    border-left: $sidebar-width solid transparent;
+  }
 }
 
 #sidebar-overlay

--- a/assets/css/custom/program.scss
+++ b/assets/css/custom/program.scss
@@ -5,60 +5,55 @@
 @import '../../../public/bootstrap_vendor/scss/mixins';
 @import 'theme_settings';
 
-button, .button
-{
+button, .button {
   color: white;
 }
 
-body
-{
+body {
   color: black;
 }
 
-a
-{
+a {
   text-decoration: none;
 }
 
-.text-area-empty
-{
+.text-area-empty {
   border-width: medium;
   border-color: red !important;
 }
 
-#program-top
-{
+#program-top {
 
-  #program-name
-  {
+  #program-name {
     float: left;
   }
 
 }
 
-h2
-{
+h2 {
   margin: 0;
 }
 
+$thumbnail-size: 300px;
 
-#project-thumbnail-big
-{
-  width: 300px;
-  height: 300px;
+.project-thumbnail-wrapper {
+  max-width: $thumbnail-size;
+  max-height: $thumbnail-size;
 }
 
-#program-middle
-{
-  #image
-  {
+#project-thumbnail-big {
+  width: $thumbnail-size;
+  height: $thumbnail-size;
+}
+
+#program-middle {
+  #image {
     float: left;
     position: relative;
-    max-width: 300px;
+    max-width: $thumbnail-size;
   }
 
-  #info
-  {
+  #info {
     overflow: auto;
     padding: 0 25px 20px;
 
@@ -68,8 +63,7 @@ h2
     }
   }
 
-  #description
-  {
+  #description {
     margin: 25px auto;
     line-height: 23px;
     @include force-word-break();
@@ -79,8 +73,8 @@ h2
     display: flex;
     flex-direction: column;
   }
-  #credits
-  {
+
+  #credits {
     margin: 25px auto;
     line-height: 23px;
     @include force-word-break();
@@ -88,13 +82,11 @@ h2
 
 }
 
-.show
-{
+.show {
   display: block;
 }
 
-#program-bottom
-{
+#program-bottom {
   border-top: 1px solid $default-text-color;
   border-bottom: 1px solid $default-text-color;
   padding-top: 25px;
@@ -102,41 +94,229 @@ h2
   display: table;
   width: 100%;
 
-  > #program-bottom-container
-  {
+  > #program-bottom-container {
     width: 90%;
     margin-left: 9%;
 
-    > div
-    {
+    > div {
       text-align: left;
       float: left;
       min-width: 30%;
       margin: 0.6em;
 
-      > .icon
-      {
+      > .icon {
         float: left;
       }
 
-      > .icon-text
-      {
+      > .icon-text {
         line-height: 35px;
         padding-left: 8px;
-        display:block;
+        display: block;
         margin-left: 3em;
       }
     }
   }
 }
 
-#social-container
-{
+#project-like {
+  margin-top: 0.8rem;
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  position: relative;
+
+
+  .btn-round {
+    border-radius: 50%;
+  }
+
+  $like-button-size: 3.2rem;
+
+  #project-like-buttons {
+    .btn {
+      border: 2px solid white;
+      border-radius: 50%;
+
+      &:not(:first-child) {
+        margin-left: -1.2rem;
+      }
+
+    }
+
+    .btn-round {
+      width: $like-button-size;
+      height: $like-button-size;
+
+      .fas {
+        font-size: 1.73rem;
+
+        &.fa-thumbs-up {
+          margin-top: 0.23rem;
+        }
+
+        &.fa-heart {
+          margin-top: 0.40rem;
+        }
+      }
+    }
+
+    .btn.icon-only {
+      font-size: $like-button-size * 0.99;
+      padding: 0;
+      line-height: 1;
+      color: $primary;
+      background-color: white;
+    }
+
+    &:hover {
+      .btn-primary {
+        background-color: darken($primary, 7.5%);
+      }
+
+      .btn.icon-only {
+        color: darken($primary, 7.5%);
+      }
+    }
+
+    &:active {
+      .btn-primary {
+        background-color: darken($primary, 10%);
+      }
+
+      .btn.icon-only {
+        color: darken($primary, 10%);
+      }
+    }
+  }
+
+  #project-like-counter {
+    font-size: 1.8rem;
+    padding-left: 0.8rem;
+    display: block;
+    cursor: pointer;
+  }
+
+  #project-like-detail {
+    $like-detail-border-color: #b2b2b2; //edit in svg too; rgb(178,178,178)
+    $like-detail-left: 0.5rem;
+    $like-detail-padding: 0.5rem;
+    $like-detail-button-size: 2.4rem;
+    $like-detail-triangle-width: 2rem;
+    $like-detail-triangle-height: $like-detail-triangle-width / 1.38;
+    $like-detail-triangle-left: $like-button-size/2 - $like-detail-left;
+
+    background-color: white;
+    border: 2px solid $like-detail-border-color;
+    position: absolute;
+    //display: flex;
+    display: none;
+    top: -$like-detail-button-size - 2 * $like-detail-padding - $like-detail-triangle-height;
+    left: $like-detail-left;
+    padding: $like-detail-padding;
+
+    .btn {
+      margin: 0 0.5rem;
+      border: none;
+    }
+
+    .btn-round {
+      width: $like-detail-button-size;
+      height: $like-detail-button-size;
+
+      .fas {
+        font-size: 1.3rem;
+
+        &.fa-thumbs-up {
+          margin-top: 0.1rem;
+        }
+
+        &.fa-heart {
+          margin-top: 0.2rem;
+        }
+      }
+    }
+
+    .btn.icon-only {
+      font-size: $like-detail-button-size * 0.99;
+      padding: 0;
+      line-height: 1;
+      color: $primary;
+
+      &:hover {
+        color: darken($primary, 7.5%);
+      }
+
+      &:active, &.active {
+        color: darken($primary, 10%);
+      }
+    }
+
+    &:after {
+      content: "";
+      position: absolute;
+      bottom: -$like-detail-triangle-height + 0.07rem;
+      left: $like-detail-triangle-left;
+      width: $like-detail-triangle-width;
+      height: $like-detail-triangle-height;
+      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 33.17 23.98"><defs><style>.a{fill:white}.b{fill:none;stroke:rgb(178,178,178);stroke-linecap:square;stroke-linejoin:round;stroke-width:2px;}</style></defs><polygon class="a" points="10.19 0 1 22.98 33.17 0 10.19 0"/><polyline class="b" points="9.28 2.27 1 22.98 30 2.27"/></svg>');
+      background-repeat: no-repeat;
+    }
+
+
+  }
+}
+
+#project-like-modal {
+  .modal-body {
+    .nav-tabs .nav-link {
+      padding: 0.2rem 0.58rem;
+      border: none;
+      background-color: transparent;
+
+      @media (min-width: 400px) {
+        padding-left: 1rem;
+        padding-right: 1rem;
+      }
+
+      &.active {
+        border-bottom: 2px solid $primary;
+      }
+
+      span {
+        padding-left: 0.5rem;
+      }
+    }
+
+    .tab-content {
+      .reaction {
+        display: flex;
+        padding: .4rem .75rem;
+        border-bottom: 1px solid #dee2e6;
+        align-items: baseline;
+        justify-content: space-between;
+
+        a {
+          flex-grow: 1;
+          text-align: left;
+          max-width: calc(100% - 4rem);
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+
+        i.fas {
+          color: $primary;
+          margin-left: 0.3rem;
+        }
+      }
+    }
+  }
+}
+
+#social-container {
   display: table;
   width: 100%;
 
-  li
-  {
+  li {
     display: table-cell;
     width: 20%; /* (100 / numItems)% */
     text-align: center;
@@ -145,39 +325,34 @@ h2
 ;
 }
 
-#social-container-footer
-{
+#social-container-footer {
   text-align: center;
   vertical-align: middle;
   margin: auto;
   font-size: 1px; /* necessary for G+ button alignment */
 
-  #social-like
-  {
+  #social-like {
     margin-left: 15px;
   }
 }
 
-#program-like-container
-{
+#program-like-container {
   margin-top: 18px;
   margin-bottom: 0;
 
-  #program-like-buttons-container
-  {
+  #program-like-buttons-container {
     text-align: center;
 
-    a
-    {
+    a {
       margin-right: 3px;
       padding: 0;
-      &.selected
-      {
+
+      &.selected {
         filter: brightness(10) invert(1);
         -webkit-filter: brightness(10) invert(1);
       }
-      .singular, .plural
-      {
+
+      .singular, .plural {
         display: none;
       }
 
@@ -186,58 +361,50 @@ h2
       }
     }
 
-    #program-like-counter
-    {
+    #program-like-counter {
       margin-left: 15px;
       font-size: 28px;
       vertical-align: middle;
     }
   }
 
-  #program-like-detail-container
-  {
+  #program-like-detail-container {
     margin-top: 16px;
     font-size: 18px;
     text-align: center;
   }
 
-  .program-like-counter
-  {
+  .program-like-counter {
     color: black;
     font-weight: bold;
   }
 }
 
-#share
-{
+#share {
   margin-top: 10px;
   margin-bottom: 10px;
 }
 
-.img-share
-{
+.img-share {
   margin-left: 5px;
   width: 40px;
   height: 40px;
 }
 
 
-.download-container
-{
+.download-container {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
 
-  .btn-container
-  {
+  .btn-container {
     padding-bottom: 15px;
     @include media-breakpoint-down(lg) {
       padding-left: 0;
       padding-right: 0;
     }
 
-    .btn
-    {
+    .btn {
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -247,8 +414,7 @@ h2
       min-height: 64px;
       width: 100%;
 
-      img
-      {
+      img {
         height: 50px;
         float: left;
 
@@ -262,13 +428,11 @@ h2
   }
 }
 
-table td:nth-child(1)
-{
+table td:nth-child(1) {
   width: 45px;
 }
 
-.popup-div
-{
+.popup-div {
   z-index: 9999;
   position: fixed;
   width: 320px;
@@ -283,8 +447,7 @@ table td:nth-child(1)
   font-size: 15px;
 }
 
-.popup-bg
-{
+.popup-bg {
   position: fixed;
   width: 100%;
   height: 100%;
@@ -294,21 +457,18 @@ table td:nth-child(1)
   opacity: 0.5;
 }
 
-.btn-close-popup
-{
+.btn-close-popup {
   min-width: 50%;
   margin-top: 10px;
   min-height: 10px !important;
 }
 
-#post-button
-{
+#post-button {
   float: right;
   margin-top: 0.5em;
 }
 
-#program-comments
-{
+#program-comments {
   margin-top: 0;
   padding-top: 25px;
 
@@ -317,89 +477,76 @@ table td:nth-child(1)
   }
 }
 
-.h1
-{
+.h1 {
   border-bottom: none;
 }
 
-#comments-wrapper
-{
+#comments-wrapper {
   //Todo style stuff
   clear: both;
   display: block;
 }
 
-.name-date-wrapper
-{
+.name-date-wrapper {
   display: block;
 }
 
-.comment-payload-wrapper
-{
+.comment-payload-wrapper {
   display: table-row;
   float: inherit;
 }
 
-.date
-{
+.date {
   display: inline-block;
   float: left;
 }
 
-.usr-name
-{
+.usr-name {
   display: inline-block;
   float: left;
 }
 
-.comment-text
-{
+.comment-text {
   padding-top: 0.4em;
   display: block;
   clear: both;
   @include force-word-break();
 }
 
-.single-comment
-{
+.single-comment {
   min-height: 80px;
   padding-bottom: 10px;
   padding-top: 10px;
   border-top: 1px solid $default-border-color;
-  &.hidden
-  {
+
+  &.hidden {
     display: none;
   }
 }
 
-.show-more
-{
+.show-more {
   padding-bottom: 10px;
   padding-top: 10px;
 }
 
-.usr-name
-{
+.usr-name {
   display: block;
   padding-right: 1em;
   font-weight: bold;
 }
 
 
-input[type='number']
-{
+input[type='number'] {
   -moz-appearance: textfield;
   box-sizing: border-box;
 }
 
-.download-button.btn
-{
+.download-button.btn {
   min-height: 64px;
   line-height: normal;
 }
 
-#comment-successfully-reported
-{
+#comment-successfully-reported {
   z-index: 1;
   display: none;
   padding-top: 10px;
@@ -416,8 +563,7 @@ input[type='number']
   font-size: 15px;
 }
 
-.delete-button
-{
+.delete-button {
   background: none;
   margin: 0;
   float: left;
@@ -427,8 +573,7 @@ input[type='number']
   padding: 0 1em 0 1em;
 }
 
-#show-more-button
-{
+#show-more-button {
   text-align: center;
   background: none;
   border: none;
@@ -437,8 +582,7 @@ input[type='number']
   transform: translate(-50%, 0);
 }
 
-.report-button
-{
+.report-button {
   background: none;
   margin: 0;
   float: left;
@@ -448,13 +592,11 @@ input[type='number']
   padding: 0 1em 0 1em;
 }
 
-.btn-jam img
-{
+.btn-jam img {
   float: none;
 }
 
-.pc-startButton, .pc-startButton:active
-{
+.pc-startButton, .pc-startButton:active {
   background: none;
   border: medium none;
   color: #a9dcf1;
@@ -470,8 +612,7 @@ input[type='number']
   left: 0;
 }
 
-.pc-startButton svg
-{
+.pc-startButton svg {
   height: 50%;
   left: 25%;
   margin: 0;
@@ -481,66 +622,55 @@ input[type='number']
   width: 50%;
 }
 
-.pc-startButton:hover
-{
+.pc-startButton:hover {
   fill: #ffffff;
 }
 
-.pc-startButton:active
-{
+.pc-startButton:active {
   fill: #17a5b8;
   margin: 0;
   padding: 0;
 }
 
-.pc-startButton:disabled
-{
+.pc-startButton:disabled {
   fill: #a5a5a5;
   cursor: default;
 }
 
-@include media-breakpoint-down(md)
-{
-  #program-top
-  {
+@include media-breakpoint-down(md) {
+  #program-top {
     display: flex;
     flex-direction: column;
     text-align: center;
   }
 
-  #program-middle
-  {
-    #image
-    {
+  #program-middle {
+    #image {
       text-align: center;
       float: none;
-      max-width: none;
+      margin-left: auto;
+      margin-right: auto;
     }
   }
 
-  #program-bottom
-  {
+  #program-bottom {
     border-top: 1px solid $default-text-color;
     padding-top: 25px;
     padding-bottom: 25px;
     display: table;
     width: 100%;
 
-    > #program-bottom-container
-    {
-      > div
-      {
+    > #program-bottom-container {
+      > div {
         text-align: left;
         float: left;
         min-width: 47%;
 
-        > .icon
-        {
+        > .icon {
           float: left;
         }
 
-        > .icon-text
-        {
+        > .icon-text {
           line-height: 35px;
           padding-left: 8px;
           display: block;
@@ -579,36 +709,29 @@ input[type='number']
   }
 }
 
-#tag-extension-container
-{
+#tag-extension-container {
   margin-bottom: 1rem;
 
-  > #tags:nth-child(2)
-  {
+  > #tags:nth-child(2) {
     margin-top: 0.5rem;
   }
 
-  #tags, #extensions
-  {
+  #tags, #extensions {
     display: flex;
     flex-direction: row;
     align-items: baseline;
     margin-top: -0.15rem;
 
-    @include media-breakpoint-down(sm)
-    {
+    @include media-breakpoint-down(sm) {
       flex-direction: column;
     }
 
-    p
-    {
+    p {
       margin-right: 1rem;
     }
 
-    .list
-    {
-      .badge
-      {
+    .list {
+      .badge {
         font-size: 100%;
         margin: 0.15rem;
       }
@@ -616,28 +739,23 @@ input[type='number']
   }
 }
 
-#recsys-headline, #recsys-specific-programs-headline
-{
+#recsys-headline, #recsys-specific-programs-headline {
   margin: 0.85em;
   text-align: center;
 }
 
-#gamejam-div
-{
+#gamejam-div {
   overflow: auto;
 }
 
-@media screen and (max-width: 534px)
-{
-  .report-button
-  {
+@media screen and (max-width: 534px) {
+  .report-button {
     clear: left;
     padding-left: 0;
   }
 }
 
-.comment-avatar
-{
+.comment-avatar {
   border-radius: 50%;
   border: solid 1px $primary;
   width: 4.5rem;
@@ -646,19 +764,16 @@ input[type='number']
   float: left;
   text-align: center;
 
-  @media screen and (max-width: 500px)
-  {
+  @media screen and (max-width: 500px) {
     margin-right: 4%;
   }
 }
 
-.comment-avatar-img
-{
+.comment-avatar-img {
   border-radius: 50%;
 }
 
-.add-comment-button
-{
+.add-comment-button {
   float: right;
   font-size: 2em;
 }

--- a/assets/js/custom/Program.js
+++ b/assets/js/custom/Program.js
@@ -1,6 +1,12 @@
-let Program = function (status_url, create_url, apk_preparing, apk_text, update_app_header, update_app_text, btn_close_popup) {
-  let self = this
+const Program = function(project_id, csrf_token, user_role, my_program, status_url, create_url, like_url,
+                         like_detail_url, apk_preparing, apk_text, update_app_header, update_app_text,
+                         btn_close_popup, like_action_add, like_action_remove, profile_url) {
+  const self = this
   
+  self.project_id = project_id
+  self.csrf_token = csrf_token
+  self.user_role = user_role
+  self.my_program = my_program
   self.status_url = status_url
   self.create_url = create_url
   self.apk_preparing = apk_preparing
@@ -8,6 +14,8 @@ let Program = function (status_url, create_url, apk_preparing, apk_text, update_
   self.update_app_header = update_app_header
   self.update_app_text = update_app_text
   self.btn_close_popup = btn_close_popup
+  self.like_action_add = like_action_add
+  self.like_action_remove = like_action_remove
   self.apk_url = null
   self.apk_download_timeout = false
   
@@ -132,4 +140,224 @@ let Program = function (status_url, create_url, apk_preparing, apk_text, update_
   }
   
   self.create_cookie('referrer', document.referrer, 1, '/')
-}
+  
+  self.showErrorAlert = function(message) {
+    if (typeof message !== 'string' || message === '')
+    {
+      message = 'Something went wrong! Please try again later.';
+    }
+    
+    swal({
+      type : 'error',
+      title: 'Oops...',
+      text : message
+    });
+  };
+  
+  self.$projectLikeCounter = undefined;
+  self.$projectLikeButtons = undefined;
+  self.$projectLikeDetail = undefined;
+  
+  self.initProjectLike = function() {
+    let detail_opened = false;
+    
+    const $container = $("#project-like");
+    const $buttons = $("#project-like-buttons", $container);
+    const $detail = $("#project-like-detail", $container);
+    const $counter = $("#project-like-counter", $container);
+    self.$projectLikeCounter = $counter;
+    self.$projectLikeButtons = $buttons;
+    self.$projectLikeDetail = $detail;
+    
+    $buttons.on('click', function() {
+      if ($detail.css('display') === 'flex')
+      {
+        return;
+      }
+      $detail.css('display', 'flex').hide().fadeIn();
+      detail_opened = true;
+    });
+    
+    $("body").on('mousedown', function() {
+      if (detail_opened)
+      {
+        $detail.fadeOut();
+        detail_opened = false;
+      }
+    });
+    
+    $counter.on('click', function() {
+      $.getJSON(like_detail_url,
+        /** @param {{user: {id: string, name: string}, types: string[]}[]} data */
+        function(data) {
+          if (!Array.isArray(data))
+          {
+            self.showErrorAlert();
+            console.error("Invalid data returned by like_detail_url", data);
+            return;
+          }
+          
+          const $modal = $("#project-like-modal");
+          
+          const thumbsUpData = data.filter(x => x.types.indexOf('thumbs_up') !== -1);
+          const smileData = data.filter(x => x.types.indexOf('smile') !== -1);
+          const loveData = data.filter(x => x.types.indexOf('love') !== -1);
+          const wowData = data.filter(x => x.types.indexOf('wow') !== -1);
+          
+          /**
+           * @param type string
+           * @param data {{user: {id: string, name: string}, types: string[]}[]}
+           */
+          const fnUpdateContent = (type, data) => {
+            const $tab = /** @type jQuery */ $modal.find('a#' + type + '-tab');
+            const $content = $modal.find('#' + type + '-tab-content');
+            $content.empty();
+            
+            // count
+            $tab.find(' > span').text(data.length);
+            
+            if (data.length === 0 && type !== 'all')
+            {
+              $tab.parent().hide();
+              return;
+            }
+            else
+            {
+              $tab.parent().show();
+            }
+            
+            // tab content
+            data.forEach(function(like) {
+              const $like = $("<div/>").addClass("reaction");
+              $like.append($("<a/>").attr('href', profile_url.replace('USERID', like.user.id)).text(like.user.name));
+              const $like_types = $("<div/>").addClass("types");
+              $like.append($like_types);
+              
+              const iconMapping = {
+                thumbs_up: "fa-thumbs-up",
+                smile    : "fa-grin-squint",
+                love     : "fa-heart",
+                wow      : "fa-surprise"
+              };
+              
+              like.types.forEach((type) => {
+                $like_types.append($("<i/>").addClass("fas").addClass(iconMapping[type]));
+              });
+              
+              $content.append($like);
+            });
+            
+          };
+          
+          fnUpdateContent('all', data);
+          fnUpdateContent('thumbs-up', thumbsUpData);
+          fnUpdateContent('smile', smileData);
+          fnUpdateContent('love', loveData);
+          fnUpdateContent('wow', wowData);
+          
+          $modal.modal('show');
+          
+        }).fail(function(jqXHR, textStatus, errorThrown) {
+        self.showErrorAlert();
+        console.error("Failed fetching like list", jqXHR, textStatus, errorThrown);
+      });
+    });
+    
+    $detail.find('.btn').on('click', function(event) {
+      event.preventDefault();
+      const action = this.classList.contains("active") ? like_action_remove : like_action_add;
+      self.sendProjectLike($(this).data('like-type'), action);
+    });
+    
+  };
+  
+  self.sendProjectLike = function(like_type, like_action) {
+    
+    const url = like_url +
+      "?type=" + encodeURIComponent(like_type) +
+      "&action=" + encodeURIComponent(like_action) +
+      "&token=" + encodeURIComponent(csrf_token);
+    
+    if (self.user_role === 'guest')
+    {
+      window.location.href = url;
+      return false;
+    }
+    
+    $.ajax({
+      url    : url,
+      type   : 'get',
+      success: function(data) {
+        // update .active of button
+        const $type_btn = self.$projectLikeDetail.find('.btn[data-like-type=' + like_type + ']');
+        if (like_action === like_action_add)
+        {
+          $type_btn.addClass('active');
+        }
+        else
+        {
+          $type_btn.removeClass('active');
+        }
+        
+        // update like count
+        self.$projectLikeCounter.text(data.totalLikeCount.stringValue);
+        if (data.totalLikeCount.value === 0)
+        {
+          self.$projectLikeCounter.addClass('d-none');
+        }
+        else
+        {
+          self.$projectLikeCounter.removeClass('d-none');
+        }
+        
+        // update like buttons (behavior like in program.html.twig)
+        if (!Array.isArray(data.activeLikeTypes) || data.activeLikeTypes.length === 0)
+        {
+          self.$projectLikeButtons.html('<div class="btn btn-primary btn-round"><i class="fas fa-thumbs-up"></i></div>');
+        }
+        else
+        {
+          let html = "";
+          
+          if (data.activeLikeTypes.indexOf('thumbs_up') !== -1)
+          {
+            html += '<div class="btn btn-primary btn-round"><i class="fas fa-thumbs-up"></i></div>';
+          }
+          
+          if (data.activeLikeTypes.indexOf('smile') !== -1)
+          {
+            html += '<div class="btn icon-only"><i class="fas fa-grin-squint"></i></div>';
+          }
+          
+          if (data.activeLikeTypes.indexOf('love') !== -1)
+          {
+            html += '<div class="btn btn-primary btn-round"><i class="fas fa-heart"></i></div>';
+          }
+          
+          if (data.activeLikeTypes.indexOf('wow') !== -1)
+          {
+            html += '<div class="btn icon-only"><i class="fas fa-surprise"></i></div>';
+          }
+          
+          self.$projectLikeButtons.html(html);
+        }
+  
+      }
+    }).fail(function(jqXHR, textStatus, errorThrown) {
+      // on 401 redirect to url to log in
+      if (jqXHR.status === 401)
+      {
+        window.location.href = url;
+      }
+      else
+      {
+        console.error("Like failure", jqXHR, textStatus, errorThrown);
+        self.showErrorAlert();
+      }
+    });
+  };
+  
+  $(function() {
+    self.initProjectLike();
+  })
+};

--- a/src/Catrobat/Controller/Api/ProgramController.php
+++ b/src/Catrobat/Controller/Api/ProgramController.php
@@ -3,11 +3,17 @@
 namespace App\Catrobat\Controller\Api;
 
 use App\Catrobat\Responses\ProgramListResponse;
+use App\Catrobat\Twig\AppExtension;
+use App\Entity\Program;
+use App\Entity\ProgramLike;
 use App\Entity\ProgramManager;
+use App\Repository\ProgramLikeRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 
 /**
@@ -19,7 +25,7 @@ class ProgramController extends AbstractController
   /**
    * @Route("/api/projects/getInfoById.json", name="api_info_by_id", defaults={"_format": "json"}, methods={"GET"})
    *
-   * @param Request $request
+   * @param Request        $request
    * @param ProgramManager $program_manager
    *
    * @return ProgramListResponse|JsonResponse
@@ -42,5 +48,91 @@ class ProgramController extends AbstractController
     }
 
     return new ProgramListResponse($programs, $numbOfTotalProjects);
+  }
+
+  /**
+   * @Route("/api/project/{id}/likes", name="api_project_likes", methods={"GET"})
+   * @param                       $id
+   * @param ProgramManager        $program_manager
+   *
+   * @return JsonResponse
+   * @throws \Exception
+   */
+  public function projectLikesAction($id, ProgramManager $program_manager)
+  {
+    /** @var Program $program */
+    $program = $program_manager->find($id);
+    if (!$program || !$program_manager->isProjectVisibleForCurrentUser($program))
+    {
+      throw $this->createNotFoundException('Unable to find Project entity.');
+    }
+
+    $data = [];
+
+    $user_objects = [];
+
+    /** @var ProgramLike $like */
+    foreach ($program->getLikes()->getIterator() as $like)
+    {
+      if (array_key_exists($like->getUser()->getId(), $user_objects))
+      {
+        $obj = $user_objects[$like->getUser()->getId()];
+        $obj->types[] = $like->getTypeAsString();
+      }
+      else
+      {
+        $obj = new \stdClass();
+        $obj->user = new \stdClass();
+        $obj->user->id = $like->getUser()->getId();
+        $obj->user->name = $like->getUser()->getUsername();
+        $obj->types = [$like->getTypeAsString()];
+        $data[] = $obj;
+        $user_objects[$like->getUser()->getId()] = $obj;
+      }
+    }
+
+    return JsonResponse::create($data);
+  }
+
+  /**
+   * @Route("/api/project/{id}/likes/count", name="api_project_likes_count", methods={"GET"})
+   * @param Request               $request
+   * @param                       $id
+   * @param ProgramManager        $program_manager
+   * @param TranslatorInterface   $translator
+   *
+   * @return JsonResponse
+   * @throws NotFoundHttpException
+   */
+  public function projectLikesCountAction(Request $request, $id, ProgramManager $program_manager,
+                                          TranslatorInterface $translator)
+  {
+    /** @var Program $program */
+    $program = $program_manager->find($id);
+    if (!$program || !$program_manager->isProjectVisibleForCurrentUser($program))
+    {
+      throw $this->createNotFoundException('Unable to find Project entity.');
+    }
+
+    $user_locale = $request->getLocale();
+
+    $data = new \stdClass();
+    $data->total = new \stdClass();
+    $data->total->value = $program_manager->totalLikeCount($program->getId());
+    $data->total->stringValue = AppExtension::humanFriendlyNumber(
+      $data->total->value, $translator, $user_locale
+    );
+
+    foreach (ProgramLike::$VALID_TYPES as $type_id)
+    {
+      $type_name = ProgramLike::$TYPE_NAMES[$type_id];
+      $data->$type_name = new \stdClass();
+      $data->$type_name->value = $program_manager->likeTypeCount($program->getId(), $type_id);
+      $data->$type_name->stringValue = AppExtension::humanFriendlyNumber(
+        $data->$type_name->value, $translator, $user_locale
+      );
+    }
+
+    return JsonResponse::create($data);
   }
 }

--- a/src/Catrobat/Controller/Web/ProgramController.php
+++ b/src/Catrobat/Controller/Web/ProgramController.php
@@ -2,9 +2,7 @@
 
 namespace App\Catrobat\Controller\Web;
 
-use App\Utils\ImageUtils;
 use App\Catrobat\RecommenderSystem\RecommendedPageId;
-use App\Catrobat\Requests\AppRequest;
 use App\Catrobat\Services\CatroNotificationService;
 use App\Catrobat\Services\Formatter\ElapsedTimeStringFormatter;
 use App\Catrobat\Services\RudeWordFilter;
@@ -12,6 +10,7 @@ use App\Catrobat\Services\ScreenshotRepository;
 use App\Catrobat\Services\StatisticsService;
 use App\Catrobat\Services\TestEnv\FakeStatisticsService;
 use App\Catrobat\StatusCode;
+use App\Catrobat\Twig\AppExtension;
 use App\Entity\LikeNotification;
 use App\Entity\Program;
 use App\Entity\ProgramInappropriateReport;
@@ -21,8 +20,8 @@ use App\Entity\RemixManager;
 use App\Entity\User;
 use App\Entity\UserComment;
 use App\Repository\CatroNotificationRepository;
-use App\Repository\FeaturedRepository;
 use App\Repository\GameJamRepository;
+use App\Utils\ImageUtils;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\Types\GuidType;
@@ -31,15 +30,16 @@ use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Exception;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use ImagickException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Twig\Error\Error;
 
 
 /**
@@ -111,95 +111,75 @@ class ProgramController extends AbstractController
    * @Route("/program/{id}", name="program_depricated")
    * @Route("/details/{id}", name="catrobat_web_detail", methods={"GET"})
    *
-   * @param Request $request
-   * @param $id
-   * @param ProgramManager $program_manager
-   * @param FeaturedRepository $featured_repository
-   * @param ScreenshotRepository $screenshot_repository
+   * @param Request                    $request
+   * @param                            $id
+   * @param ProgramManager             $program_manager
+   * @param ScreenshotRepository       $screenshot_repository
    * @param ElapsedTimeStringFormatter $elapsed_time
-   * @param AppRequest $app_request
-   * @param RemixManager $remix_manager
-   * @param GameJamRepository $game_jam_repository
+   * @param RemixManager               $remix_manager
+   * @param GameJamRepository          $game_jam_repository
    *
    * @return Response
-   * @throws Error
-   * @throws NonUniqueResultException
    * @throws ORMException
    * @throws OptimisticLockException
    */
-  public function programAction(Request $request, $id, ProgramManager $program_manager,
-                                FeaturedRepository $featured_repository, ScreenshotRepository $screenshot_repository,
-                                ElapsedTimeStringFormatter $elapsed_time, AppRequest $app_request,
+  public function projectAction(Request $request, $id, ProgramManager $program_manager,
+                                ScreenshotRepository $screenshot_repository,
+                                ElapsedTimeStringFormatter $elapsed_time,
                                 RemixManager $remix_manager, GameJamRepository $game_jam_repository)
   {
     /**
      * @var $user             User
-     * @var $program          Program
+     * @var $project          Program
      * @var $reported_program ProgramInappropriateReport
      * @var $like             ProgramLike
      */
-    $program = $program_manager->find($id);
+    $project = $program_manager->find($id);
     $router = $this->get('router');
 
-    if (!$program || !$program->isVisible())
+    if (!$program_manager->isProjectVisibleForCurrentUser($project))
     {
-      if (!$featured_repository->isFeatured($program))
-      {
-        throw $this->createNotFoundException('Unable to find Project entity.');
-      }
-    }
-
-//    Right now everyone should find even private programs via the correct link! SHARE-49
-//    if ($program->getPrivate() && $program->getUser()->getId() !== $this->getUser()->getId()) {
-//      // only program owners should be allowed to see their programs
-//      throw $this->createNotFoundException('Unable to find Project entity.');
-//    }
-
-    if ($program->isDebugBuild())
-    {
-      if (!$app_request->isDebugBuildRequest())
-      {
-        throw $this->createNotFoundException('Unable to find Project entity.');
-      }
+      throw $this->createNotFoundException('Unable to find Project entity.');
     }
 
     $viewed = $request->getSession()->get('viewed', []);
-    $this->checkAndAddViewed($request, $program, $viewed, $program_manager);
+    $this->checkAndAddViewed($request, $project, $viewed, $program_manager);
     $referrer = $request->headers->get('referer');
     $request->getSession()->set('referer', $referrer);
 
     $user = $this->getUser();
     $logged_in = false;
-    $user_name = "";
-    $like_type = ProgramLike::TYPE_NONE;
-    $like_type_count = 0;
+
+    $active_user_like_types = [];
+    $user_name = null;
 
     if ($user !== null)
     {
       $logged_in = true;
       $user_name = $user->getUsername();
-      $like = $program_manager->findUserLike($program->getId(), $user->getId());
-      if ($like !== null)
+      $likes = $program_manager->findUserLikes($project->getId(), $user->getId());
+      foreach ($likes as $like)
       {
-        $like_type = $like->getType();
-        $like_type_count = $program_manager->likeTypeCount($program->getId(), $like_type);
+        $active_user_like_types[] = $like->getType();
       }
     }
+    $active_like_types = $program_manager->findProgramLikeTypes($project->getId());
 
-    $total_like_count = $program_manager->totalLikeCount($program->getId());
-    $program_comments = $this->findCommentsById($program);
-    $program_details = $this->createProgramDetailsArray($screenshot_repository, $program,
-      $like_type, $like_type_count, $total_like_count, $elapsed_time, $referrer,
-      $program_comments, $request,$remix_manager);
+    $total_like_count = $program_manager->totalLikeCount($project->getId());
+    $program_comments = $this->findCommentsById($project);
+    $program_details = $this->createProgramDetailsArray($screenshot_repository, $project,
+      $active_like_types, $active_user_like_types, $total_like_count, $elapsed_time, $referrer,
+      $program_comments, $request, $remix_manager
+    );
 
-    $user_programs = $this->findUserPrograms($user, $program);
+    $user_programs = $this->findUserPrograms($user, $project);
 
-    $isReportedByUser = $this->checkReportedByUser($program, $user);
+    $isReportedByUser = $this->checkReportedByUser($project, $user);
 
     $program_url = $this->generateUrl('program',
-      ['id' => $program->getId()], true);
-    $share_text = trim($program->getName() . ' on ' . $program_url . ' ' .
-      $program->getDescription());
+      ['id' => $project->getId()], true);
+    $share_text = trim($project->getName() . ' on ' . $program_url . ' ' .
+      $project->getDescription());
 
     $jam = $this->extractGameJamConfig($game_jam_repository);
 
@@ -213,7 +193,7 @@ class ProgramController extends AbstractController
 
     return $this->render('Program/program.html.twig', [
       'program_details_url_template' => $router->generate('program', ['id' => 0]),
-      'program'                      => $program,
+      'program'                      => $project,
       'program_details'              => $program_details,
       'my_program'                   => $my_program,
       'already_reported'             => $isReportedByUser,
@@ -228,111 +208,137 @@ class ProgramController extends AbstractController
 
 
   /**
-   * @Route("/project/like/{id}", name="program_like", methods={"GET"})
+   * @Route("/project/like/{id}", name="project_like", methods={"GET"})
    *
-   * @param Request $request
-   * @param GuidType $id
-   * @param ProgramManager $program_manager
+   * @param Request                     $request
+   * @param GuidType                    $id
+   * @param ProgramManager              $program_manager
    * @param CatroNotificationRepository $notification_repo
-   * @param CatroNotificationService $notification_service
+   * @param CatroNotificationService    $notification_service
+   * @param TranslatorInterface         $translator
    *
    * @return JsonResponse|RedirectResponse
-   * @throws Exception
+   * @throws ORMException
    */
-  public function programLikeAction(Request $request, $id, ProgramManager $program_manager,
+  public function projectLikeAction(Request $request, $id, ProgramManager $program_manager,
                                     CatroNotificationRepository $notification_repo,
-                                    CatroNotificationService  $notification_service )
+                                    CatroNotificationService $notification_service,
+                                    TranslatorInterface $translator)
   {
-    /**
-     * @var User                     $user
-     * @var Program                  $program
-     */
+    $csrf_token = $request->query->get('token');
+    if (!$this->isCsrfTokenValid('project', $csrf_token))
+    {
+      if ($request->isXmlHttpRequest())
+      {
+        return JsonResponse::create([
+          'statusCode' => StatusCode::CSRF_FAILURE,
+          'message'    => 'Invalid CSRF token.',
+        ], Response::HTTP_BAD_REQUEST);
+      }
+      else
+      {
+        throw new InvalidCsrfTokenException();
+      }
+    }
 
-    $type = intval($request->query->get('type', ProgramLike::TYPE_THUMBS_UP));
-    $no_unlike = (bool)$request->query->get('no_unlike', false);
+    $type = intval($request->query->get('type'));
+    $action = $request->query->get('action');
 
     if (!ProgramLike::isValidType($type))
     {
       if ($request->isXmlHttpRequest())
       {
-        return JsonResponse::create(['statusCode' => StatusCode::INVALID_PARAM,
-                                     'message'    => 'Invalid like type given!']);
+        return JsonResponse::create([
+          'statusCode' => StatusCode::INVALID_PARAM,
+          'message'    => 'Invalid like type given!',
+        ], Response::HTTP_BAD_REQUEST);
       }
       else
       {
-        throw $this->createAccessDeniedException('Invalid like-type for program given!');
-      }
-    }
-    $program = $program_manager->find($id);
-    if ($program === null)
-    {
-      if ($request->isXmlHttpRequest())
-      {
-        return JsonResponse::create(['statusCode' => StatusCode::INVALID_PARAM,
-                                     'message'    => 'Program with given ID does not exist!']);
-      }
-      else
-      {
-        throw $this->createNotFoundException('Program with given ID does not exist!');
+        throw $this->createAccessDeniedException('Invalid like-type for project given!');
       }
     }
 
+    /** @var Program $project */
+    $project = $program_manager->find($id);
+    if ($project === null)
+    {
+      if ($request->isXmlHttpRequest())
+      {
+        return JsonResponse::create([
+          'statusCode' => StatusCode::INVALID_PARAM,
+          'message'    => 'Project with given ID does not exist!',
+        ], Response::HTTP_NOT_FOUND);
+      }
+      else
+      {
+        throw $this->createNotFoundException('Project with given ID does not exist!');
+      }
+    }
+
+    /** @var User $user */
     $user = $this->getUser();
     if (!$user)
     {
       if ($request->isXmlHttpRequest())
       {
-        return JsonResponse::create(['statusCode' => StatusCode::LOGIN_ERROR]);
+        return JsonResponse::create(['statusCode' => StatusCode::LOGIN_ERROR], Response::HTTP_UNAUTHORIZED);
       }
       else
       {
         $request->getSession()->set('catroweb_login_redirect', $this->generateUrl(
-          'program_like', ['id' => $id, 'type' => $type, 'no_unlike' => 1]));
+          'project_like',
+          ['id' => $id, 'type' => $type, 'action' => $action, 'token' => $csrf_token],
+          UrlGeneratorInterface::ABSOLUTE_URL
+        ));
 
         return $this->redirectToRoute('login');
       }
     }
 
-    $new_type = $program_manager->toggleLike($program, $user, $type, $no_unlike);
-    $like_type_count = $program_manager->likeTypeCount($program->getId(), $type);
-    $total_like_count = $program_manager->totalLikeCount($program->getId());
-
-    if ($program->getUser() !== $user)
+    try
     {
-      $program_notification_exists = false;
-
-      $notifications = $notification_repo->findByUser($program->getUser());
-
-      foreach ($notifications as $notification)
+      $program_manager->changeLike($project, $user, $type, $action);
+    } catch (\InvalidArgumentException $exception)
+    {
+      if ($request->isXmlHttpRequest())
       {
-        if ($notification instanceof LikeNotification)
-        {
-          if ($notification->getLikeFrom()->getId() === $user->getId() &&
-            $notification->getProgram()->getId() === $program->getId())
-          {
-            $program_notification_exists = true;
-            break;
-          }
-        }
-      }
-
-      if ($new_type === ProgramLike::TYPE_THUMBS_UP
-        || $new_type === ProgramLike::TYPE_SMILE
-        || $new_type === ProgramLike::TYPE_LOVE
-        || $new_type === ProgramLike::TYPE_WOW
-      )
-      {
-        if (!$program_notification_exists)
-        {
-          $notification = new LikeNotification($program->getUser(), $user, $program);
-          $notification_service->addNotification($notification);
-        }
+        return JsonResponse::create([
+          'statusCode' => StatusCode::INVALID_PARAM,
+          'message'    => 'Invalid action given!',
+        ], Response::HTTP_BAD_REQUEST);
       }
       else
       {
-        if ($program_notification_exists)
+        throw $this->createAccessDeniedException('Invalid action given!');
+      }
+    }
+
+
+    if ($project->getUser() !== $user)
+    {
+      $existing_notifications = $notification_repo->getLikeNotificationsForProject(
+        $project, $project->getUser(), $user
+      );
+
+      if ($action === ProgramLike::ACTION_ADD)
+      {
+
+        if (count($existing_notifications) === 0)
         {
-          $notification_service->removeNotification($notification);
+          $notification = new LikeNotification($project->getUser(), $user, $project);
+          $notification_service->addNotification($notification);
+        }
+      }
+      elseif ($action === ProgramLike::ACTION_REMOVE)
+      {
+        // check if there is no other reaction
+        if (!$program_manager->areThereOtherLikeTypes($project, $user, $type))
+        {
+          foreach ($existing_notifications as $notification)
+          {
+            $notification_service->removeNotification($notification);
+          }
         }
       }
     }
@@ -342,12 +348,19 @@ class ProgramController extends AbstractController
       return $this->redirectToRoute('program', ['id' => $id]);
     }
 
-    return new JsonResponse(['statusCode' => StatusCode::OK, 'data' => [
-      'id'             => $id,
-      'likeType'       => $new_type,
-      'likeTypeCount'  => $like_type_count,
-      'totalLikeCount' => $total_like_count,
-    ]]);
+    $user_locale = $request->getLocale();
+    $total_like_count = $program_manager->totalLikeCount($project->getId());
+    $active_like_types = array_map(function ($type_id) {
+      return ProgramLike::$TYPE_NAMES[$type_id];
+    }, $program_manager->findProgramLikeTypes($project->getId()));
+
+    return new JsonResponse([
+      'totalLikeCount' => [
+        'value'       => $total_like_count,
+        'stringValue' => AppExtension::humanFriendlyNumber($total_like_count, $translator, $user_locale),
+      ],
+      'activeLikeTypes' => $active_like_types,
+    ]);
   }
 
 
@@ -649,19 +662,19 @@ class ProgramController extends AbstractController
   /**
    * @param $screenshot_repository      ScreenshotRepository
    * @param $program                    Program
+   * @param $active_like_types          int[]
+   * @param $active_user_like_types     int[]
+   * @param $total_like_count
    * @param $elapsed_time               ElapsedTimeStringFormatter
    * @param $referrer
-   * @param $like_type
-   * @param $like_type_count
-   * @param $total_like_count
    * @param $program_comments
    * @param $request                    Request
    * @param $remix_manager              RemixManager
    *
    * @return array
    */
-  private function createProgramDetailsArray($screenshot_repository, $program, $like_type,
-                                             $like_type_count, $total_like_count, $elapsed_time,
+  private function createProgramDetailsArray($screenshot_repository, $program, $active_like_types,
+                                             $active_user_like_types, $total_like_count, $elapsed_time,
                                              $referrer, $program_comments, $request, $remix_manager)
   {
     $rec_by_page_id = intval($request->query->get('rec_by_page_id', RecommendedPageId::INVALID_PAGE));
@@ -722,23 +735,23 @@ class ProgramController extends AbstractController
     }
 
     $program_details = [
-      'screenshotBig'   => $screenshot_repository->getScreenshotWebPath($program->getId()),
-      'downloadUrl'     => $url,
-      'languageVersion' => $program->getLanguageVersion(),
-      'downloads'       => $program->getDownloads() + $program->getApkDownloads(),
-      'views'           => $program->getViews(),
-      'filesize'        => sprintf('%.2f', $program->getFilesize() / 1048576),
-      'age'             => $elapsed_time->getElapsedTime($program->getUploadedAt()->getTimestamp()),
-      'referrer'        => $referrer,
-      'id'              => $program->getId(),
-      'comments'        => $program_comments,
-      'commentsLength'  => count($program_comments),
-      'commentsAvatars' => $comments_avatars,
-      'remixesLength'   => $remix_manager->remixCount($program->getId()),
-      'likeType'        => $like_type,
-      'likeTypeCount'   => $like_type_count,
-      'totalLikeCount'  => $total_like_count,
-      'isAdmin'         => $this->isGranted("ROLE_ADMIN"),
+      'screenshotBig'       => $screenshot_repository->getScreenshotWebPath($program->getId()),
+      'downloadUrl'         => $url,
+      'languageVersion'     => $program->getLanguageVersion(),
+      'downloads'           => $program->getDownloads() + $program->getApkDownloads(),
+      'views'               => $program->getViews(),
+      'filesize'            => sprintf('%.2f', $program->getFilesize() / 1048576),
+      'age'                 => $elapsed_time->getElapsedTime($program->getUploadedAt()->getTimestamp()),
+      'referrer'            => $referrer,
+      'id'                  => $program->getId(),
+      'comments'            => $program_comments,
+      'commentsLength'      => count($program_comments),
+      'commentsAvatars'     => $comments_avatars,
+      'remixesLength'       => $remix_manager->remixCount($program->getId()),
+      'activeLikeTypes'     => $active_like_types,
+      'activeUserLikeTypes' => $active_user_like_types,
+      'totalLikeCount'      => $total_like_count,
+      'isAdmin'             => $this->isGranted("ROLE_ADMIN"),
     ];
 
     return $program_details;

--- a/src/Catrobat/StatusCode.php
+++ b/src/Catrobat/StatusCode.php
@@ -41,6 +41,8 @@ class StatusCode
   const PASSWORD_INVALID = 532;
   const CREDITS_TO_LONG = 833;
 
+  const CSRF_FAILURE = 590;
+
   const LOGIN_ERROR = 601;
   const REGISTRATION_ERROR = 602;
 

--- a/src/Entity/ProgramLike.php
+++ b/src/Entity/ProgramLike.php
@@ -24,8 +24,19 @@ class ProgramLike
     self::TYPE_SMILE,
     self::TYPE_LOVE,
     self::TYPE_WOW,
+    // -> ... and here ...
+  ];
+
+  public static $TYPE_NAMES = [
+    self::TYPE_THUMBS_UP => 'thumbs_up',
+    self::TYPE_SMILE     => 'smile',
+    self::TYPE_LOVE      => 'love',
+    self::TYPE_WOW       => 'wow',
     // -> ... and here
   ];
+
+  const ACTION_ADD = 'add';
+  const ACTION_REMOVE = 'remove';
 
   /**
    * @param $type
@@ -84,7 +95,7 @@ class ProgramLike
   /**
    * @param Program $program
    * @param User    $user
-   * @param int                                $type
+   * @param int     $type
    */
   public function __construct(Program $program, User $user, $type)
   {
@@ -183,6 +194,20 @@ class ProgramLike
   public function getType()
   {
     return $this->type;
+  }
+
+  /**
+   * @return string|null
+   */
+  public function getTypeAsString()
+  {
+    try
+    {
+      return self::$TYPE_NAMES[$this->type];
+    } catch (\ErrorException $exception)
+    {
+      return null;
+    }
   }
 
   /**

--- a/src/Entity/ProgramManager.php
+++ b/src/Entity/ProgramManager.php
@@ -16,6 +16,7 @@ use App\Catrobat\Services\ExtractedCatrobatFile;
 use App\Catrobat\Services\ProgramFileRepository;
 use App\Catrobat\Services\ScreenshotRepository;
 use App\Repository\ExtensionRepository;
+use App\Repository\FeaturedRepository;
 use Doctrine\DBAL\Types\GuidType;
 use App\Repository\ProgramLikeRepository;
 use App\Repository\ProgramRepository;
@@ -27,6 +28,7 @@ use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Exception;
+use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
@@ -84,6 +86,9 @@ class ProgramManager
    */
   protected $program_like_repository;
 
+  /** @var FeaturedRepository */
+  protected $featured_repository;
+
   /**
    * @var LoggerInterface
    */
@@ -109,6 +114,7 @@ class ProgramManager
    * @param ProgramRepository        $program_repository
    * @param TagRepository            $tag_repository
    * @param ProgramLikeRepository    $program_like_repository
+   * @param FeaturedRepository       $featured_repository
    * @param EventDispatcherInterface $event_dispatcher
    * @param LoggerInterface          $logger
    * @param AppRequest               $app_request
@@ -119,6 +125,7 @@ class ProgramManager
                               ScreenshotRepository $screenshot_repository, EntityManagerInterface $entity_manager,
                               ProgramRepository $program_repository, TagRepository $tag_repository,
                               ProgramLikeRepository $program_like_repository,
+                              FeaturedRepository $featured_repository,
                               EventDispatcherInterface $event_dispatcher,
                               LoggerInterface $logger, AppRequest $app_request,
                               ExtensionRepository $extension_repository, CatrobatFileSanitizer $file_sanitizer)
@@ -131,10 +138,50 @@ class ProgramManager
     $this->program_repository = $program_repository;
     $this->tag_repository = $tag_repository;
     $this->program_like_repository = $program_like_repository;
+    $this->featured_repository = $featured_repository;
     $this->logger = $logger;
     $this->app_request = $app_request;
     $this->file_sanitizer = $file_sanitizer;
     $this->extension_repository = $extension_repository;
+  }
+
+  /**
+   * Check visibility of the given project for the current user
+   *
+   * @param Program $project
+   *
+   * @return bool
+   */
+  public function isProjectVisibleForCurrentUser(Program $project)
+  {
+    if (!$project)
+    {
+      return false;
+    }
+
+    if (!$project->isVisible())
+    {
+      if (!$this->featured_repository->isFeatured($project))
+      {
+        return false;
+      }
+    }
+
+//    Right now everyone should find even private programs via the correct link! SHARE-49
+//    if ($program->getPrivate() && $program->getUser()->getId() !== $this->getUser()->getId()) {
+//      // only program owners should be allowed to see their programs
+//      return false;
+//    }
+
+    if ($project->isDebugBuild())
+    {
+      if (!$this->app_request->isDebugBuildRequest())
+      {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /**
@@ -291,55 +338,67 @@ class ProgramManager
   }
 
   /**
-   * @param $program_id
+   * @param $project_id
    * @param $user_id
    *
-   * @return mixed
+   * @return ProgramLike[]
    */
-  public function findUserLike($program_id, $user_id)
+  public function findUserLikes($project_id, $user_id)
   {
-    return $this->program_like_repository->findOneBy(['program_id' => $program_id, 'user_id' => $user_id]);
+    return $this->program_like_repository->findBy(['program_id' => $project_id, 'user_id' => $user_id]);
   }
 
   /**
-   * @param Program $program
+   * @param $project_id
+   *
+   * @return array
+   */
+  public function findProgramLikeTypes($project_id)
+  {
+    return $this->program_like_repository->likeTypesOfProject($project_id);
+  }
+
+  /**
+   * @param Program $project
    * @param User    $user
    * @param         $type
-   * @param         $no_unlike
+   * @param string  $action
    *
-   * @return int
+   * @throws InvalidArgumentException
+   * @throws ORMException
    */
-  public function toggleLike(Program $program, User $user, $type, $no_unlike)
+  public function changeLike(Program $project, User $user, $type, $action)
   {
-    $existing_program_like = $this->program_like_repository->findOneBy([
-      'program_id' => $program->getId(),
-      'user_id'    => $user->getId(),
-    ]);
-
-    if ($existing_program_like !== null)
+    if ($action === ProgramLike::ACTION_ADD)
     {
-      $existing_program_like_type = $existing_program_like->getType();
-      $this->entity_manager->remove($existing_program_like);
-
-      // case: unlike
-      if ($existing_program_like_type === $type)
-      {
-        if ($no_unlike)
-        {
-          return $type;
-        }
-        $this->entity_manager->flush();
-
-        return ProgramLike::TYPE_NONE;
-      }
+      $this->program_like_repository->addLike($project, $user, $type);
     }
+    elseif ($action === ProgramLike::ACTION_REMOVE)
+    {
+      $this->program_like_repository->removeLike($project, $user, $type);
+    }
+    else
+    {
+      throw new InvalidArgumentException('Invalid action "' . $action . '"');
+    }
+  }
 
-    // case: like
-    $program_like = new ProgramLike($program, $user, $type);
-    $this->entity_manager->persist($program_like);
-    $this->entity_manager->flush();
-
-    return $type;
+  /**
+   * @param Program $project
+   * @param User    $user
+   * @param         $type
+   *
+   * @return bool
+   */
+  public function areThereOtherLikeTypes(Program $project, User $user, $type)
+  {
+    try
+    {
+      return $this->program_like_repository->areThereOtherLikeTypes($project, $user, $type);
+    } catch (NonUniqueResultException $exception)
+    {
+      return false;
+    }
   }
 
   /**

--- a/src/Repository/CatroNotificationRepository.php
+++ b/src/Repository/CatroNotificationRepository.php
@@ -3,6 +3,9 @@
 namespace App\Repository;
 
 use App\Entity\CatroNotification;
+use App\Entity\LikeNotification;
+use App\Entity\Program;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -18,5 +21,39 @@ class CatroNotificationRepository extends ServiceEntityRepository
   public function __construct(ManagerRegistry $managerRegistry)
   {
     parent::__construct($managerRegistry, CatroNotification::class);
+  }
+
+  /**
+   * @param Program   $project
+   * @param User|null $owner
+   * @param User|null $likeFrom
+   *
+   * @return LikeNotification[]
+   */
+  public function getLikeNotificationsForProject(Program $project, User $owner = null, User $likeFrom = null)
+  {
+    $qb = $this->_em->createQueryBuilder();
+
+    $qb
+      ->select('n')
+      ->from('\App\Entity\LikeNotification', 'n')
+      ->where($qb->expr()->eq('n.program', ':program_id'))
+      ->setParameter(':program_id', $project->getId());
+
+    if ($owner !== null)
+    {
+      $qb
+        ->andWhere($qb->expr()->eq('n.user', ':user_id'))
+        ->setParameter(':user_id', $owner->getId());
+    }
+
+    if ($likeFrom !== null)
+    {
+      $qb
+        ->andWhere($qb->expr()->eq('n.like_from', ':like_from_id'))
+        ->setParameter(':like_from_id', $likeFrom->getId());
+    }
+
+    return $qb->getQuery()->getResult();
   }
 }

--- a/src/Repository/FeaturedRepository.php
+++ b/src/Repository/FeaturedRepository.php
@@ -5,6 +5,7 @@ namespace App\Repository;
 use App\Entity\FeaturedProgram;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\ORM\NonUniqueResultException;
 
 
 /**
@@ -119,20 +120,22 @@ class FeaturedRepository extends ServiceEntityRepository
    * @param $program
    *
    * @return bool
-   * @throws \Doctrine\ORM\NonUniqueResultException
    */
   public function isFeatured($program)
   {
     $qb = $this->createQueryBuilder('e');
     $qb
+      ->select('count(e.id)')
       ->where($qb->expr()->eq('e.program', ':program'))
-      ->setParameter('program', $program);;
-    $result = $qb->getQuery()->getOneOrNullResult();
-    if ($result == null)
+      ->setParameter('program', $program);
+    try
+    {
+      $count = $qb->getQuery()->getSingleScalarResult();
+
+      return $count > 0;
+    } catch (NonUniqueResultException $exception)
     {
       return false;
     }
-
-    return true;
   }
 }

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -45,51 +45,123 @@
 
       {% include 'Program/projectThumbnail.html.twig' %}
 
-      <div id="program-like-container">
-        <div>
-          <div id="program-like-buttons-container">
-            <a id="program-like-thumbs-up" class="program-like-button" href="#"
-               data-like-type="{{ constant('App\\Entity\\ProgramLike::TYPE_THUMBS_UP') }}"
-               data-toggle="tooltip" title="{{ 'programs.thumbsUp'|trans({}, 'catroweb') }}">
-              <div class="like-round-icon-container mr-3"><i
-                    class="like-round-icon fas fa-thumbs-up"></i></div>
-              <span
-                  class="singular">{{ "programs.likeThumbsUpDetailText"|transchoice(1, { '%persons%' : 1 }, "catroweb") }}</span>
-              <span
-                  class="plural">{{ "programs.likeThumbsUpDetailText"|transchoice(2, { '%persons%' : 2 }, "catroweb") }}</span>
-            </a>
-            <a id="program-like-smile" class="program-like-button" href="#"
-               data-like-type="{{ constant('App\\Entity\\ProgramLike::TYPE_SMILE') }}"
-               data-toggle="tooltip" title="{{ 'programs.smile'|trans({}, 'catroweb') }}">
-              <i class="like-icon mr-3 fas fa-grin-squint"></i>
-              <span
-                  class="singular">{{ "programs.likeSmileDetailText"|transchoice(1, { '%persons%' : 1 }, "catroweb") }}</span>
-              <span
-                  class="plural">{{ "programs.likeSmileDetailText"|transchoice(2, { '%persons%' : 2 }, "catroweb") }}</span>
-            </a>
-            <a id="program-like-love" class="program-like-button" href="#"
-               data-like-type="{{ constant('App\\Entity\\ProgramLike::TYPE_LOVE') }}"
-               data-toggle="tooltip" title="{{ 'programs.love'|trans({}, 'catroweb') }}">
-              <div class="like-round-icon-container mr-3"><i
-                    class="like-round-icon-heart fas fa-heart"></i></div>
-              <span
-                  class="singular">{{ "programs.likeLoveDetailText"|transchoice(1, { '%persons%' : 1 }, "catroweb") }}</span>
-              <span
-                  class="plural">{{ "programs.likeLoveDetailText"|transchoice(2, { '%persons%' : 2 }, "catroweb") }}</span>
-            </a>
-            <a id="program-like-wow" class="program-like-button" href="#"
-               data-like-type="{{ constant('App\\Entity\\ProgramLike::TYPE_WOW') }}"
-               data-toggle="tooltip" title="{{ 'programs.wow'|trans({}, 'catroweb') }}">
-              <i class="like-icon mr-3 fas fa-surprise"></i>
-              <span
-                  class="singular">{{ "programs.likeWowDetailText"|transchoice(1, { '%persons%' : 1 }, "catroweb") }}</span>
-              <span
-                  class="plural">{{ "programs.likeWowDetailText"|transchoice(2, { '%persons%' : 2 }, "catroweb") }}</span>
-            </a>
-            <span id="program-like-counter" class="program-like-counter"></span>
+      <div id="project-like">
+        {# If you change #project-like-buttons, you need to change it in Program.js in sendProjectLike too #}
+        {% if program_details.totalLikeCount is same as(0) %}
+          <div id="project-like-buttons">
+            <div class="btn btn-primary btn-round">
+              <i class="fas fa-thumbs-up"></i>
+            </div>
+          </div>
+          <span id="project-like-counter" class="d-none">0</span>
+        {% else %}
+          <div id="project-like-buttons">
+            {% if constant('App\\Entity\\ProgramLike::TYPE_THUMBS_UP') in program_details.activeLikeTypes %}
+              <div class="btn btn-primary btn-round">
+                <i class="fas fa-thumbs-up"></i>
+              </div>
+            {% endif %}
+            {% if constant('App\\Entity\\ProgramLike::TYPE_SMILE') in program_details.activeLikeTypes %}
+              <div class="btn icon-only">
+                <i class="fas fa-grin-squint"></i>
+              </div>
+            {% endif %}
+            {% if constant('App\\Entity\\ProgramLike::TYPE_LOVE') in program_details.activeLikeTypes %}
+              <div class="btn btn-primary btn-round">
+                <i class="fas fa-heart"></i>
+              </div>
+            {% endif %}
+            {% if constant('App\\Entity\\ProgramLike::TYPE_WOW') in program_details.activeLikeTypes %}
+              <div class="btn icon-only">
+                <i class="fas fa-surprise"></i>
+              </div>
+            {% endif %}
+          </div>
+          <span id="project-like-counter">{{ program_details.totalLikeCount | humanFriendlyNumber }}</span>
+        {% endif %}
+        <div id="project-like-detail">
+          {# Thumbs-Up Button #}
+          <div
+                  class="btn btn-primary btn-round{% if constant('App\\Entity\\ProgramLike::TYPE_THUMBS_UP') in program_details.activeUserLikeTypes %} active{% endif %}"
+                  data-like-type="{{ constant('App\\Entity\\ProgramLike::TYPE_THUMBS_UP') }}"
+                  data-toggle="tooltip" title="{{ 'programs.thumbsUp'|trans({}, 'catroweb') }}">
+            <i class="fas fa-thumbs-up"></i>
+          </div>
+          {# Smile Button #}
+          <div
+                  class="btn icon-only{% if constant('App\\Entity\\ProgramLike::TYPE_SMILE') in program_details.activeUserLikeTypes %} active{% endif %}"
+                  data-like-type="{{ constant('App\\Entity\\ProgramLike::TYPE_SMILE') }}"
+                  data-toggle="tooltip" title="{{ 'programs.smile'|trans({}, 'catroweb') }}">
+            <i class="fas fa-grin-squint"></i>
+          </div>
+          {# Love Button #}
+          <div
+                  class="btn btn-primary btn-round{% if constant('App\\Entity\\ProgramLike::TYPE_LOVE') in program_details.activeUserLikeTypes %} active{% endif %}"
+                  data-like-type="{{ constant('App\\Entity\\ProgramLike::TYPE_LOVE') }}"
+                  data-toggle="tooltip" title="{{ 'programs.love'|trans({}, 'catroweb') }}">
+            <i class="fas fa-heart"></i>
+          </div>
+          {# Wow Button #}
+          <div
+                  class="btn icon-only{% if constant('App\\Entity\\ProgramLike::TYPE_WOW') in program_details.activeUserLikeTypes %} active{% endif %}"
+                  data-like-type="{{ constant('App\\Entity\\ProgramLike::TYPE_WOW') }}"
+                  data-toggle="tooltip" title="{{ 'programs.wow'|trans({}, 'catroweb') }}">
+            <i class="fas fa-surprise"></i>
           </div>
         </div>
-        <div id="program-like-detail-container">&nbsp;</div>
+      </div>
+
+      <div class="modal fade" id="project-like-modal" tabindex="-1" role="dialog"
+           aria-labelledby="project-like-modal-label" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title"
+                  id="project-like-modal-label">{{ "programs.likes.likersTitle"|trans({}, 'catroweb') }}</h5>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div class="modal-body">
+              <ul class="nav nav-tabs" role="tablist">
+                <li class="nav-item">
+                  <a class="nav-link active" id="all-tab" data-toggle="tab" href="#all-tab-content" role="tab"
+                     aria-controls="all-tab-content"
+                     aria-selected="true">{{ 'programs.likes.all' | trans({}, 'catroweb') }}<span></span></a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" id="thumbs-up-tab" data-toggle="tab" href="#thumbs-up-tab-content" role="tab"
+                     aria-controls="thumbs-up-tab-content" aria-selected="false"><i
+                            class="fas fa-thumbs-up"></i><span></span></a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" id="smile-tab" data-toggle="tab" href="#smile-tab-content" role="tab"
+                     aria-controls="smile-tab-content" aria-selected="false"><i
+                            class="fas fa-grin-squint"></i><span></span></a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" id="love-tab" data-toggle="tab" href="#love-tab-content" role="tab"
+                     aria-controls="love-tab-content" aria-selected="false"><i
+                            class="fas fa-heart"></i><span></span></a>
+                </li>
+                <li class="nav-item">
+                  <a class="nav-link" id="wow-tab" data-toggle="tab" href="#wow-tab-content" role="tab"
+                     aria-controls="wow-tab-content" aria-selected="false"><i
+                            class="fas fa-surprise"></i><span></span></a>
+                </li>
+              </ul>
+              <div class="tab-content" id="myTabContent">
+                <div class="tab-pane fade show active" id="all-tab-content" role="tabpanel"
+                     aria-labelledby="all-tab"></div>
+                <div class="tab-pane fade" id="thumbs-up-tab-content" role="tabpanel"
+                     aria-labelledby="thumbs-up-tab"></div>
+                <div class="tab-pane fade" id="smile-tab-content" role="tabpanel" aria-labelledby="smile-tab"></div>
+                <div class="tab-pane fade" id="love-tab-content" role="tabpanel" aria-labelledby="love-tab"></div>
+                <div class="tab-pane fade" id="wow-tab-content" role="tabpanel" aria-labelledby="wow-tab"></div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -499,14 +571,25 @@
 
     })
 
+    const project_id = '{{ program.id }}'
+
     let program = new Program(
-      '{{ path('ci_status', { 'id' : program.id }) }}',
-      '{{ path('ci_build', { 'id' : program.id }) }}',
-      '{{ 'apk.preparing'|trans({}, "catroweb") }}',
-      '{{ 'apk.text'|trans({}, "catroweb") }}',
-      '{{ 'programs.updateAppHeader'|trans({}, "catroweb") }}',
-      '{{ 'programs.updateAppText'|trans({}, "catroweb") }}',
-      '{{ 'programs.btnClosePopup'|trans({}, "catroweb") }}'
+            project_id,
+            '{{ csrf_token('project') }}',
+            {% if app.user %} 'user', {% else %} 'guest', {% endif %}
+            {% if my_program %} true, {% else %} false, {% endif %}
+            '{{ path('ci_status', { 'id' : program.id }) }}',
+            '{{ path('ci_build', { 'id' : program.id }) }}',
+            '{{ path('project_like', { 'id' : program.id }) }}',
+            '{{ path('api_project_likes', { 'id' : program.id }) }}',
+            '{{ 'apk.preparing'|trans({}, "catroweb") }}',
+            '{{ 'apk.text'|trans({}, "catroweb") }}',
+            '{{ 'programs.updateAppHeader'|trans({}, "catroweb") }}',
+            '{{ 'programs.updateAppText'|trans({}, "catroweb") }}',
+            '{{ 'programs.btnClosePopup'|trans({}, "catroweb") }}',
+            '{{ constant('App\\Entity\\ProgramLike::ACTION_ADD') }}',
+            '{{ constant('App\\Entity\\ProgramLike::ACTION_REMOVE') }}',
+            '{{ path('profile', {'id': 'USERID'}) }}',
     )
     program.getApkStatus()
     program.createLinks()
@@ -533,17 +616,15 @@
       return false
     })
 
-    var undefined
-    var programID = '{{ program.id }}';
-    var recs = new ProjectLoader('#recommendations', '{{ path('api_recsys_programs') }}', programID)
+    var recs = new ProjectLoader('#recommendations', '{{ path('api_recsys_programs') }}', project_id)
     recs.initRecsys()
 
     var recommendedByPageId = {{ constant('App\\Catrobat\\RecommenderSystem\\RecommendedPageId::PROGRAM_DETAIL_PAGE') }};
-    var specificRecommender = new ProjectLoader('#specific-programs-recommendations', '{{ path('api_recsys_specific_projects', { 'id': program.id }) }}', programID, recommendedByPageId)
+    var specificRecommender = new ProjectLoader('#specific-programs-recommendations', '{{ path('api_recsys_specific_projects', { 'id': program.id }) }}', project_id, recommendedByPageId)
     specificRecommender.init()
 
     let more_from_this_user = new ProjectLoader('#more-from-this-user-recommendations', '{{ path('api_user_programs') }}')
-    more_from_this_user.initMoreFromThisUser('{{ program.user.id }}', programID)
+    more_from_this_user.initMoreFromThisUser('{{ program.user.id }}', project_id)
 
     counter = 10
     var cachedRemixData = null
@@ -558,52 +639,13 @@
       programUnknownUser                 : "{{ "remixGraph.programUnknownUser"|trans({}, "catroweb") }}"
     }
 
-    var PROGRAM_LIKE_TYPE_NONE = {{ constant('App\\Entity\\ProgramLike::TYPE_NONE') }};
-
-    function convertToHumanFriendlyNumberText (number)
-    {
-      if (number >= 10000)
-      {
-        return (number / 1000.0).toFixed(0) + 'k'
-      }
-      else if (number >= 1000)
-      {
-        return (number / 1000.0).toFixed(1).replace('.0', '') + 'k'
-      }
-      else
-      {
-        return number
-      }
-    }
-
-    function updateLikeCount (likeType, likeTypeCount, totalLikeCount)
-    {
-      var programLikeDetailContainer = $('#program-like-detail-container')
-      $('a.program-like-button').addClass('not-selected')
-      $('#program-like-buttons-container > .program-like-counter').text(convertToHumanFriendlyNumberText(totalLikeCount))
-      if (likeType === PROGRAM_LIKE_TYPE_NONE)
-      {
-        programLikeDetailContainer.html('&nbsp;')
-        return
-      }
-      var likeTypeButton = $('a.program-like-button[data-like-type=' + likeType + ']')
-      likeTypeButton.removeClass('not-selected')
-      var singularOrPlural = (likeTypeCount === 1)
-      var translatedDetailSpanTextTemplate = likeTypeButton.children(singularOrPlural ? '.singular' : '.plural')[0]
-      var replaceCount = '<span class="program-like-counter">' + convertToHumanFriendlyNumberText(likeTypeCount) + '<span>'
-      var translatedDetailText = translatedDetailSpanTextTemplate.innerHTML.replace((singularOrPlural ? '1' : '2'), replaceCount)
-      programLikeDetailContainer.html(translatedDetailText)
-    }
-
     $(document).ready(function () {
       var loadingAnimation = new LoadingAnimation('#177f8d', "{{ "pleaseWait"|trans({}, "catroweb") }}")
       var recommendedByRemixGraphPageId = {{ constant('App\\Catrobat\\RecommenderSystem\\RecommendedPageId::PROGRAM_DETAIL_PAGE_REMIX_GRAPH') }};
       var networkDirector = new NetworkDirector()
       var remixGraph = RemixGraph.getInstance()
-      remixGraph.init(programID, recommendedByRemixGraphPageId, 'remix-graph-modal', 'remix-graph-layer', 'close-button',
+      remixGraph.init(project_id, recommendedByRemixGraphPageId, 'remix-graph-modal', 'remix-graph-layer', 'close-button',
         "{{ program_details_url_template }}", "{{ path('click_stats') }}", remixGraphTranslations)
-
-      updateLikeCount({{ program_details.likeType }}, {{ program_details.likeTypeCount }}, {{ program_details.totalLikeCount }})
 
       $('#remix-graph-modal-link').animatedModal({
         modalTarget: 'remix-graph-modal',
@@ -616,7 +658,7 @@
           {
             document.addEventListener('gesturestart', blockEventListener)
             document.ontouchmove = blockEventListener
-            var networkBuilder = new NetworkBuilder(programID, 'remix-graph-layer', remixGraphTranslations, cachedRemixData)
+            var networkBuilder = new NetworkBuilder(project_id, 'remix-graph-layer', remixGraphTranslations, cachedRemixData)
             var networkDescription = networkDirector.construct(networkBuilder)
             remixGraph.render(loadingAnimation, networkDescription)
           }
@@ -629,7 +671,7 @@
                 cachedRemixData = remixData
                 document.addEventListener('gesturestart', blockEventListener)
                 document.ontouchmove = blockEventListener
-                var networkBuilder = new NetworkBuilder(programID, 'remix-graph-layer', remixGraphTranslations, remixData)
+                var networkBuilder = new NetworkBuilder(project_id, 'remix-graph-layer', remixGraphTranslations, remixData)
                 var networkDescription = networkDirector.construct(networkBuilder)
                 remixGraph.render(loadingAnimation, networkDescription)
               },
@@ -660,46 +702,6 @@
         $('#remix-graph-modal-link').click()
       })
 
-      $(document).on('click', 'a.program-like-button', function (event) {
-        event.preventDefault()
-        var type = $(this).attr('data-like-type')
-        var url = "{{ path('program_like', { 'id' : program.id }) }}?type=" + type
-        var username = "{{ user_name }}"
-        if (username === '')
-        {
-          window.location.href = url
-          return false
-        }
-
-        $('#program-like-detail-container').text("{{ "pleaseWait"|trans({}, "catroweb") }}")
-        $('a.program-like-button').addClass('not-selected')
-        $(this).removeClass('not-selected')
-
-        $.ajax({
-          url    : url,
-          type   : 'get',
-          data   : {type: type},
-          success: function (data) {
-            if (data.statusCode !== {{ constant('App\\Catrobat\\StatusCode::OK') }})
-            {
-              if (data.statusCode === {{ constant('App\\Catrobat\\StatusCode::LOGIN_ERROR') }})
-              {
-                window.location.href = url
-                return
-              }
-              alert('something went wrong')
-              $(this).addClass('not-selected')
-              return
-            }
-            updateLikeCount(data.data.likeType, data.data.likeTypeCount, data.data.totalLikeCount)
-          },
-          error  : function () {
-            alert('something went terribly wrong')
-            $(this).addClass('not-selected')
-          }
-        })
-        return false
-      })
     })
 
     $(document).ready(function () {

--- a/templates/Program/projectThumbnail.html.twig
+++ b/templates/Program/projectThumbnail.html.twig
@@ -13,27 +13,29 @@
   </div>
 {% endif %}
 
-{% if isWebview() %}
-<a href="{% if (checkCatrobatLanguage(program_details.languageVersion)) %}{{ program_details.downloadUrl }}{% else %}javascript:program.showUpdateAppPopup();{% endif %}">
-  {% endif %}
-
-  <img alt="project thumbnail" id="project-thumbnail-big"
-       src="{{ asset(program_details.screenshotBig) }}"/>
-
-  {% if my_program %}
-    <div id="change-project-thumbnail-button" class="upload-image">
-      <div>
-        <input type="file" name="file">
-        <a href="">{{ 'profile.changePicture'|trans({}, 'catroweb') }}</a>
-        <div class="button-show-ajax"><i class="fa fa-spinner fa-pulse fa-2x fa-fw" aria-hidden="true"></i></div>
-      </div>
-    </div>
-  {% endif %}
-
-
+<div class="project-thumbnail-wrapper">
   {% if isWebview() %}
-</a>
-{% endif %}
+  <a href="{% if (checkCatrobatLanguage(program_details.languageVersion)) %}{{ program_details.downloadUrl }}{% else %}javascript:program.showUpdateAppPopup();{% endif %}">
+    {% endif %}
+
+    <img alt="project thumbnail" id="project-thumbnail-big"
+         src="{{ asset(program_details.screenshotBig) }}"/>
+
+    {% if my_program %}
+      <div id="change-project-thumbnail-button" class="upload-image">
+        <div>
+          <input type="file" name="file">
+          <a href="">{{ 'profile.changePicture'|trans({}, 'catroweb') }}</a>
+          <div class="button-show-ajax"><i class="fa fa-spinner fa-pulse fa-2x fa-fw" aria-hidden="true"></i></div>
+        </div>
+      </div>
+    {% endif %}
+
+
+    {% if isWebview() %}
+  </a>
+  {% endif %}
+</div>
 <script src="{{ asset('compiled/js/ImageUpload.js') }}"></script>
 <script>
   setImageUploadListener('{{ path('upload_project_thumbnail', { 'id': program.id }) }}',

--- a/tests/PhpSpec/spec/App/Entity/ProgramManagerSpec.php
+++ b/tests/PhpSpec/spec/App/Entity/ProgramManagerSpec.php
@@ -15,6 +15,7 @@ use App\Entity\GameJam;
 use App\Entity\Program;
 use App\Entity\User;
 use App\Repository\ExtensionRepository;
+use App\Repository\FeaturedRepository;
 use App\Repository\ProgramLikeRepository;
 use App\Repository\ProgramRepository;
 use App\Repository\TagRepository;
@@ -50,6 +51,7 @@ class ProgramManagerSpec extends ObjectBehavior
    * @param Program                  $inserted_program
    * @param TagRepository            $tag_repository
    * @param ProgramLikeRepository    $program_like_repository
+   * @param FeaturedRepository       $featured_repository
    * @param LoggerInterface          $logger
    * @param AppRequest               $app_request
    * @param ExtensionRepository      $extension_repository
@@ -60,12 +62,12 @@ class ProgramManagerSpec extends ObjectBehavior
                       ProgramRepository $program_repository, EventDispatcherInterface $event_dispatcher,
                       AddProgramRequest $request, User $user, ExtractedCatrobatFile $extracted_file,
                       Program $inserted_program, TagRepository $tag_repository,
-                      ProgramLikeRepository $program_like_repository, LoggerInterface $logger,
-                      AppRequest $app_request, ProgramBeforeInsertEvent $event,
+                      ProgramLikeRepository $program_like_repository, FeaturedRepository $featured_repository,
+                      LoggerInterface $logger, AppRequest $app_request, ProgramBeforeInsertEvent $event,
                       ExtensionRepository $extension_repository, CatrobatFileSanitizer $catrobat_file_sanitizer)
   {
     $this->beConstructedWith($file_extractor, $file_repository, $screenshot_repository,
-      $entity_manager, $program_repository, $tag_repository, $program_like_repository,
+      $entity_manager, $program_repository, $tag_repository, $program_like_repository, $featured_repository,
       $event_dispatcher, $logger, $app_request, $extension_repository, $catrobat_file_sanitizer);
 
     fopen('/tmp/phpSpecTest', 'w');

--- a/tests/behat/features/web/ab_testing.feature
+++ b/tests/behat/features/web/ab_testing.feature
@@ -13,8 +13,8 @@ Feature: A/B testing for recommendation system & remix graph
       | 2  | Galaxy  | p2          | OtherUser | 10        | 12            | 13    | 01.02.2013 12:00 | 0.8.5   | false      |
       | 3  | Alone   | p3          | Catrobat  | 5         | 55            | 2     | 01.03.2013 12:00 | 0.8.5   | true       |
 
-    And there are likes:
-      | username  | program_id | type | created at       |
+    And there are project reactions:
+      | user      | project    | type | created at       |
       | Catrobat  | 1          | 1    | 01.01.2017 12:00 |
       | Catrobat  | 2          | 2    | 01.01.2017 12:00 |
       | OtherUser | 1          | 4    | 01.01.2017 12:00 |

--- a/tests/behat/features/web/click_statistics.feature
+++ b/tests/behat/features/web/click_statistics.feature
@@ -132,11 +132,11 @@ Feature: Creating click statistics by clicking on tags, extensions and recommend
       | 22 | Galaxy  | p2          | OtherUser | 10        | 12            | 13    | 01.02.2013 12:00 | 0.8.5   |
       | 23 | Alone   | p3          | Catrobat  | 5         | 55            | 2     | 01.03.2013 12:00 | 0.8.5   |
 
-    And there are likes:
-      | username  | program_id | type | created at       |
-      | Catrobat  | 21         | 1    | 01.01.2017 12:00 |
-      | Catrobat  | 22         | 2    | 01.01.2017 12:00 |
-      | OtherUser | 21         | 4    | 01.01.2017 12:00 |
+    And there are project reactions:
+      | user      | project | type | created at       |
+      | Catrobat  | 21      | 1    | 01.01.2017 12:00 |
+      | Catrobat  | 22      | 2    | 01.01.2017 12:00 |
+      | OtherUser | 21      | 4    | 01.01.2017 12:00 |
     Given I am on "/app"
     Then I wait 100 milliseconds
     Then I should see a recommended homepage program having ID "21" and name "Minions"

--- a/tests/behat/features/web/like.feature
+++ b/tests/behat/features/web/like.feature
@@ -1,94 +1,392 @@
 @homepage
-Feature: Like feature on program page
+Feature: Reactions to projects "likes"
 
   Background:
     Given there are users:
-      | name      | password | token      | email               | id |
-      | Catrobat  | 123456   | cccccccccc | dev1@pocketcode.org |  1 |
-      | OtherUser | 123456   | dddddddddd | dev2@pocketcode.org |  2 |
+      | id | name       |
+      | 1  | Catrobat   |
+      | 2  | OtherUser  |
+      | 3  | LovelyUser |
 
-    And there are programs:
-      | id | name     | description | owned by  | downloads | apk_downloads | views | upload time      | version | remix_root |
-      | 1  | Minions  | p1          | Catrobat  | 3         | 2             | 12    | 01.01.2013 12:00 | 0.8.5   | true       |
-      | 2  | Minimies | p2          | Catrobat  | 3         | 2             | 12    | 01.01.2013 12:00 | 0.8.5   | true       |
-      | 3  | otherPro | p3          | OtherUser | 3         | 2             | 12    | 01.01.2013 12:00 | 0.8.5   | true       |
+    And there are projects:
+      | id | name     | description | owned by  | upload time      |
+      | 1  | Minions  | p1          | Catrobat  | 01.01.2013 12:00 |
+      | 2  | Minimies | p2          | Catrobat  | 01.01.2013 12:00 |
+      | 3  | otherPro | p3          | OtherUser | 01.01.2013 12:00 |
 
-  Scenario: Like buttons should appear on program page
+    And there are project reactions:
+      | project | user       | type      |
+      | 2       | OtherUser  | smile     |
+      | 2       | OtherUser  | thumbs_up |
+      | 3       | Catrobat   | wow       |
+      | 3       | LovelyUser | love      |
+      | 3       | OtherUser  | love      |
+
+  Scenario: Thumbs up button with on-click bubble should appear for projects without reactions
     Given I am on "/app/project/1"
-    And the element "#program-like-thumbs-up" should be visible
-    And the element "#program-like-smile" should be visible
-    And the element "#program-like-love" should be visible
-    And the element "#program-like-wow" should be visible
+    Then the element "#project-like-buttons" should be visible
+    And I should see 1 "#project-like-buttons > *"
+    And the element "#project-like-buttons .fa-thumbs-up" should be visible
+    And the element "#project-like-counter" should not be visible
+    And the element "#project-like-detail" should not be visible
+    When I click "#project-like-buttons .fa-thumbs-up"
+    Then the element "#project-like-detail" should be visible
+    And I should see 4 "#project-like-detail > .btn"
+    # bubble should disappear if I click anywhere
+    And I click "body"
+    And I wait 600 milliseconds
+    Then the element "#project-like-detail" should not be visible
 
-  Scenario: By default both like counters should appear, but the specific like counter should be empty
-    Given I am on "/app/project/1"
-    And the element "#program-like-counter" should be visible
-    And the element "#program-like-detail-container" should be visible
-    And the "#program-like-detail-container" element should contain "&nbsp;"
+  Scenario: Thumbs up and smile button with on-click bubble and counter should appear for project 2
+    Given I am on "/app/project/2"
+    Then the element "#project-like-buttons" should be visible
+    And I should see 2 "#project-like-buttons > *"
+    And the element "#project-like-buttons .fa-thumbs-up" should be visible
+    And the element "#project-like-buttons .fa-grin-squint" should be visible
+    And the element "#project-like-counter" should be visible
+    And the "#project-like-counter" element should contain "2"
+    And the element "#project-like-detail" should not be visible
+    When I click "#project-like-buttons"
+    Then the element "#project-like-detail" should be visible
+    And I should see 4 "#project-like-detail > .btn"
 
-  Scenario: User should see correct like count
-    Given there are likes:
-      | username | program_id | type | created at       |
-      | Catrobat | 1          | 1    | 01.01.2017 12:00 |
+  Scenario: Detail dialog for project 2 should open and show reactions
+    Given I am on "/app/project/2"
+    Then the element "#project-like-modal" should not be visible
+    And I click "#project-like-counter"
+    And I wait 1 milliseconds
+    Then the element "#project-like-modal" should be visible
+    And I should see 3 "#project-like-modal .modal-body .nav-tabs .nav-item"
+    And the "#all-tab > span" element should contain "1"
+    And the "#thumbs-up-tab > span" element should contain "1"
+    And the "#smile-tab > span" element should contain "1"
+    And the element "#love-tab" should not be visible
+    And the element "#wow-tab" should not be visible
+    And the element "#all-tab-content" should be visible
+    And the element "#thumbs-up-tab-content" should not be visible
+    And the element "#smile-tab-content" should not be visible
+    And the element "#love-tab-content" should not be visible
+    And the element "#wow-tab-content" should not be visible
+    And I should see 1 "#all-tab-content .reaction"
+    And the "#all-tab-content .reaction:first-child a" element should contain "OtherUser"
+    And I should see 2 "#all-tab-content .reaction:first-child .types > i"
+    And the element "#all-tab-content .reaction:first-child .types .fa-grin-squint" should be visible
+    And the element "#all-tab-content .reaction:first-child .types .fa-thumbs-up" should be visible
+    When I click "#smile-tab"
+    Then the element "#smile-tab-content" should be visible
+    And the element "#all-tab-content" should not be visible
+    And I should see 1 "#smile-tab-content .reaction"
+    And the "#smile-tab-content .reaction:first-child a" element should contain "OtherUser"
+    And I should see 2 "#smile-tab-content .reaction:first-child .types > i"
+    And the element "#smile-tab-content .reaction:first-child .types .fa-grin-squint" should be visible
+    And the element "#smile-tab-content .reaction:first-child .types .fa-thumbs-up" should be visible
+    And I click "#project-like-modal button.close"
+    And I wait 1 milliseconds
+    Then the element "#project-like-modal" should not be visible
 
-    Given I am on "/app/project/1"
-    And the element "#program-like-counter" should be visible
-    And the element "#program-like-detail-container" should be visible
-    And the "#program-like-detail-container" element should contain "&nbsp;"
-    And the "#program-like-counter" element should contain "1"
-    And the "#program-like-detail-container" element should not contain "1"
+  Scenario: Detail dialog for project 3 should open and show reactions
+    Given I am on "/app/project/3"
+    Then the element "#project-like-modal" should not be visible
+    And the "#project-like-counter" element should contain "3"
+    And I click "#project-like-counter"
+    And I wait 1 milliseconds
+    Then the element "#project-like-modal" should be visible
+    And I should see 3 "#project-like-modal .modal-body .nav-tabs .nav-item"
+    And the "#all-tab > span" element should contain "3"
+    And the "#love-tab > span" element should contain "2"
+    And the "#wow-tab > span" element should contain "1"
+    And the element "#thumbs-up-tab" should not be visible
+    And the element "#smile-tab" should not be visible
+    And the element "#all-tab-content" should be visible
+    And the element "#thumbs-up-tab-content" should not be visible
+    And the element "#smile-tab-content" should not be visible
+    And the element "#love-tab-content" should not be visible
+    And the element "#wow-tab-content" should not be visible
+    And I should see 3 "#all-tab-content .reaction"
+    And the "#all-tab-content .reaction:first-child a" element should contain "Catrobat"
+    And I should see 1 "#all-tab-content .reaction:first-child .types > i"
+    And the element "#all-tab-content .reaction:first-child .types .fa-surprise" should be visible
+    And the "#all-tab-content .reaction:nth-child(3) a" element should contain "LovelyUser"
+    And I should see 1 "#all-tab-content .reaction:nth-child(3) .types > i"
+    And the element "#all-tab-content .reaction:nth-child(3) .types .fa-heart" should be visible
+    When I click "#love-tab"
+    Then the element "#love-tab-content" should be visible
+    And the element "#all-tab-content" should not be visible
+    And I should see 2 "#love-tab-content .reaction"
+    And the "#love-tab-content" element should contain "OtherUser"
+    And the "#love-tab-content" element should contain "LovelyUser"
+    And the element "#love-tab-content .reaction:nth-child(1) .types .fa-heart" should be visible
+    And the element "#love-tab-content .reaction:nth-child(2) .types .fa-heart" should be visible
 
-  Scenario: User is not logged in and should be forwarded to login page if the press on any like button
-    Given I am on "/app/project/1"
-    When I click "#program-like-thumbs-up"
-    Then I should be on "/app/login"
+  Scenario: A users reactions to a project should be marked
+    Given I log in as "OtherUser"
+    And I am on "/app/project/2"
+    And I click "#project-like-buttons"
+    Then the element "#project-like-detail" should be visible
+    And I should see 4 "#project-like-detail > .btn"
+    And I should see 2 "#project-like-detail > .btn.active"
+    And I should see 2 "#project-like-detail > .btn:not(.active)"
+    And the element "#project-like-detail > .btn.active[data-like-type=1]" should exist
+    And the element "#project-like-detail > .btn.active[data-like-type=2]" should exist
+    And the element "#project-like-detail > .btn.active[data-like-type=3]" should not exist
+    And the element "#project-like-detail > .btn.active[data-like-type=4]" should not exist
 
-  Scenario: I should be able to like a program when I am logged in and it should notify the owner
-    Given I log in as "OtherUser" with the password "123456"
+  Scenario: A logged-in user should be able to give several reactions to a single project and counter + icons should be refreshed
+    Given I log in as "OtherUser"
     And I am on "/app/project/1"
-    And I click "#program-like-thumbs-up"
-    And I wait for a second
-    When I log in as "Catrobat" with the password "123456"
-    And I am on "/app/notifications/allNotifications"
-    Then the element "#catro-notification-1" should be visible
-    And I should see "OtherUser"
+    Then the "#project-like-counter" element should contain "0"
+    And I click "#project-like-buttons"
+    Then the element "#project-like-detail" should be visible
+    When I click "#project-like-detail .btn[data-like-type=4]"
+    And I wait 600 milliseconds
+    Then the element "#project-like-detail" should not be visible
+    And the "#project-like-counter" element should contain "1"
+    And I should see 1 "#project-like-buttons > *"
+    And the element "#project-like-buttons .fa-surprise" should be visible
+    When I click "#project-like-buttons"
+    And I click "#project-like-detail .btn[data-like-type=2]"
+    Then the "#project-like-counter" element should contain "2"
+    And I should see 2 "#project-like-buttons > *"
+    And the element "#project-like-buttons .fa-grin-squint" should be visible
+    And the element "#project-like-buttons .fa-surprise" should be visible
+    When I reload the page
+    Then the "#project-like-counter" element should contain "2"
+    And I should see 2 "#project-like-buttons > *"
+    And the element "#project-like-buttons .fa-grin-squint" should be visible
+    And the element "#project-like-buttons .fa-surprise" should be visible
+    When I click "#project-like-buttons"
+    And I click "#project-like-detail .btn[data-like-type=1]"
+    Then the "#project-like-counter" element should contain "3"
+    And I should see 3 "#project-like-buttons > *"
+    And the element "#project-like-buttons .fa-thumbs-up" should be visible
+    And the element "#project-like-buttons .fa-grin-squint" should be visible
+    And the element "#project-like-buttons .fa-surprise" should be visible
+
+  Scenario: Guests should be redirected to login page if they react to a project and the reaction should count after login
+    Given I am on "/app/project/1"
+    And the "#project-like-counter" element should contain "0"
+    And I click "#project-like-buttons"
+    # click on Smile button
+    And I click "#project-like-detail .btn:nth-child(2)"
+    Then I should be on "/app/login"
+    Then I fill in "OtherUser" for "_username"
+    And I fill in "123456" for "_password"
+    And I click "#_submit.login"
+    Then I should be logged in
+    And the "#project-like-counter" element should contain "1"
+    And the element "#project-like-buttons .fa-grin-squint" should be visible
+
+  Scenario: Many user reactions with correct reaction count
+    Given there are 100 additional users
+    And there are project reactions:
+      | project | user    | type      |
+      | 1       | User100 | thumbs_up |
+      | 1       | User101 | thumbs_up |
+      | 1       | User102 | thumbs_up |
+      | 1       | User103 | thumbs_up |
+      | 1       | User104 | thumbs_up |
+      | 1       | User105 | thumbs_up |
+      | 1       | User106 | thumbs_up |
+      | 1       | User107 | thumbs_up |
+      | 1       | User108 | thumbs_up |
+      | 1       | User109 | thumbs_up |
+      | 1       | User110 | thumbs_up |
+      | 1       | User111 | thumbs_up |
+      | 1       | User112 | thumbs_up |
+      | 1       | User113 | thumbs_up |
+      | 1       | User114 | thumbs_up |
+      | 1       | User115 | thumbs_up |
+      | 1       | User116 | thumbs_up |
+      | 1       | User117 | thumbs_up |
+      | 1       | User118 | thumbs_up |
+      | 1       | User119 | thumbs_up |
+      | 1       | User120 | thumbs_up |
+      | 1       | User121 | thumbs_up |
+      | 1       | User122 | thumbs_up |
+      | 1       | User123 | thumbs_up |
+      | 1       | User124 | thumbs_up |
+      | 1       | User125 | thumbs_up |
+      | 1       | User126 | thumbs_up |
+      | 1       | User127 | thumbs_up |
+      | 1       | User128 | thumbs_up |
+      | 1       | User129 | thumbs_up |
+      | 1       | User130 | thumbs_up |
+      | 1       | User131 | thumbs_up |
+      | 1       | User132 | thumbs_up |
+      | 1       | User133 | thumbs_up |
+      | 1       | User134 | thumbs_up |
+      | 1       | User135 | thumbs_up |
+      | 1       | User136 | thumbs_up |
+      | 1       | User137 | thumbs_up |
+      | 1       | User138 | thumbs_up |
+      | 1       | User139 | thumbs_up |
+      | 1       | User140 | thumbs_up |
+      | 1       | User141 | thumbs_up |
+      | 1       | User142 | thumbs_up |
+      | 1       | User143 | thumbs_up |
+      | 1       | User144 | thumbs_up |
+      | 1       | User145 | thumbs_up |
+      | 1       | User146 | thumbs_up |
+      | 1       | User147 | thumbs_up |
+      | 1       | User148 | thumbs_up |
+      | 1       | User149 | thumbs_up |
+      | 1       | User150 | thumbs_up |
+      | 1       | User151 | thumbs_up |
+      | 1       | User152 | thumbs_up |
+      | 1       | User153 | thumbs_up |
+      | 1       | User154 | thumbs_up |
+      | 1       | User155 | thumbs_up |
+      | 1       | User156 | thumbs_up |
+      | 1       | User157 | thumbs_up |
+      | 1       | User158 | thumbs_up |
+      | 1       | User159 | thumbs_up |
+      | 1       | User160 | thumbs_up |
+      | 1       | User161 | thumbs_up |
+      | 1       | User162 | thumbs_up |
+      | 1       | User163 | thumbs_up |
+      | 1       | User164 | thumbs_up |
+      | 1       | User165 | thumbs_up |
+      | 1       | User166 | thumbs_up |
+      | 1       | User167 | thumbs_up |
+      | 1       | User168 | thumbs_up |
+      | 1       | User169 | thumbs_up |
+      | 1       | User170 | thumbs_up |
+      | 1       | User171 | thumbs_up |
+      | 1       | User172 | thumbs_up |
+      | 1       | User173 | thumbs_up |
+      | 1       | User174 | thumbs_up |
+      | 1       | User175 | thumbs_up |
+      | 1       | User176 | thumbs_up |
+      | 1       | User177 | thumbs_up |
+      | 1       | User178 | thumbs_up |
+      | 1       | User179 | thumbs_up |
+      | 1       | User180 | thumbs_up |
+      | 1       | User181 | thumbs_up |
+      | 1       | User182 | thumbs_up |
+      | 1       | User183 | thumbs_up |
+      | 1       | User184 | thumbs_up |
+      | 1       | User185 | thumbs_up |
+      | 1       | User186 | thumbs_up |
+      | 1       | User187 | thumbs_up |
+      | 1       | User188 | thumbs_up |
+      | 1       | User189 | thumbs_up |
+      | 1       | User190 | thumbs_up |
+      | 1       | User191 | thumbs_up |
+      | 1       | User192 | thumbs_up |
+      | 1       | User193 | thumbs_up |
+      | 1       | User194 | thumbs_up |
+      | 1       | User195 | thumbs_up |
+      | 1       | User196 | thumbs_up |
+      | 1       | User197 | thumbs_up |
+      | 1       | User198 | thumbs_up |
+      | 1       | User199 | thumbs_up |
+    When I am on "/app/project/1"
+    Then the "#project-like-counter" element should contain "100"
+    When I click "#project-like-counter"
+    And I wait 100 milliseconds
+    Then I should see 2 "#project-like-modal .modal-body .nav-tabs .nav-item"
+    And the "#all-tab > span" element should contain "100"
+    And the "#thumbs-up-tab > span" element should contain "100"
+    And the "#smile-tab > span" element should contain "0"
+    And the element "#love-tab" should not be visible
+    And the element "#wow-tab" should not be visible
+    And the element "#all-tab-content" should be visible
+    And the element "#thumbs-up-tab-content" should not be visible
+    And I should see 100 "#all-tab-content .reaction"
+    And I should see 1 "#all-tab-content .reaction:first-child .types > i"
+    And the element "#all-tab-content .reaction:first-child .types .fa-thumbs-up" should be visible
+    When I click "#thumbs-up-tab"
+    Then I should see 100 "#thumbs-up-tab-content .reaction"
+
+  Scenario: I should be able to give multiple reactions to a single project and the owner should be notified once
+    Given I log in as "OtherUser"
+    And I am on "/app/project/1"
+    And I click "#project-like-buttons"
+    And I click "#project-like-detail .btn[data-like-type=1]"
+    And I wait for AJAX to finish
+    And I click "#project-like-buttons"
+    And I click "#project-like-detail .btn[data-like-type=2]"
+    And I wait for AJAX to finish
+    When I log in as "Catrobat"
+    And I open the menu
+    Then the element "#project-navigation .user-notification-badge" should be visible
+    And the "#project-navigation .user-notification-badge" element should contain "1"
+    When I am on "/app/notifications/likes"
+    Then I should see 1 "#new-notifications-container .notification-container"
+    And the "#new-notifications-container > *:first-child .notification-body .card-text a:nth-child(1)" element should contain "OtherUser"
+    And the "#new-notifications-container > *:first-child .notification-body .card-text a:nth-child(2)" element should contain "Minions"
     And the element "#notifications-summary" should be visible
     And I should see "1 new Notification"
 
-  Scenario: I should be able to like multiple programs when I am logged in and it should notify the owner multiple times
-    Given I log in as "OtherUser" with the password "123456"
+  Scenario: I should be able to like multiple projects when I am logged in and it should notify the owner multiple times
+    Given I log in as "OtherUser"
     And I am on "/app/project/1"
-    And I click "#program-like-thumbs-up"
+    And I click "#project-like-detail .btn[data-like-type=1]"
+    And I wait for AJAX to finish
     And I am on "/app/project/2"
-    And I click "#program-like-thumbs-up"
-    And I wait for a second
-    When I log in as "Catrobat" with the password "123456"
-    And I am on "/app/notifications/allNotifications"
-    Then the element "#catro-notification-1" should be visible
-    Then the element "#catro-notification-2" should be visible
-    And I should see "OtherUser"
+    And I click "#project-like-detail .btn[data-like-type=4]"
+    And I wait for AJAX to finish
+    When I log in as "Catrobat"
+    And I open the menu
+    Then the element "#project-navigation .user-notification-badge" should be visible
+    And the "#project-navigation .user-notification-badge" element should contain "2"
+    When I am on "/app/notifications/likes"
+    Then I should see 2 "#new-notifications-container .notification-container"
+    And the "#new-notifications-container > *:nth-child(1) .notification-body .card-text a:nth-child(1)" element should contain "OtherUser"
+    And the "#new-notifications-container > *:nth-child(1) .notification-body .card-text a:nth-child(2)" element should contain "Minimies"
+    And the "#new-notifications-container > *:nth-child(2) .notification-body .card-text a:nth-child(1)" element should contain "OtherUser"
+    And the "#new-notifications-container > *:nth-child(2) .notification-body .card-text a:nth-child(2)" element should contain "Minions"
     And the element "#notifications-summary" should be visible
     And I should see "2 new Notifications"
 
-  Scenario: I can't notify myself
-    Given I log in as "OtherUser" with the password "123456"
+  Scenario: The notification should disappear if I remove my reaction again
+    Given I log in as "OtherUser"
     And I am on "/app/project/1"
-    And I click "#program-like-thumbs-up"
-    And I am on "/app/project/2"
-    And I click "#program-like-thumbs-up"
+    And I click "#project-like-detail .btn[data-like-type=1]"
+    And I wait for AJAX to finish
+    When I log in as "Catrobat"
+    And I am on "/app/notifications/likes"
+    Then I should see 1 "#new-notifications-container .notification-container"
+    And the "#new-notifications-container > *:first-child .notification-body .card-text a:nth-child(1)" element should contain "OtherUser"
+    And the "#new-notifications-container > *:first-child .notification-body .card-text a:nth-child(2)" element should contain "Minions"
+    And the element "#notifications-summary" should be visible
+    And I should see "1 new Notification"
+    When I log in as "OtherUser"
+    And I am on "/app/project/1"
+    And I click "#project-like-buttons"
+    Then the element "#project-like-detail > .btn.active[data-like-type=1]" should exist
+    When I click "#project-like-detail .btn[data-like-type=1]"
+    And I wait for AJAX to finish
+    Then the element "#project-like-detail > .btn:not(.active)[data-like-type=1]" should exist
+    And the element "#project-like-counter" should not be visible
+    And the "#project-like-counter" element should contain "0"
+    When I log in as "Catrobat"
+    And I am on "/app/notifications/likes"
+    Then I should see 0 "#new-notifications-container .notification-container"
+    And I should see 1 "#error.no-notifications-placeholder"
+    And the element "notifications-summary" should not exist
+    And I should not see "new Notification"
+
+  Scenario: I can't notify myself
+    Given I log in as "OtherUser"
+    And I am on "/app/project/1"
+    And I click "#project-like-detail .btn[data-like-type=1]"
+    And I am on "/app/project/3"
+    And I click "#project-like-detail .btn[data-like-type=1]"
     And I am on "/app/notifications/allNotifications"
     Then the element "#catro-notification-1" should not exist
     And the element "notifications-summary" should not exist
     And I should not see "new Notification"
 
-  Scenario: I should be able to mark a notifications as read
-    Given I log in as "OtherUser" with the password "123456"
+  Scenario: I should be able to mark all notifications as read at once
+    Given I log in as "OtherUser"
     And I am on "/app/project/1"
-    And I click "#program-like-thumbs-up"
+    And I click "#project-like-detail .btn[data-like-type=1]"
+    And I wait for AJAX to finish
     And I am on "/app/project/2"
-    And I click "#program-like-thumbs-up"
-    And I wait for a second
-    And I log in as "Catrobat" with the password "123456"
+    And I click "#project-like-detail .btn[data-like-type=3]"
+    And I wait for AJAX to finish
+    And I log in as "Catrobat"
     And I am on "/app/notifications/allNotifications"
     And the element "#catro-notification-1" should be visible
     And the element "#catro-notification-2" should be visible
@@ -103,14 +401,15 @@ Feature: Like feature on program page
     And the element "#mark-as-read-1" should not be visible
     And the element "#mark-as-read-2" should not be visible
 
-  Scenario: I should be able to mark all notifications as read at once
-    Given I log in as "OtherUser" with the password "123456"
+  Scenario: I should be able to mark a notifications as read
+    Given I log in as "OtherUser"
     And I am on "/app/project/1"
-    And I click "#program-like-thumbs-up"
+    And I click "#project-like-detail .btn[data-like-type=1]"
+    And I wait for AJAX to finish
     And I am on "/app/project/2"
-    And I click "#program-like-thumbs-up"
-    And I wait for a second
-    And I log in as "Catrobat" with the password "123456"
+    And I click "#project-like-detail .btn[data-like-type=3]"
+    And I wait for AJAX to finish
+    And I log in as "Catrobat"
     And I am on "/app/notifications/allNotifications"
     And the element "#catro-notification-1" should be visible
     And the element "#catro-notification-2" should be visible

--- a/tests/behat/features/web/my_profile.feature
+++ b/tests/behat/features/web/my_profile.feature
@@ -53,7 +53,7 @@ Feature:
     And I wait for the server response
     And I should be on "/app/user"
     When I go to "/app/logout"
-    And I try to log in as "Catrobat" with the password "123456"
+    And I log in as "Catrobat" with the password "123456"
     Then I should see "Your password or username was incorrect."
     And I try to log in as "Mr.Catro" with the password "123456"
     Then I should be logged in
@@ -67,7 +67,7 @@ Feature:
     And I should be on "/app/user"
     Then I should see "This username is not valid."
     When I go to "/app/logout"
-    And I try to log in as "Mr" with the password "123456"
+    And I log in as "Mr" with the password "123456"
     Then I should see "Your password or username was incorrect."
 
   Scenario: When changing the username the max length must be 180
@@ -90,7 +90,7 @@ Feature:
     And I wait for the server response
     And I should be on "/app/user"
     When I go to "/app/logout"
-    And I try to log in as "Catrobat" with the password "123456"
+    And I log in as "Catrobat" with the password "123456"
     Then I should see "Your password or username was incorrect."
     When I log in as "Catrobat" with the password "abcdef"
     Then I should be logged in

--- a/tests/behat/features/web/notifications.feature
+++ b/tests/behat/features/web/notifications.feature
@@ -1,5 +1,5 @@
 @homepage
-Feature: User gets notifications for new followers, likes, comments and other types like anniversary
+Feature: User gets notifications for new followers, reactions, comments and other types like anniversary
 
   Background:
     Given there are users:
@@ -26,10 +26,10 @@ Feature: User gets notifications for new followers, likes, comments and other ty
     When I click ".collapsible"
     And I wait 50 milliseconds
     Then the element ".fa-caret-down" should be visible
-    And I should see "All Notifications"
-    And I should see "Likes"
-    And I should see "Followers"
-    And I should see "Comments"
+    And the element "#notifications-dropdown-content #btn-notifications" should be visible
+    And the element "#notifications-dropdown-content #btn-followers" should be visible
+    And the element "#notifications-dropdown-content #btn-likes" should be visible
+    And the element "#notifications-dropdown-content #btn-comments" should be visible
 
   Scenario: User should not see all notification subsections on the homepage
     Given I log in as "Catrobat" with the password "123456"
@@ -174,7 +174,7 @@ Feature: User gets notifications for new followers, likes, comments and other ty
       And I log in as "User" with the password "123456"
       And I am on "/app/notifications/likes"
       Then I should see "You have 10 new Notifications!"
-      And I should see "New like"
+      And I should see "New reaction"
       Given I am on "/app/notifications/comments"
       Then I should see "You have 20 new Notifications!"
       And I should see "New comment"

--- a/tests/behat/features/web/recsys.feature
+++ b/tests/behat/features/web/recsys.feature
@@ -14,11 +14,11 @@ Feature: Recommendations on homepage (a.k.a. index page)
       | 2  | Galaxy  | p2          | OtherUser | 10        | 12            | 13    | 01.02.2013 12:00 | 0.8.5   |
       | 3  | Alone   | p3          | Catrobat  | 5         | 55            | 2     | 01.03.2013 12:00 | 0.8.5   |
 
-    And there are likes:
-      | username  | program_id | type | created at       |
-      | Catrobat  | 1          | 1    | 01.01.2017 12:00 |
-      | Catrobat  | 2          | 2    | 01.01.2017 12:00 |
-      | OtherUser | 1          | 4    | 01.01.2017 12:00 |
+    And there are project reactions:
+      | user      | project | type | created at       |
+      | Catrobat  | 1       | 1    | 01.01.2017 12:00 |
+      | Catrobat  | 2       | 2    | 01.01.2017 12:00 |
+      | OtherUser | 1       | 4    | 01.01.2017 12:00 |
 
     When I am on "/app/"
     And the selected language is "English"

--- a/tests/phpUnit/AppExtensionTest.php
+++ b/tests/phpUnit/AppExtensionTest.php
@@ -98,9 +98,10 @@ class AppExtensionTest extends \PHPUnit\Framework\TestCase
     $gamejamRepository = $this->prophet->prophesize('App\Repository\GameJamRepository');
     $theme = $this->prophet->prophesize('Liip\ThemeBundle\ActiveTheme');
     $parameter_bag = $this->mockParameterBag();
+    $translator = $this->prophet->prophesize('Symfony\Contracts\Translation\TranslatorInterface');
 
     return new AppExtension($requestStack->reveal(), $repo->reveal(), $gamejamRepository->reveal(),
-      $theme->reveal(), $parameter_bag->reveal(), $this->translationPath);
+      $theme->reveal(), $parameter_bag->reveal(), $this->translationPath, $translator->reveal());
   }
 
   private function mockMediaPackageFileRepository()

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -40,8 +40,8 @@ registrationError: 'Username or email address already in use.'
 notifications: 'Notifications'
 allNotifications: 'All Notifications'
 FollowersNotifications: 'Followers'
-LikeNotifications: 'Likes'
-likesNotificationsTitle: 'Like Notifications'
+LikeNotifications: 'Reactions'
+likesNotificationsTitle: 'Reaction Notifications'
 followersNotificationsTitle: 'Follower Notifications'
 commentsNotificationsTitle: 'Comment Notifications'
 CommentNotifications: 'Comments'
@@ -67,7 +67,7 @@ indexPage:
   recommendedSection:
     info:
       title: 'What projects are recommended here?'
-      description: 'The more Likes (including "Thumbs up", "Laugh", "Love" and "Woow!") your project receives, the higher it appears in this list.'
+      description: 'The more reactions (Thumbs up, Smile ...) your project receives, the higher it appears in this list.'
 
 programs:
   welcome:
@@ -114,10 +114,9 @@ programs:
   downloads: '%downloads% downloads'
   sample: Example projects
   views: '%views% views'
-  likeThumbsUpDetailText: '{0}0 people give thumbs up on this |{1}1 person gives thumbs up on this |]1,Inf]%persons% people give thumbs up on this'
-  likeSmileDetailText: '{0}0 people smile on this |{1}1 person smiles on this |]1,Inf]%persons% people smile on this'
-  likeLoveDetailText: '{0}0 people love this |{1}1 person loves this |]1,Inf]%persons% people love this'
-  likeWowDetailText: '{0}0 people say "Wooow!" on this |{1}1 person says "Wooow!" on this |]1,Inf]%persons% people say "Wooow!" on this'
+  likes:
+    likersTitle: "People who reacted to that project"
+    all: "All"
   remixes: '{0}0 remixes |{1}1 remix |]1,Inf]%remixes% remixes'
   newRemixesNotificationTitle: '|{1}"%programName%" has 1 new remix: |]1,Inf] "%programName%" has %remixes% new remixes:'
   submitted: Submitted Projects
@@ -561,7 +560,7 @@ help:
     download: "Download the project"
 oauth:
   username_header: Thank you for signing up to Pocket Code!
-  username_chooser: Please choose a username:
+  username_chooser: "Please choose a username:"
   username_hint: The username should not be your real name.
   usernameTaken: Username already taken, please choose a different one.
 
@@ -605,6 +604,9 @@ apk:
   prepare: 'Prepare app'
   preparing: 'Preparing app'
   text: 'The process may take a while'
+
+format:
+  million_abbreviation: M
 
 #api
 errors:
@@ -838,8 +840,8 @@ catro-notifications:
     title: 'New comment for project %program_name%!'
     message: 'User %user_link% commented on your project %program_link%.'
   like:
-    title: 'New like for project %program_name%!'
-    message: 'User %user_link% liked your project %program_link%.'
+    title: 'New reaction to project %program_name%!'
+    message: 'User %user_link% reacted to your project %program_link%.'
   follow:
     title: 'New Follower!'
     message: 'User %user_link% follows you now.'


### PR DESCRIPTION
If applied, this commit will add the change the following:
 - Move reaction buttons to overlay that shows up on click
 - Add dialog that shows who reacted to what in detail

It refactors several reaction handling parts
and adds many new behat tests for the reactions.

Additionally, the following things get refactored:
 - add project visible wrapper in ProgramManager
 - add Twig "humanFriendlyNumber" filter
 - add CSRF failure status code
 - translations:
   * change "like" to "reaction"
   * add million abbreviation for human friendly number
 - Behat tests:
   * set default password
   * user table with only name mandatory
   * project reactions/likes table
   * fix "try to" login