### PR TITLE
SHARE-220 Use system fonts before web fonts are loaded

### DIFF
--- a/assets/css/base/_bootswatch.scss
+++ b/assets/css/base/_bootswatch.scss
@@ -6,9 +6,6 @@
 @import '../../../public/bootstrap/scss/bootstrap';
 // Variables ===================================================================
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700" !default;
-@import url($web-font-path);
-
 // Font Awesome
 $fa-font-path: "../../webfonts";
 @import "../../../public/font_awesome_wrapper/fontawesome-free/scss/fontawesome";

--- a/assets/css/base/_brain.scss
+++ b/assets/css/base/_brain.scss
@@ -9,6 +9,7 @@
   src: local('Roboto Regular'), local('Roboto-Regular'), url('../fonts/Roboto-Regular-webfont.eot?#iefix') format('embedded-opentype'), url('../fonts/Roboto-Regular-webfont.woff') format('woff'), url('../fonts/Roboto-Regular-webfont.ttf') format('truetype'), url('../fonts/Roboto-Regular-webfont.svg#RobotoRegular') format('svg');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -17,6 +18,7 @@
   src: local('Roboto Italic'), local('Roboto-Italic'), url('../fonts/Roboto-Italic-webfont.eot?#iefix') format('embedded-opentype'), url('../fonts/Roboto-Italic-webfont.woff') format('woff'), url('../fonts/Roboto-Italic-webfont.ttf') format('truetype'), url('../fonts/Roboto-Italic-webfont.svg#RobotoItalic') format('svg');
   font-weight: normal;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -25,6 +27,7 @@
   src: local('Roboto Bold'), local('Roboto-Bold'), url('../fonts/Roboto-Bold-webfont.eot?#iefix') format('embedded-opentype'), url('../fonts/Roboto-Bold-webfont.woff') format('woff'), url('../fonts/Roboto-Bold-webfont.ttf') format('truetype'), url('../fonts/Roboto-Bold-webfont.svg#RobotoBold') format('svg');
   font-weight: bold;
   font-style: normal;
+  font-display: swap;
 }
 
 *, *:before, *:after {

--- a/assets/css/base/_variables.scss
+++ b/assets/css/base/_variables.scss
@@ -48,7 +48,7 @@ $border-radius-sm:            0 !default;
 
 // Fonts
 
-$font-family-sans-serif:      Roboto, "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+$font-family-sans-serif:      Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
 $font-size-base:              1rem !default;
 


### PR DESCRIPTION
Set font-display property to swap for the Roboto font.
Remove Open Sans font, because it was used just as first alternative for Roboto.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [X] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no warnings and errors 
- [X] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [X] Perform a self-review of the changes
- [X] Stick to the project’s git workflow (rebase and squash your commits)
- [X] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer