### PR TITLE
Share 176 If a logged-out user writes a program comment into the textbox it gets cleared after being prompted to log in.

### DIFF
--- a/assets/js/custom/ProgramComments.js
+++ b/assets/js/custom/ProgramComments.js
@@ -29,6 +29,10 @@ function ProgramComments (programId, visibleComments, showStep, minAmountOfVisib
     askForConfirmation(reportComment, commentId, reportConfirmation, reportIt)
   })
   
+  $(document).on('change', '#comment-message', function () {
+    sessionStorage.setItem('temp_program_comment', $('#comment-message').val())
+  })
+  
   $(document).on('click', '.add-comment-button', function () {
     let commentWrapper = $('#user-comment-wrapper')
     let showCommentWrapperButton = $('#show-add-comment-button')
@@ -55,6 +59,17 @@ function ProgramComments (programId, visibleComments, showStep, minAmountOfVisib
     showLess(showStep)
   })
   
+  if ((sessionStorage.getItem('temp_program_comment') != null) && (sessionStorage.getItem('temp_program_comment') != ''))
+  {
+    document.getElementById("comment-message").value = sessionStorage.getItem('temp_program_comment');
+    let commentWrapper = $('#user-comment-wrapper')
+    let showCommentWrapperButton = $('#show-add-comment-button')
+    let hideCommentWrapperButton = $('#hide-add-comment-button')
+    commentWrapper.slideDown()
+    showCommentWrapperButton.hide()
+    hideCommentWrapperButton.show()
+  }
+  
   function postComment ()
   {
     let msg = $('#comment-message').val()
@@ -75,6 +90,7 @@ function ProgramComments (programId, visibleComments, showStep, minAmountOfVisib
         {
           $('#comments-wrapper').load(' #comments-wrapper')
           $('#comment-message').val('')
+          sessionStorage.setItem('temp_program_comment', "");
           location.reload()
         }
       },

--- a/tests/behat/features/web/comments.feature
+++ b/tests/behat/features/web/comments.feature
@@ -57,6 +57,29 @@ Feature: As a visitor I want to write, see and report comments.
     And I wait 200 milliseconds
     Then I should be on "/app/login"
 
+
+  Scenario: If a logged out user enters a comment into the textbox, it should be remembered throughout the login process and page reloads
+    Given I am on "/app/project/1"
+    And I click "#show-add-comment-button"
+    And I wait 250 milliseconds
+    And I write "comment to remember" in textbox
+    And I wait 250 milliseconds
+    When I click "#comment-post-button"
+    And I wait 200 milliseconds
+    Then I should be on "/app/login"
+    And I fill in "username" with "Superman"
+    And I fill in "password" with "123456"
+    Then I press "Login"
+    Then I should be on "/app/project/1#login"
+    And I am on "/app/project/1"
+    And the element "#show-add-comment-button" should not be visible
+    And the element "#hide-add-comment-button" should be visible
+    And the element "#user-comment-wrapper" should be visible
+    And I click "#comment-post-button"
+    And I wait for a second
+    Then I should see "comment to remember"
+    And the element ".single-comment" should be visible
+
   Scenario: I should be able to write a comment when I am logged in
     Given I log in as "Superman" with the password "123456"
     And I am on "/app/project/3"


### PR DESCRIPTION
SHARE-176 If a logged-out user writes a program comment into the textbox
it gets cleared after being prompted to log in.

- Fixed this behavior by using Javascript Window.sessionStorage to store
 textbox content throughout the login process and page refreshes.
- Created behat scenario