### PR TITLE
SHARE-234 GithubActions tests - Shared Dev Docker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,9 +34,25 @@ jobs:
           sudo service apache2 reload
           wget --spider -S "http://catroweb:8080" 2>&1 | awk '/HTTP\// {print $2}' | grep 200
 
-      - name: Check test environment
+      - name: Check tests in dev environment
         run:
           docker exec app.catroweb bin/behat -s web-general tests/behat/features/web/general/homepage.feature
+
+      - name: Check shared development volumes must not need a rebuild
+        id: shared-test-run-must-fail
+        continue-on-error: true
+        run: |
+          echo ::set-output name=status::failure
+          echo "INVALID" > tests/behat/features/web/general/homepage.feature
+          docker exec app.catroweb bin/behat -s web-general tests/behat/features/web/general/homepage.feature
+          echo ::set-output name=status::success
+
+      - name: Check that invalid changes result in a failing testcase
+        if: steps.shared-test-run-must-fail.outputs.status == 'success'
+        run: |
+          exit -1
+
+
 
 
   tests_phpunit:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,14 @@ phpunit.xml
 *.local
 phploc.phar
 
+### Scripts ###
+bin/
+!bin/console
+!bin/recsys-similarity-computation-service.jar
+!bin/x_perm.sh
+!bin/x_reset.sh
+!bin/x_test.sh
+
 ### backups ###
 backups/**
 

--- a/bin/behat
+++ b/bin/behat
@@ -1,1 +1,0 @@
-../vendor/behat/behat/bin/behat

--- a/bin/dep
+++ b/bin/dep
@@ -1,1 +1,0 @@
-../vendor/deployer/deployer/bin/dep

--- a/bin/doctrine
+++ b/bin/doctrine
@@ -1,1 +1,0 @@
-../vendor/doctrine/orm/bin/doctrine

--- a/bin/doctrine-dbal
+++ b/bin/doctrine-dbal
@@ -1,1 +1,0 @@
-../vendor/doctrine/dbal/bin/doctrine-dbal

--- a/bin/doctrine-migrations
+++ b/bin/doctrine-migrations
@@ -1,1 +1,0 @@
-../vendor/doctrine/migrations/bin/doctrine-migrations

--- a/bin/php-cs-fixer
+++ b/bin/php-cs-fixer
@@ -1,1 +1,0 @@
-../vendor/friendsofphp/php-cs-fixer/php-cs-fixer

--- a/bin/php-parse
+++ b/bin/php-parse
@@ -1,1 +1,0 @@
-../vendor/nikic/php-parser/bin/php-parse

--- a/bin/phpcf
+++ b/bin/phpcf
@@ -1,1 +1,0 @@
-../vendor/wapmorgan/php-code-fixer/bin/phpcf

--- a/bin/phpcheckstyle
+++ b/bin/phpcheckstyle
@@ -1,1 +1,0 @@
-../vendor/phpcheckstyle/phpcheckstyle/phpcheckstyle

--- a/bin/phpstan
+++ b/bin/phpstan
@@ -1,1 +1,0 @@
-../vendor/phpstan/phpstan/phpstan

--- a/bin/phpunit
+++ b/bin/phpunit
@@ -1,1 +1,0 @@
-../vendor/phpunit/phpunit/phpunit

--- a/bin/rector
+++ b/bin/rector
@@ -1,1 +1,0 @@
-../vendor/rector/rector/bin/rector

--- a/bin/simple-phpunit
+++ b/bin/simple-phpunit
@@ -1,1 +1,0 @@
-../vendor/symfony/phpunit-bridge/bin/simple-phpunit

--- a/bin/var-dump-server
+++ b/bin/var-dump-server
@@ -1,1 +1,0 @@
-../vendor/symfony/var-dumper/Resources/bin/var-dump-server

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,19 @@
+# Use composer image for better caching
 FROM composer AS composer-build
 COPY composer.json composer.lock ./
 RUN composer install --no-scripts --prefer-dist
 
-
+# Use node image for better caching
 FROM node AS node-build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm install && npm install grunt
 
-
+# Run on:
 FROM ubuntu:18.04
 ARG DEBIAN_FRONTEND=noninteractive
 
-# DEPDEDENCIES
+# Install dependencies
 RUN apt-get update && \
     apt-get install -yq --no-install-recommends software-properties-common && \
     add-apt-repository ppa:ondrej/php && \
@@ -47,42 +48,54 @@ RUN apt-get update && \
     grunt && \
     gem install sass
 
-# APACHE CONFIG
+# Overwrite default apache config
 COPY /docker/apache/catroweb.conf /etc/apache2/sites-available/catroweb.conf
 RUN a2dissite 000-default.conf && \
     a2ensite catroweb.conf
 
+# Setting working directory
 WORKDIR /var/www/catroweb
 
-# LIBRARIES
-COPY --from=composer-build /app/vendor vendor
-COPY --from=node-build /app/node_modules node_modules
-COPY --from=composer /usr/bin/composer /usr/bin/composer
-COPY composer.json composer.lock package.json package-lock.json ./
+# Generate jwt config in container (will be overwritten with host keys if they exist)
+COPY /docker/app/init-jwt-config.sh ./docker/app/init-jwt-config.sh
+RUN sh docker/app/init-jwt-config.sh
 
-# ADD CODE
-ADD / ./
+# Copy all files to the container.
+# A change to any project file clears the cache of all layers defined after this command!
+# Make sure to define all project code indepandant commands above to improve performance.
+COPY / ./
 
-# CONFIGURATIONS
-ARG APP_ENVIRONMENT
-
-RUN echo "\n" >> .env.local && \
-    echo APP_ENV=$APP_ENVIRONMENT >> .env.local
-
- # Updating the behat config to work with our docker containers.
+# Overwrite behat config:
+COPY behat.yml.dist ./
 RUN sed -i -r "s|(base_url:)(\s+.+)|base_url: http://app.catroweb/index_test.php/|g" behat.yml.dist && \
     sed -i -r "s|(api_url:)(\s+.+)|api_url: chrome.catroweb:9222|g" behat.yml.dist
 
-# Copying legacy parameters into the project. (ToDo get rid of those file and use .env)
-RUN cp config/packages/parameters.yml.dist config/packages/parameters.yml
-
-# Setting up db configs
-RUN echo "\n" >> .env.dev.local && \
+# Overwrite project config:
+ARG APP_ENVIRONMENT
+RUN echo "\n" >> .env.local && \
+    echo APP_ENV=$APP_ENVIRONMENT >> .env.local && \
+    echo "\n" >> .env.dev.local && \
     echo DATABASE_URL=pdo-mysql://root:root@db.catroweb.dev:3306/catroweb_dev >> .env.dev.local && \
     echo "\n" >> .env.test.local && \
     echo DATABASE_URL=pdo-mysql://root:root@db.catroweb.test:3306/catroweb_test >> .env.test.local
 
+# Copying legacy parameters into the project, else scripts will crash (ToDo replace this file with .env - SHARE-39)
+COPY config/packages/parameters.yml.dist config/packages/parameters.yml
+
+# Add composer executable to the container
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+# Add libraries and modules
+COPY --from=composer-build /app/vendor vendor
+COPY --from=node-build /app/node_modules node_modules
+
+# Add library scripts symlinks
+COPY --from=composer-build /app/bin bin
+
 # Finally we set all permissions, and create required keys and test fixtures.
 RUN sh docker/app/prepare-test-env.sh
+
+# (Re-)compile public css/js files
+RUN grunt
 
 EXPOSE 80

--- a/docker/app/import-container-libraries.sh
+++ b/docker/app/import-container-libraries.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# In case you need access to container libraries just run this command from the root project directory.
+# It copies the vendor and node_modules from the container to the host.
+#
+# A simple docker cp might be enough, but on windows machines this commands often crashes.
+# Therefore this tar.gz workaround is used.
+#
+docker exec app.catroweb mkdir sharedLibraries
+docker exec app.catroweb tar -czf libraries.tar.gz node_modules vendor
+docker exec app.catroweb mv libraries.tar.gz sharedLibraries
+docker cp app.catroweb:/var/www/catroweb/sharedLibraries ./
+docker exec app.catroweb rm -rf sharedLibraries
+rm -Rf vendor
+rm -Rf node_modules
+chmod 777 -R sharedLibraries
+cd sharedLibraries || exit
+tar -xf libraries.tar.gz
+mv vendor ../
+mv node_modules ../
+cd ..
+rm -Rf sharedLibraries

--- a/docker/app/init-jwt-config.sh
+++ b/docker/app/init-jwt-config.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Jwt tokens need openssl keys with full access
+mkdir -p config/jwt
+openssl genpkey -out config/jwt/private.pem -aes256 -algorithm rsa -pkeyopt rsa_keygen_bits:4096 -pass pass:catroweb
+openssl pkey -in config/jwt/private.pem -out config/jwt/public.pem -pubout -passin pass:catroweb
+chmod -R 777 config/jwt

--- a/docker/app/prepare-test-env.sh
+++ b/docker/app/prepare-test-env.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
 rm -rf var/{cache,log}/*
+
 sh docker/app/set-permissions.sh
-grunt
+
 bin/console cache:clear -e test
 bin/console catrobat:test:generate --force
 bin/console assets:install --symlink public
+
 echo "Test environment prepared"

--- a/docker/app/set-permissions.sh
+++ b/docker/app/set-permissions.sh
@@ -1,25 +1,7 @@
 #!/usr/bin/env bash
 
-# https://github.com/Behat/Symfony2Extension/issues/149
-# Behat/Symfony2Extension seems to have a permission problem
-#
-#  As a workaround we make sure the folders already exists with the correct permissions, else
-#  var/cache/test/sessions will be created with wrong permissions
-#
-mkdir -p var/log/test
-mkdir -p var/cache/test/sessions
-mkdir -p var/cache/test/profiler
-## ~~
-
-# Symfony 4+ Permissions
-chmod -R 777 var/
-
-# Since Symfony 4 this should not be necessary anymore when using APP_DEBUG = true
-# But we set APP_DEBUG to false for our tests. Therefore no unmask() is called in index(_test).php bin/console.php.
-# Therefore we still have to set the permissions like it had to be done in Symfony 3
-HTTPDUSER=$(ps aux | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | head -1 | cut -d\  -f1)
-setfacl -R -m u:"$HTTPDUSER":rwX -m u:$(whoami):rwX var/cache var/log
-setfacl -dR -m u:"$HTTPDUSER":rwX -m u:$(whoami):rwX var/cache var/log
+# cache an dlog must be writable
+sh docker/app/set-var-permissions.sh
 
 # resource dirs must to be writable
 chmod o+w public/resources/ -R
@@ -27,11 +9,3 @@ chmod o+w public/resources_test/ -R
 
 # some test dirs must be writable
 chmod o+w tests -R
-
-# Jwt tokens need ssh keys with full access
-mkdir -p config/jwt
-openssl genpkey -out config/jwt/private.pem -aes256 -algorithm rsa -pkeyopt rsa_keygen_bits:4096 -pass pass:catroweb
-openssl pkey -in config/jwt/private.pem -out config/jwt/public.pem -pubout -passin pass:catroweb
-chmod -R 777 config/jwt
-
-echo "Permissions set"

--- a/docker/app/set-var-permissions.sh
+++ b/docker/app/set-var-permissions.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# https://github.com/Behat/Symfony2Extension/issues/149
+# Behat/Symfony2Extension seems to have a permission problem
+#
+#  As a workaround we make sure the folders already exists with the correct permissions, else
+#  var/cache/test/sessions will be created with wrong permissions
+#
+mkdir -p var/log/test
+mkdir -p var/cache/test/sessions
+mkdir -p var/cache/test/profiler
+## ~~
+
+# Symfony 4+ Permissions
+chmod -R 777 var/
+
+# Since Symfony 4 this should not be necessary anymore when using APP_DEBUG = true
+# But we set APP_DEBUG to false for our tests. Therefore no unmask() is called in index(_test).php bin/console.php.
+# Therefore we still have to set the permissions like it had to be done in Symfony 3
+HTTPDUSER=$(ps aux | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | head -1 | cut -d\  -f1)
+setfacl -R -m u:"$HTTPDUSER":rwX -m u:$(whoami):rwX var/cache var/log
+setfacl -dR -m u:"$HTTPDUSER":rwX -m u:$(whoami):rwX var/cache var/log

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
 
-  # APACHE WITH PHP
+  # Catroweb Project using APACHE with PHP
   app.catroweb:
     build:
       args:
@@ -18,6 +18,19 @@ services:
       - chrome.catroweb
     ports:
       - 8080:80
+    volumes:
+      # Changes to the following files are shared between host and container - no rebuild needed!
+      - ./../assets:/var/www/catroweb/assets:cached
+      - ./../src:/var/www/catroweb/src:cached
+      - ./../templates:/var/www/catroweb/templates:cached
+      - ./../tests:/var/www/catroweb/tests:cached
+      - ./../translations:/var/www/catroweb/translations:cached
+      # Since we need access to the vendor & node_modules in the Dockerfile, we can not share them.
+      # Shared volumes are attached after the build process,
+      # which will result in else invalid overwritten libraries in the container.
+      # If you need access to them (for example for intellisense), just copy those directories from the container to
+      # the host. E.g with `docker cp app.catroweb:/var/www/catroweb/vendor vendor` In case of errors (mainly on windows
+      # you could tar the directory before copying it from the container to the host.
 
   db.catroweb.dev:
     image: mariadb:10.3.11


### PR DESCRIPTION
- reintroduce shared volumes in dev container
- Split and change order in DockerFile to improve caching performance
- Remove bin/script symlinks. (Problems on windows machines)
  They are autogenerated at composer install anyway
- Add script generation to dockerfile
- better descriptions for docker stuff
- split docker scripts
- new docker script to import container libraries to host for intellisense
- add github action to test shared volumes

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
Reset Command is now not creating jwt keys. If needed we should create a ticket.
Docker wiki will be updated soon. Working on windows machines is now possible to without problems.

### Tests - additional information
`TODO: add additional information about testruns here`
