### PR TITLE
SHARE-266 Close Sidebar on Browser Back

### DIFF
--- a/assets/js/base/Main.js
+++ b/assets/js/base/Main.js
@@ -32,6 +32,10 @@ const Main = function () {
   // ----SideBar
   let sidebar, sidebarToggleBtn
   const fnCloseSidebar = function () {
+    window.history.back() // to remove pushed state
+  }
+  const fnCloseSidebarInternal = function () {
+    $(window).off('popstate', fnCloseSidebarInternal)
     sidebar.removeClass('active')
     sidebarToggleBtn.attr('aria-expanded', false)
   }
@@ -43,6 +47,8 @@ const Main = function () {
   const fnOpenSidebar = function () {
     sidebar.addClass('active')
     sidebarToggleBtn.attr('aria-expanded', true)
+    window.history.pushState('sidebar-open', null, '')
+    $(window).on('popstate', fnCloseSidebarInternal)
   }
   const fnOpenSidebarDesktop = function () {
     sidebar.removeClass('inactive')
@@ -96,7 +102,7 @@ const Main = function () {
 
     const touchThreshold = 25 // area where touch is possible
 
-    function refrehSidebar () {
+    function refreshSidebar () {
       const left = (curX >= sidebarWidth) ? 0 : curX - sidebarWidth
       sidebar.css('transition', 'none').css('left', left)
       if (!desktop) {
@@ -129,7 +135,7 @@ const Main = function () {
             startY = touch.pageY
             startTime = Date.now()
             opening = true
-            refrehSidebar()
+            refreshSidebar()
           }
         }
       }
@@ -145,12 +151,12 @@ const Main = function () {
           const xDiff = Math.abs(curX - startX)
 
           if (xDiff > yDiff * 1.25) {
-            refrehSidebar()
+            refreshSidebar()
           } else {
             reset()
           }
         } else {
-          refrehSidebar()
+          refreshSidebar()
         }
       }
     })

--- a/tests/behat/features/web/general/sidebar.feature
+++ b/tests/behat/features/web/general/sidebar.feature
@@ -1,0 +1,29 @@
+@homepage
+Feature: Sidebar Navigation
+
+  Scenario: Button opens and closes sidebar
+    Given I am on the homepage
+    Then the element "#sidebar" should not be visible
+    And the element "#sidebar-overlay" should not be visible
+    When I click "#top-app-bar__btn-sidebar-toggle"
+    Then the url should match "/app/$"
+    And the element "#sidebar" should be visible
+    And the element "#sidebar-overlay" should be visible
+    When I click "#top-app-bar__btn-sidebar-toggle"
+    Then the url should match "/app/$"
+    And the element "#sidebar" should not be visible
+    And the element "#sidebar-overlay" should not be visible
+
+  Scenario: Back button closes sidebar
+    Given I am on the homepage
+    And I open the menu
+    And I click "#btn-tutorials"
+    And I click "#top-app-bar__btn-sidebar-toggle"
+    Then the url should match "/app/help$"
+    And the element "#sidebar" should be visible
+    And the element "#sidebar-overlay" should be visible
+    When I click browser's back button
+    Then the url should match "/app/help$"
+    And the element "#sidebar" should not be visible
+    And the element "#sidebar-overlay" should not be visible
+    And I should see "Game Design"


### PR DESCRIPTION
Close the sidebar when the user navigates back
(e.g. browser back button or Android back)

Unfortunately, this is only possible if a user action happened, and swiping is no user action. So if opening the menu using the swipe gesture is the first action, back button can not close it. See https://stackoverflow.com/a/57298299.

Add two simple behat tests (one general sidebar open/close, one back button)

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional
Jenkins Build: https://jenkins.catrob.at/job/Catroid/job/develop/13/
