### PR TITLE
SHARE-388 Incorrect notification text for remixes

### DIFF
--- a/assets/js/custom/UserNotifications.js
+++ b/assets/js/custom/UserNotifications.js
@@ -216,8 +216,8 @@ class UserNotifications {
       msg = msg.replace('%program_link%', '<a href="' + self.programPath + '/' + fetched.program +
         '">' + fetched.program_name + '</a>')
     }
-    if (msg.includes('%remixed_program_link%')) {
-      msg = msg.replace('%remixed_program_link%', '<a href="' + self.programPath + '/' +
+    if (msg.includes('%remix_program_link%')) {
+      msg = msg.replace('%remix_program_link%', '<a href="' + self.programPath + '/' +
         fetched.remixed_program + '">' + fetched.remixed_program_name + '</a>')
     }
     if (fetched.prize) {

--- a/templates/Notifications/NotificationTypes/remix_notification.html.twig
+++ b/templates/Notifications/NotificationTypes/remix_notification.html.twig
@@ -18,7 +18,7 @@
       {
         '%user_link%': '<a href="'~path('profile', {'id': notification.getRemixFrom.id})~'">'~notification.getRemixFrom.getUserName~'</a>',
         '%program_link%': '<a href="'~path('program', {'id': notification.getRemixProgram.id})~'">'~notification.getRemixProgram.name~'</a>',
-        '%remixed_program_link%': '<a href="'~path('program', {'id': notification.program.id})~'">'~notification.program.name~'</a>'
+        '%remix_program_link%': '<a href="'~path('program', {'id': notification.program.id})~'">'~notification.program.name~'</a>'
       },
       'catroweb'
     )

--- a/tests/behat/features/web/notifications/notifications_type_remix.feature
+++ b/tests/behat/features/web/notifications/notifications_type_remix.feature
@@ -20,7 +20,7 @@ Feature: User gets notifications when somebody uploads a remix of his project
     And the element "#remix-notif" should be visible
     And I click "#remix-notif"
     And I wait for AJAX to finish
-    And I should see "User created a remix"
+    And I should see "User created a remix test of your game project 1."
 
   Scenario: Uses should not be notified about their own remixes
     Given I have a project with "url" set to "/app/project/1"

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -891,7 +891,7 @@ catro-notifications:
   program-upload:
     message: '%user_link% created a new game %program_link%.'
   remix:
-    message: '%user_link% created a remix %program_link% of your game %remixed_program_link%.'
+    message: '%user_link% created a remix %program_link% of your game %remix_program_link%.'
 
 clipboard:
   success: Link to project copied to clipboard!


### PR DESCRIPTION
there was an "typo" in the english translation file. instead of '%remix_program_link%' as in all other trans-files there was '%remixed_program_link%'. i changed it in the corresponding JS and TWIG file for notifications and in the english translation file to fit with the other translations.
adjusted test case to test whole notification, not just a part of it

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
~Psalm can't download imagick
Get:1 http://azure.archive.ubuntu.com/ubuntu bionic/universe amd64 ttf-dejavu-core all 2.37-1 [2978 B]
Err:2 http://ppa.launchpad.net/ondrej/php/ubuntu bionic/main amd64 php-imagick amd64 3.4.4-4+ubuntu18.04.1+deb.sury.org+1
  404  Not Found [IP: 91.189.95.83 80]~

Edit: A simple update before the install fixed the CI.