### PR TITLE
SHARE-386 Uniform color for spinners

### DIFF
--- a/assets/css/custom/program.scss
+++ b/assets/css/custom/program.scss
@@ -16,10 +16,6 @@
   border-width: medium;
 }
 
-.project-view-spinner{
-  @include color(red);
-}
-
 .show {
   display: block;
 }

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -34,7 +34,7 @@
           {{ program.user }}
         </a>
         <span>
-          <i class="material-icons d-none project-view-spinner" id="project-user-spinner{{ suffix|default('') }}">
+          <i class="material-icons d-none" id="project-user-spinner{{ suffix|default('') }}">
             {% include 'Default/loadingSpinner.html.twig' with {'spinner_id': 'user-spinner' ~ suffix|default(), small: 'true'} %}
           </i>
         </span>

--- a/templates/Program/program_apk_generation_buttons.html.twig
+++ b/templates/Program/program_apk_generation_buttons.html.twig
@@ -9,7 +9,7 @@
 <div>
   <button id="apk-pending{{ suffix|default('') }}"
           class="btn btn-outline-primary btn-block d-none">
-    <i class="material-icons align-bottom text-left project-view-spinner">
+    <i class="material-icons align-bottom text-left">
       {% include 'Default/loadingSpinner.html.twig' with {'spinner_id': 'apk-progressbar' ~ suffix|default(), 'small': true} %}
     </i>
     <span>{{ "apk.preparing"|trans({}, "catroweb") }}</span>
@@ -19,12 +19,12 @@
 <div>
   <button id="apk-download{{ suffix|default('') }}"
           class="btn btn-outline-primary btn-block d-none">
-    <i class="material-icons text-left d-none  project-view-spinner">
+    <i class="material-icons text-left d-none">
       {% include 'Default/loadingSpinner.html.twig' with {'spinner_id': 'download-spinner' ~ suffix|default(), 'small': true} %}
     </i>
     <i class="material-icons align-bottom">casino</i>
     <span>{{ "apk.download"|trans({}, "catroweb") }}</span>
   </button>
 </div>
-<i class="material-icons text-left d-none  project-view-spinner" id="apk-pb{{ suffix|default('') }}">
+<i class="material-icons text-left d-none" id="apk-pb{{ suffix|default('') }}">
   {% include 'Default/loadingSpinner.html.twig' with {'spinner_id': 'download-progressbar' ~ suffix|default(), 'small': 'true'} only %}</i>

--- a/templates/Program/program_code_statistics_button.html.twig
+++ b/templates/Program/program_code_statistics_button.html.twig
@@ -2,7 +2,7 @@
         class="btn btn-outline-primary btn-block"
         onclick="program.projectViewButtonsAction('{{ path('code_statistics', {'id': program.id }) }}', '#code-statistics-button-spinner{{ suffix|default('') }}',
 '#code-statistics-icon{{ suffix|default('') }}')">
-  <i class="material-icons d-none text-left project-view-spinner" id="code-statistics-button-spinner{{ suffix|default('') }}">
+  <i class="material-icons d-none text-left" id="code-statistics-button-spinner{{ suffix|default('') }}">
     {% include 'Default/loadingSpinner.html.twig' with {'spinner_id': 'code-statistics-spinner' ~ suffix|default(), 'small': true} %}
   </i>
   <i class="material-icons align-bottom" id="code-statistics-icon{{ suffix|default('') }}">show_chart</i>

--- a/templates/Program/program_code_view_button.html.twig
+++ b/templates/Program/program_code_view_button.html.twig
@@ -2,7 +2,7 @@
         class="btn btn-outline-primary btn-block"
         onclick="program.projectViewButtonsAction('{{ path('code_view', {'id': program.id }) }}', '#code-view-button-spinner{{ suffix|default('') }}',
                 '#code-view-icon{{ suffix|default('') }}')">
-  <i class="material-icons d-none text-left project-view-spinner" id="code-view-button-spinner{{ suffix|default('') }}">
+  <i class="material-icons d-none text-left" id="code-view-button-spinner{{ suffix|default('') }}">
     {% include 'Default/loadingSpinner.html.twig' with {'spinner_id': 'code-view-spinner' ~ suffix|default(), 'small': true} %}
   </i>
   <i class="material-icons align-bottom" id="code-view-icon">extension</i>

--- a/templates/Program/program_download_button.html.twig
+++ b/templates/Program/program_download_button.html.twig
@@ -10,7 +10,7 @@
            '#download-pb{{ suffix|default('') }}',
            '#download-icon{{ suffix|default('') }}')">
 
-  <i class="material-icons text-left d-none project-view-spinner" id="download-pb{{ suffix|default('') }}">
+  <i class="material-icons text-left d-none" id="download-pb{{ suffix|default('') }}">
   {% include 'Default/loadingSpinner.html.twig' with {'spinner_id': 'download-progressbar' ~ suffix|default(), 'small': 'true'} only %}</i>
   <i class="material-icons" id="download-icon{{ suffix|default('') }}">get_app</i>
   <span>{{ "download"|trans({}, "catroweb") }}</span>

--- a/templates/Program/program_reactions.html.twig
+++ b/templates/Program/program_reactions.html.twig
@@ -48,7 +48,7 @@
     {{ 'programs.reactionsText'|trans({}, 'catroweb') }}
     </span>
     <span>
-    <i class="material-icons d-none project-view-spinner" id="project-reactions-spinner{{ suffix|default('') }}">
+    <i class="material-icons d-none" id="project-reactions-spinner{{ suffix|default('') }}">
       {% include 'Default/loadingSpinner.html.twig' with {'spinner_id': 'reactions-spinner' ~ suffix|default(), small: 'true'} %}
     </i>
     </span>

--- a/templates/Program/program_remix_graph_button.html.twig
+++ b/templates/Program/program_remix_graph_button.html.twig
@@ -2,7 +2,7 @@
         class="btn btn-outline-primary btn-block"
         onclick="program.projectViewButtonsAction('{{path('remix_graph', {'id': program.id })}}', '#remix-graph-button-spinner{{ suffix|default('') }}',
                 '#remix-graph-icon{{ suffix|default('') }}')">
-  <i class="material-icons d-none text-left project-view-spinner" id="remix-graph-button-spinner{{ suffix|default('') }}">
+  <i class="material-icons d-none text-left" id="remix-graph-button-spinner{{ suffix|default('') }}">
     {% include 'Default/loadingSpinner.html.twig' with {'spinner_id': 'remix-graph-spinner' ~ suffix|default(), 'small': true} %}
   </i>
   <i class="material-icons align-bottom" id="remix-graph-icon{{ suffix|default('') }}">call_split</i>

--- a/templates/Program/projectThumbnail.html.twig
+++ b/templates/Program/projectThumbnail.html.twig
@@ -15,7 +15,7 @@
         </div>
       </div>
       <div class="text-center">
-        <i class="material-icons text-left d-none project-view-spinner" id="upload-image-spinner">
+        <i class="material-icons text-left d-none" id="upload-image-spinner">
           {% include 'Default/loadingSpinner.html.twig' with {'spinner_id': 'upload-image-pb', 'small': 'true'} only %}</i>
       </div>
       <div class="d-none error-message text-img-upload-too-large alert alert-danger">

--- a/templates/UserManagement/Profile/avatarEdit.html.twig
+++ b/templates/UserManagement/Profile/avatarEdit.html.twig
@@ -18,7 +18,7 @@
   <div>
     <input type="file" name="file">
     <a href="">{{ 'profile.changePicture'|trans({}, 'catroweb') }}</a>
-    <div class="button-show-ajax"> <i class="material-icons text-left d-none project-view-spinner" id="upload-image-spinner">
+    <div class="button-show-ajax"> <i class="material-icons text-left d-none" id="upload-image-spinner">
         {% include 'Default/loadingSpinner.html.twig' with {'spinner_id': 'upload-image-pb', 'small': 'true'} only %}</i></div>
   </div>
 </div>


### PR DESCRIPTION
Remove class setting spinners to red so that they will all appear in the primary color.
---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`

