### PR TITLE
SHARE-332 File Download Error Handling

### DIFF
--- a/assets/js/custom/Program.js
+++ b/assets/js/custom/Program.js
@@ -4,7 +4,7 @@
 // eslint-disable-next-line no-unused-vars
 const Program = function (projectId, csrfToken, userRole, myProgram, statusUrl, createUrl, likeUrl,
   likeDetailUrl, apkPreparing, apkText, updateAppHeader, updateAppText,
-  btnClosePopup, likeActionAdd, likeActionRemove, profileUrl, wowWhite, wowBlack, reactionsText) {
+  btnClosePopup, likeActionAdd, likeActionRemove, profileUrl, wowWhite, wowBlack, reactionsText, downloadErrorText) {
   const self = this
 
   self.projectId = projectId
@@ -25,6 +25,7 @@ const Program = function (projectId, csrfToken, userRole, myProgram, statusUrl, 
   self.wowWhite = wowWhite
   self.wowBlack = wowBlack
   self.reactionsText = reactionsText
+  self.downloadErrorText = downloadErrorText
   self.download = function (downloadUrl, projectId, buttonId, supported = true, isWebView = false,
     downloadPbID, downloadIconID) {
     const downloadProgressBar = $(downloadPbID)
@@ -44,7 +45,14 @@ const Program = function (projectId, csrfToken, userRole, myProgram, statusUrl, 
     downloadProgressBar.removeClass('d-none')
     downloadProgressBar.addClass('d-inline-block')
     fetch(downloadUrl)
-      .then(resp => resp.blob())
+      .then(function (response) {
+        if (!response.ok) {
+          // eslint-disable-next-line no-undef
+          showSnackbar('#share-snackbar', self.downloadErrorText)
+          return null
+        }
+        return response.blob()
+      })
       .then(blob => {
         const url = window.URL.createObjectURL(blob)
         const a = document.createElement('a')

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -223,6 +223,7 @@
       '{{ asset('images/default/wow_white.svg') }}',
       '{{ asset('images/default/wow_black.svg') }}',
       '{{ 'programs.reactionsText'|trans({}, 'catroweb') }}',
+      '{{ 'programs.downloadErrorText'|trans({}, 'catroweb') }}',
     )
     program.getApkStatus()
     program.createLinks()

--- a/tests/behat/context/BrowserContext.php
+++ b/tests/behat/context/BrowserContext.php
@@ -159,6 +159,24 @@ class BrowserContext extends MinkContext implements KernelAwareContext
   }
 
   /**
+   * @Then /^download button is pointing to the non existing project$/
+   */
+  public function downloadButtonIsPointingToTheNonExistingProject(): void
+  {
+    $program = $this->getProgramManager()->find('1');
+    $program->setId('123456');
+    $this->getManager()->flush();
+  }
+
+  /**
+   * @Then /^project has no valid program file$/
+   */
+  public function projectHasNoValidFile(): void
+  {
+    $this->getFileRepository()->deleteProgramFile('2');
+  }
+
+  /**
    * @Then /^no "([^"]*)" element should be visible$/
    *
    * @param mixed $locator

--- a/tests/behat/features/web/project-details/project_download.feature
+++ b/tests/behat/features/web/project-details/project_download.feature
@@ -8,12 +8,40 @@ Feature: As a visitor I want to be able to download projects
     And there are projects:
       | id | name      | downloads | owned by | apk_ready |
       | 1  | project 1 | 5         | Catrobat | true      |
+      | 2  | project 2 | 5         | Catrobat | true      |
 
   Scenario: I want to download a project via the button
     When I am on "/app/project/1"
     And I wait for the page to be loaded
     Then the element "#url-download-small" should be visible
     And the element "#url-download-small" should have a attribute "onclick" with value "program.download("
+    And I click "#url-download-small"
+    And the element "#share-snackbar" should not be visible
+    And I should not see "Error occurred while downloading the project"
+
+
+
+  Scenario: If download fails user should see popup and the file should not be downloaded
+    When I am on "/app/project/1"
+    And I wait for the page to be loaded
+    And download button is pointing to the non existing project
+    Then the element "#url-download-small" should be visible
+    And the element "#url-download-small" should have a attribute "onclick" with value "program.download("
+    And I click "#url-download-small"
+    Then the element "#share-snackbar" should be visible
+    And I should see "Error occurred while downloading the project"
+    When I am on "/app/project/2"
+    And I wait for the page to be loaded
+    And project has no valid program file
+    Then the element "#url-download-small" should be visible
+    And the element "#url-download-small" should have a attribute "onclick" with value "program.download("
+    And I click "#url-download-small"
+    Then the element "#share-snackbar" should be visible
+    And I should see "Error occurred while downloading the project"
+
+
+
+
 
   @disabled
   Scenario: Clicking the download button should deactivate the download button until download is finished

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -188,6 +188,7 @@ programs:
   linkTitle: Link
   link: Copy project link to clipboard
   reactionsText: Reactions
+  downloadErrorText: Error occurred while downloading the project. Please try again later.
 
 remixGraph:
   title: Remixes


### PR DESCRIPTION
-made popup that is shown to the user when download fails and file is not being downloaded anymore in this case
-wrote test case

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
