### PR TITLE
SHARE-311 Caching Mutable Assets

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -9,4 +9,4 @@ framework:
   session:         ~
   fragments:       ~
   assets:
-    version: '%env(string:APP_VERSION)%'
+    version_strategy: 'catrobat.versioning'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -498,6 +498,12 @@ services:
     tags:
       - { name: kernel.event_listener, event: kernel.terminate, method: onTerminateEvent }
 
+  # ======== Versioning ========
+
+  catrobat.versioning:
+    class: App\Utils\VersionStrategy
+    arguments:
+      - '%env(string:APP_VERSION)%'
 
   # ====================================================================================================================
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/Api/ProjectsApi.php
+++ b/src/Api/ProjectsApi.php
@@ -103,7 +103,7 @@ class ProjectsApi extends AbstractController implements ProjectsApiInterface
         'id' => $featured_program->getId(),
         'name' => $featured_program->getProgram()->getName(),
         'author' => $featured_program->getProgram()->getUser()->getUsername(),
-        'featured_image' => $this->featured_image_repository->getAbsoluteWWebPath($featured_program->getId(), $featured_program->getImageType(), true),
+        'featured_image' => $this->featured_image_repository->getAbsoluteWebPath($featured_program->getId(), $featured_program->getImageType(), true),
       ];
       $new_featured_project = new FeaturedProject($result);
       $featured_programs[] = $new_featured_project;

--- a/src/Catrobat/Services/ImageRepository.php
+++ b/src/Catrobat/Services/ImageRepository.php
@@ -3,6 +3,7 @@
 namespace App\Catrobat\Services;
 
 use App\Catrobat\Exceptions\InvalidStorageDirectoryException;
+use App\Utils\Utils;
 use Imagick;
 use ImagickException;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -104,20 +105,19 @@ class ImageRepository
   {
     if ($featured)
     {
-      return $this->featured_path.$this->generateFileNameFromId($id, $extension, $featured);
+      $path = $this->featured_path.$this->generateFileNameFromId($id, $extension, $featured);
+    }
+    else
+    {
+      $path = $this->example_path.$this->generateFileNameFromId($id, $extension, $featured);
     }
 
-    return $this->example_path.$this->generateFileNameFromId($id, $extension, $featured);
+    return $path.Utils::getTimestampParameter($this->example_dir.$this->generateFileNameFromId($id, $extension, $featured));
   }
 
-  public function getAbsoluteWWebPath(int $id, string $extension, bool $featured): string
+  public function getAbsoluteWebPath(int $id, string $extension, bool $featured): string
   {
-    if ($featured)
-    {
-      return $this->urlHelper->getAbsoluteUrl('/').$this->featured_path.$this->generateFileNameFromId($id, $extension, $featured);
-    }
-
-    return $this->urlHelper->getAbsoluteUrl('/').$this->example_path.$this->generateFileNameFromId($id, $extension, $featured);
+    return $this->urlHelper->getAbsoluteUrl('/').$this->getWebPath($id, $extension, $featured);
   }
 
   /**

--- a/src/Catrobat/Services/MediaPackageFileRepository.php
+++ b/src/Catrobat/Services/MediaPackageFileRepository.php
@@ -5,6 +5,7 @@ namespace App\Catrobat\Services;
 use App\Catrobat\Exceptions\InvalidStorageDirectoryException;
 use App\Entity\MediaPackageCategory;
 use App\Entity\MediaPackageFile;
+use App\Utils\Utils;
 use function Deployer\Support\str_contains;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -199,7 +200,7 @@ class MediaPackageFileRepository extends ServiceEntityRepository
    */
   public function getWebPath(int $id, string $extension): string
   {
-    return $this->path.$this->generateFileNameFromId((string) $id, $extension);
+    return $this->path.$this->generateFileNameFromId((string) $id, $extension).Utils::getTimestampParameter($this->getMediaPath($id, $extension));
   }
 
   /**
@@ -214,7 +215,7 @@ class MediaPackageFileRepository extends ServiceEntityRepository
   {
     $extension = 'catrobat' == $extension ? 'png' : $extension;
 
-    return $this->path.'/thumbs/'.$id.'.'.$extension;
+    return $this->path.'/thumbs/'.$id.'.'.$extension.Utils::getTimestampParameter($this->getMediaPath($id, $extension));
   }
 
   /**
@@ -225,7 +226,16 @@ class MediaPackageFileRepository extends ServiceEntityRepository
    */
   public function getMediaFile(int $id, string $extension): File
   {
-    return new File($this->dir.$id.'.'.$extension);
+    return new File($this->getMediaPath($id, $extension));
+  }
+
+  /**
+   * @param int    $id        the database id of the file
+   * @param string $extension File extension
+   */
+  public function getMediaPath(int $id, string $extension): string
+  {
+    return $this->dir.$id.'.'.$extension;
   }
 
   /**

--- a/src/Catrobat/Services/ScreenshotRepository.php
+++ b/src/Catrobat/Services/ScreenshotRepository.php
@@ -119,9 +119,10 @@ class ScreenshotRepository
 
   public function getScreenshotWebPath(string $id): string
   {
-    if (file_exists($this->screenshot_dir.$this->generateFileNameFromId($id)))
+    $filename = $this->screenshot_dir.$this->generateFileNameFromId($id);
+    if (file_exists($filename))
     {
-      return $this->screenshot_path.$this->generateFileNameFromId($id);
+      return $this->screenshot_path.$this->generateFileNameFromId($id).Utils::getTimestampParameter($filename);
     }
 
     return self::DEFAULT_SCREENSHOT;
@@ -132,9 +133,10 @@ class ScreenshotRepository
    */
   public function getThumbnailWebPath($id): string
   {
-    if (file_exists($this->thumbnail_dir.$this->generateFileNameFromId((string) $id)))
+    $filename = $this->thumbnail_dir.$this->generateFileNameFromId((string) $id);
+    if (file_exists($filename))
     {
-      return $this->thumbnail_path.$this->generateFileNameFromId((string) $id);
+      return $this->thumbnail_path.$this->generateFileNameFromId((string) $id).Utils::getTimestampParameter($filename);
     }
 
     return self::DEFAULT_THUMBNAIL;

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -19,6 +19,16 @@ class Utils
     }
   }
 
+  public static function getTimestampParameter(string $filename): string
+  {
+    if (file_exists($filename))
+    {
+      return '?t='.filemtime($filename);
+    }
+
+    return '';
+  }
+
   private static function recursiveRemoveDirectory(string $directory): void
   {
     foreach (glob(sprintf('%s/*', $directory)) as $file)

--- a/src/Utils/VersionStrategy.php
+++ b/src/Utils/VersionStrategy.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Utils;
+
+use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
+
+class VersionStrategy implements VersionStrategyInterface
+{
+  private string $catrobat_version;
+
+  public function __construct(string $catrobat_version)
+  {
+    $this->catrobat_version = $catrobat_version;
+  }
+
+  public function getVersion($path)
+  {
+    if (preg_match('/\?/', $path))
+    {
+      return '&v='.$this->catrobat_version;
+    }
+
+    return '?v='.$this->catrobat_version;
+  }
+
+  public function applyVersion($path)
+  {
+    return $path.$this->getVersion($path);
+  }
+}

--- a/tests/behat/context/ApiContext.php
+++ b/tests/behat/context/ApiContext.php
@@ -1681,28 +1681,7 @@ class ApiContext implements KernelAwareContext
     $returned_program = array_pop($returned_program);
     $stored_program = $this->findProgram($stored_programs, $returned_program['name']);
 
-    foreach ($this->program_structure as $key)
-    {
-      Assert::assertNotEmpty($stored_program);
-      if (array_key_exists($key, $stored_program))
-      {
-        Assert::assertEquals($returned_program[$key], $stored_program[$key]);
-      }
-      elseif ('screenshot_large' === $key)
-      {
-        Assert::assertContains($returned_program[$key],
-          ['http://localhost/resources/screenshots/screen_'.$returned_program['id'].'.png',
-            'http://localhost/resources_test/screenshots/screen_'.$returned_program['id'].'.png',
-            'http://localhost/images/default/screenshot.png', ]);
-      }
-      elseif ('screenshot_small' === $key)
-      {
-        Assert::assertContains($returned_program[$key],
-          ['http://localhost/resources/thumbnails/screen_'.$returned_program['id'].'.png',
-            'http://localhost/resources_test/thumbnails/screen_'.$returned_program['id'].'.png',
-            'http://localhost/images/default/thumbnail.png', ]);
-      }
-    }
+    $this->assertProgramsEqual($stored_program, $returned_program);
   }
 
   /**
@@ -1723,28 +1702,7 @@ class ApiContext implements KernelAwareContext
     foreach ($returned_programs as $returned_program)
     {
       $stored_program = $this->findProgram($stored_programs, $returned_program['name']);
-      foreach ($this->program_structure as $key)
-      {
-        Assert::assertNotEmpty($stored_program);
-        if (array_key_exists($key, $stored_program))
-        {
-          Assert::assertEquals($returned_program[$key], $stored_program[$key]);
-        }
-        elseif ('screenshot_large' === $key)
-        {
-          Assert::assertContains($returned_program[$key],
-            ['http://localhost/resources/screenshots/screen_'.$returned_program['id'].'.png',
-              'http://localhost/resources_test/screenshots/screen_'.$returned_program['id'].'.png',
-              'http://localhost/images/default/screenshot.png', ]);
-        }
-        elseif ('screenshot_small' === $key)
-        {
-          Assert::assertContains($returned_program[$key],
-            ['http://localhost/resources/thumbnails/screen_'.$returned_program['id'].'.png',
-              'http://localhost/resources_test/thumbnails/screen_'.$returned_program['id'].'.png',
-              'http://localhost/images/default/thumbnail.png', ]);
-        }
-      }
+      $this->assertProgramsEqual($stored_program, $returned_program);
     }
   }
 
@@ -3726,5 +3684,37 @@ class ApiContext implements KernelAwareContext
     $user_agent = 'Catrobat/'.$lang_version.' '.$flavor.'/'.$app_version.' Platform/'.$platform.
       ' BuildType/'.$build_type.' Theme/'.$theme;
     $this->iUseTheUserAgent($user_agent);
+  }
+
+  private function pathWithoutParam(string $path): string
+  {
+    return strtok($path, '?');
+  }
+
+  private function assertProgramsEqual(array $stored_program, array $returned_program): void
+  {
+    Assert::assertNotEmpty($stored_program);
+    Assert::assertNotEmpty($returned_program);
+    foreach ($this->program_structure as $key)
+    {
+      if (array_key_exists($key, $stored_program))
+      {
+        Assert::assertEquals($stored_program[$key], $returned_program[$key]);
+      }
+      elseif ('screenshot_large' === $key)
+      {
+        Assert::assertContains($this->pathWithoutParam($returned_program[$key]),
+          ['http://localhost/resources/screenshots/screen_'.$returned_program['id'].'.png',
+            'http://localhost/resources_test/screenshots/screen_'.$returned_program['id'].'.png',
+            'http://localhost/images/default/screenshot.png', ]);
+      }
+      elseif ('screenshot_small' === $key)
+      {
+        Assert::assertContains($this->pathWithoutParam($returned_program[$key]),
+          ['http://localhost/resources/thumbnails/screen_'.$returned_program['id'].'.png',
+            'http://localhost/resources_test/thumbnails/screen_'.$returned_program['id'].'.png',
+            'http://localhost/images/default/thumbnail.png', ]);
+      }
+    }
   }
 }

--- a/tests/phpUnit/Catrobat/Services/ScreenshotRepositoryTest.php
+++ b/tests/phpUnit/Catrobat/Services/ScreenshotRepositoryTest.php
@@ -106,7 +106,9 @@ class ScreenshotRepositoryTest extends TestCase
     $filepath = RefreshTestEnvHook::$GENERATED_FIXTURES_DIR.'base/automatic_screenshot.png';
     $id = 'test';
     $this->screenshot_repository->saveProgramAssets($filepath, $id);
-    $this->assertSame($this->screenshot_base_url.'screen_test.png', $this->screenshot_repository->getScreenshotWebPath($id));
+    $web_path = $this->screenshot_repository->getScreenshotWebPath($id);
+    $this->assertStringStartsWith($this->screenshot_base_url.'screen_test.png', $web_path);
+    $this->assertRegExp('/\?t=\d+$/', $web_path);
   }
 
   /**
@@ -117,7 +119,9 @@ class ScreenshotRepositoryTest extends TestCase
     $filepath = RefreshTestEnvHook::$GENERATED_FIXTURES_DIR.'base/automatic_screenshot.png';
     $id = 'test';
     $this->screenshot_repository->saveProgramAssets($filepath, $id);
-    $this->assertSame($this->thumbnail_base_url.'screen_test.png', $this->screenshot_repository->getThumbnailWebPath($id));
+    $web_path = $this->screenshot_repository->getThumbnailWebPath($id);
+    $this->assertStringStartsWith($this->thumbnail_base_url.'screen_test.png', $web_path);
+    $this->assertRegExp('/\?t=\d+$/', $web_path);
   }
 
   public function testDeletesAllTemporaryFilesFromUploadProcess(): void


### PR DESCRIPTION
Added the last-modified date of mutable assets to their webpaths.
Changed the asset versioning so that it uses '&' instead of '?' if there
are already parameters.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no warnings and errors 
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [ ] Perform a self-review of the changes
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
Alternative approaches would be:

- Hash instead of the timestamp

- Purging the cache of the reverse proxy (not supported in free version of nginx)

- Adding the timestamp in the VersionStrategyInterface (but there the original filepath must be reconstructed from the webpath)

### Tests - additional information
`TODO: add additional information about testruns here`
