### PR TITLE
SHARE-140 reset command enhancement

### DIFF
--- a/src/Catrobat/Commands/CreateCommentCommand.php
+++ b/src/Catrobat/Commands/CreateCommentCommand.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Catrobat\Commands;
+
+use App\Catrobat\Commands\Helpers\RemixManipulationProgramManager;
+use App\Catrobat\Commands\Helpers\ResetController;
+use App\Entity\Program;
+use App\Entity\User;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use App\Entity\UserManager;
+
+
+/**
+ * Class CreateCommentCommand
+ * @package App\Catrobat\Commands
+ */
+class CreateCommentCommand extends Command
+{
+  /**
+   * @var UserManager
+   */
+  private $user_manager;
+
+  /**
+   * @var RemixManipulationProgramManager
+   */
+  private $remix_manipulation_program_manager;
+
+
+  /**
+   * @var ResetController
+   */
+  private $reset_controller;
+
+  /**
+   * ProgramImportCommand constructor.
+   *
+   * @param UserManager                     $user_manager
+   * @param RemixManipulationProgramManager $program_manager
+   */
+  public function __construct(UserManager $user_manager,
+                              RemixManipulationProgramManager $program_manager,
+                              ResetController $reset_controller)
+  {
+    parent::__construct();
+    $this->user_manager = $user_manager;
+    $this->remix_manipulation_program_manager = $program_manager;
+    $this->reset_controller = $reset_controller;
+  }
+
+  /**
+   *
+   */
+  protected function configure()
+  {
+    $this->setName('catrobat:comment')
+      ->setDescription('Add comment to a project')
+      ->addArgument('user', InputArgument::REQUIRED, 'User who comments on program')
+      ->addArgument('program_name', InputArgument::REQUIRED, 'Program name of program to comment on')
+      ->addArgument('message', InputArgument::REQUIRED, 'Comment message')
+      ->addArgument('reported', InputArgument::REQUIRED, 'Boolean if it should be a reported comment');
+  }
+
+  /**
+   * @param InputInterface  $input
+   * @param OutputInterface $output
+   *
+   * @return int|void|null
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+    /**
+     * @var $user    User
+     * @var $program Program
+     */
+
+    $username = $input->getArgument('user');
+    $program_name = $input->getArgument('program_name');
+    $message = $input->getArgument('message');
+    $reported = $input->getArgument('reported');
+
+    $user = $this->user_manager->findUserByUsername($username);
+    $program = $this->remix_manipulation_program_manager->findOneByName($program_name);
+
+    if ($user == null || $program == null)
+    {
+      return;
+    }
+
+    try
+    {
+      $this->reset_controller->postComment($user, $program, $message, $reported);
+    } catch (\Exception $e)
+    {
+      return;
+    }
+    $output->writeln('Commenting on ' . $program->getName() . ' with user ' . $user->getUsername());
+  }
+}

--- a/src/Catrobat/Commands/CreateDownloadsCommand.php
+++ b/src/Catrobat/Commands/CreateDownloadsCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+
+namespace App\Catrobat\Commands;
+
+use App\Catrobat\Commands\Helpers\RemixManipulationProgramManager;
+use App\Catrobat\Commands\Helpers\ResetController;
+use App\Entity\User;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use App\Entity\UserManager;
+
+class CreateDownloadsCommand extends Command
+{
+  /**
+   * @var UserManager
+   */
+  private $user_manager;
+
+  /**
+   * @var RemixManipulationProgramManager
+   */
+  private $remix_manipulation_program_manager;
+
+
+  /**
+   * @var ResetController
+   */
+  private $reset_controller;
+
+  /**
+   * CreateDownloadsCommand constructor.
+   *
+   * @param UserManager                     $user_manager
+   * @param RemixManipulationProgramManager $program_manager
+   * @param ResetController                 $reset_controller
+   */
+  public function __construct(UserManager $user_manager,
+                              RemixManipulationProgramManager $program_manager,
+                              ResetController $reset_controller)
+  {
+    parent::__construct();
+    $this->user_manager = $user_manager;
+    $this->remix_manipulation_program_manager = $program_manager;
+    $this->reset_controller = $reset_controller;
+  }
+
+  /**
+   *
+   */
+  protected function configure()
+  {
+    $this->setName('catrobat:download')
+      ->setDescription('download a project')
+      ->addArgument('program_name', InputArgument::REQUIRED, 'Name of program which gets downloaded')
+      ->addArgument('user_name', InputArgument::REQUIRED, 'User who download program');
+  }
+
+  /**
+   * @param InputInterface  $input
+   * @param OutputInterface $output
+   *
+   * @return int|void|null
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+    $program_name = $input->getArgument('program_name');
+    $user_name = $input->getArgument('user_name');
+
+    $program = $this->remix_manipulation_program_manager->findOneByName($program_name);
+
+    /**
+     * @var $user User
+     */
+    $user = $this->user_manager->findUserByUsername($user_name);
+
+    if ($program == null || $user == null || $this->reset_controller == null)
+    {
+      return;
+    }
+
+    try
+    {
+      $this->reset_controller->downloadProgram($program, $user);
+    } catch (\Exception $e)
+    {
+      return;
+    }
+    $output->writeln('Downloading ' . $program->getName() . ' with user ' . $user->getUsername());
+  }
+}

--- a/src/Catrobat/Commands/CreateFeatureProgramCommand.php
+++ b/src/Catrobat/Commands/CreateFeatureProgramCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+
+namespace App\Catrobat\Commands;
+
+use App\Catrobat\Commands\Helpers\RemixManipulationProgramManager;
+use App\Catrobat\Commands\Helpers\ResetController;
+use App\Entity\Program;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use App\Entity\UserManager;
+
+class CreateFeatureProgramCommand extends Command
+{
+  /**
+   * @var UserManager
+   */
+  private $user_manager;
+
+  /**
+   * @var RemixManipulationProgramManager
+   */
+  private $remix_manipulation_program_manager;
+
+  /**
+   * @var ResetController
+   */
+  private $reset_controller;
+
+  /**
+   * FeaturedProgramCommand constructor.
+   *
+   * @param UserManager                     $user_manager
+   * @param RemixManipulationProgramManager $program_manager
+   * @param ResetController                 $reset_controller
+   */
+  public function __construct(UserManager $user_manager,
+                              RemixManipulationProgramManager $program_manager,
+                              ResetController $reset_controller)
+  {
+    parent::__construct();
+    $this->user_manager = $user_manager;
+    $this->remix_manipulation_program_manager = $program_manager;
+    $this->reset_controller = $reset_controller;
+  }
+
+  /**
+   *
+   */
+  protected function configure()
+  {
+    $this->setName('catrobat:feature')
+      ->setDescription('feature a project')
+      ->addArgument('program_name', InputArgument::REQUIRED, 'Name of program  which gets featured');
+  }
+
+  /**
+   * @param InputInterface  $input
+   * @param OutputInterface $output
+   *
+   * @return int|void|null
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+    /**
+     * @var $program Program
+     */
+
+    $program_name = $input->getArgument('program_name');
+
+    $program = $this->remix_manipulation_program_manager->findOneByName($program_name);
+
+    if ($program == null || $this->reset_controller == null)
+    {
+      return;
+    }
+
+    try
+    {
+      $this->reset_controller->featureProgram($program);
+    } catch (\Exception $e)
+    {
+      return;
+    }
+    $output->writeln('Featuring ' . $program->getName());
+  }
+}

--- a/src/Catrobat/Commands/CreateFollowersCommand.php
+++ b/src/Catrobat/Commands/CreateFollowersCommand.php
@@ -1,0 +1,99 @@
+<?php
+
+
+namespace App\Catrobat\Commands;
+
+use App\Catrobat\Commands\Helpers\RemixManipulationProgramManager;
+use App\Catrobat\Commands\Helpers\ResetController;
+use App\Entity\User;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use App\Entity\UserManager;
+
+class CreateFollowersCommand extends Command
+{
+  /**
+   * @var UserManager
+   */
+  private $user_manager;
+
+  /**
+   * @var RemixManipulationProgramManager
+   */
+  private $remix_manipulation_program_manager;
+
+
+  /**
+   * @var ResetController
+   */
+  private $reset_controller;
+
+  /**
+   * CreateFollowersCommand constructor.
+   *
+   * @param UserManager                     $user_manager
+   * @param RemixManipulationProgramManager $program_manager
+   * @param ResetController                 $reset_controller
+   */
+  public function __construct(UserManager $user_manager,
+                              RemixManipulationProgramManager $program_manager,
+                              ResetController $reset_controller)
+  {
+    parent::__construct();
+    $this->user_manager = $user_manager;
+    $this->remix_manipulation_program_manager = $program_manager;
+    $this->reset_controller = $reset_controller;
+  }
+
+  /**
+   *
+   */
+  protected function configure()
+  {
+    $this->setName('catrobat:follow')
+      ->setDescription('follow an user')
+      ->addArgument('user_name', InputArgument::REQUIRED, 'Name of user who gets followed')
+      ->addArgument('follower', InputArgument::REQUIRED, 'User who follows');
+  }
+
+  /**
+   * @param InputInterface  $input
+   * @param OutputInterface $output
+   *
+   * @return int|void|null
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+    $user_name = $input->getArgument('user_name');
+    $follower_name = $input->getArgument('follower');
+
+    if ($user_name == $follower_name)
+    {
+      return;
+    }
+
+    /**
+     * @var $user     User
+     * @var $follower User
+     */
+    $user = $this->user_manager->findUserByUsername($user_name);
+    $follower = $this->user_manager->findUserByUsername($follower_name);
+
+    if ($user == null || $follower == null || $this->reset_controller == null)
+    {
+      return;
+    }
+
+    try
+    {
+      $this->reset_controller->followUser($user, $follower);
+    } catch (\Exception $e)
+    {
+      return;
+    }
+    $output->writeln($follower_name . ' follows ' . $user_name);
+  }
+}

--- a/src/Catrobat/Commands/CreateLikeCommand.php
+++ b/src/Catrobat/Commands/CreateLikeCommand.php
@@ -1,0 +1,95 @@
+<?php
+
+
+namespace App\Catrobat\Commands;
+
+use App\Catrobat\Commands\Helpers\RemixManipulationProgramManager;
+use App\Catrobat\Commands\Helpers\ResetController;
+use App\Entity\Program;
+use App\Entity\User;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use App\Entity\UserManager;
+
+class CreateLikeCommand extends Command
+{
+  /**
+   * @var UserManager
+   */
+  private $user_manager;
+
+  /**
+   * @var RemixManipulationProgramManager
+   */
+  private $remix_manipulation_program_manager;
+
+
+  /**
+   * @var ResetController
+   */
+  private $reset_controller;
+
+  /**
+   * CreateLikeCommand constructor.
+   *
+   * @param UserManager                     $user_manager
+   * @param RemixManipulationProgramManager $program_manager
+   * @param ResetController                 $reset_controller
+   */
+  public function __construct(UserManager $user_manager,
+                              RemixManipulationProgramManager $program_manager,
+                              ResetController $reset_controller)
+  {
+    parent::__construct();
+    $this->user_manager = $user_manager;
+    $this->remix_manipulation_program_manager = $program_manager;
+    $this->reset_controller = $reset_controller;
+  }
+
+  /**
+   *
+   */
+  protected function configure()
+  {
+    $this->setName('catrobat:like')
+      ->setDescription('like a project')
+      ->addArgument('program_name', InputArgument::REQUIRED, 'Name of program  which gets liked')
+      ->addArgument('user_name', InputArgument::REQUIRED, 'User who likes program');
+  }
+
+  /**
+   * @param InputInterface  $input
+   * @param OutputInterface $output
+   *
+   * @return int|void|null
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+    $program_name = $input->getArgument('program_name');
+    $user_name = $input->getArgument('user_name');
+
+    /**
+     * @var $program Program
+     * @var $user    User
+     */
+    $program = $this->remix_manipulation_program_manager->findOneByName($program_name);
+    $user = $this->user_manager->findUserByUsername($user_name);
+
+    if ($program == null || $user == null || $this->reset_controller == null)
+    {
+      return;
+    }
+
+    try
+    {
+      $this->reset_controller->likeProgram($program, $user);
+    } catch (\Exception $e)
+    {
+      return;
+    }
+    $output->writeln('Liking ' . $program->getName() . ' with user ' . $user_name);
+  }
+}

--- a/src/Catrobat/Commands/CreateProgramInappropriateReportCommand.php
+++ b/src/Catrobat/Commands/CreateProgramInappropriateReportCommand.php
@@ -1,0 +1,103 @@
+<?php
+
+
+namespace App\Catrobat\Commands;
+
+use App\Catrobat\Commands\Helpers\RemixManipulationProgramManager;
+use App\Catrobat\Commands\Helpers\ResetController;
+use App\Entity\Program;
+use App\Entity\User;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use App\Entity\UserManager;
+
+class CreateProgramInappropriateReportCommand extends Command
+{
+  /**
+   * @var UserManager
+   */
+  private $user_manager;
+
+  /**
+   * @var RemixManipulationProgramManager
+   */
+  private $remix_manipulation_program_manager;
+
+
+  /**
+   * @var ResetController
+   */
+  private $reset_controller;
+
+  /**
+   * CreateProgramInappropriateReportCommand constructor.
+   *
+   * @param UserManager                     $user_manager
+   * @param RemixManipulationProgramManager $program_manager
+   * @param ResetController                 $reset_controller
+   */
+  public function __construct(UserManager $user_manager,
+                              RemixManipulationProgramManager $program_manager,
+                              ResetController $reset_controller)
+  {
+    parent::__construct();
+    $this->user_manager = $user_manager;
+    $this->remix_manipulation_program_manager = $program_manager;
+    $this->reset_controller = $reset_controller;
+  }
+
+  /**
+   *
+   */
+  protected function configure()
+  {
+    $this->setName('catrobat:report')
+      ->setDescription('Report a project')
+      ->addArgument('user', InputArgument::REQUIRED, 'User who reports on program')
+      ->addArgument('program_name', InputArgument::REQUIRED, 'Name of program  which gets reported')
+      ->addArgument('note', InputArgument::REQUIRED, 'Report message');
+  }
+
+  /**
+   * @param InputInterface  $input
+   * @param OutputInterface $output
+   *
+   * @return int|void|null
+   * @throws \Exception
+   */
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+    /**
+     * @var $user    User
+     * @var $program Program
+     */
+
+    $username = $input->getArgument('user');
+    $program_name = $input->getArgument('program_name');
+    $note = $input->getArgument('note');
+
+    $user = $this->user_manager->findUserByUsername($username);
+    $program = $this->remix_manipulation_program_manager->findOneByName($program_name);
+
+    if ($user == null || $program == null || $this->reset_controller == null)
+    {
+      return;
+    }
+
+    if ($program->getUser() === $user)
+    {
+      return;
+    }
+
+    try
+    {
+      $this->reset_controller->reportProgram($program, $user, $note);
+    } catch (\Exception $e)
+    {
+      return;
+    }
+    $output->writeln('Reporting ' . $program->getName());
+  }
+}

--- a/src/Catrobat/Commands/Helpers/ResetController.php
+++ b/src/Catrobat/Commands/Helpers/ResetController.php
@@ -66,7 +66,7 @@ class ResetController extends AbstractController
   {
     $temp_comment = new UserComment();
     $temp_comment->setUsername($user->getUsername());
-    $temp_comment->setUserId($user->getId());
+    $temp_comment->setUser($user);
     $temp_comment->setText($message);
     $temp_comment->setProgram($program);
     $temp_comment->setUploadDate(date_create());

--- a/src/Catrobat/Commands/Helpers/ResetController.php
+++ b/src/Catrobat/Commands/Helpers/ResetController.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Catrobat\Commands\Helpers;
+
+use App\Catrobat\Services\ScreenshotRepository;
+use App\Entity\FeaturedProgram;
+use App\Entity\Program;
+use App\Entity\ProgramDownloads;
+use App\Entity\ProgramInappropriateReport;
+use App\Entity\ProgramLike;
+use App\Entity\User;
+use App\Entity\UserComment;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\File\File;
+
+/**
+ * Class ResetController
+ * @package App\Catrobat\Commands\Helpers
+ */
+class ResetController extends AbstractController
+{
+  /**
+   * @param Program $program
+   */
+  public function featureProgram(Program $program)
+  {
+    $entity_manager = $this->getDoctrine()->getManager();
+    $feature = new FeaturedProgram();
+    $feature->setProgram($program);
+    $feature->setActive(true);
+    $feature->setFlavor('pocketcode');
+    $feature->setImageType('jpeg'); //todo picture?
+    $feature->setUrl(null);
+
+    $source_img = "public/resources/screenshots/screen_" . $program->getId() . ".png";
+    $dest_img = "public/resources/featured/screen_" . $program->getId() . ".png";
+    copy($source_img, $dest_img);
+    $file = new File($dest_img);
+    $feature->setNewFeaturedImage($file);
+
+    $entity_manager->persist($feature);
+    $entity_manager->flush();
+  }
+
+  /**
+   * @param Program $program
+   * @param User    $user
+   */
+  public function likeProgram(Program $program, User $user)
+  {
+    $entity_manager = $this->getDoctrine()->getManager();
+    $like = new ProgramLike($program, $user, array_rand(ProgramLike::$TYPE_NAMES));
+    $like->setCreatedAt(date_create());
+
+    $entity_manager->persist($like);
+    $entity_manager->flush();
+  }
+
+  /**
+   * @param User    $user
+   * @param Program $program
+   * @param string  $message
+   * @param bool    $reported
+   */
+  public function postComment(User $user, Program $program, string $message, bool $reported)
+  {
+    $temp_comment = new UserComment();
+    $temp_comment->setUsername($user->getUsername());
+    $temp_comment->setUserId($user->getId());
+    $temp_comment->setText($message);
+    $temp_comment->setProgram($program);
+    $temp_comment->setUploadDate(date_create());
+    $temp_comment->setIsReported($reported);
+
+    $em = $this->getDoctrine()->getManager();
+    $em->persist($temp_comment);
+    $em->flush();
+    $em->refresh($temp_comment);
+  }
+
+  /**
+   * @param Program $program
+   * @param User    $user
+   * @param string  $note
+   */
+  public function reportProgram(Program $program, User $user, string $note)
+  {
+    $entity_manager = $this->getDoctrine()->getManager();
+    $report = new ProgramInappropriateReport();
+    $report->setReportingUser($user);
+    $program->setVisible(false);
+    $report->setCategory('Inappropriate');
+    $report->setNote($note);
+    $report->setProgram($program);
+
+    $entity_manager->persist($report);
+    $entity_manager->flush();
+  }
+
+  /**
+   * @param Program $program
+   * @param User    $user
+   */
+  public function downloadProgram(Program $program, User $user)
+  {
+    $entity_manager = $this->getDoctrine()->getManager();
+    $download = new ProgramDownloads();
+    $download->setUser($user);
+    $download->setProgram($program);
+    $download->setDownloadedAt(date_create());
+    $download->setIp('127.0.0.1');
+    $download->setUserAgent('TestBrowser/5.0');
+    $download->setLocale('de_at');
+    $program->setDownloads($program->getDownloads() + 1);
+
+    $entity_manager->persist($program);
+    $entity_manager->persist($download);
+    $entity_manager->flush();
+  }
+
+  /**
+   * @param User $user
+   * @param User $follower
+   */
+  public function followUser(User $user, User $follower)
+  {
+    $entity_manager = $this->getDoctrine()->getManager();
+    $user->addFollower($follower);
+    $follower->addFollowing($user);
+
+    $entity_manager->persist($user);
+    $entity_manager->persist($follower);
+    $entity_manager->flush();
+  }
+}

--- a/src/Catrobat/Commands/ProgramImportCommand.php
+++ b/src/Catrobat/Commands/ProgramImportCommand.php
@@ -115,6 +115,7 @@ class ProgramImportCommand extends Command
         /** @var User $user */
         $add_program_request = new AddProgramRequest($user, new File($file));
         $program = $this->remix_manipulation_program_manager->addProgram($add_program_request);
+        $program->setViews(random_int(0, 10));
         $output->writeln('Added Program <' . $program->getName() . '>');
       } catch (InvalidCatrobatFileException $e)
       {

--- a/src/Catrobat/Commands/ResetCommand.php
+++ b/src/Catrobat/Commands/ResetCommand.php
@@ -10,7 +10,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
-
 /**
  * Class ResetCommand
  * @package App\Catrobat\Commands
@@ -80,7 +79,7 @@ class ResetCommand extends Command
     CommandHelper::emptyDirectory($this->parameter_bag->get('catrobat.screenshot.dir'),
       'Delete screenshots', $output);
     CommandHelper::emptyDirectory($this->parameter_bag->get('catrobat.thumbnail.dir'),
-      'Delete thumnails', $output);
+      'Delete thumbnails', $output);
     CommandHelper::emptyDirectory($this->parameter_bag->get('catrobat.file.storage.dir'),
       'Delete programs', $output);
     CommandHelper::emptyDirectory($this->parameter_bag->get('catrobat.file.extract.dir'),
@@ -110,27 +109,53 @@ class ResetCommand extends Command
     CommandHelper::executeShellCommand(
       'php bin/console fos:user:create catroweb catroweb@localhost.at catroweb --super-admin', [],
       'Create default admin user', $output);
-    CommandHelper::executeShellCommand('php bin/console fos:user:create user user@localhost.at catroweb', [],
-      'Create default user', $output);
+
+    $user_array = ['catroweb', 'user', 'Elliot', 'Darlene', 'Angela', 'Tyrell', 'Edward', 'Price', 'Dom',
+                  'ZhiZhang', 'Irving', 'Janice', 'Vera', 'Sam', 'TheHero', 'Esmail'];
+
+    for($i = 1; $i < sizeof($user_array); $i++) //starting at one because of admin user
+    {
+      CommandHelper::executeShellCommand('php bin/console fos:user:create ' .
+        $user_array[$i] . ' ' . $user_array[$i] . '@localhost.at catroweb', [],
+        'Create default user named '.$user_array[$i], $output);
+    }
 
     $temp_dir = sys_get_temp_dir() . '/catrobat.program.import/';
 
     $filesystem = new Filesystem();
     $filesystem->remove($temp_dir);
-    $filesystem->mkdir($temp_dir);
 
-    $this->downloadPrograms($temp_dir, intval($input->getOption('more')), $output);
+    foreach ($user_array as $user)
+    {
+      $filesystem->mkdir($temp_dir . $user);
+    }
+
+    $program_names = $this->downloadPrograms($temp_dir, intval($input->getOption('more')), $output, $user_array);
 
     $remix_layout_option = '--remix-layout=' . intval($input->getOption('remix-layout'));
-    CommandHelper::executeShellCommand(
-      "php bin/console catrobat:import $temp_dir catroweb $remix_layout_option",
-      ['timeout' => 900], 'Importing Projects', $output);
-    CommandHelper::executeSymfonyCommand('catrobat:import', $this->getApplication(), [
-      'directory'      => $temp_dir,
-      'user'           => 'catroweb',
-      '--remix-layout' => intval($input->getOption('remix-layout')),
-    ], $output);
-    $filesystem->remove($temp_dir);
+    foreach ($user_array as $user) {
+      $temp_dir_user = $temp_dir . $user;
+      CommandHelper::executeShellCommand(
+        "php bin/console catrobat:import $temp_dir_user $user $remix_layout_option",
+        ['timeout' => 900], 'Importing Projects', $output);
+      CommandHelper::executeSymfonyCommand('catrobat:import', $this->getApplication(), [
+        'directory' => $temp_dir_user,
+        'user' => $user,
+        '--remix-layout' => intval($input->getOption('remix-layout')),
+      ], $output);
+
+      $filesystem->remove($temp_dir_user);
+      $output->write("Removing directory $temp_dir_user");
+    }
+
+    $this->commentOnProjects($program_names, $user_array, $output);
+    $this->reportProjects($program_names, $user_array, $output);
+    $this->likeProjects($program_names, $user_array, $output);
+    $this->featureProjects($program_names, $output);
+    $this->followUsers($user_array, $output);
+    $this->downloadProjects($program_names, $user_array, $output);
+
+
 
     CommandHelper::executeShellCommand('chmod o+w -R public/resources', [],
       'Setting resources permissions', $output);
@@ -143,18 +168,24 @@ class ResetCommand extends Command
 
     CommandHelper::executeShellCommand('chmod o+w+x tests/behat/sqlite/ -R', [],
       'Setting permissions for behat sqlite test database', $output);
+
   }
 
   /**
    * @param                 $dir
    * @param                 $amount int The amount of programs to be downloaded
    * @param OutputInterface $output
+   * @param                 $user_array
+   * @return array
    */
-  private function downloadPrograms($dir, $amount, OutputInterface $output)
+  private function downloadPrograms($dir, $amount, OutputInterface $output, $user_array = null)
   {
     $already_downloaded = 0;
+    $user = 0;
+    $program_ids = [];
 
     $output->writeln('Downloading ' . $amount . ' Projects...');
+
 
     while ($already_downloaded < $amount)
     {
@@ -169,19 +200,160 @@ class ResetCommand extends Command
         }
 
         $url = $base_url . $program['DownloadUrl'];
-        $name = $dir . $program['ProjectId'] . '.catrobat';
+        if($user_array !== null)
+        {
+          $name = $dir . $user_array[$user % sizeof($user_array)] . '/' . $program['ProjectId'] . '.catrobat';
+          $program_ids[$already_downloaded] = $program['ProjectName'];
+          $user++;
+        }
+        else
+        {
+          $name = $dir . $program['ProjectId'] . '.catrobat';
+        }
         $output->writeln('Saving <' . $url . '> to <' . $name . '>');
         try
         {
           file_put_contents($name, file_get_contents($url));
           $already_downloaded++;
-        } catch (\Exception $e)
+        }
+        catch (\Exception $e)
         {
           $output->writeln("File <" . $url . "> returned error 500, continuing...");
           continue;
         }
       }
     }
+    return $program_ids;
+  }
 
+
+  private function randomCommentGenerator()
+  {
+    $first = ["I am", "You are", "He is", "They are", "She is", "It is", "We are", "This is"];
+    $second = [" ", " not ", " extremly "];
+    $third = ["good", "hideous", "fabulous", "amazing", "cute", "lovely"];
+    $fourth = [" ;)", " :D", " :(", " xD", " :O"];
+
+    return $first[array_rand($first)] . $second[array_rand($second)] . $third[array_rand($third)] . $fourth[array_rand($fourth)];
+  }
+
+  /**
+   * @param $program_names
+   * @param $user_array
+   * @param $output
+   * @throws \Exception
+   */
+  private function commentOnProjects($program_names, $user_array, $output)
+  {
+    $i = 0;
+    foreach ($program_names as $program_name)
+    {
+      $random_reported = random_int(-10, 1);
+      if($random_reported <= 0){
+        $random_reported = 0;
+      }
+      $random_comment_amount = random_int(0, 3);
+      for($j = 0; $j <= $random_comment_amount; $j++)
+      {
+        CommandHelper::executeSymfonyCommand('catrobat:comment', $this->getApplication(), [
+          'user' => $user_array[array_rand($user_array)],
+          'program_name' => $program_name,
+          'message' => $this->randomCommentGenerator(),
+          'reported' => $random_reported
+        ], $output);
+      }
+      $i++;
+    }
+  }
+
+  /**
+   * @param $program_names
+   * @param $user_array
+   * @param $output
+   * @throws \Exception
+   */
+  private function reportProjects($program_names, $user_array, $output)
+  {
+    for($i = 0; $i < sizeof($program_names); $i += 10)
+    {
+      CommandHelper::executeSymfonyCommand('catrobat:report', $this->getApplication(), [
+        'user' => $user_array[$i],
+        'program_name' => $program_names[$i],
+        'note' => "bad"
+      ], $output);
+    }
+  }
+
+  /**
+   * @param $program_names
+   * @param $user_array
+   * @param $output
+   * @throws \Exception
+   */
+  private function likeProjects($program_names, $user_array, $output)
+  {
+    foreach ($program_names as $program_name)
+    {
+      $like_amount = random_int(1, 5);
+      for($i = 0; $i < $like_amount; $i++)
+      {
+        CommandHelper::executeSymfonyCommand('catrobat:like', $this->getApplication(), [
+          'program_name' => $program_name,
+          'user_name' =>  $user_array[($i+$like_amount)%sizeof($user_array)]
+        ], $output);
+      }
+    }
+  }
+
+  /**
+   * @param $program_names
+   * @param $user_array
+   * @param $output
+   * @throws \Exception
+   */
+  private function downloadProjects($program_names, $user_array, $output)
+  {
+    foreach ($program_names as $program_name)
+    {
+      $download_amount = random_int(1, 5);
+      for($i = 0; $i < $download_amount; $i++)
+      {
+        CommandHelper::executeSymfonyCommand('catrobat:download', $this->getApplication(), [
+          'program_name' => $program_name,
+          'user_name' =>  $user_array[array_rand($user_array)]
+        ], $output);
+      }
+    }
+  }
+
+  /**
+   * @param $program_names
+   * @param $output
+   * @throws \Exception
+   */
+  private function featureProjects($program_names, $output)
+  {
+    for($i = 0; $i < sizeof($program_names); $i += 5)
+    {
+      CommandHelper::executeSymfonyCommand('catrobat:feature', $this->getApplication(), [
+        'program_name' => $program_names[$i % sizeof($program_names)]
+      ], $output);
+    }
+  }
+
+  /**
+   * @param array $user_array
+   * @param OutputInterface $output
+   * @throws \Exception
+   */
+  private function followUsers(array $user_array, OutputInterface $output)
+  {
+    for($i = 0; $i < sizeof($user_array); $i++)
+    {
+      CommandHelper::executeSymfonyCommand('catrobat:follow', $this->getApplication(), [
+        'user_name' => $user_array[$i],
+        'follower'  => $user_array[($i+random_int(1, sizeof($user_array)))%sizeof($user_array)]
+      ], $output);
+    }
   }
 }


### PR DESCRIPTION
The reset command is more natural now. It creates multiple users who randomly follow each other and randomly generates comments,
likes, downloads, reported and featured projects (currently screenshots are used for featured projects)

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
For featured projects the screenshots of the projects are used.

### Tests - additional information
Reset command has no tests as far as I know