### PR TITLE
SHARE-290 Reset command crash

### DIFF
--- a/src/Catrobat/Commands/CreateRemixCommand.php
+++ b/src/Catrobat/Commands/CreateRemixCommand.php
@@ -55,9 +55,15 @@ class CreateRemixCommand extends Command
     $original_program_name = $input->getArgument('program_original');
     $remix_program_name = $input->getArgument('program_remix');
 
+    if ($original_program_name === $remix_program_name)
+    {
+      return -1;
+    }
+
     $program_original = $this->remix_manipulation_program_manager->findOneByName($original_program_name);
     $program_remix = $this->remix_manipulation_program_manager->findOneByName($remix_program_name);
-    if ($original_program_name === $remix_program_name)
+
+    if (null == $program_original || null == $program_remix)
     {
       return -1;
     }
@@ -66,8 +72,7 @@ class CreateRemixCommand extends Command
     $program_remixes_of_original[0] = $remix_data_of_original;
     $notification = new RemixNotification($program_original->getUser(), $program_remix->getUser(), $program_original, $program_remix);
     $this->notification_service->addNotification($notification);
-
-    if (null == $program_original || 0 == sizeof($program_remixes_of_original))
+    if (0 == sizeof($program_remixes_of_original))
     {
       return -1;
     }


### PR DESCRIPTION
Problem occured when no program could be found. after querying the programs I test the programs for null. If so, it returns -1 and don't remix. Error should not happen anymore.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
