### PR TITLE
SHARE-377-Notification-Pagination

### DIFF
--- a/assets/js/custom/UserNotifications.js
+++ b/assets/js/custom/UserNotifications.js
@@ -3,8 +3,10 @@
 
 // eslint-disable-next-line no-unused-vars
 class UserNotifications {
-  constructor (markAsReadUrl, markAllSeen, countNotificationsUrl, somethingWentWrongError,
-    notificationsClearError, notificationsUnauthorizedError) {
+  constructor (markAsReadUrl, markAllSeen, countNotificationsUrl, fetchNotificationsUrl, somethingWentWrongError,
+    notificationsClearError, notificationsUnauthorizedError, allNotificationsCount,
+    followNotificationCount, reactionNotificationCount, commentNotificationCount, remixNotificationCount,
+    profilePath, programPath, imgAsset) {
     this.all = true
     this.follower = false
     this.comment = false
@@ -13,9 +15,21 @@ class UserNotifications {
     this.markAsReadUrl = markAsReadUrl
     this.markAllSeen = markAllSeen
     this.countNotificationsUrl = countNotificationsUrl
+    this.fetchNotificationsUrl = fetchNotificationsUrl
     this.somethingWentWrongError = somethingWentWrongError
     this.notificationsClearError = notificationsClearError
     this.notificationsUnauthorizedError = notificationsUnauthorizedError
+    this.notificationsFetchCount = 20
+    this.allNotificationsLoaded = document.getElementById('notifications').childElementCount
+    this.followerNotificationsLoaded = document.getElementById('follow-notifications').childElementCount
+    this.reactionNotificationsLoaded = document.getElementById('reaction-notifications').childElementCount
+    this.commentNotificationsLoaded = document.getElementById('comment-notifications').childElementCount
+    this.remixNotificationsLoaded = document.getElementById('remix-notifications').childElementCount
+    this.empty = false
+    this.fetchActive = false
+    this.profilePath = profilePath
+    this.programPath = programPath
+    this.imgAsset = imgAsset
 
     this._initListeners()
   }
@@ -26,6 +40,7 @@ class UserNotifications {
       if (self.all === false) {
         self.resetChips()
         self.selectChip('all-notif', self.all)
+        self.all = true
       }
     })
 
@@ -33,6 +48,12 @@ class UserNotifications {
       if (self.follower === false) {
         self.resetChips()
         self.selectChip('follow-notif', self.follower)
+        self.follower = true
+        if (self.followerNotificationsLoaded < self.notificationsFetchCount) {
+          self.followerNotificationsLoaded = document.getElementById('follow-notifications').childElementCount
+          self.fetchMoreNotifications(self.notificationsFetchCount, self.followerNotificationsLoaded,
+            'follow', 'follow-notification-', $('#follow-notifications'))
+        }
       }
     })
 
@@ -40,6 +61,12 @@ class UserNotifications {
       if (self.comment === false) {
         self.resetChips()
         self.selectChip('comment-notif', self.comment)
+        self.comment = true
+        if (self.commentNotificationsLoaded < self.notificationsFetchCount) {
+          self.commentNotificationsLoaded = document.getElementById('comment-notifications').childElementCount
+          self.fetchMoreNotifications(self.notificationsFetchCount, self.commentNotificationsLoaded,
+            'comment', 'comment-notification-', $('#comment-notifications'))
+        }
       }
     })
 
@@ -47,14 +74,157 @@ class UserNotifications {
       if (self.reactions === false) {
         self.resetChips()
         self.selectChip('reaction-notif', self.reactions)
+        self.reactions = true
+        if (self.reactionNotificationsLoaded < self.notificationsFetchCount) {
+          self.reactionNotificationsLoaded = document.getElementById('reaction-notifications').childElementCount
+          self.fetchMoreNotifications(self.notificationsFetchCount, self.reactionNotificationsLoaded,
+            'reaction', 'reaction-notification-', $('#reaction-notifications'))
+        }
       }
     })
     $(document).on('click', '#remix-notif', function () {
       if (self.remixes === false) {
         self.resetChips()
         self.selectChip('remix-notif', self.remixes)
+        self.remixes = true
+        if (self.remixNotificationsLoaded < self.notificationsFetchCount) {
+          self.remixNotificationsLoaded = document.getElementById('remix-notifications').childElementCount
+          self.fetchMoreNotifications(self.notificationsFetchCount, self.remixNotificationsLoaded,
+            'remix', 'remix-notification-', $('#remix-notifications'))
+        }
       }
     })
+
+    $(document).on('scroll', function () {
+      const position = $(window).scrollTop()
+      const bottom = $(document).height() - $(window).height()
+      const pctVertical = position / bottom
+      if (pctVertical >= 0.7) {
+        if (self.all === true) {
+          self.allNotificationsLoaded = document.getElementById('notifications').childElementCount
+          self.fetchMoreNotifications(self.notificationsFetchCount, self.allNotificationsLoaded,
+            'all', 'catro-notification-', $('#notifications'))
+        } else if (self.follower === true) {
+          self.followerNotificationsLoaded = document.getElementById('follow-notifications').childElementCount
+          self.fetchMoreNotifications(self.notificationsFetchCount, self.followerNotificationsLoaded,
+            'follow', 'follow-notification-', $('#follow-notifications'))
+        } else if (self.comment === true) {
+          self.commentNotificationsLoaded = document.getElementById('comment-notifications').childElementCount
+          self.fetchMoreNotifications(self.notificationsFetchCount, self.commentNotificationsLoaded,
+            'comment', 'comment-notification-', $('#comment-notifications'))
+        } else if (self.reactions === true) {
+          self.reactionNotificationsLoaded = document.getElementById('reaction-notifications').childElementCount
+          self.fetchMoreNotifications(self.notificationsFetchCount, self.reactionNotificationsLoaded,
+            'reaction', 'reaction-notification-', $('#reaction-notifications'))
+        } else if (self.remixes === true) {
+          self.remixNotificationsLoaded = document.getElementById('remix-notifications').childElementCount
+          self.fetchMoreNotifications(self.notificationsFetchCount, self.remixNotificationsLoaded,
+            'remix', 'remix-notification-', $('#remix-notifications'))
+        }
+      }
+    })
+  }
+
+  fetchMoreNotifications (limit, loadedCount, type, idPrefix, $container) {
+    const self = this
+    if (this.empty === true || this.fetchActive === true) {
+      return
+    }
+    this.fetchActive = true
+    $.ajax({
+      url: self.fetchNotificationsUrl + '/' + limit + '/' + loadedCount + '/' + type,
+      type: 'get',
+      success: function (data) {
+        data['fetched-notifications'].forEach(function (fetched) {
+          self.generateNotificationBody(fetched, idPrefix, $container)
+        })
+        self.updateNoNotificationsPlaceholder(type, data['fetched-notifications'].length)
+        self.fetchActive = false
+      },
+      error: function (xhr) {
+        self.handleError(xhr)
+      }
+    })
+  }
+
+  updateNoNotificationsPlaceholder (type, fetchedAmount) {
+    if (fetchedAmount > 0) {
+      if (type === 'all') {
+        document.getElementById('no-notif-all').style.display = 'none'
+      }
+      if (type === 'follow') {
+        document.getElementById('no-notif-follow').style.display = 'none'
+      }
+      if (type === 'comment') {
+        document.getElementById('no-notif-comment').style.display = 'none'
+      }
+      if (type === 'reaction') {
+        document.getElementById('no-notif-reaction').style.display = 'none'
+      }
+      if (type === 'remix') {
+        document.getElementById('no-notif-remix').style.display = 'none'
+      }
+    }
+  }
+
+  generateNotificationBody (fetched, idPrefix, $container) {
+    const self = this
+    const imgLeft = self.generateNotificationImage(fetched)
+    const msg = self.generateNotificationMessage(fetched)
+    const notificationId = idPrefix + fetched.id
+    let notificationDot = ''
+    if (!fetched.seen) {
+      notificationDot = '<div class="my-auto mark-as-read">' +
+        '<span class="dot">' + '</span>' + '</div>'
+    }
+    const notificationBody = '<div onclick="' + 'notification.handleNotificationInteract(' + "'" + fetched.id +
+      "'" + ',' + "'" + fetched.type + "'" + ',' + "'" + fetched.seen +
+      "'" + ',' + "'" + fetched.program + "'" + ')' +
+      '" id="' + notificationId + '" class="row my-3 no-gutters ripple notif">' +
+      '<div class="col-2 col-sm-1 my-auto">' + imgLeft + '</div>' +
+      '<div class="col-8 col-sm-8 pl-3 my-auto">' + msg + '</div>' + notificationDot + '</div>'
+    $container.append(notificationBody)
+  }
+
+  generateNotificationImage (fetched) {
+    const self = this
+    if (fetched.type !== 'other') {
+      let imgLeft = self.imgAsset
+      if (fetched.avatar) {
+        imgLeft = fetched.avatar
+      }
+      imgLeft = '<a href="' + self.profilePath + '/' + fetched.from + '">' +
+        '<img class="img-fluid notification-avatar-round" src="' + imgLeft + '" alt="">' + '</a>'
+      return imgLeft
+    } else {
+      let imgLeft = '<span class="material-icons broadcast-icon">' + 'notifications_active' + '</span>'
+      if (fetched.prize) {
+        imgLeft = '<span class="material-icons broadcast-icon">' + 'cake' + '</span>'
+      }
+      return imgLeft
+    }
+  }
+
+  generateNotificationMessage (fetched) {
+    const self = this
+    let msg = fetched.message
+    if (msg.includes('%user_link%')) {
+      msg = msg.replace('%user_link%', '<a href="' + self.profilePath + '/' + fetched.from + '">' +
+        fetched.from_name + '</a>')
+    }
+    if (msg.includes('%program_link%')) {
+      msg = msg.replace('%program_link%', '<a href="' + self.programPath + '/' + fetched.program +
+        '">' + fetched.program_name + '</a>')
+    }
+    if (msg.includes('%remixed_program_link%')) {
+      msg = msg.replace('%remixed_program_link%', '<a href="' + self.programPath + '/' +
+        fetched.remixed_program + '">' + fetched.remixed_program_name + '</a>')
+    }
+    if (fetched.prize) {
+      msg = '<div class="message">' + fetched.message + '</div>' +
+        '<div class="prize">' + fetched.prize + '</div>'
+    }
+    return msg
   }
 
   resetChips () {

--- a/migrations/2020/Version20200815124747.php
+++ b/migrations/2020/Version20200815124747.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200815124747 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE CatroNotification ADD type VARCHAR(255) NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE CatroNotification DROP type');
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -841,9 +841,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@material/progress-indicator": "^7.0.0",
     "@material/snackbar": "^7.0.0",
     "@material/top-app-bar": "^7.0.0",
-    "ajv": "^6.12.3",
+    "ajv": "^6.12.4",
     "animate.css": "^4.1.0",
     "animatedmodal": "^1.0.0",
     "bootstrap": "^4.5.2",

--- a/src/Catrobat/Controller/Web/NotificationsController.php
+++ b/src/Catrobat/Controller/Web/NotificationsController.php
@@ -3,6 +3,7 @@
 namespace App\Catrobat\Controller\Web;
 
 use App\Catrobat\Services\CatroNotificationService;
+use App\Entity\AnniversaryNotification;
 use App\Entity\CatroNotification;
 use App\Entity\CommentNotification;
 use App\Entity\FollowNotification;
@@ -17,9 +18,13 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class NotificationsController extends AbstractController
 {
+  const load_limit = 20;
+  const load_offset = 0;
+
   /**
    * @Route("/user_notifications", name="notifications", methods={"GET"})
    */
@@ -32,10 +37,8 @@ class NotificationsController extends AbstractController
       return $this->redirectToRoute('login');
     }
 
-    $catro_user_notifications = $notification_repository->findBy(['user' => $user], ['id' => 'DESC']);
+    $catro_user_notifications = $notification_repository->findBy(['user' => $user], ['id' => 'DESC'], self::load_limit, self::load_offset);
     $avatars = [];
-    $new_notifications = [];
-    $old_notifications = [];
     $all_notifications = [];
     $follower_notifications = [];
     $comment_notifications = [];
@@ -45,14 +48,12 @@ class NotificationsController extends AbstractController
     $redirect_array = [];
     foreach ($catro_user_notifications as $notification)
     {
-      $found_notification = false;
       $user = null;
       $notification_instance[$notification->getId()] = null;
       $redirect_array[$notification->getId()] = null;
 
       if ($notification instanceof LikeNotification)
       {
-        $found_notification = true;
         $user = $notification->getLikeFrom();
         if ($user != $this->getUser())
         {
@@ -64,7 +65,6 @@ class NotificationsController extends AbstractController
       }
       elseif ($notification instanceof CommentNotification)
       {
-        $found_notification = true;
         if ($notification->getComment()->getUser() != $this->getUser())
         {
           $all_notifications[$notification->getId()] = $notification;
@@ -75,7 +75,6 @@ class NotificationsController extends AbstractController
       }
       elseif ($notification instanceof NewProgramNotification)
       {
-        $found_notification = true;
         $user = $notification->getProgram()->getUser();
         if ($user != $this->getUser())
         {
@@ -87,7 +86,6 @@ class NotificationsController extends AbstractController
       }
       elseif ($notification instanceof FollowNotification)
       {
-        $found_notification = true;
         $user = $notification->getFollower();
         if ($user != $this->getUser())
         {
@@ -99,7 +97,6 @@ class NotificationsController extends AbstractController
       }
       elseif ($notification instanceof RemixNotification)
       {
-        $found_notification = true;
         $user = $notification->getRemixFrom();
         if ($user != $this->getUser())
         {
@@ -129,18 +126,14 @@ class NotificationsController extends AbstractController
           $avatars[$notification->getId()] = $avatar;
         }
       }
-      if ($notification->getSeen() && $found_notification)
-      {
-        $old_notifications[$notification->getId()] = $notification;
-      }
-      elseif (!$notification->getSeen() && $found_notification)
-      {
-        $new_notifications[$notification->getId()] = $notification;
-      }
     }
+
+    $all_notifications_count = sizeof($all_notifications);
+    $follower_count = sizeof($follower_notifications);
+    $reaction_count = sizeof($reaction_notifications);
+    $comment_count = sizeof($comment_notifications);
+    $remix_count = sizeof($remix_notifications);
     $response = $this->render('Notifications/notifications.html.twig', [
-      'oldNotifications' => $old_notifications,
-      'newNotifications' => $new_notifications,
       'avatars' => $avatars,
       'allNotifications' => $all_notifications,
       'followerNotifications' => $follower_notifications,
@@ -149,6 +142,11 @@ class NotificationsController extends AbstractController
       'remixNotifications' => $remix_notifications,
       'instance' => $notification_instance,
       'redirect' => $redirect_array,
+      'allNotificationsCount' => $all_notifications_count,
+      'followNotificationCount' => $follower_count,
+      'reactionNotificationCount' => $reaction_count,
+      'commentNotificationCount' => $comment_count,
+      'remixNotificationCount' => $remix_count,
     ]);
     $response->headers->set('Cache-Control', 'no-store, must-revalidate, max-age=0');
     $response->headers->set('Pragma', 'no-cache');
@@ -162,8 +160,8 @@ class NotificationsController extends AbstractController
    * Todo -> move to CAPI
    */
   public function markNotificationAsRead(int $notification_id,
-                                              CatroNotificationService $notification_service,
-                                              CatroNotificationRepository $notification_repo): JsonResponse
+                                         CatroNotificationService $notification_service,
+                                         CatroNotificationRepository $notification_repo): JsonResponse
   {
     $user = $this->getUser();
     if (null === $user)
@@ -185,7 +183,7 @@ class NotificationsController extends AbstractController
    * Todo -> move to CAPI
    */
   public function unseenNotificationsCountAction(CatroNotificationRepository $notification_repo,
-                                               RemixManager $remix_manager): JsonResponse
+                                                 RemixManager $remix_manager): JsonResponse
   {
     /** @var User|null $user */
     $user = $this->getUser();
@@ -268,5 +266,167 @@ class NotificationsController extends AbstractController
     $remix_manager->markAllUnseenRemixRelationsOfUserAsSeen($user);
 
     return new JsonResponse([], Response::HTTP_NO_CONTENT);
+  }
+
+  /**
+   * @Route("/user_notifications/fetch/{limit}/{offset}/{type}", name="notifications_fetch",
+   * defaults={"limit": null, "offset": null, "type": null}, methods={"GET"})
+   */
+  public function fetchMoreNotifications(CatroNotificationRepository $notification_repo,
+                                         CatroNotificationService $notification_service,
+                                         RemixManager $remix_manager, TranslatorInterface $translator,
+                                         int $limit, int $offset, string $type): JsonResponse
+  {
+    /** @var User|null $user */
+    $user = $this->getUser();
+    if (!$user)
+    {
+      return JsonResponse::create([], Response::HTTP_UNAUTHORIZED);
+    }
+    $catro_user_notifications = null;
+    if ('all' === $type)
+    {
+      $catro_user_notifications = $notification_repo->findBy(['user' => $user], ['id' => 'DESC'], $limit, $offset);
+    }
+    else
+    {
+      $catro_user_notifications = $notification_repo->findBy(['user' => $user, 'type' => $type], ['id' => 'DESC'], $limit, $offset);
+    }
+
+    $fetched_notifications = [];
+    foreach ($catro_user_notifications as $notification)
+    {
+      if ($notification instanceof LikeNotification && ('reaction' === $type || 'all' === $type))
+      {
+        if (($notification->getLikeFrom() === $this->getUser()))
+        {
+          continue;
+        }
+        array_push($fetched_notifications,
+          ['id' => $notification->getId(),
+            'from' => $notification->getLikeFrom()->getId(),
+            'from_name' => $notification->getLikeFrom()->getUsername(),
+            'program' => $notification->getProgram()->getId(),
+            'program_name' => $notification->getProgram()->getName(),
+            'avatar' => $notification->getLikeFrom()->getAvatar(),
+            'remixed_program' => null,
+            'remixed_program_name' => null,
+            'type' => 'reaction',
+            'message' => $translator->trans('catro-notifications.like.message', [], 'catroweb'),
+            'prize' => null,
+            'seen' => $notification->getSeen(), ]);
+
+        continue;
+      }
+      if (($notification instanceof FollowNotification || $notification instanceof NewProgramNotification)
+        && ('follow' === $type || 'all' === $type))
+      {
+        if (($notification instanceof FollowNotification && $notification->getFollower() === $this->getUser())
+          || ($notification instanceof NewProgramNotification && $notification->getProgram()->getUser() === $this->getUser()))
+        {
+          continue;
+        }
+        if ($notification instanceof FollowNotification)
+        {
+          array_push($fetched_notifications,
+            ['id' => $notification->getId(),
+              'from' => $notification->getFollower()->getId(),
+              'from_name' => $notification->getFollower()->getUsername(),
+              'program' => null,
+              'program_name' => null,
+              'avatar' => $notification->getFollower()->getAvatar(),
+              'remixed_program' => null,
+              'remixed_program_name' => null,
+              'type' => 'follow',
+              'message' => $translator->trans('catro-notifications.follow.message', [], 'catroweb'),
+              'prize' => null,
+              'seen' => $notification->getSeen(), ]);
+        }
+        else
+        {
+          array_push($fetched_notifications,
+            ['id' => $notification->getId(),
+              'from' => $notification->getProgram()->getUser()->getId(),
+              'from_name' => $notification->getProgram()->getUser()->getUsername(),
+              'program' => $notification->getProgram()->getId(),
+              'program_name' => $notification->getProgram()->getName(),
+              'avatar' => $notification->getProgram()->getUser()->getAvatar(),
+              'remixed_program' => null,
+              'remixed_program_name' => null,
+              'type' => 'program',
+              'message' => $translator->trans('catro-notifications.program-upload.message', [], 'catroweb'),
+              'prize' => null,
+              'seen' => $notification->getSeen(), ]);
+        }
+        continue;
+      }
+      if ($notification instanceof CommentNotification && ('comment' === $type || 'all' === $type))
+      {
+        if ($notification->getComment()->getUser() === $this->getUser())
+        {
+          continue;
+        }
+        array_push($fetched_notifications,
+          ['id' => $notification->getId(),
+            'from' => $notification->getComment()->getUser()->getId(),
+            'from_name' => $notification->getComment()->getUser()->getUsername(),
+            'program' => $notification->getComment()->getProgram()->getId(),
+            'program_name' => $notification->getComment()->getProgram()->getName(),
+            'avatar' => $notification->getComment()->getUser()->getAvatar(),
+            'remixed_program' => null,
+            'remixed_program_name' => null,
+            'type' => 'comment',
+            'message' => $translator->trans('catro-notifications.comment.message', [], 'catroweb'),
+            'prize' => null,
+            'seen' => $notification->getSeen(), ]);
+        continue;
+      }
+      if ($notification instanceof RemixNotification && ('remix' === $type || 'all' === $type))
+      {
+        if ($notification->getRemixFrom() === $this->getUser())
+        {
+          continue;
+        }
+
+        array_push($fetched_notifications,
+          ['id' => $notification->getId(),
+            'from' => $notification->getRemixFrom()->getId(),
+            'from_name' => $notification->getRemixFrom()->getUsername(),
+            'program' => $notification->getRemixProgram()->getId(),
+            'program_name' => $notification->getRemixProgram()->getName(),
+            'avatar' => $notification->getRemixFrom()->getAvatar(),
+            'remixed_program' => $notification->getProgram()->getId(),
+            'remixed_program_name' => $notification->getProgram()->getName(),
+            'type' => 'remix',
+            'message' => $translator->trans('catro-notifications.remix.message', [], 'catroweb'),
+            'prize' => null,
+            'seen' => $notification->getSeen(), ]);
+        continue;
+      }
+      if ('all' === $type)
+      {
+        $prize = null;
+        if ($notification instanceof AnniversaryNotification)
+        {
+          $prize = $notification->getPrize();
+        }
+        array_push($fetched_notifications,
+          ['id' => $notification->getId(),
+            'from' => null,
+            'from_name' => null,
+            'program' => 'other',
+            'program_name' => null,
+            'avatar' => null,
+            'remixed_program' => null,
+            'remixed_program_name' => null,
+            'type' => 'other',
+            'message' => $notification->getMessage(),
+            'prize' => $prize,
+            'seen' => $notification->getSeen(), ]);
+      }
+    }
+
+    return new JsonResponse([
+      'fetched-notifications' => $fetched_notifications, ], Response::HTTP_OK);
   }
 }

--- a/src/Catrobat/Controller/Web/ProgramController.php
+++ b/src/Catrobat/Controller/Web/ProgramController.php
@@ -86,7 +86,7 @@ class ProgramController extends AbstractController
   }
 
   /**
-   * @Route("/project/{id}", name="program")
+   * @Route("/project/{id}", name="program", defaults={"id": "0"})
    *
    * Legacy routes:
    * @Route("/program/{id}", name="program_depricated")

--- a/src/Entity/AchievementNotification.php
+++ b/src/Entity/AchievementNotification.php
@@ -21,7 +21,7 @@ class AchievementNotification extends CatroNotification
 
   public function __construct(User $user, string $title, string $message, ?string $image_path)
   {
-    parent::__construct($user, $title, $message);
+    parent::__construct($user, $title, $message, 'achievement');
     $this->image_path = $image_path;
   }
 

--- a/src/Entity/AnniversaryNotification.php
+++ b/src/Entity/AnniversaryNotification.php
@@ -21,7 +21,7 @@ class AnniversaryNotification extends CatroNotification
 
   public function __construct(User $user, string $title, string $message, string $prize)
   {
-    parent::__construct($user, $title, $message);
+    parent::__construct($user, $title, $message, 'anniversary');
     $this->prize = $prize;
   }
 

--- a/src/Entity/BroadcastNotification.php
+++ b/src/Entity/BroadcastNotification.php
@@ -17,7 +17,7 @@ class BroadcastNotification extends CatroNotification
 
   public function __construct(User $user, string $title, string $message)
   {
-    parent::__construct($user, $title, $message);
+    parent::__construct($user, $title, $message, 'broadcast');
   }
 
   /**

--- a/src/Entity/CatroNotification.php
+++ b/src/Entity/CatroNotification.php
@@ -66,13 +66,19 @@ class CatroNotification
    */
   private bool $seen = false;
 
+  /**
+   * @ORM\Column(name="type", type="string")
+   */
+  private string $type = '';
+
   private string $twig_template = 'Notifications/NotificationTypes/catro_notification.html.twig';
 
-  public function __construct(User $user, string $title = '', string $message = '')
+  public function __construct(User $user, string $title = '', string $message = '', string $type = '')
   {
     $this->user = $user;
     $this->title = $title;
     $this->message = $message;
+    $this->type = $type;
   }
 
   public function getId(): ?int
@@ -147,5 +153,17 @@ class CatroNotification
   public function setTwigTemplate(string $twig_template): void
   {
     $this->twig_template = $twig_template;
+  }
+
+  public function setType(string $type): CatroNotification
+  {
+    $this->type = $type;
+
+    return $this;
+  }
+
+  public function getType(): string
+  {
+    return $this->type;
   }
 }

--- a/src/Entity/CommentNotification.php
+++ b/src/Entity/CommentNotification.php
@@ -39,7 +39,7 @@ class CommentNotification extends CatroNotification
    */
   public function __construct(User $user, UserComment $comment)
   {
-    parent::__construct($user);
+    parent::__construct($user, '', '', 'comment');
     $this->comment = $comment;
   }
 

--- a/src/Entity/FollowNotification.php
+++ b/src/Entity/FollowNotification.php
@@ -38,7 +38,7 @@ class FollowNotification extends CatroNotification
    */
   public function __construct(User $user, User $profile)
   {
-    parent::__construct($user);
+    parent::__construct($user, '', '', 'follow');
     $this->follower = $profile;
   }
 

--- a/src/Entity/LikeNotification.php
+++ b/src/Entity/LikeNotification.php
@@ -54,7 +54,7 @@ class LikeNotification extends CatroNotification
    */
   public function __construct(User $user, User $like_from, Program $program)
   {
-    parent::__construct($user);
+    parent::__construct($user, '', '', 'reaction');
     $this->like_from = $like_from;
     $this->program = $program;
   }

--- a/src/Entity/NewProgramNotification.php
+++ b/src/Entity/NewProgramNotification.php
@@ -32,7 +32,7 @@ class NewProgramNotification extends CatroNotification
 
   public function __construct(User $user, ?Program $program)
   {
-    parent::__construct($user);
+    parent::__construct($user, '', '', 'follow');
     $this->program = $program;
   }
 

--- a/src/Entity/RemixNotification.php
+++ b/src/Entity/RemixNotification.php
@@ -68,7 +68,7 @@ class RemixNotification extends CatroNotification
    */
   public function __construct(User $user, User $remix_from, Program $program, Program $remix_program)
   {
-    parent::__construct($user);
+    parent::__construct($user, '', '', 'remix');
     $this->remix_from = $remix_from;
     $this->program = $program;
     $this->remix_program = $remix_program;

--- a/templates/Notifications/NotificationTypes/remix_notification.html.twig
+++ b/templates/Notifications/NotificationTypes/remix_notification.html.twig
@@ -17,8 +17,8 @@
       (
       {
         '%user_link%': '<a href="'~path('profile', {'id': notification.getRemixFrom.id})~'">'~notification.getRemixFrom.getUserName~'</a>',
-        '%remix_program_link%': '<a href="'~path('program', {'id': notification.getRemixProgram.id})~'">'~notification.getRemixProgram.name~'</a>',
-        '%program_link%': '<a href="'~path('program', {'id': notification.program.id})~'">'~notification.program.name~'</a>'
+        '%program_link%': '<a href="'~path('program', {'id': notification.getRemixProgram.id})~'">'~notification.getRemixProgram.name~'</a>',
+        '%remixed_program_link%': '<a href="'~path('program', {'id': notification.program.id})~'">'~notification.program.name~'</a>'
       },
       'catroweb'
     )

--- a/templates/Notifications/notifications.html.twig
+++ b/templates/Notifications/notifications.html.twig
@@ -66,83 +66,88 @@
   </div>
   <div class="tab-content mt-4">
     <div id="all" class="tab-pane fade show active" role="tabpanel">
-      <div id="no-notifications"
-           class="text-center mb-5 {{ allNotifications is empty ? 'd-block' : 'd-none' }}">
-        {{ "notificationsReadMessage"|trans({}, "catroweb") }}
-      </div>
       <div id="notifications" class="mb-5">
         {% for notification in allNotifications %}
           <div
               onclick="notification.handleNotificationInteract('{{ notification.id }}',
                   '{{ instance[notification.id] }}', '{{ notification.getSeen() }}', '{{ redirect[notification.id] }}')"
-              id="catro-notification-{{ notification.id }}" class="row my-3 no-gutters ripple notif">
+              id="catro-notification-{{ notification.id }}"
+              class="row my-3 no-gutters ripple notif">
             {{ include(notification.getTwigTemplate) }}
           </div>
         {% endfor %}
       </div>
+      <div id="no-notifications"
+           class="text-center mb-5 {{ allNotifications is empty ? 'd-block' : 'd-none' }}">
+        <span id="no-notif-all">{{ "notificationsReadMessage"|trans({}, "catroweb") }}</span>
+      </div>
     </div>
     <div id="follow" class="tab-pane fade" role="tabpanel">
-      <div id="no-follow-notifications"
-           class="text-center mb-5 {{ followerNotifications is empty ? 'd-block' : 'd-none' }}">
-        {{ "catro-notifications.noFollowers"|trans({}, "catroweb") }}
-      </div>
       <div id="follow-notifications" class="mb-5">
         {% for notification in followerNotifications %}
           <div
               onclick="notification.handleNotificationInteract('{{ notification.id }}',
                   '{{ instance[notification.id] }}', '{{ notification.getSeen() }}', '{{ redirect[notification.id] }}')"
-              id="follow-notification-{{ notification.id }}" class="row my-3 no-gutters ripple notif">
+              id="follow-notification-{{ notification.id }}"
+              class="row my-3 no-gutters ripple notif">
             {{ include(notification.getTwigTemplate) }}
           </div>
         {% endfor %}
       </div>
+      <div id="no-follow-notifications"
+           class="text-center mb-5 {{ followerNotifications is empty ? 'd-block' : 'd-none' }}">
+        <span id="no-notif-follow">{{ "catro-notifications.noFollowers"|trans({}, "catroweb") }}</span>
+      </div>
     </div>
     <div id="comment" class="tab-pane fade" role="tabpanel">
-      <div id="no-comment-notifications"
-           class="text-center mb-5 {{ commentNotifications is empty ? 'd-block' : 'd-none' }}">
-        {{ "catro-notifications.noComments"|trans({}, "catroweb") }}
-      </div>
       <div id="comment-notifications" class="mb-5">
         {% for notification in commentNotifications %}
           <div
               onclick="notification.handleNotificationInteract('{{ notification.id }}', 'comment',
                   '{{ notification.getSeen() }}', '{{ notification.comment.program.id }}')"
-              id="comment-notification-{{ notification.id }}" class="row my-3 no-gutters ripple notif">
+              id="comment-notification-{{ notification.id }}"
+              class="row my-3 no-gutters ripple notif">
             {{ include(notification.getTwigTemplate) }}
           </div>
         {% endfor %}
       </div>
+      <div id="no-comment-notifications"
+           class="text-center mb-5 {{ commentNotifications is empty ? 'd-block' : 'd-none' }}">
+        <span id="no-notif-comment">{{ "catro-notifications.noComments"|trans({}, "catroweb") }}</span>
+      </div>
     </div>
     <div id="reaction" class="tab-pane fade" role="tabpanel">
-      <div id="no-reaction-notifications"
-           class="text-center mb-5 {{ reactionNotifications is empty ? 'd-block' : 'd-none' }}">
-        {{ "catro-notifications.noReactions"|trans({}, "catroweb") }}
-      </div>
       <div id="reaction-notifications" class="mb-5">
         {% for notification in reactionNotifications %}
           <div
               onclick="notification.handleNotificationInteract('{{ notification.id }}', 'reaction',
                   '{{ notification.getSeen() }}', '{{ notification.program.id }}')"
-              id="reaction-notification-{{ notification.id }}" class="row my-3 no-gutters ripple notif">
+              id="reaction-notification-{{ notification.id }}"
+              class="row my-3 no-gutters ripple notif">
             {{ include(notification.getTwigTemplate) }}
           </div>
         {% endfor %}
       </div>
+      <div id="no-reaction-notifications"
+           class="text-center mb-5 {{ reactionNotifications is empty ? 'd-block' : 'd-none' }}">
+        <span id="no-notif-reaction">{{ "catro-notifications.noReactions"|trans({}, "catroweb") }}</span>
+      </div>
     </div>
     <div id="remix" class="tab-pane fade" role="tabpanel">
-      <div id="no-remix-notifications"
-           class="text-center mb-5 {{ remixNotifications is empty ? 'd-block' : 'd-none' }}">
-        {{ "catro-notifications.noRemixes"|trans({}, "catroweb") }}
-      </div>
       <div id="remix-notifications" class="mb-5">
         {% for notification in remixNotifications %}
           <div
               onclick="notification.handleNotificationInteract('{{ notification.id }}', 'remix',
                   '{{ notification.getSeen() }}', '{{ notification.getRemixProgram.id }}')"
-              id="remix-notification-{{ notification.id }}" class="row my-3 no-gutters ripple notif">
+              id="remix-notification-{{ notification.id }}"
+              class="row my-3 no-gutters ripple notif">
             {{ include(notification.getTwigTemplate) }}
           </div>
         {% endfor %}
+      </div>
+      <div id="no-remix-notifications"
+           class="text-center mb-5 {{ remixNotifications is empty ? 'd-block' : 'd-none' }}">
+        <span id="no-notif-remix">{{ "catro-notifications.noRemixes"|trans({}, "catroweb") }}</span>
       </div>
     </div>
   </div>
@@ -152,9 +157,12 @@
   <script src="{{ asset('js/UserNotifications.min.js') }}"></script>
   <script>
     let notification = new UserNotifications("{{ url('notification_mark_as_read') }}", "{{ url('notifications_seen') }}",
-      "{{ path('notifications_count') }}", "{{ "somethingWentWrong"|trans({}, "catroweb") }}",
+      "{{ path('notifications_count') }}", "{{ path('notifications_fetch') }}", "{{ "somethingWentWrong"|trans({}, "catroweb") }}",
       "{{ "notificationsClearError"|trans({}, "catroweb") }}",
-      "{{ "notificationsUnauthorizedError"|trans({}, "catroweb") }}");
+      "{{ "notificationsUnauthorizedError"|trans({}, "catroweb") }}", {{ allNotificationsCount }},
+        {{ followNotificationCount }}, {{ reactionNotificationCount }}, {{ commentNotificationCount }},
+        {{ remixNotificationCount }}, "{{ path('profile') }}", "{{ path('program') }}",
+      "{{ asset('images/default/avatar_default.png') }}");
     notification.markAllRead()
   </script>
 {% endblock %}

--- a/tests/behat/features/web/notifications1/notifications.feature
+++ b/tests/behat/features/web/notifications1/notifications.feature
@@ -18,6 +18,7 @@ Feature: User gets notifications for new followers, reactions, comments and othe
       | 11 | Brent    |
 
 
+
     And there are projects:
       | id | name      | owned by |
       | 1  | program 1 | Catrobat |
@@ -100,10 +101,10 @@ Feature: User gets notifications for new followers, reactions, comments and othe
 
   Scenario: If user goes to one of the Notifications subsections he should see
   just notifications of that type
-    Given there are "10" "like" notifications for program "program 3" from "Andrew"
-    And there are "20" "comment" notifications for program "program 3" from "Chris"
-    And there are "12" "remix" notifications for program "program 3" from "Chris"
-    And there are "5"+ notifications for "Sue"
+    Given there are "2" "like" notifications for program "program 3" from "Andrew"
+    And there are "4" "comment" notifications for program "program 3" from "Chris"
+    And there are "4" "remix" notifications for program "program 3" from "Chris"
+    And there are "2"+ notifications for "Sue"
     And there is a notification that "Catrobat" follows "Sue"
     And there is a notification that "Drago" follows "Sue"
     And I log in as "Sue"

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -888,7 +888,7 @@ catro-notifications:
   program-upload:
     message: '%user_link% created a new game %program_link%.'
   remix:
-    message: '%user_link% created a remix %remix_program_link% of your game %program_link%.'
+    message: '%user_link% created a remix %program_link% of your game %remixed_program_link%.'
 
 clipboard:
   success: Link to project copied to clipboard!


### PR DESCRIPTION
- Added pagination to the notification page
- In case a user has a large number of notifications (> 20), only the first 20 notifications per container are loaded immediately upon page load. Further notifications are then loaded if necessary when the user scrolls down

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
