### PR TITLE
Deleting a user should also delete associated notifications

### DIFF
--- a/src/Entity/CatroNotification.php
+++ b/src/Entity/CatroNotification.php
@@ -39,7 +39,7 @@ class CatroNotification
   /**
    * @var User
    *
-   * @ORM\ManyToOne(targetEntity="\App\Entity\User")
+   * @ORM\ManyToOne(targetEntity="\App\Entity\User", inversedBy="notifications")
    * @ORM\JoinColumn(name="user", referencedColumnName="id", nullable=false)
    */
   private $user;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -54,6 +54,17 @@ class User extends BaseUser implements LdapUserInterface
   protected $programs;
 
   /**
+   * @ORM\OneToMany(
+   *     targetEntity="CatroNotification",
+   *     mappedBy="user",
+   *     fetch="EXTRA_LAZY",
+   *     cascade={"remove"}
+   *   )
+   * @var Collection|CatroNotification[]
+   */
+  protected $notifications;
+
+  /**
    * @ORM\ManyToMany(targetEntity="\App\Entity\User", mappedBy="following")
    */
   protected $followers;
@@ -383,6 +394,22 @@ class User extends BaseUser implements LdapUserInterface
   public function setLikes($likes)
   {
     $this->likes = $likes;
+  }
+
+  /**
+   * @return CatroNotification[]|Collection
+   */
+  public function getNotifications()
+  {
+    return ($this->notifications != null) ? $this->notifications : new ArrayCollection();
+  }
+
+  /**
+   * @param CatroNotification[]|Collection $notifications
+   */
+  public function setNotifications($notifications)
+  {
+    $this->notifications = $notifications;
   }
 
   /**


### PR DESCRIPTION
Currently when deleting a user with (like) notifications an error will
be displayed

- Created Doctrine annotations to facilitate cascade remove.