### PR TITLE
SHARE-137 Translation deprecation

### DIFF
--- a/src/Catrobat/Services/Formatter/ElapsedTimeStringFormatter.php
+++ b/src/Catrobat/Services/Formatter/ElapsedTimeStringFormatter.php
@@ -47,29 +47,29 @@ class ElapsedTimeStringFormatter
     {
       $minutes = round($elapsed / 60);
 
-      return $this->translator->transChoice('time.minutes.ago', $minutes, ['%count%' => $minutes], 'catroweb');
+      return $this->translator->trans('time.minutes.ago', ['%count%' => $minutes], 'catroweb');
     }
     elseif ($elapsed <= 82800)
     {
       $hours = round($elapsed / 3600);
 
-      return $this->translator->transChoice('time.hours.ago', $hours, ['%count%' => $hours], 'catroweb');
+      return $this->translator->trans('time.hours.ago', ['%count%' => $hours], 'catroweb');
     }
     elseif ($elapsed <= 2505600)
     {
       $days = round($elapsed / 86400);
 
-      return $this->translator->transChoice('time.days.ago', $days, ['%count%' => $days], 'catroweb');
+      return $this->translator->trans('time.days.ago', ['%count%' => $days], 'catroweb');
     }
     elseif ($elapsed <= 28927800)
     {
       $months = round($elapsed / 2629800);
 
-      return $this->translator->transChoice('time.months.ago', $months, ['%count%' => $months], 'catroweb');
+      return $this->translator->trans('time.months.ago', ['%count%' => $months], 'catroweb');
     }
 
     $years = round($elapsed / 31557600);
 
-    return $this->translator->transChoice('time.years.ago', $years, ['%count%' => $years], 'catroweb');
+    return $this->translator->trans('time.years.ago', ['%count%' => $years], 'catroweb');
   }
 }

--- a/tests/PhpSpec/spec/App/Catrobat/Services/Formatter/ElapsedTimeStringFormatterSpec.php
+++ b/tests/PhpSpec/spec/App/Catrobat/Services/Formatter/ElapsedTimeStringFormatterSpec.php
@@ -42,10 +42,10 @@ class ElapsedTimeStringFormatterSpec extends ObjectBehavior
    */
   public function it_returns_the_elapsed_time_since_timestamps_in_minutes($translator)
   {
-    $translator->transChoice(Argument::exact('time.minutes.ago'), Argument::exact(0), Argument::any(), Argument::any())->willReturn('< 1 minute ago');
-    $translator->transChoice(Argument::exact('time.minutes.ago'), Argument::exact(1), Argument::any(), Argument::any())->willReturn('1 minute ago');
-    $translator->transChoice(Argument::exact('time.minutes.ago'), Argument::exact(5), Argument::any(), Argument::any())->willReturn('5 minutes ago');
-    $translator->transChoice(Argument::exact('time.minutes.ago'), Argument::exact(59), Argument::any(), Argument::any())->willReturn('59 minutes ago');
+    $translator->trans(Argument::exact('time.minutes.ago'), ['%count%' => 0], Argument::any(), Argument::any())->willReturn('< 1 minute ago');
+    $translator->trans(Argument::exact('time.minutes.ago'), ['%count%' => 1], Argument::any(), Argument::any())->willReturn('1 minute ago');
+    $translator->trans(Argument::exact('time.minutes.ago'), ['%count%' => 5], Argument::any(), Argument::any())->willReturn('5 minutes ago');
+    $translator->trans(Argument::exact('time.minutes.ago'), ['%count%' => 59], Argument::any(), Argument::any())->willReturn('59 minutes ago');
 
     $this->getElapsedTime($this->testTime - 10)->shouldReturn('< 1 minute ago');
     $this->getElapsedTime($this->testTime - 80)->shouldReturn('1 minute ago');
@@ -59,9 +59,9 @@ class ElapsedTimeStringFormatterSpec extends ObjectBehavior
    */
   public function it_returns_the_elapsed_time_since_timestamps_in_hours($translator)
   {
-    $translator->transChoice(Argument::exact('time.hours.ago'), Argument::exact(1), Argument::any(), Argument::any())->willReturn('1 hour ago');
-    $translator->transChoice(Argument::exact('time.hours.ago'), Argument::exact(5), Argument::any(), Argument::any())->willReturn('5 hours ago');
-    $translator->transChoice(Argument::exact('time.hours.ago'), Argument::exact(23), Argument::any(), Argument::any())->willReturn('23 hours ago');
+    $translator->trans(Argument::exact('time.hours.ago'), ['%count%' => 1], Argument::any(), Argument::any())->willReturn('1 hour ago');
+    $translator->trans(Argument::exact('time.hours.ago'), ['%count%' => 5], Argument::any(), Argument::any())->willReturn('5 hours ago');
+    $translator->trans(Argument::exact('time.hours.ago'), ['%count%' => 23], Argument::any(), Argument::any())->willReturn('23 hours ago');
 
     $this->getElapsedTime($this->testTime - 3600)->shouldReturn('1 hour ago');
     $this->getElapsedTime($this->testTime - 3600 * 5)->shouldReturn('5 hours ago');
@@ -71,9 +71,9 @@ class ElapsedTimeStringFormatterSpec extends ObjectBehavior
 
   public function it_returns_the_elapsed_time_since_timestamps_in_days($translator)
   {
-    $translator->transChoice(Argument::exact('time.days.ago'), Argument::exact(1), Argument::any(), Argument::any())->willReturn('1 day ago');
-    $translator->transChoice(Argument::exact('time.days.ago'), Argument::exact(5), Argument::any(), Argument::any())->willReturn('5 days ago');
-    $translator->transChoice(Argument::exact('time.days.ago'), Argument::exact(6), Argument::any(), Argument::any())->willReturn('6 days ago');
+    $translator->trans(Argument::exact('time.days.ago'), ['%count%' => 1], Argument::any(), Argument::any())->willReturn('1 day ago');
+    $translator->trans(Argument::exact('time.days.ago'), ['%count%' => 5], Argument::any(), Argument::any())->willReturn('5 days ago');
+    $translator->trans(Argument::exact('time.days.ago'), ['%count%' => 6], Argument::any(), Argument::any())->willReturn('6 days ago');
 
     $this->getElapsedTime($this->testTime - 86400)->shouldReturn('1 day ago');
     $this->getElapsedTime($this->testTime - 86400 * 5)->shouldReturn('5 days ago');
@@ -83,9 +83,9 @@ class ElapsedTimeStringFormatterSpec extends ObjectBehavior
 
   public function it_returns_the_elapsed_time_since_timestamps_in_months($translator)
   {
-    $translator->transChoice(Argument::exact('time.months.ago'), Argument::exact(1), Argument::any(), Argument::any())->willReturn('1 month ago');
-    $translator->transChoice(Argument::exact('time.months.ago'), Argument::exact(6), Argument::any(), Argument::any())->willReturn('6 months ago');
-    $translator->transChoice(Argument::exact('time.months.ago'), Argument::exact(11), Argument::any(), Argument::any())->willReturn('11 months ago');
+    $translator->trans(Argument::exact('time.months.ago'), ['%count%' => 1], Argument::any(), Argument::any())->willReturn('1 month ago');
+    $translator->trans(Argument::exact('time.months.ago'), ['%count%' => 6], Argument::any(), Argument::any())->willReturn('6 months ago');
+    $translator->trans(Argument::exact('time.months.ago'), ['%count%' => 11], Argument::any(), Argument::any())->willReturn('11 months ago');
 
     $this->getElapsedTime($this->testTime - 2629800)->shouldReturn('1 month ago');
     $this->getElapsedTime($this->testTime - 2629800 * 6)->shouldReturn('6 months ago');
@@ -95,9 +95,9 @@ class ElapsedTimeStringFormatterSpec extends ObjectBehavior
 
   public function it_returns_the_elapsed_time_since_timestamps_in_years($translator)
   {
-    $translator->transChoice(Argument::exact('time.years.ago'), Argument::exact(1), Argument::any(), Argument::any())->willReturn('1 year ago');
-    $translator->transChoice(Argument::exact('time.years.ago'), Argument::exact(3), Argument::any(), Argument::any())->willReturn('3 years ago');
-    $translator->transChoice(Argument::exact('time.years.ago'), Argument::exact(100), Argument::any(), Argument::any())->willReturn('100 years ago');
+    $translator->trans(Argument::exact('time.years.ago'), ['%count%' => 1], Argument::any(), Argument::any())->willReturn('1 year ago');
+    $translator->trans(Argument::exact('time.years.ago'), ['%count%' => 3], Argument::any(), Argument::any())->willReturn('3 years ago');
+    $translator->trans(Argument::exact('time.years.ago'), ['%count%' => 100], Argument::any(), Argument::any())->willReturn('100 years ago');
 
     $this->getElapsedTime($this->testTime - 31557600)->shouldReturn('1 year ago');
     $this->getElapsedTime($this->testTime - 31557600 * 3)->shouldReturn('3 years ago');

--- a/tests/phpUnit/TranschoiceTest.php
+++ b/tests/phpUnit/TranschoiceTest.php
@@ -23,9 +23,9 @@ class TranschoiceTest extends \PHPUnit\Framework\TestCase
   {
     foreach ($message_ids as $message_id)
     {
-      $translator->transChoice($message_id, 1, [], 'catroweb', $language_code);
-      $translator->transChoice($message_id, 2, [], 'catroweb', $language_code);
-      $translator->transChoice($message_id, 10, [], 'catroweb', $language_code);
+      $translator->trans($message_id, ['%count%' => 1], 'catroweb', $language_code);
+      $translator->trans($message_id, ['%count%' => 2], 'catroweb', $language_code);
+      $translator->trans($message_id, ['%count%' => 10], 'catroweb', $language_code);
     }
     $this->assertTrue(true);
   }


### PR DESCRIPTION
- transChoice is replaced with the trans method
- Translation deprecation for transChoice method are gone

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

:white_check_mark:  Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
:white_check_mark: Choose the proper base branch (*develop*)
:white_check_mark: Confirm that the changes follow the project’s coding guidelines
:white_check_mark: Verify that the changes generate no warnings and errors 
:white_check_mark: Verify to commit no other files than the intentionally changed ones
:white_check_mark: Include reasonable and readable tests verifying the added or changed behavior
:white_check_mark: Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
:white_check_mark: Perform a self-review of the changes
:white_check_mark: Stick to the project’s git workflow (rebase and squash your commits)
:white_check_mark: Verify that your changes do not have any conflicts with the base branch
:white_check_mark: Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
:white_check_mark: Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
