### PR TITLE
SHARE-35 Status Codes Misleading

### DIFF
--- a/src/Api/MediaLibraryApi.php
+++ b/src/Api/MediaLibraryApi.php
@@ -12,6 +12,7 @@ use OpenAPI\Server\Model\MediaFile;
 use OpenAPI\Server\Model\MediaFiles;
 use OpenAPI\Server\Model\Package;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -39,7 +40,7 @@ class MediaLibraryApi implements MediaLibraryApiInterface
   public function mediaFileSearchGet(string $query_string, ?string $flavor = null, ?int $limit = 20, ?int $offset = 0, ?string $package_name = null, &$responseCode, array &$responseHeaders)
   {
     $json_response_array = [];
-    $responseCode = 200; // 200 => OK
+    $responseCode = Response::HTTP_OK; // 200 => OK
 
     $found_media_files = $this->mediapackage_file_repository->search($query_string, $flavor, $package_name, $limit, $offset);
 
@@ -87,7 +88,7 @@ class MediaLibraryApi implements MediaLibraryApiInterface
 
     if (null === $media_package)
     {
-      $responseCode = 404; // => Not found
+      $responseCode = Response::HTTP_NOT_FOUND; // => Not found
       return null;
     }
 

--- a/src/Api/ProjectsApi.php
+++ b/src/Api/ProjectsApi.php
@@ -156,7 +156,7 @@ class ProjectsApi extends AbstractController implements ProjectsApiInterface
     // File uploaded successful?
     if (!$file->isValid())
     {
-      $responseCode = 422; // 422 => UploadError
+      $responseCode = Response::HTTP_UNPROCESSABLE_ENTITY; // 422 => UploadError
       return new UploadError(['error' => $this->translator->trans('api.projectsPost.upload_error', [], 'catroweb')]);
     }
 
@@ -165,7 +165,7 @@ class ProjectsApi extends AbstractController implements ProjectsApiInterface
 
     if (strtolower($calculated_checksum) != strtolower($checksum))
     {
-      $responseCode = 422; // 422 => UploadError
+      $responseCode = Response::HTTP_UNPROCESSABLE_ENTITY; // 422 => UploadError
       return new UploadError(['error' => $this->translator->trans('api.projectsPost.invalid_checksum', [], 'catroweb')]);
     }
 
@@ -187,7 +187,7 @@ class ProjectsApi extends AbstractController implements ProjectsApiInterface
     }
     catch (Exception $e)
     {
-      $responseCode = 422; // 422 => UploadError
+      $responseCode = Response::HTTP_UNPROCESSABLE_ENTITY; // 422 => UploadError
       return new UploadError(['error' => $this->translator->trans('api.projectsPost.creating_error', [], 'catroweb')]);
     }
 
@@ -199,7 +199,7 @@ class ProjectsApi extends AbstractController implements ProjectsApiInterface
     }
 
     // Since we have come this far, the project upload is completed
-    $responseCode = 201; // 201 => Successful upload
+    $responseCode = Response::HTTP_CREATED; // 201 => Successful upload
     $responseHeaders['Location'] = $this->url_generator->generate(
       'program',
       [

--- a/src/Api/UserApi.php
+++ b/src/Api/UserApi.php
@@ -8,6 +8,7 @@ use App\Entity\UserManager;
 use OpenAPI\Server\Api\UserApiInterface;
 use OpenAPI\Server\Model\Register;
 use OpenAPI\Server\Model\ValidationSchema;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -50,12 +51,12 @@ class UserApi implements UserApiInterface
 
     if ($validation_schema->getEmail() || $validation_schema->getUsername() || $validation_schema->getPassword())
     {
-      $responseCode = 422; // 422 => Unprocessable entity
+      $responseCode = Response::HTTP_UNPROCESSABLE_ENTITY; // 422 => Unprocessable entity
       return $validation_schema;
     }
     if ($register->isDryRun())
     {
-      $responseCode = 204; // 204 => Dry-run successful, no validation error
+      $responseCode = Response::HTTP_NO_CONTENT; // 204 => Dry-run successful, no validation error
     }
     else
     {

--- a/src/Catrobat/Controller/Api/MediaPackageController.php
+++ b/src/Catrobat/Controller/Api/MediaPackageController.php
@@ -81,7 +81,7 @@ class MediaPackageController extends AbstractController
     }
 
     return JsonResponse::create([
-      'statusCode' => StatusCode::OK,
+      'statusCode' => Response::HTTP_OK,
       'data' => $json_response_array,
     ]
     );
@@ -130,7 +130,7 @@ class MediaPackageController extends AbstractController
     }
 
     return JsonResponse::create([
-      'statusCode' => StatusCode::OK,
+      'statusCode' => Response::HTTP_OK,
       'data' => $json_response_array,
     ]
     );

--- a/src/Catrobat/Controller/Api/ReportController.php
+++ b/src/Catrobat/Controller/Api/ReportController.php
@@ -73,7 +73,7 @@ class ReportController extends AbstractController
     {
       $response = [];
       $response['answer'] = $this->translator->trans('success.report', [], 'catroweb');
-      $response['statusCode'] = StatusCode::OK;
+      $response['statusCode'] = Response::HTTP_OK;
 
       return JsonResponse::create($response);
     }
@@ -114,7 +114,7 @@ class ReportController extends AbstractController
 
     $response = [];
     $response['answer'] = $this->translator->trans('success.report', [], 'catroweb');
-    $response['statusCode'] = StatusCode::OK;
+    $response['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($response);
   }

--- a/src/Catrobat/Controller/Api/SecurityController.php
+++ b/src/Catrobat/Controller/Api/SecurityController.php
@@ -14,6 +14,7 @@ use Exception;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -37,7 +38,7 @@ class SecurityController extends AbstractController
   public function checkTokenAction(TranslatorInterface $translator): JsonResponse
   {
     return JsonResponse::create([
-      'statusCode' => StatusCode::OK,
+      'statusCode' => Response::HTTP_OK,
       'answer' => $translator->trans('success.token', [], 'catroweb'),
       'preHeaderMessages' => "  \n",
     ]);
@@ -161,7 +162,7 @@ class SecurityController extends AbstractController
         $dd = null;
         if ($correct_pass)
         {
-          $retArray['statusCode'] = StatusCode::OK;
+          $retArray['statusCode'] = Response::HTTP_OK;
           $user->setUploadToken($token_generator->generateToken());
           $retArray['token'] = $user->getUploadToken();
           $retArray['email'] = $user->getEmail();

--- a/src/Catrobat/Controller/Api/UploadController.php
+++ b/src/Catrobat/Controller/Api/UploadController.php
@@ -22,6 +22,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -187,7 +188,7 @@ class UploadController
     $this->user_manager->updateUser($user);
 
     $response['projectId'] = $program->getId();
-    $response['statusCode'] = StatusCode::OK;
+    $response['statusCode'] = Response::HTTP_OK;
     $response['answer'] = $this->trans('success.upload');
     $response['token'] = $user->getUploadToken();
     if (null !== $game_jam && !$program->isAcceptedForGameJam())

--- a/src/Catrobat/Controller/Web/CommentsController.php
+++ b/src/Catrobat/Controller/Web/CommentsController.php
@@ -39,7 +39,7 @@ class CommentsController extends AbstractController
     $comment->setIsReported(true);
     $em->flush();
 
-    return new Response(StatusCode::OK);
+    return new Response(Response::HTTP_OK);
   }
 
   /**
@@ -71,7 +71,7 @@ class CommentsController extends AbstractController
     $em->remove($comment);
     $em->flush();
 
-    return new Response(StatusCode::OK);
+    return new Response(Response::HTTP_OK);
   }
 
   /**
@@ -116,6 +116,6 @@ class CommentsController extends AbstractController
       $em->flush();
     }
 
-    return new Response(StatusCode::OK);
+    return new Response(Response::HTTP_OK);
   }
 }

--- a/src/Catrobat/Controller/Web/ProfileController.php
+++ b/src/Catrobat/Controller/Web/ProfileController.php
@@ -139,7 +139,7 @@ class ProfileController extends AbstractController
     $user_manager->updateUser($user);
 
     return JsonResponse::create([
-      'statusCode' => StatusCode::OK,
+      'statusCode' => Response::HTTP_OK,
     ]);
   }
 
@@ -190,7 +190,7 @@ class ProfileController extends AbstractController
     $user_manager->updateUser($user);
 
     return JsonResponse::create([
-      'statusCode' => StatusCode::OK,
+      'statusCode' => Response::HTTP_OK,
       'saved_password' => 'supertoll',
     ]);
   }
@@ -266,7 +266,7 @@ class ProfileController extends AbstractController
     $user_manager->updateUser($user);
 
     return JsonResponse::create([
-      'statusCode' => StatusCode::OK,
+      'statusCode' => Response::HTTP_OK,
     ]);
   }
 
@@ -311,7 +311,7 @@ class ProfileController extends AbstractController
     $user_manager->updateUser($user);
 
     return JsonResponse::create([
-      'statusCode' => StatusCode::OK,
+      'statusCode' => Response::HTTP_OK,
     ]);
   }
 
@@ -342,7 +342,7 @@ class ProfileController extends AbstractController
     $user_manager->updateUser($user);
 
     return JsonResponse::create([
-      'statusCode' => StatusCode::OK,
+      'statusCode' => Response::HTTP_OK,
       'image_base64' => $image_base64,
     ]);
   }
@@ -367,7 +367,7 @@ class ProfileController extends AbstractController
     $em->flush();
 
     return JsonResponse::create([
-      'statusCode' => StatusCode::OK,
+      'statusCode' => Response::HTTP_OK,
       'count' => count($user_comments),
     ]);
   }

--- a/src/Catrobat/Controller/Web/ProgramController.php
+++ b/src/Catrobat/Controller/Web/ProgramController.php
@@ -480,7 +480,7 @@ class ProgramController extends AbstractController
     $em->persist($program);
     $em->flush();
 
-    return JsonResponse::create(['statusCode' => StatusCode::OK]);
+    return JsonResponse::create(['statusCode' => Response::HTTP_OK]);
   }
 
   /**
@@ -529,7 +529,7 @@ class ProgramController extends AbstractController
     $em->persist($program);
     $em->flush();
 
-    return JsonResponse::create(['statusCode' => StatusCode::OK]);
+    return JsonResponse::create(['statusCode' => Response::HTTP_OK]);
   }
 
   /**
@@ -569,7 +569,7 @@ class ProgramController extends AbstractController
     $this->screenshot_repository->updateProgramAssets($image, $id);
 
     return JsonResponse::create([
-      'statusCode' => StatusCode::OK,
+      'statusCode' => Response::HTTP_OK,
       'image_base64' => null,
     ]);
   }

--- a/src/Catrobat/Listeners/NameValidator.php
+++ b/src/Catrobat/Listeners/NameValidator.php
@@ -8,9 +8,9 @@ use App\Catrobat\Exceptions\Upload\NameTooLongException;
 use App\Catrobat\Exceptions\Upload\RudewordInNameException;
 use App\Catrobat\Services\ExtractedCatrobatFile;
 use App\Catrobat\Services\RudeWordFilter;
-use App\Catrobat\StatusCode;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
+use Symfony\Component\HttpFoundation\Response;
 
 class NameValidator
 {
@@ -40,7 +40,7 @@ class NameValidator
     {
       throw new MissingProgramNameException();
     }
-    if (strlen($file->getName()) > StatusCode::OK)
+    if (strlen($file->getName()) > Response::HTTP_OK)
     {
       throw new NameTooLongException();
     }

--- a/src/Catrobat/Listeners/VersionValidator.php
+++ b/src/Catrobat/Listeners/VersionValidator.php
@@ -6,8 +6,8 @@ use App\Catrobat\Events\ProgramBeforeInsertEvent;
 use App\Catrobat\Exceptions\InvalidCatrobatFileException;
 use App\Catrobat\Exceptions\Upload\OldApplicationVersionException;
 use App\Catrobat\Exceptions\Upload\OldCatrobatLanguageVersionException;
-use App\Catrobat\StatusCode;
 use SimpleXMLElement;
+use Symfony\Component\HttpFoundation\Response;
 
 class VersionValidator
 {
@@ -65,7 +65,7 @@ class VersionValidator
         }
         break;
       default:
-        throw new InvalidCatrobatFileException('unsupported platform', StatusCode::INTERNAL_SERVER_ERROR);
+        throw new InvalidCatrobatFileException('unsupported platform', Response::HTTP_INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/src/Catrobat/Services/OAuthService.php
+++ b/src/Catrobat/Services/OAuthService.php
@@ -86,7 +86,7 @@ class OAuthService
     }
 
     $retArray['is_oauth_user'] = $user && $user->getGplusUid();
-    $retArray['statusCode'] = StatusCode::OK;
+    $retArray['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($retArray);
   }
@@ -111,7 +111,7 @@ class OAuthService
     {
       $retArray['email_available'] = false;
     }
-    $retArray['statusCode'] = StatusCode::OK;
+    $retArray['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($retArray);
   }
@@ -130,7 +130,7 @@ class OAuthService
     ]);
 
     $retArray['username_available'] = (bool) $user;
-    $retArray['statusCode'] = StatusCode::OK;
+    $retArray['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($retArray);
   }
@@ -157,7 +157,7 @@ class OAuthService
     {
       $retArray['token_available'] = false;
     }
-    $retArray['statusCode'] = StatusCode::OK;
+    $retArray['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($retArray);
   }
@@ -364,7 +364,7 @@ class OAuthService
   {
     $retArray = [];
     $retArray['deleted'] = 'deprecated';
-    $retArray['statusCode'] = StatusCode::OK;
+    $retArray['statusCode'] = Response::HTTP_OK;
 
     return JsonResponse::create($retArray);
   }
@@ -485,6 +485,11 @@ class OAuthService
     $client->refreshToken($refresh_token);
 
     return $client;
+  }
+
+  private function setLoginOAuthUserStatusCode(array $retArray): void
+  {
+    $retArray['statusCode'] = Response::HTTP_OK;
   }
 
   /**

--- a/src/Catrobat/StatusCode.php
+++ b/src/Catrobat/StatusCode.php
@@ -2,24 +2,19 @@
 
 namespace App\Catrobat;
 
+use Symfony\Component\HttpFoundation\Response;
+
 class StatusCode
 {
   /**
    * @var int
    */
-  const OK = 200;
-  /**
-   * @var int
-   */
-  const INTERNAL_SERVER_ERROR = 500;
+  const UPLOAD_EXCEEDING_FILESIZE = Response::HTTP_REQUEST_ENTITY_TOO_LARGE;
   /**
    * @var int
    */
   const MISSING_POST_DATA = 501;
-  /**
-   * @var int
-   */
-  const UPLOAD_EXCEEDING_FILESIZE = 502;
+
   /**
    * @var int
    */
@@ -67,31 +62,8 @@ class StatusCode
   /**
    * @var int
    */
-  const RUDE_WORD_IN_CREDITS = 813;
-  /**
-   * @var int
-   */
-  const UPLOAD_UNSUPPORTED_MIME_TYPE = 516;
-  /**
-   * @var int
-   */
-  const UPLOAD_UNSUPPORTED_FILE_TYPE = 517;
-  /**
-   * @var int
-   */
-  const OLD_CATROBAT_LANGUAGE = 518;
-  /**
-   * @var int
-   */
-  const OLD_APPLICATION_VERSION = 519;
-  /**
-   * @var int
-   */
-  const INVALID_PARAM = 520;
-  /**
-   * @var int
-   */
   const FILE_UPLOAD_FAILED = 521;
+
   /**
    * @var int
    */
@@ -100,6 +72,16 @@ class StatusCode
    * @var int
    */
   const MEDIA_LIB_PACKAGE_NOT_FOUND = 523;
+
+  /**
+   * @var int
+   */
+  const OLD_CATROBAT_LANGUAGE = 518;
+  /**
+   * @var int
+   */
+  const OLD_APPLICATION_VERSION = 519;
+
   /**
    * @var int
    */
@@ -108,55 +90,50 @@ class StatusCode
    * @var int
    */
   const DESCRIPTION_TOO_LONG = 527;
+  const INVALID_FILE_UPLOAD = 528; //705; //upload failed but program still in DB
+
+  const LOGIN_ERROR = 601;
+
+  const RUDE_WORD_IN_CREDITS = Response::HTTP_UNPROCESSABLE_ENTITY;
+  const INVALID_PARAM = Response::HTTP_UNPROCESSABLE_ENTITY;
+
   /**
    * @var int
    */
-  const INVALID_FILE_UPLOAD = 528;  // upload failed but program still in DB
-  const NOT_MY_PROGRAM = 529;
-  const NO_ADMIN_RIGHTS = 530;
-  const NOT_LOGGED_IN = 531;
-  const PASSWORD_INVALID = 532;
-  const CREDITS_TO_LONG = 833;
+  const UPLOAD_UNSUPPORTED_MIME_TYPE = Response::HTTP_UNSUPPORTED_MEDIA_TYPE;
+  /**
+   * @var int
+   */
+  const UPLOAD_UNSUPPORTED_FILE_TYPE = Response::HTTP_UNSUPPORTED_MEDIA_TYPE;
 
-  const CSRF_FAILURE = 590;
+  const NO_ADMIN_RIGHTS = Response::HTTP_FORBIDDEN;
 
-  const LOGIN_ERROR = 601;
-  const REGISTRATION_ERROR = 602;
+  const NOT_LOGGED_IN = Response::HTTP_UNAUTHORIZED;
+  const PASSWORD_INVALID = Response::HTTP_UNAUTHORIZED;
 
-  const USER_PASSWORD_MISSING = 751;
-  const USER_USERNAME_PASSWORD_EQUAL = 752;
-  const USER_PASSWORD_TOO_SHORT = 753;
-  const USER_PASSWORD_TOO_LONG = 754;
-  const USER_NEW_PASSWORD_BOARD_UPDATE_FAILED = 755;
-  const USER_UPDATE_EMAIL_FAILED = 756;
+  const REGISTRATION_ERROR = Response::HTTP_UNAUTHORIZED;
+
   const USER_ADD_EMAIL_EXISTS = 757;
-  const USER_UPDATE_CITY_FAILED = 758;
-  const USER_UPDATE_COUNTRY_FAILED = 759;
-  const USER_UPDATE_GENDER_FAILED = 760;
-  const USER_UPDATE_BIRTHDAY_FAILED = 761;
-  const USER_USERNAME_MISSING = 762;
-  const USER_USERNAME_INVALID_CHARACTER = 763;
-  const USER_USERNAME_INVALID = 764;
-  const USER_EMAIL_INVALID = 765;
-  const USER_COUNTRY_INVALID = 766;
-  const USER_REGISTRATION_FAILED = 767;
-  const USER_UPDATE_LANGUAGE_FAILED = 768;
-  const USER_POST_DATA_MISSING = 769;
-  const USER_RECOVERY_NOT_FOUND = 770;
-  const USER_RECOVERY_HASH_CREATION_FAILED = 771;
-  const USER_RECOVERY_EXPIRED = 772;
-  const USER_AVATER_CREATION_FAILED = 773;
-  const USER_PASSWORD_NOT_EQUAL_PASSWORD2 = 774;
-  const USER_NAME_IS_EMAIL_ADDRESS = 775;
-  const USER_AVATAR_UPLOAD_ERROR = 776;
   const USER_ADD_USERNAME_EXISTS = 777;
-  const USER_EMAIL_MISSING = 778;
-  const USER_EMAIL_ALREADY_EXISTS = 779;
-  const USERNAME_MISSING = 800;
-  const USERNAME_ALREADY_EXISTS = 801;
-  const USERNAME_INVALID = 802;
+
+  const CSRF_FAILURE = 706;
+  const CREDITS_TO_LONG = 707;
+
+  //8xx
+  const USER_COUNTRY_INVALID = 801;
+  const USER_PASSWORD_NOT_EQUAL_PASSWORD2 = 802;
   const USERNAME_NOT_FOUND = 803;
-  const USERNAME_CONTAINS_EMAIL = 804;
+  const USERNAME_INVALID = 804;
+  const USER_PASSWORD_TOO_SHORT = 753;
+  const USER_PASSWORD_TOO_LONG = 806;
+  const USER_EMAIL_INVALID = 765;
+  const USER_EMAIL_MISSING = 808;
+  const USERNAME_CONTAINS_EMAIL = 809;
+  const USER_EMAIL_ALREADY_EXISTS = 810;
+  const USERNAME_MISSING = 811;
+  const USERNAME_ALREADY_EXISTS = 812;
+  const USER_USERNAME_PASSWORD_EQUAL = 813;
+  const USER_AVATAR_UPLOAD_ERROR = 814;
 
   const NO_GAME_JAM = 900;
 }

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -450,7 +450,7 @@
   <script>
     setImageUploadListener('{{ path('upload_project_thumbnail', { 'id': program.id }) }}',
       '#change-project-thumbnail-button', '#project-thumbnail-big',
-        {{ constant('App\\Catrobat\\StatusCode::OK') }},
+        {{ constant('Symfony\\Component\\HttpFoundation\\Response::HTTP_OK') }},
         {{ constant('App\\Catrobat\\StatusCode::UPLOAD_EXCEEDING_FILESIZE') }},
         {{ constant('App\\Catrobat\\StatusCode::UPLOAD_UNSUPPORTED_MIME_TYPE') }}
     )
@@ -470,7 +470,7 @@
       '{{ "programs.reportRadioButtonCopyright"     |trans({}, "catroweb") }}',
       '{{ "programs.reportRadioButtonSpam"          |trans({}, "catroweb") }}',
       '{{ "programs.reportRadioButtonDislike"       |trans({}, "catroweb") }}',
-        {{ constant('App\\Catrobat\\StatusCode::OK') }},
+        {{ constant('Symfony\\Component\\HttpFoundation\\Response::HTTP_OK') }},
         {{ logged_in }}
     )
   </script>
@@ -490,7 +490,7 @@
       "{{ 'programs.deleted_popup'                  |trans({}, 'catroweb') }}",
       "{{ 'programs.noAdminRights'                  |trans({}, 'catroweb') }}",
       "{{ 'somethingWentWrong'                      |trans({}, 'catroweb') }}",
-      "{{ constant('App\\Catrobat\\StatusCode::OK') }}",
+      "{{ constant('Symfony\\Component\\HttpFoundation\\Response::HTTP_OK') }}",
       "{{ constant('App\\Catrobat\\StatusCode::NOT_LOGGED_IN') }}",
       "{{ constant('App\\Catrobat\\StatusCode::NO_ADMIN_RIGHTS') }}"
     )
@@ -500,7 +500,7 @@
     new ProgramDescription('{{ program.id }}',
       '{{ ("show-more")                             |trans({}, "catroweb") }}',
       '{{ ("show-less")                             |trans({}, "catroweb") }}',
-        {{ constant('App\\Catrobat\\StatusCode::OK') }},
+        {{ constant('Symfony\\Component\\HttpFoundation\\Response::HTTP_OK') }},
         {{ constant('App\\Catrobat\\StatusCode::DESCRIPTION_TOO_LONG') }},
         {{ constant('App\\Catrobat\\StatusCode::RUDE_WORD_IN_DESCRIPTION') }}
     )
@@ -511,7 +511,7 @@
     new ProgramCredits('{{ program.id }}',
       '{{ ("show-more")                             |trans({}, "catroweb") }}',
       '{{ ("show-less")                             |trans({}, "catroweb") }}',
-        {{ constant('App\\Catrobat\\StatusCode::OK') }},
+        {{ constant('Symfony\\Component\\HttpFoundation\\Response::HTTP_OK') }},
         {{ constant('App\\Catrobat\\StatusCode::CREDITS_TO_LONG') }},
         {{ constant('App\\Catrobat\\StatusCode::RUDE_WORD_IN_CREDITS') }}
     )

--- a/templates/UserManagement/Profile/myProfile.html.twig
+++ b/templates/UserManagement/Profile/myProfile.html.twig
@@ -37,7 +37,7 @@
         '{{ path('profile_delete_program') }}', '{{ path('profile_delete_account') }}',
         '{{ path('profile_toggle_program_visibility') }}',
         '{{ path('profile_upload_avatar') }}',
-        {{ constant('App\\Catrobat\\StatusCode::OK') }},
+        {{ constant('Symfony\\Component\\HttpFoundation\\Response::HTTP_OK') }},
         {{ constant('App\\Catrobat\\StatusCode::USERNAME_ALREADY_EXISTS') }},
         {{ constant('App\\Catrobat\\StatusCode::USERNAME_MISSING') }},
         {{ constant('App\\Catrobat\\StatusCode::USERNAME_INVALID') }},
@@ -67,7 +67,7 @@
   <script>
     setImageUploadListener('{{ path('profile_upload_avatar') }}',
       '#avatar-upload', '#avatar-img',
-        {{ constant('App\\Catrobat\\StatusCode::OK') }},
+        {{ constant('Symfony\\Component\\HttpFoundation\\Response::HTTP_OK') }},
         {{ constant('App\\Catrobat\\StatusCode::UPLOAD_EXCEEDING_FILESIZE') }},
         {{ constant('App\\Catrobat\\StatusCode::UPLOAD_UNSUPPORTED_MIME_TYPE') }}
     )


### PR DESCRIPTION
-Changed status codes that were overriding http status codes
-Changed some custom status codes to http status codes that describe best the cases where status codes were used
-Moved other staus codes to 7xx or 8xx space
-Deleted unused status codes

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
