### PR TITLE
SHARE-281 Multiple flavors for assets

### DIFF
--- a/src/Admin/MediaPackageFileAdmin.php
+++ b/src/Admin/MediaPackageFileAdmin.php
@@ -3,6 +3,7 @@
 namespace App\Admin;
 
 use App\Catrobat\Services\MediaPackageFileRepository;
+use App\Entity\Flavor;
 use App\Entity\MediaPackageCategory;
 use App\Entity\MediaPackageFile;
 use ImagickException;
@@ -14,7 +15,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class MediaPackageFileAdmin extends AbstractAdmin
 {
@@ -58,8 +58,6 @@ class MediaPackageFileAdmin extends AbstractAdmin
     }
 
     $object->setExtension(('catrobat' == $file->getClientOriginalExtension()) ? 'catrobat' : $file->guessExtension());
-
-    $this->checkFlavor();
   }
 
   /**
@@ -93,7 +91,6 @@ class MediaPackageFileAdmin extends AbstractAdmin
       return;
     }
     $object->setExtension(('catrobat' == $file->getClientOriginalExtension()) ? 'catrobat' : $file->guessExtension());
-    $this->checkFlavor();
   }
 
   /**
@@ -143,7 +140,7 @@ class MediaPackageFileAdmin extends AbstractAdmin
       ->add('category', EntityType::class, [
         'class' => MediaPackageCategory::class,
         'required' => true, ])
-      ->add('flavor', TextType::class, ['required' => true])
+      ->add('flavors', null, ['class' => Flavor::class, 'multiple' => true, 'required' => true])
       ->add('author', TextType::class, ['label' => 'Author', 'required' => false])
       ->add('active', null, ['required' => false])
     ;
@@ -162,7 +159,7 @@ class MediaPackageFileAdmin extends AbstractAdmin
       ->add('file', 'string', ['template' => 'Admin/mediapackage_file.html.twig'])
       ->add('category', EntityType::class, ['class' => MediaPackageCategory::class])
       ->add('author', null, ['editable' => true])
-      ->add('flavor', null, ['editable' => true])
+      ->add('flavors', null, ['multiple' => true])
       ->add('downloads')
       ->add('active', null, ['editable' => true])
       ->add('_action', 'actions', [
@@ -172,22 +169,5 @@ class MediaPackageFileAdmin extends AbstractAdmin
         ],
       ])
     ;
-  }
-
-  private function checkFlavor(): void
-  {
-    $flavor = $this->getForm()->get('flavor')->getData();
-
-    if (!$flavor)
-    {
-      return; // There was no required flavor form field in this Action, so no check is needed!
-    }
-
-    $flavor_options = $this->parameter_bag->get('themes');
-
-    if (!in_array($flavor, $flavor_options, true))
-    {
-      throw new NotFoundHttpException('"'.$flavor.'"Flavor is unknown! Choose either '.implode(',', $flavor_options));
-    }
   }
 }

--- a/src/Catrobat/Services/TestEnv/SymfonySupport.php
+++ b/src/Catrobat/Services/TestEnv/SymfonySupport.php
@@ -12,6 +12,7 @@ use App\Catrobat\Services\TestEnv\DataFixtures\UserDataFixtures;
 use App\Entity\ExampleProgram;
 use App\Entity\Extension;
 use App\Entity\FeaturedProgram;
+use App\Entity\Flavor;
 use App\Entity\GameJam;
 use App\Entity\Notification;
 use App\Entity\Program;
@@ -31,6 +32,7 @@ use App\Entity\UserRemixSimilarityRelation;
 use App\Kernel;
 use App\Repository\CatroNotificationRepository;
 use App\Repository\ExtensionRepository;
+use App\Repository\FlavorRepository;
 use App\Repository\ProgramRemixBackwardRepository;
 use App\Repository\ProgramRemixRepository;
 use App\Repository\ScratchProgramRemixRepository;
@@ -186,6 +188,11 @@ trait SymfonySupport
   public function getCatroNotificationRepository(): CatroNotificationRepository
   {
     return $this->kernel->getContainer()->get(CatroNotificationRepository::class);
+  }
+
+  public function getFlavorRepository(): FlavorRepository
+  {
+    return $this->kernel->getContainer()->get(FlavorRepository::class);
   }
 
   public function getManager(): EntityManagerInterface
@@ -726,6 +733,20 @@ trait SymfonySupport
     $delimter = '#';
     $json = json_encode(json_decode($json, false, 512, JSON_THROW_ON_ERROR), JSON_THROW_ON_ERROR);
     Assert::assertMatchesRegularExpression($delimter.$pattern.$delimter, $json);
+  }
+
+  public function insertFlavor(array $config = [], bool $andFlush = true): Flavor
+  {
+    $flavor = new Flavor();
+    $flavor->setName($config['name']);
+
+    $this->getManager()->persist($flavor);
+    if ($andFlush)
+    {
+      $this->getManager()->flush();
+    }
+
+    return $flavor;
   }
 
   /**

--- a/src/Commands/Create/CreateMediaPackageSamplesCommand.php
+++ b/src/Commands/Create/CreateMediaPackageSamplesCommand.php
@@ -3,6 +3,7 @@
 namespace App\Commands\Create;
 
 use App\Catrobat\Services\MediaPackageFileRepository;
+use App\Repository\FlavorRepository;
 use App\Repository\MediaPackageCategoryRepository;
 use App\Repository\MediaPackageRepository;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -35,12 +36,14 @@ class CreateMediaPackageSamplesCommand extends Command
   private MediaPackageCategoryRepository $media_package_category_repo;
   private MediaPackageFileRepository $media_package_file_repo;
   private ParameterBagInterface $parameter_bag;
+  private FlavorRepository $flavor_repo;
 
   /**
    * CreateMediaPackageSamplesCommand constructor.
    */
   public function __construct(MediaPackageRepository $media_package_repo, MediaPackageCategoryRepository $media_package_category_repo,
-                              MediaPackageFileRepository $media_package_file_repo, ParameterBagInterface $parameter_bag)
+                              MediaPackageFileRepository $media_package_file_repo, ParameterBagInterface $parameter_bag,
+                              FlavorRepository $flavor_repo)
   {
     parent::__construct();
 
@@ -48,6 +51,7 @@ class CreateMediaPackageSamplesCommand extends Command
     $this->media_package_category_repo = $media_package_category_repo;
     $this->media_package_file_repo = $media_package_file_repo;
     $this->parameter_bag = $parameter_bag;
+    $this->flavor_repo = $flavor_repo;
   }
 
   protected function configure(): void
@@ -67,20 +71,24 @@ class CreateMediaPackageSamplesCommand extends Command
     $package_looks = $this->media_package_repo->createMediaPackage('Looks', 'looks');
 
     // Creating MediaPackageCategory Animals and filling it with MediaPackageFiles
+    $pocketcode_flavor = $this->flavor_repo->getFlavorByName('pocketcode');
+    $luna_flavor = $this->flavor_repo->getFlavorByName('luna');
+    $create_at_school_flavor = $this->flavor_repo->getFlavorByName('create@school');
+
     $category_pocket_family = $this->media_package_category_repo->createMediaPackageCategory('Pocket Family', new ArrayCollection([$package_looks]));
-    $this->media_package_file_repo->createMediaPackageFile('Penguin', new File($sample_pckg_path.'Looks/Pocket Family/Penguin.png'), $category_pocket_family, 'pocketcode', 'Catrobat');
-    $this->media_package_file_repo->createMediaPackageFile('Elephant', new File($sample_pckg_path.'Looks/Pocket Family/Elephant.png'), $category_pocket_family, 'pocketcode', 'Catrobat');
-    $this->media_package_file_repo->createMediaPackageFile('Panda', new File($sample_pckg_path.'Looks/Pocket Family/Panda.png'), $category_pocket_family, 'pocketcode', 'Catrobat');
+    $this->media_package_file_repo->createMediaPackageFile('Penguin', new File($sample_pckg_path.'Looks/Pocket Family/Penguin.png'), $category_pocket_family, [$pocketcode_flavor], 'Catrobat');
+    $this->media_package_file_repo->createMediaPackageFile('Elephant', new File($sample_pckg_path.'Looks/Pocket Family/Elephant.png'), $category_pocket_family, [$pocketcode_flavor], 'Catrobat');
+    $this->media_package_file_repo->createMediaPackageFile('Panda', new File($sample_pckg_path.'Looks/Pocket Family/Panda.png'), $category_pocket_family, [$pocketcode_flavor], 'Catrobat');
 
     // Creating MediaPackageCategory People and filling it with MediaPackageFiles
     $category_people = $this->media_package_category_repo->createMediaPackageCategory('People', new ArrayCollection([$package_looks]));
-    $this->media_package_file_repo->createMediaPackageFile('Boy', new File($sample_pckg_path.'Looks/People/Boy.png'), $category_people, 'pocketcode', 'Catrobat');
-    $this->media_package_file_repo->createMediaPackageFile('Girl', new File($sample_pckg_path.'Looks/People/Girl.png'), $category_people, 'pocketcode', 'Catrobat');
+    $this->media_package_file_repo->createMediaPackageFile('Boy', new File($sample_pckg_path.'Looks/People/Boy.png'), $category_people, [$pocketcode_flavor], 'Catrobat');
+    $this->media_package_file_repo->createMediaPackageFile('Girl', new File($sample_pckg_path.'Looks/People/Girl.png'), $category_people, [$pocketcode_flavor], 'Catrobat');
 
     // Creating MediaPackageCategory Luna and filling it with MediaPackageFiles
     $category_luna = $this->media_package_category_repo->createMediaPackageCategory('ThemeSpecial Luna & Cat', new ArrayCollection([$package_looks]));
-    $this->media_package_file_repo->createMediaPackageFile('Luna Cat', new File($sample_pckg_path.'Looks/Luna/Luna-Cat.png'), $category_luna, 'luna', 'Catrobat');
-    $this->media_package_file_repo->createMediaPackageFile('Luna Girl', new File($sample_pckg_path.'Looks/Luna/Luna-Girl.png'), $category_luna, 'luna', 'Catrobat');
+    $this->media_package_file_repo->createMediaPackageFile('Luna Cat', new File($sample_pckg_path.'Looks/Luna/Luna-Cat.png'), $category_luna, [$luna_flavor], 'Catrobat');
+    $this->media_package_file_repo->createMediaPackageFile('Luna Girl', new File($sample_pckg_path.'Looks/Luna/Luna-Girl.png'), $category_luna, [$luna_flavor], 'Catrobat');
 
     /*
      * Creating MediaPackage Sounds
@@ -89,13 +97,13 @@ class CreateMediaPackageSamplesCommand extends Command
 
     // Creating MediaPackageCategory Animals and filling it with MediaPackageFiles
     $category_animal_sounds = $this->media_package_category_repo->createMediaPackageCategory('Animals', new ArrayCollection([$package_looks]));
-    $this->media_package_file_repo->createMediaPackageFile('Owl', new File($sample_pckg_path.'Sounds/Animals/Owl.wav'), $category_animal_sounds, 'pocketcode', 'Catrobat');
-    $this->media_package_file_repo->createMediaPackageFile('SeaLion', new File($sample_pckg_path.'Sounds/Animals/SeaLion.mpga'), $category_animal_sounds, 'pocketcode', 'Catrobat');
+    $this->media_package_file_repo->createMediaPackageFile('Owl', new File($sample_pckg_path.'Sounds/Animals/Owl.wav'), $category_animal_sounds, [$pocketcode_flavor], 'Catrobat');
+    $this->media_package_file_repo->createMediaPackageFile('SeaLion', new File($sample_pckg_path.'Sounds/Animals/SeaLion.mpga'), $category_animal_sounds, [$pocketcode_flavor], 'Catrobat');
 
     // Creating MediaPackageCategory Machines and filling it with MediaPackageFiles
     $category_machine_sounds = $this->media_package_category_repo->createMediaPackageCategory('Machines', new ArrayCollection([$package_looks]));
-    $this->media_package_file_repo->createMediaPackageFile('Plane', new File($sample_pckg_path.'Sounds/Machines/Plane.mpga'), $category_machine_sounds, 'pocketcode', 'Catrobat');
-    $this->media_package_file_repo->createMediaPackageFile('Ufo', new File($sample_pckg_path.'Sounds/Machines/Ufo.wav'), $category_machine_sounds, 'pocketcode', 'Catrobat');
+    $this->media_package_file_repo->createMediaPackageFile('Plane', new File($sample_pckg_path.'Sounds/Machines/Plane.mpga'), $category_machine_sounds, [$pocketcode_flavor, $create_at_school_flavor], 'Catrobat');
+    $this->media_package_file_repo->createMediaPackageFile('Ufo', new File($sample_pckg_path.'Sounds/Machines/Ufo.wav'), $category_machine_sounds, [$pocketcode_flavor, $create_at_school_flavor], 'Catrobat');
 
     /*
      * Creating MediaPackage Objects
@@ -103,7 +111,7 @@ class CreateMediaPackageSamplesCommand extends Command
     $package_objects = $this->media_package_repo->createMediaPackage('Objects', 'Objects');
     // Creating MediaPackageCategory Miscellaneous and filling it with MediaPackageFiles
     $category_miscellaneous = $this->media_package_category_repo->createMediaPackageCategory('Miscellaneous', new ArrayCollection([$package_objects]));
-    $this->media_package_file_repo->createMediaPackageFile('House', new File($sample_pckg_path.'Objects/Miscellaneous/House.catrobat'), $category_miscellaneous, 'pocketcode', 'Catrobat');
+    $this->media_package_file_repo->createMediaPackageFile('House', new File($sample_pckg_path.'Objects/Miscellaneous/House.catrobat'), $category_miscellaneous, [$pocketcode_flavor], 'Catrobat');
 
     // Creating MediaPackageCategory Miscellaneous
 

--- a/src/Entity/Flavor.php
+++ b/src/Entity/Flavor.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="flavor")
+ */
+class Flavor
+{
+  /**
+   * @ORM\Id
+   * @ORM\Column(type="integer")
+   * @ORM\GeneratedValue(strategy="AUTO")
+   */
+  protected ?int $id = null;
+
+  /**
+   * @ORM\Column(type="string", length=255, unique=true)
+   */
+  protected ?string $name = null;
+
+  /**
+   * @ORM\ManyToMany(targetEntity="\App\Entity\MediaPackageFile", mappedBy="flavors", fetch="EXTRA_LAZY")
+   */
+  protected Collection $media_package_files;
+
+  public function __construct()
+  {
+    $this->media_package_files = new ArrayCollection();
+  }
+
+  public function __toString(): string
+  {
+    return $this->getName() ?? '';
+  }
+
+  public function setId(?int $id): void
+  {
+    $this->id = $id;
+  }
+
+  public function getId(): ?int
+  {
+    return $this->id;
+  }
+
+  public function setName(?string $name): void
+  {
+    $this->name = $name;
+  }
+
+  public function getName(): ?string
+  {
+    return $this->name;
+  }
+
+  public function addMediaPackageFile(MediaPackageFile $media_package_file): void
+  {
+    if ($this->media_package_files->contains($media_package_file))
+    {
+      return;
+    }
+    $this->media_package_files[] = $media_package_file;
+  }
+
+  public function removeMediaPackageFile(MediaPackageFile $media_package_file): void
+  {
+    if (!$this->media_package_files->contains($media_package_file))
+    {
+      return;
+    }
+    $this->media_package_files->removeElement($media_package_file);
+  }
+
+  public function getMediaPackageFiles(): Collection
+  {
+    return $this->media_package_files;
+  }
+}

--- a/src/Migrations/2020/Version20200624085848.php
+++ b/src/Migrations/2020/Version20200624085848.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200624085848 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is not auto generated
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE flavor (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_BC2534545E237E06 (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE mediapackagefile_flavor (mediapackagefile_id INT NOT NULL, flavor_id INT NOT NULL, INDEX IDX_F139CC7D1F3493BC (mediapackagefile_id), INDEX IDX_F139CC7DFDDA6450 (flavor_id), PRIMARY KEY(mediapackagefile_id, flavor_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE mediapackagefile_flavor ADD CONSTRAINT FK_F139CC7D1F3493BC FOREIGN KEY (mediapackagefile_id) REFERENCES media_package_file (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE mediapackagefile_flavor ADD CONSTRAINT FK_F139CC7DFDDA6450 FOREIGN KEY (flavor_id) REFERENCES flavor (id) ON DELETE CASCADE');
+
+        $this->addSql('INSERT IGNORE INTO flavor(name) VALUES(\'pocketcode\'), (\'pocketalice\'), (\'pocketgalaxy\'), (\'phirocode\'), (\'luna\'), (\'create@school\'), (\'embroidery\'), (\'arduino\')');
+        //Converts the old string flavors into the many_to_many relation. The first SELECT is for files with a valid flavor, the second SELECT adds the 'pocketcode' flavor to all files with invalid flavors(NULL, 'app')
+        $this->addSql('INSERT IGNORE INTO mediapackagefile_flavor(mediapackagefile_id, flavor_id)
+            SELECT f.id, flavor.id FROM flavor INNER JOIN media_package_file AS f ON f.flavor = flavor.name
+            UNION
+            SELECT f.id, (SELECT id from flavor WHERE name = \'pocketcode\') FROM media_package_file as f WHERE NOT EXISTS(SELECT * FROM flavor WHERE flavor.name = f.flavor)
+        ');
+
+        $this->addSql('ALTER TABLE media_package_file DROP flavor');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE mediapackagefile_flavor DROP FOREIGN KEY FK_F139CC7DFDDA6450');
+        $this->addSql('DROP TABLE flavor');
+        $this->addSql('DROP TABLE mediapackagefile_flavor');
+        $this->addSql('ALTER TABLE media_package_file ADD flavor VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT \'pocketcode\' COLLATE `utf8mb4_unicode_ci`');
+    }
+}

--- a/src/Repository/FlavorRepository.php
+++ b/src/Repository/FlavorRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Flavor;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class FlavorRepository extends ServiceEntityRepository
+{
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, Flavor::class);
+  }
+
+  /** @noinspection PhpIncompatibleReturnTypeInspection */
+  public function getFlavorByName(string $name): ?Flavor
+  {
+    return $this->findOneBy(['name' => $name]);
+  }
+
+  public function getFlavorsByNames(iterable $names): array
+  {
+    return $this->findBy(['name' => $names]);
+  }
+
+  public function getAllFlavors(): array
+  {
+    return $this->findAll();
+  }
+}

--- a/src/Utils/APIQueryHelper.php
+++ b/src/Utils/APIQueryHelper.php
@@ -37,6 +37,25 @@ class APIQueryHelper
     return $query_builder;
   }
 
+  public static function addFileFlavorsCondition(QueryBuilder $query_builder, ?string $flavor = null, string $alias = 'e', bool $include_pocketcode = false): QueryBuilder
+  {
+    if (null !== $flavor)
+    {
+      $where = 'fl.name = :name';
+      if ($include_pocketcode)
+      {
+        $where .= ' OR fl.name = \'pocketcode\'';
+      }
+      $query_builder
+        ->join($alias.'.flavors', 'fl')
+        ->andWhere($where)
+        ->setParameter('name', $flavor)
+      ;
+    }
+
+    return $query_builder;
+  }
+
   public static function addPlatformCondition(QueryBuilder $query_builder, ?string $platform = null): QueryBuilder
   {
     if (null !== $platform)

--- a/tests/behat/features/api-deprecated/project/get_media_lib_json.feature
+++ b/tests/behat/features/api-deprecated/project/get_media_lib_json.feature
@@ -11,9 +11,13 @@ Feature: Get data from the media library in json format
       | 1  | Animals | Looks   |
       | 2  | Fantasy | Sounds  |
       | 3  | Space   | Looks   |
+    And there are flavors:
+      | name       |
+      | pocketcode |
+      | luna       |
 
     And there are media package files:
-      | id | name      | category | extension | active | file   | flavor     | author         |
+      | id | name      | category | extension | active | file   | flavors    | author         |
       | 1  | Dog       | Animals  | png       | 1      | 1.png  | pocketcode | Bob Schmidt    |
       | 2  | Magic     | Fantasy  | mpga      | 1      | 2.mpga | pocketcode |                |
       | 3  | Spaceship | Space    | png       | 0      | 3.png  |            | Micheal John   |

--- a/tests/behat/features/api/mediapackage/mediafile_all_get.feature
+++ b/tests/behat/features/api/mediapackage/mediafile_all_get.feature
@@ -11,15 +11,20 @@ Feature: Get data from the media library in json format
       | 1  | Animals | Looks   |
       | 2  | Fantasy | Sounds  |
       | 3  | Space   | Looks   |
+    And there are flavors:
+      | id | name       |
+      | 1  | pocketcode |
+      | 2  | luna       |
+      | 3  | arduino    |
 
     And there are media package files:
-      | id | name      | category | extension | active | file   | flavor     | author         |
-      | 1  | Dog 1     | Animals  | png       | 1      | 1.png  | pocketcode | Bob Schmidt    |
-      | 2  | Dog 2     | Fantasy  | mpga      | 1      | 2.mpga | pocketcode |                |
-      | 3  | Spaceship | Space    | png       | 0      | 3.png  |            | Micheal John   |
-      | 4  | Cat       | Animals  | png       | 1      | 4.png  | luna       |                |
-      | 5  | Ape       | Animals  | png       | 1      | 5.png  |            |                |
-      | 6  | Metroid   | Space    | png       | 1      | 6.png  | pocketcode | Jennifer Shawn |
+      | id | name      | category | extension | active | file   | flavors             | author         |
+      | 1  | Dog 1     | Animals  | png       | 1      | 1.png  | pocketcode          | Bob Schmidt    |
+      | 2  | Dog 2     | Fantasy  | mpga      | 1      | 2.mpga | pocketcode          |                |
+      | 3  | Spaceship | Space    | png       | 0      | 3.png  | pocketcode, arduino | Micheal John   |
+      | 4  | Cat       | Animals  | png       | 1      | 4.png  | luna, arduino       |                |
+      | 5  | Ape       | Animals  | png       | 1      | 5.png  | pocketcode          |                |
+      | 6  | Metroid   | Space    | png       | 1      | 6.png  | pocketcode          | Jennifer Shawn |
 
 
   Scenario: Requests with wrong HTTP_ACCEPT value should result in an error
@@ -207,6 +212,41 @@ Feature: Get data from the media library in json format
       }
       ],
       "total_results": 1
+   }
+    """
+
+  Scenario: Getting files with flavor "arduino" should return 2 media file
+    Given I have a request header "HTTP_ACCEPT" with value "application/json"
+    And I have a parameter "flavor" with value "arduino"
+    And I request "GET" "/api/media/files"
+    Then the response status code should be "200"
+    And I should get the json object:
+    """
+      {
+        "media_files":
+    [
+      {
+        "id": 3,
+        "name": "Spaceship",
+        "flavor": "pocketcode",
+        "package": "Looks",
+        "category": "Space",
+        "author": "Micheal John",
+        "extension": "png",
+        "download_url": "http:\/\/localhost\/app\/download-media\/3"
+      },
+        {
+        "id": 4,
+        "name": "Cat",
+        "flavor": "luna",
+        "package": "Looks",
+        "category": "Animals",
+        "author": "",
+        "extension": "png",
+        "download_url": "http:\/\/localhost\/app\/download-media\/4"
+      }
+      ],
+      "total_results": 2
    }
     """
 

--- a/tests/behat/features/api/mediapackage/mediafile_id_get.feature
+++ b/tests/behat/features/api/mediapackage/mediafile_id_get.feature
@@ -11,14 +11,18 @@ Feature: Get data from the media library in json format
       | 1  | Animals | Looks   |
       | 2  | Fantasy | Sounds  |
       | 3  | Space   | Looks   |
+    And there are flavors:
+      | id | name       |
+      | 1  | pocketcode |
+      | 2  | luna       |
 
     And there are media package files:
-      | id | name      | category | extension | active | file   | flavor     | author         |
+      | id | name      | category | extension | active | file   | flavors    | author         |
       | 1  | Dog 1     | Animals  | png       | 1      | 1.png  | pocketcode | Bob Schmidt    |
       | 2  | Dog 2     | Fantasy  | mpga      | 1      | 2.mpga | pocketcode |                |
-      | 3  | Spaceship | Space    | png       | 0      | 3.png  |            | Micheal John   |
+      | 3  | Spaceship | Space    | png       | 0      | 3.png  | pocketcode | Micheal John   |
       | 4  | Cat       | Animals  | png       | 1      | 4.png  | luna       |                |
-      | 5  | Ape       | Animals  | png       | 1      | 5.png  |            |                |
+      | 5  | Ape       | Animals  | png       | 1      | 5.png  | pocketcode |                |
       | 6  | Metroid   | Space    | png       | 1      | 6.png  | pocketcode | Jennifer Shawn |
 
 

--- a/tests/behat/features/api/mediapackage/mediafile_search_get.feature
+++ b/tests/behat/features/api/mediapackage/mediafile_search_get.feature
@@ -11,14 +11,18 @@ Feature: Get data from the media library in json format
       | 1  | Animals | Looks   |
       | 2  | Fantasy | Sounds  |
       | 3  | Space   | Looks   |
+    And there are flavors:
+      | id | name       |
+      | 1  | pocketcode |
+      | 2  | luna       |
 
     And there are media package files:
-      | id | name      | category | extension | active | file   | flavor     | author         |
+      | id | name      | category | extension | active | file   | flavors    | author         |
       | 1  | Dog 1     | Animals  | png       | 1      | 1.png  | pocketcode | Bob Schmidt    |
       | 2  | Dog 2     | Fantasy  | mpga      | 1      | 2.mpga | pocketcode |                |
-      | 3  | Spaceship | Space    | png       | 0      | 3.png  |            | Micheal John   |
+      | 3  | Spaceship | Space    | png       | 0      | 3.png  | pocketcode | Micheal John   |
       | 4  | Cat       | Animals  | png       | 1      | 4.png  | luna       |                |
-      | 5  | Ape       | Animals  | png       | 1      | 5.png  |            |                |
+      | 5  | Ape       | Animals  | png       | 1      | 5.png  | pocketcode |                |
       | 6  | Metroid   | Space    | png       | 1      | 6.png  | pocketcode | Jennifer Shawn |
 
 

--- a/tests/behat/features/api/mediapackage/mediapackage_packagename_get.feature
+++ b/tests/behat/features/api/mediapackage/mediapackage_packagename_get.feature
@@ -11,14 +11,18 @@ Feature: Get data from the media library in json format
       | 1  | Animals | Looks   |
       | 2  | Fantasy | Sounds  |
       | 3  | Space   | Looks   |
+    And there are flavors:
+      | id | name       |
+      | 1  | pocketcode |
+      | 2  | luna       |
 
     And there are media package files:
-      | id | name      | category | extension | active | file   | flavor     | author         |
+      | id | name      | category | extension | active | file   | flavors    | author         |
       | 1  | Dog       | Animals  | png       | 1      | 1.png  | pocketcode | Bob Schmidt    |
       | 2  | Magic     | Fantasy  | mpga      | 1      | 2.mpga | pocketcode |                |
-      | 3  | Spaceship | Space    | png       | 0      | 3.png  |            | Micheal John   |
+      | 3  | Spaceship | Space    | png       | 0      | 3.png  | pocketcode | Micheal John   |
       | 4  | Cat       | Animals  | png       | 1      | 4.png  | pocketcode |                |
-      | 5  | Ape       | Animals  | png       | 1      | 5.png  |            |                |
+      | 5  | Ape       | Animals  | png       | 1      | 5.png  | pocketcode |                |
       | 6  | Metroid   | Space    | png       | 1      | 6.png  | pocketcode | Jennifer Shawn |
 
 

--- a/tests/behat/features/web/media-library/mediapackage.feature
+++ b/tests/behat/features/web/media-library/mediapackage.feature
@@ -16,14 +16,18 @@ Feature:
       | 2  | Fantasy      | Sounds  |
       | 3  | Bla          | Looks   |
       | 4  | ThemeSpecial | Looks   |
+    And there are flavors:
+      | id | name       |
+      | 1  | pocketcode |
+      | 2  | luna       |
 
     And there are media package files:
-      | id | name       | category     | extension | active | file       | flavor     | author        |
+      | id | name       | category     | extension | active | file       | flavors    | author        |
       | 1  | Dog (😊🐶)   | Animals      | png       | 1      | 1.png      | pocketcode | Bob Schmidt   |
       | 2  | Bubble     | Fantasy      | mpga      | 1      | 2.mpga     | pocketcode |               |
       | 3  | SexyGrexy  | Bla          | png       | 0      | 3.png      | luna       | Micheal John  |
       | 4  | SexyFlavor | Animals      | png       | 1      | 4.png      | luna       |               |
-      | 5  | SexyNULL   | Animals      | png       | 1      | 5.png      |            |               |
+      | 5  | SexyNULL   | Animals      | png       | 1      | 5.png      | pocketcode |               |
       | 6  | SexyWolfi  | Animals      | png       | 1      | 6.png      | pocketcode | Jenifer Shawn |
       | 7  | MyLuna     | ThemeSpecial | png       | 1      | 7.png      | luna       |               |
       | 8  | MyObject   | Bla          | catrobat  | 1      | 8.catrobat | pocketcode |               |


### PR DESCRIPTION
Changed the file-flavor relation to a many_to_many relation.
Added flavor table.
Converts the old flavor structure into the new one.
Added flavors to api (except CAPI), additionaly first flavor is returned as flavor for backward compatibility.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [ ] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
