### PR TITLE
SHARE-215 reset command enhancement

### DIFF
--- a/src/Catrobat/Commands/CreateCommentCommand.php
+++ b/src/Catrobat/Commands/CreateCommentCommand.php
@@ -4,6 +4,8 @@ namespace App\Catrobat\Commands;
 
 use App\Catrobat\Commands\Helpers\RemixManipulationProgramManager;
 use App\Catrobat\Commands\Helpers\ResetController;
+use App\Catrobat\Services\CatroNotificationService;
+use App\Entity\CommentNotification;
 use App\Entity\Program;
 use App\Entity\User;
 use App\Entity\UserManager;
@@ -33,16 +35,23 @@ class CreateCommentCommand extends Command
   private $reset_controller;
 
   /**
+   * @var CatroNotificationService
+   */
+  private $notification_service;
+
+  /**
    * ProgramImportCommand constructor.
    */
   public function __construct(UserManager $user_manager,
                               RemixManipulationProgramManager $program_manager,
-                              ResetController $reset_controller)
+                              ResetController $reset_controller,
+                              CatroNotificationService $notification_service)
   {
     parent::__construct();
     $this->user_manager = $user_manager;
     $this->remix_manipulation_program_manager = $program_manager;
     $this->reset_controller = $reset_controller;
+    $this->notification_service = $notification_service;
   }
 
   protected function configure()
@@ -82,7 +91,10 @@ class CreateCommentCommand extends Command
 
     try
     {
-      $this->reset_controller->postComment($user, $program, $message, $reported);
+      /** @var User $user */
+      $notification = new CommentNotification($user, null);
+      $this->reset_controller->postComment($user, $program, $message, $reported, $notification);
+      $this->notification_service->addNotification($notification);
     }
     catch (\Exception $e)
     {

--- a/src/Catrobat/Commands/CreateDownloadsCommand.php
+++ b/src/Catrobat/Commands/CreateDownloadsCommand.php
@@ -62,9 +62,7 @@ class CreateDownloadsCommand extends Command
 
     $program = $this->remix_manipulation_program_manager->findOneByName($program_name);
 
-    /**
-     * @var User
-     */
+    /** @var User */
     $user = $this->user_manager->findUserByUsername($user_name);
 
     if (null == $program || null == $user || null == $this->reset_controller)
@@ -74,6 +72,7 @@ class CreateDownloadsCommand extends Command
 
     try
     {
+      /* @var User $user */
       $this->reset_controller->downloadProgram($program, $user);
     }
     catch (\Exception $e)

--- a/src/Catrobat/Commands/CreateFollowersCommand.php
+++ b/src/Catrobat/Commands/CreateFollowersCommand.php
@@ -4,6 +4,8 @@ namespace App\Catrobat\Commands;
 
 use App\Catrobat\Commands\Helpers\RemixManipulationProgramManager;
 use App\Catrobat\Commands\Helpers\ResetController;
+use App\Catrobat\Services\CatroNotificationService;
+use App\Entity\FollowNotification;
 use App\Entity\User;
 use App\Entity\UserManager;
 use Symfony\Component\Console\Command\Command;
@@ -29,16 +31,23 @@ class CreateFollowersCommand extends Command
   private $reset_controller;
 
   /**
+   * @var CatroNotificationService
+   */
+  private $notification_service;
+
+  /**
    * CreateFollowersCommand constructor.
    */
   public function __construct(UserManager $user_manager,
                               RemixManipulationProgramManager $program_manager,
-                              ResetController $reset_controller)
+                              ResetController $reset_controller,
+                              CatroNotificationService $notification_service)
   {
     parent::__construct();
     $this->user_manager = $user_manager;
     $this->remix_manipulation_program_manager = $program_manager;
     $this->reset_controller = $reset_controller;
+    $this->notification_service = $notification_service;
   }
 
   protected function configure()
@@ -79,7 +88,9 @@ class CreateFollowersCommand extends Command
 
     try
     {
+      $notification = new FollowNotification($user, $follower);
       $this->reset_controller->followUser($user, $follower);
+      $this->notification_service->addNotification($notification);
     }
     catch (\Exception $e)
     {

--- a/src/Catrobat/Commands/CreateLikeCommand.php
+++ b/src/Catrobat/Commands/CreateLikeCommand.php
@@ -4,6 +4,8 @@ namespace App\Catrobat\Commands;
 
 use App\Catrobat\Commands\Helpers\RemixManipulationProgramManager;
 use App\Catrobat\Commands\Helpers\ResetController;
+use App\Catrobat\Services\CatroNotificationService;
+use App\Entity\LikeNotification;
 use App\Entity\Program;
 use App\Entity\User;
 use App\Entity\UserManager;
@@ -30,16 +32,23 @@ class CreateLikeCommand extends Command
   private $reset_controller;
 
   /**
+   * @var CatroNotificationService
+   */
+  private $notification_service;
+
+  /**
    * CreateLikeCommand constructor.
    */
   public function __construct(UserManager $user_manager,
                               RemixManipulationProgramManager $program_manager,
-                              ResetController $reset_controller)
+                              ResetController $reset_controller,
+                              CatroNotificationService $notification_service)
   {
     parent::__construct();
     $this->user_manager = $user_manager;
     $this->remix_manipulation_program_manager = $program_manager;
     $this->reset_controller = $reset_controller;
+    $this->notification_service = $notification_service;
   }
 
   protected function configure()
@@ -72,10 +81,12 @@ class CreateLikeCommand extends Command
     {
       return;
     }
-
     try
     {
+      $notification = new LikeNotification($program->getUser(), $user, $program);
       $this->reset_controller->likeProgram($program, $user);
+      $notification->setSeen(random_int(0, 3));
+      $this->notification_service->addNotification($notification);
     }
     catch (\Exception $e)
     {

--- a/src/Catrobat/Commands/CreateRemixCommand.php
+++ b/src/Catrobat/Commands/CreateRemixCommand.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Catrobat\Commands;
+
+use App\Catrobat\Commands\Helpers\RemixManipulationProgramManager;
+use App\Catrobat\Commands\Helpers\ResetController;
+use App\Catrobat\Services\CatroNotificationService;
+use App\Catrobat\Services\RemixData;
+use App\Entity\RemixManager;
+use App\Entity\RemixNotification;
+use App\Entity\UserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CreateRemixCommand extends Command
+{
+  /**
+   * @var UserManager
+   */
+  private $user_manager;
+
+  /**
+   * @var RemixManipulationProgramManager
+   */
+  private $remix_manipulation_program_manager;
+
+  /**
+   * @var ResetController
+   */
+  private $reset_controller;
+
+  /**
+   * @var RemixManager
+   */
+  private $remix_manager;
+
+  /**
+   * @var CatroNotificationService
+   */
+  private $notification_service;
+
+  /**
+   * CreateDownloadsCommand constructor.
+   */
+  public function __construct(UserManager $user_manager,
+                              RemixManipulationProgramManager $program_manager,
+                              ResetController $reset_controller,
+                              RemixManager $remix_manager,
+                              CatroNotificationService $notification_service)
+  {
+    parent::__construct();
+    $this->user_manager = $user_manager;
+    $this->remix_manipulation_program_manager = $program_manager;
+    $this->reset_controller = $reset_controller;
+    $this->remix_manager = $remix_manager;
+    $this->notification_service = $notification_service;
+  }
+
+  protected function configure()
+  {
+    $this->setName('catrobat:remix')
+      ->setDescription('add remixes to projects')
+      ->addArgument('program_original', InputArgument::REQUIRED, 'Name of program which gets remixed')
+      ->addArgument('program_remix', InputArgument::REQUIRED, 'Names of program which is the remix')
+    ;
+  }
+
+  /**
+   * @throws \Exception
+   *
+   * @return int|void|null
+   */
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+    $original_program_name = $input->getArgument('program_original');
+    $remix_program_name = $input->getArgument('program_remix');
+
+    $program_original = $this->remix_manipulation_program_manager->findOneByName($original_program_name);
+    $program_remix = $this->remix_manipulation_program_manager->findOneByName($remix_program_name);
+    if ($original_program_name === $remix_program_name)
+    {
+      return;
+    }
+
+    $remix_data_of_original = new RemixData($program_original->getId());
+    $program_remixes_of_original[0] = $remix_data_of_original;
+    $notification = new RemixNotification($program_original->getUser(), $program_remix->getUser(), $program_original, $program_remix);
+    $this->notification_service->addNotification($notification);
+
+    if (null == $program_original || 0 == sizeof($program_remixes_of_original) || null == $this->reset_controller)
+    {
+      return;
+    }
+
+    try
+    {
+      $this->remix_manager->addRemixes($program_remix, $program_remixes_of_original);
+    }
+    catch (\Exception $e)
+    {
+      return;
+    }
+    $output->writeln('Remixing '.$program_original->getName().' with '.$remix_program_name);
+  }
+}

--- a/src/Catrobat/Commands/Helpers/ResetController.php
+++ b/src/Catrobat/Commands/Helpers/ResetController.php
@@ -2,6 +2,7 @@
 
 namespace App\Catrobat\Commands\Helpers;
 
+use App\Entity\CommentNotification;
 use App\Entity\FeaturedProgram;
 use App\Entity\Program;
 use App\Entity\ProgramDownloads;
@@ -47,7 +48,7 @@ class ResetController extends AbstractController
     $entity_manager->flush();
   }
 
-  public function postComment(User $user, Program $program, string $message, bool $reported)
+  public function postComment(User $user, Program $program, string $message, bool $reported, CommentNotification $notification)
   {
     $temp_comment = new UserComment();
     $temp_comment->setUsername($user->getUsername());
@@ -56,9 +57,20 @@ class ResetController extends AbstractController
     $temp_comment->setProgram($program);
     $temp_comment->setUploadDate(date_create());
     $temp_comment->setIsReported($reported);
+    $notification->setComment($temp_comment);
+    $temp_comment->setNotification($notification);
 
     $em = $this->getDoctrine()->getManager();
     $em->persist($temp_comment);
+    try
+    {
+      $notification->setSeen(random_int(0, 2));
+    }
+    catch (\Exception $e)
+    {
+      $notification->setSeen(0);
+    }
+    $em->persist($notification);
     $em->flush();
     $em->refresh($temp_comment);
   }
@@ -72,7 +84,6 @@ class ResetController extends AbstractController
     $report->setCategory('Inappropriate');
     $report->setNote($note);
     $report->setProgram($program);
-
     $entity_manager->persist($report);
     $entity_manager->flush();
   }


### PR DESCRIPTION
added remix projects; notifications by comments, followers, likes and remixes; some notifications are marked as read; reported programs fixed (broken after merge into develop); enhanced randomness; added permission script

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
No scratch programs; example projects not possible because not implemented
### Tests - additional information
No tests for reset command
