### PR TITLE
SHARE-282 CreateLikeCommand crash

### DIFF
--- a/src/Catrobat/Commands/CreateLikeCommand.php
+++ b/src/Catrobat/Commands/CreateLikeCommand.php
@@ -64,7 +64,7 @@ class CreateLikeCommand extends Command
 
     if (null === $program || null === $user)
     {
-      $output->writeln('Liking '.$program->getName().' with user '.$user_name.'failed');
+      $output->writeln('Liking '.$program_name.' with user '.$user_name.' failed');
 
       return -1;
     }


### PR DESCRIPTION
- Fixed CreateLikeCommand.php by removing the possibility of calling a member
  function on null

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
