### PR TITLE
SHARE-376-Faulty-Notification-Generation

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -7,4 +7,4 @@ coverage:
 # do not comment until at least X builds have been uploaded from the CI pipeline
 # Important keep up to date with behat + phpunit testsuites
 comment:
-    after_n_builds: 31
+    after_n_builds: 32

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -199,6 +199,7 @@ jobs:
           - web-notifications1
           - web-notifications2
           - web-notifications3
+          - web-notifications4
           - web-profile
           - web-project
           - web-project-details

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -227,6 +227,14 @@ default:
                 - Tests\behat\context\CatrowebBrowserContext
                 - Tests\behat\context\ApiContext
 
+        web-notifications4:
+                    paths: ["tests/behat/features/web/notifications4"]
+                    contexts:
+                        - Tests\behat\context\RefreshEnvironmentContext
+                        - Tests\behat\context\DataFixturesContext
+                        - Tests\behat\context\CatrowebBrowserContext
+                        - Tests\behat\context\ApiContext
+
         web-profile:
             paths:    [ "tests/behat/features/web/profile" ]
             contexts:

--- a/src/Catrobat/Controller/Web/NotificationsController.php
+++ b/src/Catrobat/Controller/Web/NotificationsController.php
@@ -47,7 +47,6 @@ class NotificationsController extends AbstractController
     {
       $found_notification = false;
       $user = null;
-      $all_notifications[$notification->getId()] = $notification;
       $notification_instance[$notification->getId()] = null;
       $redirect_array[$notification->getId()] = null;
 
@@ -55,40 +54,64 @@ class NotificationsController extends AbstractController
       {
         $found_notification = true;
         $user = $notification->getLikeFrom();
-        $reaction_notifications[$notification->getId()] = $notification;
-        $notification_instance[$notification->getId()] = 'reaction';
-        $redirect_array[$notification->getId()] = $notification->getProgram()->getId();
+        if ($user != $this->getUser())
+        {
+          $all_notifications[$notification->getId()] = $notification;
+          $reaction_notifications[$notification->getId()] = $notification;
+          $notification_instance[$notification->getId()] = 'reaction';
+          $redirect_array[$notification->getId()] = $notification->getProgram()->getId();
+        }
       }
       elseif ($notification instanceof CommentNotification)
       {
         $found_notification = true;
-        $comment_notifications[$notification->getId()] = $notification;
-        $notification_instance[$notification->getId()] = 'comment';
-        $redirect_array[$notification->getId()] = $notification->getComment()->getProgram()->getId();
+        if ($notification->getComment()->getUser() != $this->getUser())
+        {
+          $all_notifications[$notification->getId()] = $notification;
+          $comment_notifications[$notification->getId()] = $notification;
+          $notification_instance[$notification->getId()] = 'comment';
+          $redirect_array[$notification->getId()] = $notification->getComment()->getProgram()->getId();
+        }
       }
       elseif ($notification instanceof NewProgramNotification)
       {
         $found_notification = true;
         $user = $notification->getProgram()->getUser();
-        $follower_notifications[$notification->getId()] = $notification;
-        $notification_instance[$notification->getId()] = 'program';
-        $redirect_array[$notification->getId()] = $notification->getProgram()->getId();
+        if ($user != $this->getUser())
+        {
+          $all_notifications[$notification->getId()] = $notification;
+          $follower_notifications[$notification->getId()] = $notification;
+          $notification_instance[$notification->getId()] = 'program';
+          $redirect_array[$notification->getId()] = $notification->getProgram()->getId();
+        }
       }
       elseif ($notification instanceof FollowNotification)
       {
         $found_notification = true;
         $user = $notification->getFollower();
-        $follower_notifications[$notification->getId()] = $notification;
-        $notification_instance[$notification->getId()] = 'follow';
-        $redirect_array[$notification->getId()] = $notification->getFollower()->getId();
+        if ($user != $this->getUser())
+        {
+          $all_notifications[$notification->getId()] = $notification;
+          $follower_notifications[$notification->getId()] = $notification;
+          $notification_instance[$notification->getId()] = 'follow';
+          $redirect_array[$notification->getId()] = $notification->getFollower()->getId();
+        }
       }
       elseif ($notification instanceof RemixNotification)
       {
         $found_notification = true;
         $user = $notification->getRemixFrom();
-        $remix_notifications[$notification->getId()] = $notification;
-        $notification_instance[$notification->getId()] = 'remix';
-        $redirect_array[$notification->getId()] = $notification->getRemixProgram()->getId();
+        if ($user != $this->getUser())
+        {
+          $all_notifications[$notification->getId()] = $notification;
+          $remix_notifications[$notification->getId()] = $notification;
+          $notification_instance[$notification->getId()] = 'remix';
+          $redirect_array[$notification->getId()] = $notification->getRemixProgram()->getId();
+        }
+      }
+      else
+      {
+        $all_notifications[$notification->getId()] = $notification;
       }
       if (null == $notification_instance[$notification->getId()])
       {

--- a/src/Commands/Create/CreateCommentCommand.php
+++ b/src/Commands/Create/CreateCommentCommand.php
@@ -94,8 +94,7 @@ class CreateCommentCommand extends Command
     $temp_comment->setIsReported($reported);
 
     $this->em->persist($temp_comment);
-
-    $notification = new CommentNotification($user, $temp_comment);
+    $notification = new CommentNotification($program->getUser(), $temp_comment);
     $notification->setComment($temp_comment);
     $this->notification_service->addNotification($notification);
 

--- a/src/Commands/Create/CreateFollowersCommand.php
+++ b/src/Commands/Create/CreateFollowersCommand.php
@@ -73,9 +73,12 @@ class CreateFollowersCommand extends Command
 
     try
     {
-      $notification = new FollowNotification($user, $follower);
-      $this->followUser($user, $follower);
-      $this->notification_service->addNotification($notification);
+      if ($user !== $follower)
+      {
+        $notification = new FollowNotification($user, $follower);
+        $this->followUser($user, $follower);
+        $this->notification_service->addNotification($notification);
+      }
     }
     catch (Exception $e)
     {

--- a/src/Commands/Create/CreateLikeCommand.php
+++ b/src/Commands/Create/CreateLikeCommand.php
@@ -70,10 +70,13 @@ class CreateLikeCommand extends Command
     }
     try
     {
-      $notification = new LikeNotification($program->getUser(), $user, $program);
-      $this->likeProgram($program, $user);
-      $notification->setSeen(boolval(random_int(0, 3)));
-      $this->notification_service->addNotification($notification);
+      if ($program->getUser() !== $user)
+      {
+        $notification = new LikeNotification($program->getUser(), $user, $program);
+        $this->likeProgram($program, $user);
+        $notification->setSeen(boolval(random_int(0, 3)));
+        $this->notification_service->addNotification($notification);
+      }
     }
     catch (Exception $e)
     {

--- a/tests/behat/features/web/notifications4/notifications_validity.feature
+++ b/tests/behat/features/web/notifications4/notifications_validity.feature
@@ -1,0 +1,85 @@
+@web @notifications
+Feature: User should only get notifications from other users, and not from himself
+
+
+  Background:
+    Given there are users:
+      | id | name     |
+      | 1  | Catrobat |
+      | 2  | User     |
+      | 3  | Drago    |
+      | 4  | John     |
+      | 5  | Achiever |
+      | 6  | Sue      |
+      | 7  | Chris    |
+      | 8  | Andrew   |
+      | 9  | Peter    |
+      | 10 | Karen    |
+      | 11 | Brent    |
+
+
+    And there are projects:
+      | id | name      | owned by |
+      | 1  | program 1 | Catrobat |
+      | 2  | program 2 | User     |
+      | 3  | program 3 | Sue      |
+
+    And there are comments:
+      | id  | program_id | user_id | upload_date      | text | user_name | reported |
+      | 1   | 2          | 1       | 01.01.2013 12:01 | c1   | Catrobat  | true     |
+      | 2   | 1          | 2       | 01.01.2013 12:02 | c2   | User      | true     |
+      | 3   | 1          | 1       | 01.01.2013 12:03 | c3   | Catrobat  | true     |
+      | 4   | 2          | 2       | 01.01.2013 12:04 | c4   | User      | true     |
+
+    And there are catro notifications:
+      | id  | user     | title                 | message                                               | type            | commentID | like_from | follower_id | program_id  | prize | image_path |
+      | 1   | Catrobat |                       |                                                       | comment         | 2         |           |             |            |       |            |
+      | 2   | Catrobat |                       |                                                       | like            |           | 1         |             | 1           |       |            |
+      | 3   | Catrobat |                       |                                                       | follower        |           |           | 1           |             |       |            |
+      | 4   | Catrobat | title                 | Default msg                                           | default         |           |           |             |             |       |            |
+      | 5   | Catrobat |                       |                                                       | follow_program  |           |           |             | 2           |       |            |
+      | 6   | Catrobat | title                 | Congratulations, you uploaded your first app          | anniversary     |           |           |             |             | prize |            |
+      | 7   | Catrobat | title                 | Congratulations, you reached a total of 2 views       | achievement     |           |           |             |             |       | image path |
+      | 8   | User     |                       |                                                       | comment         | 1         |           |             | 2           |       |            |
+      | 9   | User     |                       |                                                       | like            |           | 2         |             | 2           |       |            |
+      | 10  | User     |                       |                                                       | follower        |           |           | 1           |             |       |            |
+      | 11  | User     | title                 | Default msg                                           | default         |           |           |             |             |       |            |
+      | 12  | User     |                       |                                                       | follow_program  |           |           |             | 3           |       |            |
+      | 13  | User     | title                 | Congratulations, you uploaded your first app          | anniversary     |           |           |             |             | prize |            |
+      | 14  | User     | title                 | Congratulations, you uploaded your first app          | achievement     |           |           |             |             |       | image path |
+      | 15  | Catrobat | title                 | Broadcast msg                                         | broadcast       |           |           |             |             |       |            |
+      | 16  | User     | title                 | Broadcast msg                                         | broadcast       |           |           |             |             |       |            |
+      | 17  | Catrobat |                       |                                                       | comment         | 3         |           |             |             |       |            |
+      | 18  | User     |                       |                                                       | comment         | 4         |           |             |             |       |            |
+
+
+
+  Scenario: Users don't get notifications from themselves
+    Given I log in as "Catrobat"
+    And I am on "/app/user_notifications"
+    And I wait for the page to be loaded
+    Then I should see "Congratulations, you uploaded your first app"
+    And I should see "Congratulations, you reached a total of 2 views"
+    And I should see "Default msg"
+    And I should see "Broadcast msg"
+    And I should not see "Catrobat is now following you"
+    And I should not see "Catrobat reacted to program 1"
+    Then I log in as "User"
+    And I am on "/app/user_notifications"
+    And I wait for the page to be loaded
+    Then I should see "Catrobat is now following you"
+    And I should see "Default msg"
+    And I should see "Broadcast msg"
+    And I should not see "User reacted to program 2"
+
+  Scenario: Comment notifications are shown to the user who recieved the comment
+    And I log in as "Catrobat"
+    And I am on "/app/user_notifications"
+    And I wait for the page to be loaded
+    Then I should see "User commented on program 1"
+    And I should not see "Catrobat commented on program 1"
+    Then I log in as "User"
+    And I am on "/app/user_notifications"
+    And I wait for the page to be loaded
+    Then I should see "Catrobat commented on program 2"
+    And I should not see "User commented on program 2"


### PR DESCRIPTION
- Fixed an issue in which comment notifications would be sent to the wrong user (the sender and not the reciever).
- Wrote additional checks in order to ensure that a user doesn't receive notifications from himself.
- Wrote testcase

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
