### PR TITLE
SHARE-96 MAX_VERSION is back

### DIFF
--- a/src/Catrobat/Controller/Api/SearchController.php
+++ b/src/Catrobat/Controller/Api/SearchController.php
@@ -28,13 +28,15 @@ class SearchController extends AbstractController
 
 
   /**
+   *
    * @Route("/api/projects/search.json", name="api_search_programs", defaults={"_format": "json"},
    *    methods={"GET"})
    *
-   * @param Request $request
+   * @param Request        $request
    * @param ProgramManager $program_manager
    *
    * @return ProgramListResponse
+   * @throws \Exception
    */
   public function searchProgramsAction(Request $request, ProgramManager $program_manager)
   {
@@ -47,12 +49,13 @@ class SearchController extends AbstractController
 
     $limit = intval($request->query->get('limit', $this->DEFAULT_LIMIT));
     $offset = intval($request->query->get('offset', $this->DEFAULT_OFFSET));
+    $max_version = $request->query->get('max_version', "0");
 
-    $programs = $program_manager->search($query, $limit, $offset);
+    $programs = $program_manager->search($query, $limit, $offset, $max_version);
     // we can't count the results since we apply limit and offset.
     // so we indeed have to use a separate query that ignores
     // limit and offset to get the number of results.
-    $numbOfTotalProjects = $program_manager->searchCount($query);
+    $numbOfTotalProjects = $program_manager->searchCount($query, $max_version);
 
     return new ProgramListResponse($programs, $numbOfTotalProjects);
   }
@@ -62,7 +65,7 @@ class SearchController extends AbstractController
    * @Route("/api/projects/search/tagProjects.json", name="api_search_tag",
    *   defaults={"_format":"json"}, methods={"GET"})
    *
-   * @param Request $request
+   * @param Request        $request
    * @param ProgramManager $program_manager
    *
    * @return ProgramListResponse
@@ -84,8 +87,9 @@ class SearchController extends AbstractController
    * @Route("/api/projects/search/extensionProjects.json", name="api_search_extension",
    *                                                       defaults={"_format": "json"},
    *                                                       methods={"GET"})
-   * @param Request $request
+   * @param Request        $request
    * @param ProgramManager $program_manager
+   *
    * @return ProgramListResponse
    */
   public function extensionSearchProgramsAction(Request $request, ProgramManager $program_manager)

--- a/src/Catrobat/Controller/Web/ProgramController.php
+++ b/src/Catrobat/Controller/Web/ProgramController.php
@@ -432,11 +432,6 @@ class ProgramController extends AbstractController
      * @var $user_programs ArrayCollection
      */
 
-    if ($id === 0)
-    {
-      return new Response("false");
-    }
-
     $user = $this->getUser();
     if (!$user)
     {
@@ -444,8 +439,9 @@ class ProgramController extends AbstractController
     }
 
     $user_programs = $user->getPrograms();
-    $programs = $user_programs->matching(Criteria::create()
-      ->where(Criteria::expr()->eq('id', $id)));
+    $programs = $user_programs->matching(
+      Criteria::create()->where(Criteria::expr()->eq('id', $id))
+    );
 
     $program = $programs[0];
 

--- a/src/Catrobat/Services/TestEnv/SymfonySupport.php
+++ b/src/Catrobat/Services/TestEnv/SymfonySupport.php
@@ -647,7 +647,7 @@ class SymfonySupport
     $program->setRemixMigratedAt(isset($config['remixmigratedtime']) ? new \DateTime($config['remixmigratedtime'], new \DateTimeZone('UTC')) : null);
     $program->setCatrobatVersion(isset($config['catrobatversion']) ? $config['catrobatversion'] : 1);
     $program->setCatrobatVersionName(isset($config['catrobatversionname']) ? $config['catrobatversionname'] : '0.9.1');
-    $program->setLanguageVersion(isset($config['languageversion']) ? $config['languageversion'] : 1);
+    $program->setLanguageVersion(isset($config['language_version']) ? $config['language_version'] : 1);
     $program->setUploadIp('127.0.0.1');
     $program->setFilesize(isset($config['filesize']) ? $config['filesize'] : 0);
     $program->setVisible(isset($config['visible']) ? boolval($config['visible']) : true);

--- a/src/Entity/ProgramManager.php
+++ b/src/Entity/ProgramManager.php
@@ -106,15 +106,15 @@ class ProgramManager
    * @param CatrobatFileExtractor    $file_extractor
    * @param ProgramFileRepository    $file_repository
    * @param ScreenshotRepository     $screenshot_repository
-   * @param EntityManagerInterface            $entity_manager
+   * @param EntityManagerInterface   $entity_manager
    * @param ProgramRepository        $program_repository
    * @param TagRepository            $tag_repository
    * @param ProgramLikeRepository    $program_like_repository
    * @param EventDispatcherInterface $event_dispatcher
-   * @param LoggerInterface $logger
-   * @param AppRequest $app_request
-   * @param ExtensionRepository $extension_repository
-   * @param CatrobatFileSanitizer $file_sanitizer
+   * @param LoggerInterface          $logger
+   * @param AppRequest               $app_request
+   * @param ExtensionRepository      $extension_repository
+   * @param CatrobatFileSanitizer    $file_sanitizer
    */
   public function __construct(CatrobatFileExtractor $file_extractor, ProgramFileRepository $file_repository,
                               ScreenshotRepository $screenshot_repository, EntityManagerInterface $entity_manager,
@@ -147,7 +147,7 @@ class ProgramManager
   public function addProgram(AddProgramRequest $request)
   {
     /**
-     * @var $program Program
+     * @var $program        Program
      * @var $extracted_file ExtractedCatrobatFile
      */
     $file = $request->getProgramfile();
@@ -317,8 +317,6 @@ class ProgramManager
    * @param         $no_unlike
    *
    * @return int
-   * @throws ORMException
-   * @throws OptimisticLockException
    */
   public function toggleLike(Program $program, User $user, $type, $no_unlike)
   {
@@ -416,20 +414,20 @@ class ProgramManager
 
 
   /**
-   * @param Program $program
+   * @param Program               $program
    * @param ExtractedCatrobatFile $extracted_file
-   *
-   * @throws ORMException
    */
   public function addExtensions(Program $program, ExtractedCatrobatFile $extracted_file)
   {
 //     Adding the embroidery extension if an embroidery block was used in the project
     $EMBROIDERY = "Embroidery";
     if ($extracted_file !== null && $extracted_file->getProgramXmlProperties() !== null &&
-      strpos($extracted_file->getProgramXmlProperties()->asXML(), '<brick type="StitchBrick">') !== false) {
+      strpos($extracted_file->getProgramXmlProperties()->asXML(), '<brick type="StitchBrick">') !== false)
+    {
       /** @var Extension $embroidery_extension */
       $embroidery_extension = $this->extension_repository->findOneBy(['name' => $EMBROIDERY]);
-      if ($embroidery_extension === null) {
+      if ($embroidery_extension === null)
+      {
         $embroidery_extension = new Extension();
         $embroidery_extension->setName($EMBROIDERY);
         $embroidery_extension->setPrefix(strtoupper($EMBROIDERY));
@@ -512,30 +510,31 @@ class ProgramManager
 
   /**
    * @param GuidType $user_id
-   * @param bool $include_debug_build_programs If programs marked as debug_build should be returned
+   * @param bool     $include_debug_build_programs If programs marked as debug_build should be returned
+   * @param string   $max_version
    *
    * @return Program[]
    */
-  public function getUserPrograms($user_id, bool $include_debug_build_programs = false)
+  public function getUserPrograms($user_id, bool $include_debug_build_programs = false, string $max_version = "0")
   {
-    $debug_build = ($include_debug_build_programs === true) ?
-      true : $this->app_request->isDebugBuildRequest();
+    $debug_build = ($include_debug_build_programs === true) ? true : $this->app_request->isDebugBuildRequest();
 
-    return $this->program_repository->getUserPrograms($user_id, $debug_build);
+    return $this->program_repository->getUserPrograms($user_id, $debug_build, $max_version);
   }
 
   /**
-   * @param      $user_id
-   * @param bool $include_debug_build_programs If programs marked as debug_build should be returned
+   * @param        $user_id
+   * @param bool   $include_debug_build_programs If programs marked as debug_build should be returned
+   * @param string $max_version
    *
    * @return Program[]
    */
-  public function getPublicUserPrograms($user_id, bool $include_debug_build_programs = false)
+  public function getPublicUserPrograms($user_id, bool $include_debug_build_programs = false, string $max_version = "0")
   {
     $debug_build = ($include_debug_build_programs === true) ?
       true : $this->app_request->isDebugBuildRequest();
 
-    return $this->program_repository->getPublicUserPrograms($user_id, $debug_build);
+    return $this->program_repository->getPublicUserPrograms($user_id, $debug_build, $max_version);
   }
 
   /**
@@ -604,13 +603,14 @@ class ProgramManager
    * @param string|null $flavor
    * @param int|null    $limit
    * @param int         $offset
+   * @param string      $max_version
    *
    * @return Program[]
    */
-  public function getRecentPrograms($flavor, $limit = null, $offset = 0)
+  public function getRecentPrograms($flavor, $limit = null, $offset = 0, string $max_version = "0")
   {
     return $this->program_repository->getRecentPrograms(
-      $this->app_request->isDebugBuildRequest(), $flavor, $limit, $offset
+      $this->app_request->isDebugBuildRequest(), $flavor, $limit, $offset, $max_version
     );
   }
 
@@ -618,13 +618,14 @@ class ProgramManager
    * @param string|null $flavor
    * @param int|null    $limit
    * @param int         $offset
+   * @param string      $max_version
    *
    * @return Program[]
    */
-  public function getMostViewedPrograms($flavor, $limit = null, $offset = 0)
+  public function getMostViewedPrograms($flavor, $limit = null, $offset = 0, string $max_version = "0")
   {
     return $this->program_repository->getMostViewedPrograms(
-      $this->app_request->isDebugBuildRequest(), $flavor, $limit, $offset
+      $this->app_request->isDebugBuildRequest(), $flavor, $limit, $offset, $max_version
     );
   }
 
@@ -632,13 +633,14 @@ class ProgramManager
    * @param string|null $flavor
    * @param int|null    $limit
    * @param int         $offset
+   * @param string      $max_version
    *
    * @return mixed
    */
-  public function getMostDownloadedPrograms($flavor, $limit = null, $offset = 0)
+  public function getMostDownloadedPrograms($flavor, $limit = null, $offset = 0, string $max_version = "0")
   {
     return $this->program_repository->getMostDownloadedPrograms(
-      $this->app_request->isDebugBuildRequest(), $flavor, $limit, $offset
+      $this->app_request->isDebugBuildRequest(), $flavor, $limit, $offset, $max_version
     );
   }
 
@@ -646,47 +648,57 @@ class ProgramManager
    * @param string|null $flavor
    * @param int|null    $limit
    * @param int         $offset
+   * @param string      $max_version
    *
    * @return array
    */
-  public function getRandomPrograms($flavor, $limit = null, $offset = 0)
+  public function getRandomPrograms($flavor, $limit = null, $offset = 0, string $max_version = "0")
   {
     return $this->program_repository->getRandomPrograms(
-      $this->app_request->isDebugBuildRequest(), $flavor, $limit, $offset
+      $this->app_request->isDebugBuildRequest(), $flavor, $limit, $offset, $max_version
+    );
+  }
+
+  /**
+   * @param string $query
+   * @param int    $limit
+   * @param int    $offset
+   * @param string $max_version
+   *
+   * @return array
+   * @throws Exception
+   */
+  public function search(string $query, $limit = 10, $offset = 0, string $max_version = "0")
+  {
+    return $this->program_repository->search(
+      $query, $this->app_request->isDebugBuildRequest(), $limit, $offset, $max_version
     );
   }
 
   /**
    * @param string $query The query to search for (search terms)
-   * @param int    $limit
-   * @param int    $offset
-   *
-   * @return array
-   */
-  public function search(string $query, $limit = 10, $offset = 0)
-  {
-    return $this->program_repository->search($query, $this->app_request->isDebugBuildRequest(), $limit, $offset);
-  }
-
-  /**
-   * @param string $query The query to search for (search terms)
+   * @param string $max_version
    *
    * @return int
    */
-  public function searchCount(string $query)
+  public function searchCount(string $query, string $max_version = "0")
   {
-    return $this->program_repository->searchCount($query, $this->app_request->isDebugBuildRequest());
+    return $this->program_repository->searchCount($query, $this->app_request->isDebugBuildRequest(), $max_version);
   }
 
   /**
-   * @param string|null $flavor
+   * @param        $flavor
+   * @param string $max_version
    *
    * @return int
    * @throws NonUniqueResultException
+   * @throws \Doctrine\ORM\NoResultException
    */
-  public function getTotalPrograms($flavor)
+  public function getTotalPrograms($flavor, string $max_version = "0")
   {
-    return $this->program_repository->getTotalPrograms($this->app_request->isDebugBuildRequest(), $flavor);
+    return $this->program_repository->getTotalPrograms(
+      $this->app_request->isDebugBuildRequest(), $flavor, $max_version
+    );
   }
 
   /**

--- a/tests/behat/features/api/get_projects_with_max_version.feature
+++ b/tests/behat/features/api/get_projects_with_max_version.feature
@@ -1,0 +1,223 @@
+@api
+Feature: MAX version feature; Allows old Apps to request only projects they can support
+
+  Background:
+    Given there are users:
+      | name     | password | token      |
+      | Catrobat | 12345    | cccccccccc |
+      | User1    | vwxyz    | aaaaaaaaaa |
+    And there are programs:
+      | id | name      | description | owned by | downloads | views | upload time      | language version |
+      | 1  | project 1 | p1          | Catrobat | 3         | 12    | 01.01.2013 12:00 | 0.999            |
+      | 2  | project 2 |             | Catrobat | 333       | 9     | 22.04.2014 13:00 | 0.999            |
+      | 3  | project 3 |             | User1    | 133       | 33    | 01.01.2012 13:00 | 0.999            |
+      | 4  | project 4 |             | User1    | 133       | 34    | 01.01.2012 13:10 | 0.993            |
+      | 5  | project 5 |             | User1    | 500       | 35    | 01.01.2012 13:20 | 0.993            |
+      | 6  | project 6 |             | User1    | 600       | 36    | 01.01.2012 13:30 | 0.991            |
+    And the current time is "01.08.2014 13:00"
+
+  Scenario: show most recent projects with limit and max_version
+    Given I have a parameter "limit" with value "2"
+    And I have a parameter "offset" with value "0"
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/recent.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 6 |
+      | project 5 |
+
+  Scenario: show most recent projects with limit, offset and max_version
+    Given I have a parameter "limit" with value "2"
+    And I have a parameter "offset" with value "1"
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/recent.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 5 |
+      | project 4 |
+
+  Scenario: show only visible projects
+    Given program "project 6" is not visible
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/recent.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 5 |
+      | project 4 |
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+  Scenario: show most recent projects with limit and max_version (IDs)
+    Given I have a parameter "limit" with value "2"
+    And I have a parameter "offset" with value "0"
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/recentIDs.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 6 |
+      | project 5 |
+
+  Scenario: show most recent projects with limit, offset and max_version (IDs)
+    Given I have a parameter "limit" with value "2"
+    And I have a parameter "offset" with value "1"
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/recentIDs.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 5 |
+      | project 4 |
+
+  Scenario: show only visible projects
+    Given program "project 6" is not visible
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/recentIDs.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 5 |
+      | project 4 |
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+  Scenario: show most downloaded projects with limit and max_version
+    Given I have a parameter "limit" with value "2"
+    And I have a parameter "offset" with value "0"
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/mostDownloaded.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 6 |
+      | project 5 |
+
+  Scenario: show most downloaded projects with limit, offset and max_version
+    Given I have a parameter "limit" with value "2"
+    And I have a parameter "offset" with value "1"
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/mostDownloaded.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 5 |
+      | project 4 |
+
+  Scenario: show only visible projects
+    Given program "project 6" is not visible
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/mostDownloaded.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 5 |
+      | project 4 |
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+  Scenario: show most downloaded projects with limit and max_version (IDs)
+    Given I have a parameter "limit" with value "2"
+    And I have a parameter "offset" with value "0"
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/mostDownloadedIDs.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 6 |
+      | project 5 |
+
+  Scenario: show most downloaded projects with limit, offset and max_version (IDs)
+    Given I have a parameter "limit" with value "2"
+    And I have a parameter "offset" with value "1"
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/mostDownloadedIDs.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 5 |
+      | project 4 |
+
+  Scenario: show only visible projects
+    Given program "project 6" is not visible
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/mostDownloadedIDs.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 5 |
+      | project 4 |
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+  Scenario: show most viewed projects with limit and max_version
+    Given I have a parameter "limit" with value "2"
+    And I have a parameter "offset" with value "0"
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/mostViewed.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 6 |
+      | project 5 |
+
+  Scenario: show most viewed projects with limit, offset and max_version
+    Given I have a parameter "limit" with value "2"
+    And I have a parameter "offset" with value "1"
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/mostViewed.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 5 |
+      | project 4 |
+
+  Scenario: show only visible projects
+    Given program "project 6" is not visible
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/mostViewed.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 5 |
+      | project 4 |
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+  Scenario: show most viewed projects with limit and max_version (IDs)
+    Given I have a parameter "limit" with value "2"
+    And I have a parameter "offset" with value "0"
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/mostViewedIDs.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 6 |
+      | project 5 |
+
+  Scenario: show most viewed project with limit, offset and max_version (IDs)
+    Given I have a parameter "limit" with value "2"
+    And I have a parameter "offset" with value "1"
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/mostViewedIDs.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 5 |
+      | project 4 |
+
+  Scenario: show only visible projects
+    Given program "project 6" is not visible
+    And I have a parameter "max_version" with value "0.993"
+    When I GET "/app/api/projects/mostViewedIDs.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 5 |
+      | project 4 |
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+  Scenario: show random projects with limit and max_version
+    Given I have a parameter "limit" with value "2"
+    And I have a parameter "offset" with value "0"
+    And I have a parameter "max_version" with value "0.991"
+    When I GET "/app/api/projects/randomProjects.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 6 |
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+  Scenario: show random projects with limit and max_version (IDs)
+    Given I have a parameter "limit" with value "2"
+    And I have a parameter "offset" with value "0"
+    And I have a parameter "max_version" with value "0.991"
+    When I GET "/app/api/projects/randomProjectIDs.json" with these parameters
+    Then I should get programs in the following order:
+      | Name      |
+      | project 6 |

--- a/tests/behat/features/bootstrap/ApiFeatureContext.php
+++ b/tests/behat/features/bootstrap/ApiFeatureContext.php
@@ -714,6 +714,7 @@ class ApiFeatureContext extends BaseContext
         'uploadtime'          => $programs[$i]['upload time'],
         'apk_status'          => $programs[$i]['apk_status'],
         'catrobatversionname' => $programs[$i]['version'],
+        'language_version'    => $programs[$i]['language version'],
         'directory_hash'      => $programs[$i]['directory_hash'],
         'filesize'            => @$programs[$i]['FileSize'],
         'visible'             => isset($programs[$i]['visible']) ? $programs[$i]['visible'] == 'true' : true,
@@ -1200,6 +1201,8 @@ class ApiFeatureContext extends BaseContext
     $responseArray = json_decode($response->getContent(), true);
     $returned_programs = $responseArray['CatrobatProjects'];
     $expected_programs = $table->getHash();
+
+    Assert::assertEquals(count($returned_programs), count($expected_programs));
 
     for ($i = 0; $i < count($returned_programs); ++$i)
     {

--- a/tests/behat/features/flavor/flavor_filter.feature
+++ b/tests/behat/features/flavor/flavor_filter.feature
@@ -78,10 +78,14 @@ Feature: Filtering programs with specific flavor
     When I get the recent programs with "app/api/projects/recent.json"
     Then I should get following programs:
       | name         |
+      | Simple click |
+      | Soon to be   |
+      | Just for fun |
       | Invaders     |
       | A new world  |
+      | New adventure|
+      | Amazing race |
       | Test game    |
-
   Scenario: Get recent programs of flavor luna
 
     When I get the recent programs with "luna/api/projects/recent.json"

--- a/tests/behat/features/web/catro_notification.feature
+++ b/tests/behat/features/web/catro_notification.feature
@@ -23,6 +23,7 @@ Feature: User gets generic notifications additionally to the remix notifications
     And I am on "/app/notifications/allNotifications"
     Then I should see "Achievement - Uploads"
     And I should see "Achievement - View"
+    And I open the menu
     And the ".all-notifications-dropdown" element should contain "2"
     When I click "#mark-as-read-1"
     And I wait for fadeEffect to finish
@@ -34,36 +35,26 @@ Feature: User gets generic notifications additionally to the remix notifications
     And I should not see "#mark-as-read-2"
     And I should see "You have no new Notifications"
 
-
   Scenario: User should see the amount of his notifications in the menu
     Given I log in as "Catrobat" with the password "123456"
     And I am on "/app/"
     And I open the menu
     Then I wait 1000 milliseconds
-    And the element "#btn-notifications" should be visible
-    And the element ".all-notifications-dropdown" should be visible
+    And the element "#notifications-dropdown-toggler" should be visible
+    And the "#notifications-dropdown-toggler" element should contain "2"
 
-  Scenario: User should see the amount of his notifications in the menu
-    Given I log in as "Catrobat" with the password "123456"
-    And I am on "/app/"
-    And I open the menu
-    Then I wait 1000 milliseconds
-    Then the element "#btn-notifications" should be visible
-    And the element ".all-notifications-dropdown" should be visible
-    And the ".all-notifications-dropdown" element should contain "2"
-
-  Scenario: User should see the amount of his notifications in the menu only if he has notifcations
+  Scenario: User should see the amount of his notifications in the menu only if he has notifications
     Given I log in as "OtherUser" with the password "123456"
     And I am on "/app/"
     And I open the menu
-    Then the element "#btn-notifications" should be visible
-    And the element ".all-notifications-dropdown" should not be visible
+    Then the element "#notifications-dropdown-toggler" should be visible
+    And the element "#notifications-dropdown-toggler .badge-pill" should not be visible
 
   Scenario: User should see the amount of his notifications in the menu
     Given there are "105"+ notifications for "Catrobat"
     And I log in as "Catrobat" with the password "123456"
     And I am on "/app/"
     And I open the menu
-    Then the element "#btn-notifications" should be visible
+    Then the element "#notifications-dropdown-toggler" should be visible
     And the element ".all-notifications-dropdown" should be visible
     And the ".all-notifications-dropdown" element should contain "99+"

--- a/tests/behat/features/web/notifications.feature
+++ b/tests/behat/features/web/notifications.feature
@@ -21,7 +21,6 @@ Feature: User gets notifications for new followers, likes, comments and other ty
     And I am on "/app/"
     And I open the menu
     Then I wait 100 milliseconds
-    Then I should see "All Notifications"
     And the element ".collapsible" should be visible
     And the element ".fa-caret-left" should be visible
     When I click ".collapsible"


### PR DESCRIPTION
- reintroducing max_version parameter check for

  -- api/projects/mostDownloaded(IDs).json
  -- api/projects/recent(IDs).json
  -- api/projects/search(IDs).json
  -- api/projects/mostViewed(IDs).json
  -- api/projects/userProjects.json

- reintroducing/fixing tests

**IMPORTANT: **
Use the follwoing format:
max_version=A.BCD where A,B,C,D have values between 0 and 9
E.g. **max_version=0.993**

This is necessary because the language version is stored as a string in the database and we are comparing them directly with SQL. This is no problem as long the format is the same! (use zero-padding if needed -> max_version=9.900)