### PR TITLE
SHARE-316 Debian Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,13 +10,16 @@ COPY package.json package-lock.json ./
 RUN npm install && npm install grunt
 
 # Run on:
-FROM ubuntu:18.04
+FROM debian:buster
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
 RUN apt-get update && \
+    apt-get install -yq --no-install-recommends wget apt-transport-https lsb-release ca-certificates && \
+    wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
+    echo "deb https://packages.sury.org/php/ buster main" >> /etc/apt/sources.list.d/php.list && \
+    apt-get update && \
     apt-get install -yq --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:ondrej/php && \
     apt-get install -yq --no-install-recommends \
     php7.4-common \
     php7.4-cli \
@@ -41,10 +44,10 @@ RUN apt-get update && \
     curl \
     php-xdebug \
     libgconf-2-4 \
-    grunt \
-    npm && \
-    npm install -g n && \
-    n stable && \
+    npm
+RUN npm install -g n
+RUN n stable && \
+    npm install -g grunt-cli && \
     npm install -g sass
 
 # Overwrite default apache config


### PR DESCRIPTION
Replaced Ubuntu 18.04 in the Dockerfile with Debian 10.

Install grunt-cli with npm (dependency problems with apt)
Split install of n and execution of n into two RUN (error with only one RUN)

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
