### PR TITLE
SHARE-313 Docker Ubuntu 20.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ COPY package.json package-lock.json ./
 RUN npm install && npm install grunt
 
 # Run on:
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
@@ -36,16 +36,16 @@ RUN apt-get update && \
     apache2 \
     php-imagick \
     php-mbstring \
-    php-gettext \
+    gettext \
     git \
     curl \
     php-xdebug \
     libgconf-2-4 \
-    grunt \
-    npm && \
-    npm install -g n && \
-    n stable && \
-    npm install -g sass
+    npm
+RUN npm install -g n
+RUN n stable && \
+    npm install -g sass && \
+    npm install -g grunt-cli
 
 # Overwrite default apache config
 COPY /docker/apache/catroweb.conf /etc/apache2/sites-available/catroweb.conf


### PR DESCRIPTION
Bumped the ubuntu version for docker to 20.04
Replaced php-gettext package with gettext (php-gettext package not yet in Ubuntu 20.04)
Install grunt-cli with npm (dependency problems with apt)
Split install of n and execution of n into two RUN (error with only one RUN)
---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no warnings and errors 
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [ ] Perform a self-review of the changes
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
