### PR TITLE
SHARE-315 Can't close remix graph

### DIFF
--- a/assets/js/custom/ProgramRecommender.js
+++ b/assets/js/custom/ProgramRecommender.js
@@ -94,9 +94,6 @@ function ProgramRecommender (program, programId, recs, specificRecommender, more
         beforeClose: function () {
           console.log('The animation was called')
           loadingAnimation.hide()
-        },
-        afterClose: function () {
-          console.log('The animation is completed')
           document.removeEventListener('gesturestart', blockEventListener)
           document.ontouchmove = null
           location.reload()


### PR DESCRIPTION
afterClose isn't triggered anymore since version bump (commit #9f4b9f1213902f52d543fcd8a21f660b610fd2a7), moved "closing" of remix graph to beforeClose.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [ ] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
