### PR TITLE
SHARE-302 isWebview Check

### DIFF
--- a/src/Catrobat/Twig/AppExtension.php
+++ b/src/Catrobat/Twig/AppExtension.php
@@ -119,8 +119,10 @@ class AppExtension extends AbstractExtension
   {
     return [
       new TwigFunction('countriesList', [$this, 'getCountriesList']),
+      new TwigFunction('isMobile', [$this, 'isMobile']),
       new TwigFunction('isWebview', [$this, 'isWebview']),
-      new TwigFunction('isIOSWebview', [$this, 'isIOSWebview']),
+      new TwigFunction('isAndroid', [$this, 'isAndroid']),
+      new TwigFunction('isIOS', [$this, 'isIOS']),
       new TwigFunction('checkCatrobatLanguage', [$this, 'checkCatrobatLanguage']),
       new TwigFunction('getLanguageOptions', [$this, 'getLanguageOptions']),
       new TwigFunction('getMediaPackageImageUrl', [$this, 'getMediaPackageImageUrl']),
@@ -210,22 +212,25 @@ class AppExtension extends AbstractExtension
     return $list;
   }
 
-  public function isWebview(): bool
+  public function isMobile(): bool
   {
-    $request = $this->request_stack->getCurrentRequest();
-    $user_agent = $request->headers->get('User-Agent');
-
-    // Example Webview: $user_agent = "Catrobat/0.93 PocketCode/0.9.14 Platform/Android";
-    return preg_match('/Catrobat/', $user_agent) || false !== strpos($user_agent, 'Android') ||
-      false !== strpos($user_agent, 'iPad') || false !== strpos($user_agent, 'iPhone');
+    return preg_match('/(Catrobat|Android|Windows Phone|iPad|iPhone)/', $this->getUserAgent());
   }
 
-  public function isIOSWebview(): bool
+  public function isWebview(): bool
   {
-    $request = $this->request_stack->getCurrentRequest();
-    $user_agent = $request->headers->get('User-Agent');
+    // Example Webview: $user_agent = "Catrobat/0.93 PocketCode/0.9.14 Platform/Android";
+    return preg_match('/Catrobat/', $this->getUserAgent());
+  }
 
-    return false !== strpos($user_agent, 'iPad') || false !== strpos($user_agent, 'iPhone');
+  public function isAndroid(): bool
+  {
+    return preg_match('/Android/', $this->getUserAgent());
+  }
+
+  public function isIOS(): bool
+  {
+    return preg_match('/(iPad|iPhone)/', $this->getUserAgent());
   }
 
   /**
@@ -233,8 +238,7 @@ class AppExtension extends AbstractExtension
    */
   public function checkCatrobatLanguage($program_catrobat_language): bool
   {
-    $request = $this->request_stack->getCurrentRequest();
-    $user_agent = $request->headers->get('User-Agent');
+    $user_agent = $this->getUserAgent();
 
     // Example Webview: $user_agent = "Catrobat/0.93 PocketCode/0.9.14 Platform/Android";
     if (preg_match('/Catrobat/', $user_agent))
@@ -394,5 +398,12 @@ class AppExtension extends AbstractExtension
     $lastOccurrence = strpos($filename, '.', $firstOccurrence);
 
     return substr($filename, $firstOccurrence, $lastOccurrence - $firstOccurrence);
+  }
+
+  private function getUserAgent(): string
+  {
+    $request = $this->request_stack->getCurrentRequest();
+
+    return $request->headers->get('User-Agent');
   }
 }

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -314,7 +314,7 @@
           </button>
         </div>
 
-        {% if not isIOSWebview() %}
+        {% if not isIOS() %}
         <div id="apk-generate" class="btn-container col-12 col-xl-6">
           <button class="btn btn-primary">
             <i class="program-big-button-icon mr-3 fab fa-android"></i>


### PR DESCRIPTION
IsWebview now only returns true if it's the webview, and not for all mobile devices.
Added isMobile, isAndroid, isIOS.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no warnings and errors 
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [ ] Perform a self-review of the changes
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
