### PR TITLE
SHARE-305 Language dropdown wrong selected

### DIFF
--- a/src/Catrobat/Twig/AppExtension.php
+++ b/src/Catrobat/Twig/AppExtension.php
@@ -158,11 +158,6 @@ class AppExtension extends AbstractExtension
     $path = $this->translation_path;
     $current_language = $this->request_stack->getCurrentRequest()->getLocale();
 
-    if (false !== strpos($current_language, '_DE') || false !== strpos($current_language, '_US'))
-    {
-      $current_language = substr($current_language, 0, 2);
-    }
-
     $list = [];
 
     $finder = new Finder();
@@ -175,10 +170,25 @@ class AppExtension extends AbstractExtension
 
     $available_locales = Locales::getNames();
 
+    $shortNames = [];
+    $current_language_exists = false;
     foreach ($finder as $translationFileName)
     {
       $shortName = $this->getShortLanguageNameFromFileName($translationFileName->getRelativePathname());
+      $shortNames[] = $shortName;
+      if ($current_language === $shortName)
+      {
+        $current_language_exists = true;
+      }
+    }
 
+    if (!$current_language_exists)
+    {
+      $current_language = explode('_', $current_language)[0];
+    }
+
+    foreach ($shortNames as $shortName)
+    {
       $isSelectedLanguage = $current_language === $shortName;
 
       if (strcmp($current_language, $shortName))


### PR DESCRIPTION
On first visit the site shows the wrong language in the dropdown menu on certain browsers. We added some new cases and some scenario handling (for example de_AT -> de).

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [X] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no warnings and errors 
- [X] Verify to commit no other files than the intentionally changed ones
- [X] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [X] Perform a self-review of the changes
- [X] Stick to the project’s git workflow (rebase and squash your commits)
- [X] Verify that your changes do not have any conflicts with the base branch
- [X] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
