### PR TITLE
SHARE-174 Admin interface - unnecessary flavor check

### DIFF
--- a/src/Admin/AllProgramsAdmin.php
+++ b/src/Admin/AllProgramsAdmin.php
@@ -205,6 +205,12 @@ class AllProgramsAdmin extends AbstractAdmin
   private function checkFlavor()
   {
     $flavor = $this->getForm()->get('flavor')->getData();
+
+    if (!$flavor)
+    {
+      return; // There was no required flavor form field in this Action, so no check is needed!
+    }
+
     $flavor_options =  $this->getConfigurationPool()->getContainer()->getParameter('themes');
 
     if (!in_array($flavor, $flavor_options)) {

--- a/src/Admin/FeaturedProgramAdmin.php
+++ b/src/Admin/FeaturedProgramAdmin.php
@@ -241,6 +241,12 @@ class FeaturedProgramAdmin extends AbstractAdmin
   private function checkFlavor()
   {
     $flavor = $this->getForm()->get('flavor')->getData();
+
+    if (!$flavor)
+    {
+      return; // There was no required flavor form field in this Action, so no check is needed!
+    }
+
     $flavor_options =  $this->parameter_bag->get('themes');
 
     if (!in_array($flavor, $flavor_options)) {

--- a/src/Admin/FeaturedUrlAdmin.php
+++ b/src/Admin/FeaturedUrlAdmin.php
@@ -190,6 +190,12 @@ class FeaturedUrlAdmin extends AbstractAdmin
   private function checkFlavor()
   {
     $flavor = $this->getForm()->get('flavor')->getData();
+
+    if (!$flavor)
+    {
+      return; // There was no required flavor form field in this Action, so no check is needed!
+    }
+
     $flavor_options =  $this->parameter_bag->get('themes');
 
     if (!in_array($flavor, $flavor_options)) {

--- a/src/Admin/MediaPackageFileAdmin.php
+++ b/src/Admin/MediaPackageFileAdmin.php
@@ -210,6 +210,12 @@ class MediaPackageFileAdmin extends AbstractAdmin
   private function checkFlavor()
   {
     $flavor = $this->getForm()->get('flavor')->getData();
+
+    if (!$flavor)
+    {
+      return; // There was no required flavor form field in this Action, so no check is needed!
+    }
+
     $flavor_options =  $this->parameter_bag->get('themes');
 
     if (!in_array($flavor, $flavor_options)) {


### PR DESCRIPTION
In the Admin interface there is a check for valid flavor for every every action affecting projects.
This PR removes this check when there was no required flavor form in the action.