### PR TITLE
SHARE-289 Sidebar styling, especially notifications

### DIFF
--- a/assets/css/base/_bootswatch.scss
+++ b/assets/css/base/_bootswatch.scss
@@ -11,6 +11,7 @@ $fa-font-path: "../../webfonts";
 @import "../../../public/font_awesome_wrapper/fontawesome-free/scss/fontawesome";
 @import "../../../public/font_awesome_wrapper/fontawesome-free/scss/solid";
 @import "../../../public/font_awesome_wrapper/fontawesome-free/scss/regular";
+@import "../../../public/font_awesome_wrapper/fontawesome-free/scss/brands";
 
 
 // Navbar ======================================================================

--- a/assets/css/base/_navbar.scss
+++ b/assets/css/base/_navbar.scss
@@ -53,6 +53,3 @@
     width: 100% !important;
   }
 }
-#btn-followers, #btn-likes, #btn-comments, #btn-remix{
-  margin-left: 12px;
-}

--- a/assets/css/base/_sidebar.scss
+++ b/assets/css/base/_sidebar.scss
@@ -1,11 +1,12 @@
+@import 'mixins';
+
 $sidebar-width: 250px;
 
-#sidebar
-{
+#sidebar {
   width: $sidebar-width;
   height: 100vh;
   position: fixed;
-  background: white;
+  background: #fff;
   top: 0;
   left: ($sidebar-width * -1) - 50px;
   /* top layer */
@@ -15,8 +16,7 @@ $sidebar-width: 250px;
   overflow-y: auto;
   box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.2);
 
-  &.active
-  {
+  &.active {
     left: 0;
   }
 
@@ -30,10 +30,8 @@ $sidebar-width: 250px;
     background-size: contain;
   }
 
-  li
-  {
-    a
-    {
+  li {
+    a {
       display: block;
       text-decoration: none;
       color: #222;
@@ -42,30 +40,91 @@ $sidebar-width: 250px;
       padding-top: 1rem;
       padding-bottom: 1rem;
 
-      &:hover
-      {
+      &.nav-link {
+        cursor: pointer;
+      }
+
+      &:hover {
         text-decoration: none;
         background: rgba(0, 0, 0, 0.2);
       }
 
-      &:active, &:focus
-      {
+      &:active, &:focus {
         text-decoration: none;
       }
 
-      .user-notification-badge {
-        display: none;
+      .link-icon {
+        margin-right: 0.25rem;
+        display: inline-block;
+        width: 1.3rem;
+        text-align: center;
       }
-      .user-notification-badge-dropdown
-      {
+    }
+  }
+
+  #notifications-dropdown-toggler {
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+    justify-items: flex-start;
+
+    .text {
+      @include force-word-break();
+      flex-grow: 1;
+      padding-left: 0.3rem;
+    }
+
+    #notifications-dropdown-arrow, .badge-pill {
+      margin-left: 0.25rem;
+    }
+
+    #notifications-dropdown-arrow {
+      width: 0.9rem;
+      text-align: center;
+    }
+
+    .badge-pill {
+      display: none;
+    }
+  }
+
+  #notifications-dropdown-content {
+    overflow: hidden;
+    transition: height 0.4s ease-out;
+
+    &:not(.shown) {
+      height: 0;
+    }
+
+    > .nav-link {
+      padding-left: 1.7rem;
+      display: flex;
+      flex-direction: row;
+      align-items: baseline;
+      justify-items: flex-start;
+
+      .fa, .fas, .far, .fab, .fad {
+        font-size: 1.1rem;
+      }
+
+      .text {
+        @include force-word-break();
+        flex-grow: 1;
+        max-width: calc(100% - 3rem);
+      }
+
+      .badge-pill {
+        margin-left: 0.25rem;
         display: none;
+        font-size: 1rem;
+        padding-left: 0.5em;
+        padding-right: 0.5em;
       }
     }
   }
 
   @include media-breakpoint-up(md) {
-    &:not(.inactive)
-    {
+    &:not(.inactive) {
       left: 0;
     }
   }
@@ -81,8 +140,7 @@ $sidebar-width: 250px;
   }
 }
 
-#sidebar-overlay
-{
+#sidebar-overlay {
   display: none;
   position: fixed;
   /* full screen */
@@ -99,39 +157,8 @@ $sidebar-width: 250px;
   transition: all 0.5s ease-in-out;
 }
 
-#sidebar.active + #sidebar-overlay
-{
+#sidebar.active + #sidebar-overlay {
   display: block;
   opacity: 1;
-}
-
-.collapsible
-{
-  cursor: pointer;
-}
-
-.caret-icon
-{
- float:right;
-}
-
-#btn-notifications
-{
-  margin-left: 11px;
-}
-
-.user-notification-badge-dropdown
-{
-font-size: 15px;
-}
-
-.notifications-dropdown-content
-{
-
-  max-height: 0;
-  overflow: hidden;
-  background-color: white;
-  transition: max-height 0.4s ease-out;
-
 }
 

--- a/assets/js/base/Sidebar.js
+++ b/assets/js/base/Sidebar.js
@@ -56,7 +56,7 @@ function manageNotificationsDropdown () {
   }
 
   notificationDropdownToggler.addEventListener('click', function () {
-    notificationDropdownContent.style.maxHeight ? collapseNotificationDropdownMenu() : expandNotificationDropdownMenu()
+    notificationDropdownContent.classList.contains('shown') ? collapseNotificationDropdownMenu() : expandNotificationDropdownMenu()
   })
 
   // automatically expand the notification dropdown when the user is on a notification page
@@ -79,7 +79,7 @@ function expandNotificationDropdownMenu () {
   const notificationDropdownArrow = document.getElementById('notifications-dropdown-arrow')
   const notificationDropdownContent = document.getElementById('notifications-dropdown-content')
 
-  notificationDropdownContent.style.maxHeight = notificationDropdownContent.scrollHeight + 'px'
+  notificationDropdownContent.classList.add('shown')
   notificationDropdownArrow.classList.remove('fa-caret-left')
   notificationDropdownArrow.classList.add('fa-caret-down')
 
@@ -93,7 +93,7 @@ function collapseNotificationDropdownMenu () {
   const notificationDropdownArrow = document.getElementById('notifications-dropdown-arrow')
   const notificationDropdownContent = document.getElementById('notifications-dropdown-content')
 
-  notificationDropdownContent.style.maxHeight = null
+  notificationDropdownContent.classList.remove('shown')
   notificationDropdownArrow.classList.remove('fa-caret-down')
   notificationDropdownArrow.classList.add('fa-caret-left')
 

--- a/assets/js/custom/FetchNotifications.js
+++ b/assets/js/custom/FetchNotifications.js
@@ -13,7 +13,7 @@ function FetchNotifications (countNotificationsUrl, maxAmountToFetch, refreshRat
       type: 'get',
       success: function (data) {
         for (const notificationType in data.count) {
-          const userNotificationBadge = $('.' + notificationType)
+          const userNotificationBadge = $('#sidebar-notifications .badge-pill.' + notificationType)
           const numOfNotifications = data.count[notificationType]
           if (numOfNotifications > 0) {
             const text = (numOfNotifications <= self.maxAmountToFetch)

--- a/assets/js/custom/Notifications.js
+++ b/assets/js/custom/Notifications.js
@@ -176,9 +176,9 @@ function Notification (newNotifications, oldNotifications, markAsReadUrl, markAl
       const fetchNotifications = new FetchNotifications(countNotificationsUrl, 99, 10000)
       fetchNotifications.run('markAsRead')
     } else {
-      const userNotificationBadge = $('.' + notificationType)
-      const userNotificationBadgeAll = $('.all-notifications')
-      const userNotificationBadgeDropdown = $('.all-notifications-dropdown')
+      const userNotificationBadge = $('#sidebar-notifications .badge-pill.' + notificationType)
+      const userNotificationBadgeAll = $('#notifications-dropdown-content .badge-pill.all-notifications')
+      const userNotificationBadgeDropdown = $('#notifications-dropdown-toggler .badge-pill')
       if (specificNotification === 'specificNotification') {
         self.updateBadgeNumberCurrentType(userNotificationBadgeAll, specificNotification)
         self.updateBadgeNumberCurrentType(userNotificationBadgeDropdown, specificNotification)
@@ -200,7 +200,7 @@ function Notification (newNotifications, oldNotifications, markAsReadUrl, markAl
         userNotificationBadge.hide()
       }
     } else {
-      const userNotificationBadgeSpecific = $('.' + notificationType)
+      const userNotificationBadgeSpecific = $('#sidebar-notifications .badge-pill.' + notificationType)
       userNotificationBadgeSpecific.load(location.href)
       let currentNumberSpecific = Number(userNotificationBadgeSpecific.text())
 

--- a/templates/Default/sidebar.html.twig
+++ b/templates/Default/sidebar.html.twig
@@ -15,72 +15,59 @@
     {% if app.user %}
 
 
-    <li class="nav-item">
-
-      <div>
+    <li class="nav-item" id="sidebar-notifications">
         <a id="notifications-dropdown-toggler" class="nav-link collapsible">
-          <i class="fas fa-bell mr-1"></i>
-          {{ "notifications"|trans({}, "catroweb") }}
-          <span
-              class="badge-pill badge-danger user-notification-badge all-notifications-dropdown user-notification-badge-font"></span>
-          <i id="notifications-dropdown-arrow" class="caret-icon fa fa-caret-left"></i>
+          <i class="link-icon fas fa-bell"></i>
+          <span class="text">{{ "notifications"|trans({}, "catroweb") }}</span>
+          <span class="badge-pill badge-danger all-notifications-dropdown"></span>
+          <i id="notifications-dropdown-arrow" class="fas fa-caret-left"></i>
         </a>
 
         <div id="notifications-dropdown-content" class="notifications-dropdown-content">
 
           <a class="nav-link" href="{{ path('user_notifications', { 'notification_type': "allNotifications" })}}" id="btn-notifications">
-            <i class="fas fa-bell mr-1"></i>
-            {{ "allNotifications"|trans({}, "catroweb") }}
-            <span
-                class="badge-pill badge-danger user-notification-badge-dropdown all-notifications user-notification-badge-font"></span>
+            <i class="link-icon fas fa-bell"></i>
+            <span class="text">{{ "allNotifications"|trans({}, "catroweb") }}</span>
+            <span class="badge-pill badge-danger all-notifications"></span>
           </a>
 
           <a class="nav-link" href="{{ path('user_notifications', { 'notification_type': "followers" }) }}" id="btn-followers">
 
-            <i class="fas fa-user"></i>
-            {{ "FollowersNotifications"|trans({}, "catroweb") }}
-            <span
-                class="badge-pill badge-danger user-notification-badge-dropdown followers user-notification-badge-font"></span>
+            <i class="link-icon fas fa-user"></i>
+            <span class="text">{{ "FollowersNotifications"|trans({}, "catroweb") }}</span>
+            <span class="badge-pill badge-danger followers"></span>
           </a>
 
           <a class="nav-link" href="{{ path('user_notifications', { 'notification_type': "likes" }) }}" id="btn-likes">
-            <i class="fas fa-thumbs-up"></i>
-            {{ "LikeNotifications"|trans({}, "catroweb") }}
-            <span
-                class="badge-pill badge-danger user-notification-badge-dropdown likes user-notification-badge-font"></span>
+            <i class="link-icon fas fa-thumbs-up"></i>
+            <span class="text">{{ "LikeNotifications"|trans({}, "catroweb") }}</span>
+            <span class="badge-pill badge-danger likes"></span>
           </a>
 
           <a class="nav-link" href="{{ path('user_notifications', { 'notification_type': "comments" }) }}" id="btn-comments">
-            <i class="fas fa-comments"></i>
-
-            {{ "CommentNotifications"|trans({}, "catroweb") }}
-            <span
-                class="badge-pill badge-danger user-notification-badge-dropdown comments user-notification-badge-font"></span>
+            <i class="link-icon fas fa-comments"></i>
+            <span class="text">{{ "CommentNotifications"|trans({}, "catroweb") }}</span>
+            <span class="badge-pill badge-danger comments"></span>
           </a>
           <a class="nav-link" href="{{ path('user_notifications', { 'notification_type': "remix" }) }}" id="btn-remix">
-            <i class="fab fa-r-project"></i>
-
-            {{ "RemixNotifications"|trans({}, "catroweb") }}
-            <span
-                class="badge-pill badge-danger user-notification-badge-dropdown remixes user-notification-badge-font"></span>
+            <i class="link-icon fab fa-r-project"></i>
+            <span class="text">{{ "RemixNotifications"|trans({}, "catroweb") }}</span>
+            <span class="badge-pill badge-danger remixes"></span>
           </a>
 
         </div>
-
-      </div>
-
       </li>
 
       <li class="nav-item">
         <a class="nav-link" href="{{ url('profile') }}" id="btn-profile">
-          <i class="fas fa-user-circle mr-1"></i>
+          <i class="link-icon fas fa-user-circle"></i>
           {{ 'menu.profile'|trans({}, "catroweb") }}
         </a>
       </li>
       {% if is_granted('ROLE_ADMIN') %}
         <li class="nav-item">
           <a class="nav-link" href="{{ url('sonata_admin_dashboard') }}" id="btn-admin">
-            <i class="fas fa-user-tie mr-1"></i>
+            <i class="link-icon fas fa-user-tie"></i>
             {{ 'menu.admin'|trans({}, "catroweb") }}
           </a>
         </li>
@@ -89,7 +76,7 @@
     {% else %} {# login #}
       <li class="nav-item">
         <a class="nav-link" href="{{ url('login') }}" id="btn-login">
-          <i class="fas fa-sign-in-alt mr-1"></i>
+          <i class="link-icon fas fa-sign-in-alt"></i>
           <span>{{ 'menu.login'|trans({}, "catroweb") }}</span>
         </a>
       </li>
@@ -98,7 +85,7 @@
     {# Always visible #}
     <li class="nav-item">
       <a class="nav-link" href="{{ url('catrobat_web_help') }}" id="btn-tutorials">
-        <i class="fas fa-hands-helping mr-1"></i>
+        <i class="link-icon fas fa-hands-helping"></i>
         <span>{{ 'menu.helpAndTutorials'|trans({}, "catroweb") }}</span>
       </a>
     </li>
@@ -107,7 +94,7 @@
     {% if app.user and app.session and not app.session.get('webview-auth') %}
       <li class="nav-item">
         <a class="nav-link" href="{{ url('logout') }}" id="btn-logout">
-          <i class="fas fa-sign-out-alt mr-1"></i>
+          <i class="link-icon fas fa-sign-out-alt"></i>
           {{ 'menu.logout'|trans({}, "catroweb") }}
         </a>
       </li>
@@ -118,49 +105,49 @@
     {# Programs #}
     <li id="nav-featured" class="nav-item">
       <a class="nav-link" href="{{ path('index') }}#featured" id="btn-featured">
-        <i class="fas fa-star mr-1"></i>
+        <i class="link-icon fas fa-star"></i>
         <span>{{ 'programs.featured'|trans({}, "catroweb") }}</span>
       </a>
     </li>
 
     <li id="nav-newest" class="nav-item" style="display:none">
       <a class="nav-link" href="{{ path('index') }}#newest" id="btn-newest">
-        <i class="fas fa-clock mr-1"></i>
+        <i class="link-icon fas fa-clock"></i>
         <span>{{ 'programs.newest'|trans({}, "catroweb") }}</span>
       </a>
     </li>
 
     <li id="nav-recommended" class="nav-item" style="display:none">
       <a class="nav-link" href="{{ path('index') }}#recommended" id="btn-recommended">
-        <i class="fas fa-thumbs-up mr-1"></i>
+        <i class="link-icon fas fa-thumbs-up"></i>
         <span>{{ 'programs.recommended'|trans({}, "catroweb") }}</span>
       </a>
     </li>
 
     <li id="nav-scratch-remixes" class="nav-item" style="display:none">
       <a class="nav-link" href="{{ path('index') }}#scratchRemixes" id="btn-recommended">
-        <i class="fab fa-r-project"></i>
+        <i class="link-icon fab fa-r-project"></i>
         <span>{{ 'programs.scratchremixes'|trans({}, "catroweb") }}</span>
       </a>
     </li>
 
     <li id="nav-most-downloaded" class="nav-item" style="display:none">
       <a class="nav-link" href="{{ path('index') }}#mostDownloaded" id="btn-most-downloaded">
-        <i class="fas fa-download mr-1"></i>
+        <i class="link-icon fas fa-download"></i>
         <span>{{ 'programs.most.downloaded'|trans({}, "catroweb") }}</span>
       </a>
     </li>
 
     <li id="nav-most-viewed" class="nav-item" style="display:none">
       <a class="nav-link" href="{{ path('index') }}#mostViewed" id="btn-most-viewed">
-        <i class="fas fa-eye mr-1"></i>
+        <i class="link-icon fas fa-eye"></i>
         <span>{{ 'programs.most.viewed'|trans({}, "catroweb") }}</span>
       </a>
     </li>
 
     <li id="nav-random" class="nav-item" style="display:none">
       <a class="nav-link" href="{{ path('index') }}#random" id="btn-random">
-        <i class="fas fa-dice mr-1"></i>
+        <i class="link-icon fas fa-dice"></i>
         <span>{{ 'programs.random'|trans({}, "catroweb") }}</span>
       </a>
     </li>

--- a/tests/behat/features/web/project/project_reactions.feature
+++ b/tests/behat/features/web/project/project_reactions.feature
@@ -334,8 +334,8 @@ Feature: Reactions to projects "likes"
     And I wait for AJAX to finish
     When I log in as "Catrobat"
     And I open the menu
-    Then the element "#project-navigation .user-notification-badge" should be visible
-    And the "#project-navigation .user-notification-badge" element should contain "1"
+    Then the element "#project-navigation #notifications-dropdown-toggler .badge-pill" should be visible
+    And the "#project-navigation #notifications-dropdown-toggler .badge-pill" element should contain "1"
     When I am on "/app/notifications/likes"
     And I wait for the page to be loaded
     Then I should see 1 "#new-notifications-container .notification-container"
@@ -356,8 +356,8 @@ Feature: Reactions to projects "likes"
     And I wait for AJAX to finish
     When I log in as "Catrobat"
     And I open the menu
-    Then the element "#project-navigation .user-notification-badge" should be visible
-    And the "#project-navigation .user-notification-badge" element should contain "2"
+    Then the element "#project-navigation #notifications-dropdown-toggler .badge-pill" should be visible
+    And the "#project-navigation #notifications-dropdown-toggler .badge-pill" element should contain "2"
     When I am on "/app/notifications/likes"
     And I wait for the page to be loaded
     Then I should see 2 "#new-notifications-container .notification-container"


### PR DESCRIPTION
 * Fix alignment of sidebar menu items: text/icon
 * Fix notifications dropdown:
   - icon/badge alignment
   - text word-break
   - cropped text (max-height)
   - HTML cleanup
 * Add fontawesome brand icons

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
![Screenshot_20200426-214456_Chrome](https://user-images.githubusercontent.com/19662531/80319417-a00f7800-87ff-11ea-8545-1bb84cafa6df.png)
![Screenshot_20200426-214502_Chrome](https://user-images.githubusercontent.com/19662531/80319418-a0a80e80-87ff-11ea-80a3-ff4c92ab6f0e.png)

