### PR TITLE
SHARE-383 Refactor copy paste erros (phpunit tests)

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -268,7 +268,7 @@ jobs:
       - name: PHP Copy Paste Detector
         uses: StephaneBour/actions-php-cpd@7.4
         with:
-          args: src tests --exclude src/Admin --exclude tests/phpUnit
+          args: src tests --exclude src/Admin
   #
   # phpcf (Php Code Fixer):
   #

--- a/tests/phpUnit/Catrobat/Services/AsyncHttpClientTest.php
+++ b/tests/phpUnit/Catrobat/Services/AsyncHttpClientTest.php
@@ -71,24 +71,8 @@ class AsyncHttpClientTest extends TestCase
     $expected_id_of_second_program = 118_499_611;
 
     $scratch_info_data = $this->async_http_client->fetchScratchProgramDetails([$expected_id_of_first_program, $expected_id_of_second_program]);
-    $this->assertIsIterable($scratch_info_data);
-    $this->assertCount(2, $scratch_info_data);
-    Assert::assertArrayHasKey($expected_id_of_first_program, $scratch_info_data);
-    Assert::assertArrayHasKey($expected_id_of_second_program, $scratch_info_data);
 
-    $first_program_data = $scratch_info_data[$expected_id_of_first_program];
-    Assert::assertEquals($expected_id_of_first_program, $first_program_data['id']);
-    Assert::assertArrayHasKey('title', $first_program_data);
-    Assert::assertArrayHasKey('description', $first_program_data);
-    Assert::assertArrayHasKey('author', $first_program_data);
-    Assert::assertEquals('nposss', $first_program_data['author']['username']);
-
-    $second_program_data = $scratch_info_data[$expected_id_of_second_program];
-    Assert::assertEquals($expected_id_of_second_program, $second_program_data['id']);
-    Assert::assertArrayHasKey('title', $second_program_data);
-    Assert::assertArrayHasKey('description', $second_program_data);
-    Assert::assertArrayHasKey('author', $second_program_data);
-    Assert::assertEquals('Techno-CAT', $second_program_data['author']['username']);
+    $this->assertTheTwoFetchedPrograms($scratch_info_data, $expected_id_of_first_program, $expected_id_of_second_program);
   }
 
   public function testFetchesScratchProgramDetailsOfMoreThanTwoProgramsAtOnceShouldOnlyFetchDetailsOfFirstTwoProgramsBecauseMaximumLimitIsExceeded(): void
@@ -101,6 +85,12 @@ class AsyncHttpClientTest extends TestCase
 
     $scratch_info_data = $this->async_http_client->fetchScratchProgramDetails([$expected_id_of_first_program,
       $expected_id_of_second_program, $expected_id_of_third_program, ]);
+
+    $this->assertTheTwoFetchedPrograms($scratch_info_data, $expected_id_of_first_program, $expected_id_of_second_program);
+  }
+
+  private function assertTheTwoFetchedPrograms(array $scratch_info_data, int $expected_id_of_first_program, int $expected_id_of_second_program): void
+  {
     $this->assertIsIterable($scratch_info_data);
     $this->assertCount(2, $scratch_info_data);
     Assert::assertArrayHasKey($expected_id_of_first_program, $scratch_info_data);

--- a/tests/phpUnit/Catrobat/Services/ExtractedCatrobatFileTest.php
+++ b/tests/phpUnit/Catrobat/Services/ExtractedCatrobatFileTest.php
@@ -63,17 +63,26 @@ class ExtractedCatrobatFileTest extends TestCase
     $second_expected_url = '/app/project/3570';
     $new_program_id = '3571';
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, true, $program_repository);
-    $this->assertCount(2, $urls);
+
+    $expectedCount = 2;
+    $expectedProgramIds = ['117697631', '3570'];
+    $expectedUrls = [$first_expected_url, $second_expected_url];
+    $this->assertions($expectedCount, $urls, $expectedUrls, $expectedProgramIds, [true, false], [true, false]);
+
+    /*
+     $this->assertCount(2, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($first_expected_url, $urls[0]->getUrl());
     $this->assertSame('117697631', $urls[0]->getProgramId());
     $this->assertTrue($urls[0]->isScratchProgram());
     $this->assertTrue($urls[0]->isAbsoluteUrl());
+
     $this->assertInstanceOf(RemixData::class, $urls[1]);
     $this->assertSame($second_expected_url, $urls[1]->getUrl());
     $this->assertSame('3570', $urls[1]->getProgramId());
     $this->assertFalse($urls[1]->isScratchProgram());
     $this->assertFalse($urls[1]->isAbsoluteUrl());
+     */
   }
 
   public function testCanExtractSimpleCatrobatAbsoluteRemixUrl(): void
@@ -83,12 +92,17 @@ class ExtractedCatrobatFileTest extends TestCase
     $this->extracted_catrobat_file->getProgramXmlProperties()->header->url = $first_expected_url;
     $new_program_id = '1300';
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, true, $program_repository);
+
+    $this->assertions(1, $urls, [$first_expected_url], ['1234'], [false], [true]);
+
+    /*
     $this->assertCount(1, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($first_expected_url, $urls[0]->getUrl());
     $this->assertSame('1234', $urls[0]->getProgramId());
     $this->assertFalse($urls[0]->isScratchProgram());
     $this->assertTrue($urls[0]->isAbsoluteUrl());
+     */
   }
 
   public function testNotExtractNumberFromNormalText(): void
@@ -108,12 +122,17 @@ class ExtractedCatrobatFileTest extends TestCase
     $this->extracted_catrobat_file->getProgramXmlProperties()->header->url = $first_expected_url;
     $new_program_id = '1';
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, true, $program_repository);
+
+    $this->assertions(1, $urls, [$first_expected_url], ['117697631'], [true], [true]);
+
+    /*
     $this->assertCount(1, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($first_expected_url, $urls[0]->getUrl());
     $this->assertSame('117697631', $urls[0]->getProgramId());
     $this->assertTrue($urls[0]->isScratchProgram());
     $this->assertTrue($urls[0]->isAbsoluteUrl());
+     */
   }
 
   public function testCanExtractSimpleRelativeCatrobatRemixUrl(): void
@@ -123,12 +142,17 @@ class ExtractedCatrobatFileTest extends TestCase
     $this->extracted_catrobat_file->getProgramXmlProperties()->header->url = $first_expected_url;
     $new_program_id = '6310';
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, true, $program_repository);
+
+    $this->assertions(1, $urls, [$first_expected_url], ['3570'], [false], [false]);
+
+    /*
     $this->assertCount(1, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($first_expected_url, $urls[0]->getUrl());
     $this->assertSame('3570', $urls[0]->getProgramId());
     $this->assertFalse($urls[0]->isScratchProgram());
     $this->assertFalse($urls[0]->isAbsoluteUrl());
+     */
   }
 
   public function testCanExtractMergedProgramRemixUrls(): void
@@ -140,17 +164,23 @@ class ExtractedCatrobatFileTest extends TestCase
     $remixes_string = 'スーパー時計 12 ['.$first_expected_url.'], The Periodic Table 2 ['.$second_expected_url.']]';
     $this->extracted_catrobat_file->getProgramXmlProperties()->header->url = $remixes_string;
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, true, $program_repository);
+
+    $this->assertions(2, $urls, [$first_expected_url, $second_expected_url], ['1234', '3570'], [false, false], [true, true]);
+
+    /*
     $this->assertCount(2, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($first_expected_url, $urls[0]->getUrl());
     $this->assertSame('1234', $urls[0]->getProgramId());
     $this->assertFalse($urls[0]->isScratchProgram());
     $this->assertTrue($urls[0]->isAbsoluteUrl());
+     *
     $this->assertInstanceOf(RemixData::class, $urls[1]);
     $this->assertSame($second_expected_url, $urls[1]->getUrl());
     $this->assertSame('3570', $urls[1]->getProgramId());
     $this->assertFalse($urls[1]->isScratchProgram());
     $this->assertTrue($urls[1]->isAbsoluteUrl());
+     */
   }
 
   public function testExtractUniqueProgramRemixUrls(): void
@@ -162,12 +192,17 @@ class ExtractedCatrobatFileTest extends TestCase
     $remixes_string = 'スーパー時計 12 ['.$first_expected_url.'], The Periodic Table 2 ['.$second_expected_url.']]';
     $this->extracted_catrobat_file->getProgramXmlProperties()->header->url = $remixes_string;
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, true, $program_repository);
+
+    $this->assertions(1, $urls, [$first_expected_url, $second_expected_url], ['1234'], [false], [true]);
+
+    /*
     $this->assertCount(1, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($first_expected_url, $urls[0]->getUrl());
     $this->assertSame('1234', $urls[0]->getProgramId());
     $this->assertFalse($urls[0]->isScratchProgram());
     $this->assertTrue($urls[0]->isAbsoluteUrl());
+     */
   }
 
   public function testDontExtractProgramRemixUrlsReferencingToCurrentProgram(): void
@@ -179,12 +214,17 @@ class ExtractedCatrobatFileTest extends TestCase
     $remixes_string = 'スーパー時計 12 ['.$first_expected_url.'], The Periodic Table 2 ['.$second_expected_url.']]';
     $this->extracted_catrobat_file->getProgramXmlProperties()->header->url = $remixes_string;
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, true, $program_repository);
+
+    $this->assertions(1, $urls, [$second_expected_url], ['790'], [false], [true]);
+
+    /*
     $this->assertCount(1, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($second_expected_url, $urls[0]->getUrl());
     $this->assertSame('790', $urls[0]->getProgramId());
     $this->assertFalse($urls[0]->isScratchProgram());
     $this->assertTrue($urls[0]->isAbsoluteUrl());
+     * */
   }
 
   public function testExtractOnlyOlderProgramRemixUrls(): void
@@ -196,12 +236,17 @@ class ExtractedCatrobatFileTest extends TestCase
     $remixes_string = 'スーパー時計 12 ['.$first_expected_url.'], The Periodic Table 2 ['.$second_expected_url.']]';
     $this->extracted_catrobat_file->getProgramXmlProperties()->header->url = $remixes_string;
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, true, $program_repository);
+
+    $this->assertions(1, $urls, [$second_expected_url], ['790'], [false], [true]);
+
+    /*
     $this->assertCount(1, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($second_expected_url, $urls[0]->getUrl());
     $this->assertSame('790', $urls[0]->getProgramId());
     $this->assertFalse($urls[0]->isScratchProgram());
     $this->assertTrue($urls[0]->isAbsoluteUrl());
+     * */
   }
 
   public function testCanExtractDoubleMergedProgramRemixUrls(): void
@@ -216,22 +261,30 @@ class ExtractedCatrobatFileTest extends TestCase
         .'], The Periodic Table 2 ['.$third_expected_url.']]';
     $this->extracted_catrobat_file->getProgramXmlProperties()->header->url = $remixes_string;
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, true, $program_repository);
+
+    $this->assertions(3, $urls, [$first_expected_url, $second_expected_url, $third_expected_url],
+      ['1234', '3570', '121648946'], [false, false, true], [true, true, true]);
+
+    /*
     $this->assertCount(3, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($first_expected_url, $urls[0]->getUrl());
     $this->assertSame('1234', $urls[0]->getProgramId());
     $this->assertFalse($urls[0]->isScratchProgram());
     $this->assertTrue($urls[0]->isAbsoluteUrl());
+
     $this->assertInstanceOf(RemixData::class, $urls[1]);
     $this->assertSame($second_expected_url, $urls[1]->getUrl());
     $this->assertSame('3570', $urls[1]->getProgramId());
     $this->assertFalse($urls[1]->isScratchProgram());
     $this->assertTrue($urls[1]->isAbsoluteUrl());
+
     $this->assertInstanceOf(RemixData::class, $urls[2]);
     $this->assertSame($third_expected_url, $urls[2]->getUrl());
     $this->assertSame('121648946', $urls[2]->getProgramId());
     $this->assertTrue($urls[2]->isScratchProgram());
     $this->assertTrue($urls[2]->isAbsoluteUrl());
+     * */
   }
 
   public function testExtractUniqueProgramRemixUrlsOfDoubleMergedProgram(): void
@@ -246,17 +299,24 @@ class ExtractedCatrobatFileTest extends TestCase
         .'], The Periodic Table 2 ['.$third_expected_url.']]';
     $this->extracted_catrobat_file->getProgramXmlProperties()->header->url = $remixes_string;
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, true, $program_repository);
+
+    $this->assertions(2, $urls, [$first_expected_url, $second_expected_url],
+      ['1234', '121648946'], [false, true], [true, true]);
+
+    /*
     $this->assertCount(2, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($first_expected_url, $urls[0]->getUrl());
     $this->assertSame('1234', $urls[0]->getProgramId());
     $this->assertFalse($urls[0]->isScratchProgram());
     $this->assertTrue($urls[0]->isAbsoluteUrl());
+
     $this->assertInstanceOf(RemixData::class, $urls[1]);
     $this->assertSame($second_expected_url, $urls[1]->getUrl());
     $this->assertSame('121648946', $urls[1]->getProgramId());
     $this->assertTrue($urls[1]->isScratchProgram());
     $this->assertTrue($urls[1]->isAbsoluteUrl());
+     * */
   }
 
   public function testDontExtractProgramRemixUrlsReferencingToCurrentDoubleMergedProgram(): void
@@ -271,12 +331,18 @@ class ExtractedCatrobatFileTest extends TestCase
         .'], The Periodic Table 2 ['.$third_expected_url.']]';
     $this->extracted_catrobat_file->getProgramXmlProperties()->header->url = $remixes_string;
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, true, $program_repository);
+
+    $this->assertions(1, $urls, [$first_expected_url],
+      ['1234'], [false], [true]);
+
+    /*
     $this->assertCount(1, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($first_expected_url, $urls[0]->getUrl());
     $this->assertSame('1234', $urls[0]->getProgramId());
     $this->assertFalse($urls[0]->isScratchProgram());
     $this->assertTrue($urls[0]->isAbsoluteUrl());
+     * */
   }
 
   public function testCanExtractMultipleMergedRemixUrls(): void
@@ -292,27 +358,36 @@ class ExtractedCatrobatFileTest extends TestCase
         .']], NYAN CAT RUNNER (BETA) ['.$fourth_expected_url.']';
     $this->extracted_catrobat_file->getProgramXmlProperties()->header->url = $remixes_string;
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, true, $program_repository);
+
+    $this->assertions(4, $urls, [$first_expected_url, $second_expected_url, $third_expected_url, $fourth_expected_url],
+      ['117697631', '3570', '121648946', '16267'], [true, false, true, false], [true, false, true, true]);
+
+    /*
     $this->assertCount(4, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($first_expected_url, $urls[0]->getUrl());
     $this->assertSame('117697631', $urls[0]->getProgramId());
     $this->assertTrue($urls[0]->isScratchProgram());
     $this->assertTrue($urls[0]->isAbsoluteUrl());
+
     $this->assertInstanceOf(RemixData::class, $urls[1]);
     $this->assertSame($second_expected_url, $urls[1]->getUrl());
     $this->assertSame('3570', $urls[1]->getProgramId());
     $this->assertFalse($urls[1]->isScratchProgram());
     $this->assertFalse($urls[1]->isAbsoluteUrl());
+
     $this->assertInstanceOf(RemixData::class, $urls[2]);
     $this->assertSame($third_expected_url, $urls[2]->getUrl());
     $this->assertSame('121648946', $urls[2]->getProgramId());
     $this->assertTrue($urls[2]->isScratchProgram());
     $this->assertTrue($urls[2]->isAbsoluteUrl());
+
     $this->assertInstanceOf(RemixData::class, $urls[3]);
     $this->assertSame($fourth_expected_url, $urls[3]->getUrl());
     $this->assertSame('16267', $urls[3]->getProgramId());
     $this->assertFalse($urls[3]->isScratchProgram());
     $this->assertTrue($urls[3]->isAbsoluteUrl());
+     * */
   }
 
   public function testExtractUniqueProgramRemixUrlsOfMultipleMergedProgram(): void
@@ -328,17 +403,24 @@ class ExtractedCatrobatFileTest extends TestCase
         .']], NYAN CAT RUNNER (BETA) ['.$fourth_expected_url.']';
     $this->extracted_catrobat_file->getProgramXmlProperties()->header->url = $remixes_string;
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, true, $program_repository);
+
+    $this->assertions(2, $urls, [$first_expected_url, $second_expected_url],
+      ['117697631', '16267'], [true, false], [true, false]);
+
+    /*
     $this->assertCount(2, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($first_expected_url, $urls[0]->getUrl());
     $this->assertSame('117697631', $urls[0]->getProgramId());
     $this->assertTrue($urls[0]->isScratchProgram());
     $this->assertTrue($urls[0]->isAbsoluteUrl());
+
     $this->assertInstanceOf(RemixData::class, $urls[1]);
     $this->assertSame($second_expected_url, $urls[1]->getUrl());
     $this->assertSame('16267', $urls[1]->getProgramId());
     $this->assertFalse($urls[1]->isScratchProgram());
     $this->assertFalse($urls[1]->isAbsoluteUrl());
+     * */
   }
 
   public function testExtractOnlyOlderProgramRemixUrlsOfMultipleMergedProgramIfItIsAnInitialVersion(): void
@@ -354,12 +436,18 @@ class ExtractedCatrobatFileTest extends TestCase
         .']], NYAN CAT RUNNER (BETA) ['.$fourth_expected_url.']';
     $this->extracted_catrobat_file->getProgramXmlProperties()->header->url = $remixes_string;
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, true, $program_repository);
+
+    $this->assertions(1, $urls, [$first_expected_url],
+      ['117697631'], [true], [true]);
+
+    /*
     $this->assertCount(1, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($first_expected_url, $urls[0]->getUrl());
     $this->assertSame('117697631', $urls[0]->getProgramId());
     $this->assertTrue($urls[0]->isScratchProgram());
     $this->assertTrue($urls[0]->isAbsoluteUrl());
+     * */
   }
 
   public function testExtractOlderProgramRemixUrlsOfMultipleMergedProgramIfItIsNotAnInitialVersion(): void
@@ -375,17 +463,24 @@ class ExtractedCatrobatFileTest extends TestCase
         .']], NYAN CAT RUNNER (BETA) ['.$fourth_expected_url.']';
     $this->extracted_catrobat_file->getProgramXmlProperties()->header->url = $remixes_string;
     $urls = $this->extracted_catrobat_file->getRemixesData($new_program_id, false, $program_repository);
+
+    $this->assertions(2, $urls, [$first_expected_url, $fourth_expected_url],
+      ['117697631', '16268'], [true, false], [true, true]);
+
+    /*
     $this->assertCount(2, $urls);
     $this->assertInstanceOf(RemixData::class, $urls[0]);
     $this->assertSame($first_expected_url, $urls[0]->getUrl());
     $this->assertSame('117697631', $urls[0]->getProgramId());
     $this->assertTrue($urls[0]->isScratchProgram());
     $this->assertTrue($urls[0]->isAbsoluteUrl());
+
     $this->assertInstanceOf(RemixData::class, $urls[1]);
     $this->assertSame($fourth_expected_url, $urls[1]->getUrl());
     $this->assertSame('16268', $urls[1]->getProgramId());
     $this->assertFalse($urls[1]->isScratchProgram());
     $this->assertTrue($urls[1]->isAbsoluteUrl());
+    */
   }
 
   public function testReturnsThePathOfTheBaseDirectory(): void
@@ -476,5 +571,33 @@ class ExtractedCatrobatFileTest extends TestCase
     Assert::assertTrue($this->extracted_catrobat_file->isFileMentionedInXml('4728a2ce6b682ac056b8f8185353108d_Moving Mole.png'));
     Assert::assertTrue($this->extracted_catrobat_file->isFileMentionedInXml('1fb4ecf442b988ad20279d95acaf608e_Whacked Mole.png'));
     Assert::assertTrue($this->extracted_catrobat_file->isFileMentionedInXml('0370b09e8cd2cd025397a47e24b129d5_Hit2.m4a'));
+  }
+
+  private function assertions(int $expectedCount, array $urls, array $expectedURLs, array $expectedProgramIds, array $scratch, array $absolutePaths): void
+  {
+    $this->assertCount($expectedCount, $urls);
+
+    for ($i = 0; $i < $expectedCount; ++$i)
+    {
+      $this->assertInstanceOf(RemixData::class, $urls[$i]);
+      $this->assertSame($expectedURLs[$i], $urls[$i]->getUrl());
+      $this->assertSame($expectedProgramIds[$i], $urls[$i]->getProgramId());
+      if ($scratch[$i])
+      {
+        $this->assertTrue($urls[$i]->isScratchProgram());
+      }
+      else
+      {
+        $this->assertFalse($urls[$i]->isScratchProgram());
+      }
+      if ($absolutePaths[$i])
+      {
+        $this->assertTrue($urls[$i]->isAbsoluteUrl());
+      }
+      else
+      {
+        $this->assertFalse($urls[$i]->isAbsoluteUrl());
+      }
+    }
   }
 }

--- a/tests/phpUnit/Entity/ProgramManagerTest.php
+++ b/tests/phpUnit/Entity/ProgramManagerTest.php
@@ -150,20 +150,27 @@ class ProgramManagerTest extends TestCase
    */
   public function testReturnsTheProgramAfterSuccessfullyAddingAProgram(): void
   {
+    $func = function (Program $project): Program
+    {
+      $project->setId('1');
+
+      return $project;
+    };
+
     $metadata = $this->createMock(ClassMetadata::class);
     $metadata->expects($this->atLeastOnce())->method('getFieldNames')->willReturn(['id']);
     $this->entity_manager->expects($this->atLeastOnce())->method('getClassMetadata')->willReturn($metadata);
     $this->entity_manager->expects($this->atLeastOnce())->method('persist')->with($this->isInstanceOf(Program::class))
-      ->will($this->returnCallback(function (Program $project): Program
-      {
-        $project->setId('1');
-
-        return $project;
-      }))
+      ->will($this->returnCallback($func))
     ;
     $this->entity_manager->expects($this->atLeastOnce())->method('flush');
-    $this->entity_manager->expects($this->atLeastOnce())->method('refresh')->with($this->isInstanceOf(Program::class));
-    $this->event_dispatcher->expects($this->atLeastOnce())->method('dispatch')->willReturn($this->programBeforeInsertEvent);
+    $this->entity_manager->expects($this->atLeastOnce())->method('refresh')
+      ->with($this->isInstanceOf(Program::class))
+    ;
+    $this->event_dispatcher->expects($this->atLeastOnce())->method('dispatch')
+      ->willReturn($this->programBeforeInsertEvent)
+    ;
+
     $this->assertInstanceOf(Program::class, $this->program_manager->addProgram($this->request));
   }
 
@@ -234,16 +241,18 @@ class ProgramManagerTest extends TestCase
    */
   public function testFiresAnEventBeforeInsertingAProgram(): void
   {
+    $func = function (Program $project): Program
+    {
+      $project->setId('1');
+
+      return $project;
+    };
+
     $metadata = $this->createMock(ClassMetadata::class);
     $metadata->expects($this->atLeastOnce())->method('getFieldNames')->willReturn(['id']);
     $this->entity_manager->expects($this->atLeastOnce())->method('getClassMetadata')->willReturn($metadata);
     $this->entity_manager->expects($this->atLeastOnce())->method('persist')
-      ->will($this->returnCallback(function (Program $project): Program
-      {
-        $project->setId('1');
-
-        return $project;
-      }))
+      ->will($this->returnCallback($func))
     ;
 
     $this->entity_manager->expects($this->atLeastOnce())->method('flush');

--- a/tests/phpUnit/Entity/RemixManagerTest.php
+++ b/tests/phpUnit/Entity/RemixManagerTest.php
@@ -330,31 +330,14 @@ class RemixManagerTest extends TestCase
     //                                                     (123)              <--------- to be added
     //
     //--------------------------------------------------------------------------------------------------------------
-    $program_entity = $this->createMock(Program::class);
-    $program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('123');
-    $program_entity->expects($this->atLeastOnce())
-      ->method('isInitialVersion')->willReturn(true);
-    $program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
 
-    $first_parent_entity = $this->createMock(Program::class);
-    $first_parent_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('3570');
-    $first_parent_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
+    $program_entities = $this->getProgramEntityAndParents(2);
 
-    $second_parent_entity = $this->createMock(Program::class);
-    $second_parent_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('16267');
-    $second_parent_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
+    $program_entity = $program_entities[0];
+
+    $first_parent_entity = $program_entities[1];
+
+    $second_parent_entity = $program_entities[2];
 
     $parent_data = [
       $first_parent_entity->getId() => [
@@ -391,32 +374,13 @@ class RemixManagerTest extends TestCase
     //                       (123)              <--------- to be added
     //
     //--------------------------------------------------------------------------------------------------------------
-    $program_entity = $this->createMock(Program::class);
-    $program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('123');
-    $program_entity->expects($this->atLeastOnce())
-      ->method('isInitialVersion')->willReturn(true);
-    $program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
+    $program_entities = $this->getProgramEntityAndParents();
 
-    $first_parent_entity = $this->createMock(Program::class);
-    $first_parent_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('3570');
-    $first_parent_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $second_parent_entity = $this->createMock(Program::class);
-    $second_parent_entity->expects($this->atLeastOnce())
-      ->method('getId')
-      ->willReturn('16267')
-    ;
-    $second_parent_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
+    $program_entity = $program_entities[0];
+
+    $first_parent_entity = $program_entities[1];
+
+    $second_parent_entity = $program_entities[2];
 
     $parent_data = [
       $first_parent_entity->getId() => [
@@ -455,6 +419,7 @@ class RemixManagerTest extends TestCase
     //                       (4)              <--------- to be added
     //
     //--------------------------------------------------------------------------------------------------------------
+
     $parent_entity_of_both_parents = $this->createMock(Program::class);
     $parent_entity_of_both_parents->expects($this->atLeastOnce())
       ->method('getId')->willReturn('1');
@@ -462,29 +427,12 @@ class RemixManagerTest extends TestCase
       ->method('getUser')
       ->willReturn($this->createMock(User::class))
     ;
-    $first_parent_entity = $this->createMock(Program::class);
-    $first_parent_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('2');
-    $first_parent_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $second_parent_entity = $this->createMock(Program::class);
-    $second_parent_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('3');
-    $second_parent_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $program_entity = $this->createMock(Program::class);
-    $program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('4');
-    $program_entity->expects($this->atLeastOnce())
-      ->method('isInitialVersion')->willReturn(true);
-    $program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
+
+    $entities = $this->getProgramEntityAndParents(4, 2, 3);
+    $program_entity = $entities[0];
+    $first_parent_entity = $entities[1];
+    $second_parent_entity = $entities[2];
+
     $parent_data = [
       $first_parent_entity->getId() => [
         'isScratch' => false,
@@ -505,6 +453,7 @@ class RemixManagerTest extends TestCase
         ],
       ],
     ];
+
     $expected_relations = [
       // self-relation
       new ProgramRemixRelation($program_entity, $program_entity, 0),
@@ -621,6 +570,8 @@ class RemixManagerTest extends TestCase
     //                        (4) ____/        <--------- to be added
     //
     //--------------------------------------------------------------------------------------------------------------
+    $scratch_parent_id = '29495624';
+
     $parent_entity_of_first_parent = $this->createMock(Program::class);
     $parent_entity_of_first_parent->expects($this->atLeastOnce())
       ->method('getId')->willReturn('1');
@@ -628,30 +579,12 @@ class RemixManagerTest extends TestCase
       ->method('getUser')
       ->willReturn($this->createMock(User::class))
     ;
-    $scratch_parent_id = '29495624';
-    $first_parent_entity = $this->createMock(Program::class);
-    $first_parent_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('2');
-    $first_parent_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $second_parent_entity = $this->createMock(Program::class);
-    $second_parent_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('3');
-    $second_parent_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $program_entity = $this->createMock(Program::class);
-    $program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('4');
-    $program_entity->expects($this->atLeastOnce())
-      ->method('isInitialVersion')->willReturn(true);
-    $program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
+
+    $entities = $this->getProgramEntityAndParents(4, 2, 3);
+    $program_entity = $entities[0];
+    $first_parent_entity = $entities[1];
+    $second_parent_entity = $entities[2];
+
     $parent_data = [
       $first_parent_entity->getId() => [
         'isScratch' => false,
@@ -711,41 +644,15 @@ class RemixManagerTest extends TestCase
     //                         (5)             <--------- to be added
     //
     //--------------------------------------------------------------------------------------------------------------
-    $first_program_entity = $this->createMock(Program::class);
-    $first_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('1');
-    $first_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $second_program_entity = $this->createMock(Program::class);
-    $second_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('2');
-    $second_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $third_program_entity = $this->createMock(Program::class);
-    $third_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('3');
-    $third_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $fourth_program_entity = $this->createMock(Program::class);
-    $fourth_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('4');
-    $fourth_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $program_entity = $this->createMock(Program::class);
-    $program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('5');
-    $program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
+
+    $program_entities = $this->getProgramEntities(4);
+    $first_program_entity = $program_entities[0];
+    $second_program_entity = $program_entities[1];
+    $third_program_entity = $program_entities[2];
+    $fourth_program_entity = $program_entities[3];
+
+    $program_entity = $program_entities[4];
+
     $program_entity->expects($this->atLeastOnce())
       ->method('isInitialVersion')->willReturn(true);
     $parent_data = [
@@ -807,57 +714,16 @@ class RemixManagerTest extends TestCase
     //                        (7)              <--------- to be added
     //
     //--------------------------------------------------------------------------------------------------------------
-    $first_program_entity = $this->createMock(Program::class);
-    $first_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('1');
-    $first_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $second_program_entity = $this->createMock(Program::class);
-    $second_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('2');
-    $second_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $third_program_entity = $this->createMock(Program::class);
-    $third_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('3');
-    $third_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $fourth_program_entity = $this->createMock(Program::class);
-    $fourth_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('4');
-    $fourth_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $fifth_program_entity = $this->createMock(Program::class);
-    $fifth_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('5');
-    $fifth_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $sixth_program_entity = $this->createMock(Program::class);
-    $sixth_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('6');
-    $sixth_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $program_entity = $this->createMock(Program::class);
-    $program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('7');
-    $program_entity->expects($this->atLeastOnce())
-      ->method('isInitialVersion')->willReturn(true);
-    $program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
+    $program_entities = $this->getProgramEntities(6);
+    $first_program_entity = $program_entities[0];
+    $second_program_entity = $program_entities[1];
+    $third_program_entity = $program_entities[2];
+    $fourth_program_entity = $program_entities[3];
+    $fifth_program_entity = $program_entities[4];
+    $sixth_program_entity = $program_entities[5];
+
+    $program_entity = $program_entities[6];
+
     $parent_data = [
       $fifth_program_entity->getId() => [
         'isScratch' => false,
@@ -921,57 +787,16 @@ class RemixManagerTest extends TestCase
     //                          (7)              <--------- to be added
     //
     //--------------------------------------------------------------------------------------------------------------
-    $first_program_entity = $this->createMock(Program::class);
-    $first_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('1');
-    $first_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $second_program_entity = $this->createMock(Program::class);
-    $second_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('2');
-    $second_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $third_program_entity = $this->createMock(Program::class);
-    $third_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('3');
-    $third_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $fourth_program_entity = $this->createMock(Program::class);
-    $fourth_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('4');
-    $fourth_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $fifth_program_entity = $this->createMock(Program::class);
-    $fifth_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('5');
-    $fifth_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $sixth_program_entity = $this->createMock(Program::class);
-    $sixth_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('6');
-    $sixth_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $program_entity = $this->createMock(Program::class);
-    $program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('7');
-    $program_entity->expects($this->atLeastOnce())
-      ->method('isInitialVersion')->willReturn(true);
-    $program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
+    $program_entities = $this->getProgramEntities(6);
+    $first_program_entity = $program_entities[0];
+    $second_program_entity = $program_entities[1];
+    $third_program_entity = $program_entities[2];
+    $fourth_program_entity = $program_entities[3];
+    $fifth_program_entity = $program_entities[4];
+    $sixth_program_entity = $program_entities[5];
+
+    $program_entity = $program_entities[6];
+
     $parent_data = [
       $fifth_program_entity->getId() => [
         'isScratch' => false,
@@ -1036,56 +861,17 @@ class RemixManagerTest extends TestCase
     //                  \______ (7)              <--------- to be added
     //
     //--------------------------------------------------------------------------------------------------------------
-    $first_program_entity = $this->createMock(Program::class);
-    $first_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('1');
-    $first_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $second_program_entity = $this->createMock(Program::class);
-    $second_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('2');
-    $second_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $third_program_entity = $this->createMock(Program::class);
-    $third_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('3');
-    $third_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $fourth_program_entity = $this->createMock(Program::class);
-    $fourth_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('4');
-    $fourth_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $fifth_program_entity = $this->createMock(Program::class);
-    $fifth_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('5');
-    $fifth_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $sixth_program_entity = $this->createMock(Program::class);
-    $sixth_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('6');
-    $sixth_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $program_entity = $this->createMock(Program::class);
-    $program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('7');
-    $program_entity->expects($this->atLeastOnce())->method('isInitialVersion')->willReturn(true);
-    $program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
+
+    $program_entities = $this->getProgramEntities(6);
+    $first_program_entity = $program_entities[0];
+    $second_program_entity = $program_entities[1];
+    $third_program_entity = $program_entities[2];
+    $fourth_program_entity = $program_entities[3];
+    $fifth_program_entity = $program_entities[4];
+    $sixth_program_entity = $program_entities[5];
+
+    $program_entity = $program_entities[6];
+
     $parent_data = [
       $third_program_entity->getId() => [
         'isScratch' => false,
@@ -1167,50 +953,14 @@ class RemixManagerTest extends TestCase
 
     $scratch_parent_id = '29495624';
 
-    $first_program_entity = $this->createMock(Program::class);
-    $first_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('1');
-    $first_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $second_program_entity = $this->createMock(Program::class);
-    $second_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('2');
-    $second_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $third_program_entity = $this->createMock(Program::class);
-    $third_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('3');
-    $third_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $fourth_program_entity = $this->createMock(Program::class);
-    $fourth_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('4');
-    $fourth_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $fifth_program_entity = $this->createMock(Program::class);
-    $fifth_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('5');
-    $fifth_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $program_entity = $this->createMock(Program::class);
-    $program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('6');
-    $program_entity->expects($this->atLeastOnce())
-      ->method('isInitialVersion')->willReturn(true);
-    $program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
+    $program_entities = $this->getProgramEntities(5);
+    $first_program_entity = $program_entities[0];
+    $second_program_entity = $program_entities[1];
+    $third_program_entity = $program_entities[2];
+    $fourth_program_entity = $program_entities[3];
+    $fifth_program_entity = $program_entities[4];
+
+    $program_entity = $program_entities[5];
 
     $parent_data = [
       $second_program_entity->getId() => [
@@ -1296,43 +1046,13 @@ class RemixManagerTest extends TestCase
     $first_scratch_ancestor_id = '124742637';
     $second_scratch_parent_id = '29495624';
 
-    $first_program_entity = $this->createMock(Program::class);
-    $first_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('1');
-    $first_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $second_program_entity = $this->createMock(Program::class);
-    $second_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('2');
-    $second_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $third_program_entity = $this->createMock(Program::class);
-    $third_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('3');
-    $third_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $fourth_program_entity = $this->createMock(Program::class);
-    $fourth_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('4');
-    $fourth_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $program_entity = $this->createMock(Program::class);
-    $program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('5');
-    $program_entity->expects($this->atLeastOnce())
-      ->method('isInitialVersion')->willReturn(true);
-    $program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
+    $program_entities = $this->getProgramEntities(4);
+    $first_program_entity = $program_entities[0];
+    $second_program_entity = $program_entities[1];
+    $third_program_entity = $program_entities[2];
+    $fourth_program_entity = $program_entities[3];
+
+    $program_entity = $program_entities[4];
 
     $parent_data = [
       $first_program_entity->getId() => [
@@ -1373,6 +1093,7 @@ class RemixManagerTest extends TestCase
         'existingRelations' => [],
       ],
     ];
+
     $expected_relations = [
       // self-relation
       new ProgramRemixRelation($program_entity, $program_entity, 0),
@@ -1415,34 +1136,12 @@ class RemixManagerTest extends TestCase
     $second_scratch_parent_id = '29495624';
     $third_scratch_parent_id = '124742637';
 
-    $first_program_entity = $this->createMock(Program::class);
-    $first_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('1');
-    $first_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $second_program_entity = $this->createMock(Program::class);
-    $second_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('2');
-    $second_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $third_program_entity = $this->createMock(Program::class);
-    $third_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('3');
-    $third_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
-    $fourth_program_entity = $this->createMock(Program::class);
-    $fourth_program_entity->expects($this->atLeastOnce())
-      ->method('getId')->willReturn('4');
-    $fourth_program_entity->expects($this->any())
-      ->method('getUser')
-      ->willReturn($this->createMock(User::class))
-    ;
+    $program_entities = $this->getProgramEntities(4);
+    $first_program_entity = $program_entities[0];
+    $second_program_entity = $program_entities[1];
+    $third_program_entity = $program_entities[2];
+    $fourth_program_entity = $program_entities[3];
+
     $program_entity = $this->createMock(Program::class);
     $program_entity->expects($this->atLeastOnce())
       ->method('getId')->willReturn('5');
@@ -1453,37 +1152,43 @@ class RemixManagerTest extends TestCase
       ->willReturn($this->createMock(User::class))
     ;
 
+    $existingRelationsFirstProgramEntity = [
+      new ProgramRemixRelation($first_program_entity, $first_program_entity, 0),
+      new ScratchProgramRemixRelation($first_scratch_ancestor_id, $first_program_entity),
+      new ScratchProgramRemixRelation($second_scratch_parent_id, $first_program_entity),
+    ];
+
+    $existingRelationsThirdProgramEntity = [
+      new ProgramRemixRelation($third_program_entity, $third_program_entity, 0),
+      new ProgramRemixRelation($second_program_entity, $third_program_entity, 1),
+      new ProgramRemixRelation($first_program_entity, $third_program_entity, 1),
+      new ScratchProgramRemixRelation($second_scratch_parent_id, $third_program_entity),
+    ];
+
+    $existingRelationsFourthProgramEntity = [
+      new ProgramRemixRelation($fourth_program_entity, $fourth_program_entity, 0),
+      new ProgramRemixRelation($second_program_entity, $fourth_program_entity, 1),
+      new ScratchProgramRemixRelation($second_scratch_parent_id, $fourth_program_entity),
+    ];
+
     $parent_data = [
       $first_program_entity->getId() => [
         'isScratch' => false,
         'entity' => $first_program_entity,
         'exists' => true,
-        'existingRelations' => [
-          new ProgramRemixRelation($first_program_entity, $first_program_entity, 0),
-          new ScratchProgramRemixRelation($first_scratch_ancestor_id, $first_program_entity),
-          new ScratchProgramRemixRelation($second_scratch_parent_id, $first_program_entity),
-        ],
+        'existingRelations' => $existingRelationsFirstProgramEntity,
       ],
       $third_program_entity->getId() => [
         'isScratch' => false,
         'entity' => $third_program_entity,
         'exists' => true,
-        'existingRelations' => [
-          new ProgramRemixRelation($third_program_entity, $third_program_entity, 0),
-          new ProgramRemixRelation($second_program_entity, $third_program_entity, 1),
-          new ProgramRemixRelation($first_program_entity, $third_program_entity, 1),
-          new ScratchProgramRemixRelation($second_scratch_parent_id, $third_program_entity),
-        ],
+        'existingRelations' => $existingRelationsThirdProgramEntity,
       ],
       $fourth_program_entity->getId() => [
         'isScratch' => false,
         'entity' => $fourth_program_entity,
         'exists' => true,
-        'existingRelations' => [
-          new ProgramRemixRelation($fourth_program_entity, $fourth_program_entity, 0),
-          new ProgramRemixRelation($second_program_entity, $fourth_program_entity, 1),
-          new ScratchProgramRemixRelation($second_scratch_parent_id, $fourth_program_entity),
-        ],
+        'existingRelations' => $existingRelationsFourthProgramEntity,
       ],
       $second_scratch_parent_id => [
         'isScratch' => true,
@@ -1498,6 +1203,7 @@ class RemixManagerTest extends TestCase
         'existingRelations' => [],
       ],
     ];
+
     $expected_relations = [
       // self-relation
       new ProgramRemixRelation($program_entity, $program_entity, 0),
@@ -1596,5 +1302,70 @@ class RemixManagerTest extends TestCase
       ->method('isRemixRoot')->willReturn($expected_to_be_root);
     $this->remix_manager->addRemixes($program_entity, $remixes_data);
     Assert::assertCount(0, $expected_relations_map);
+  }
+
+  private function getProgramEntities(int $amount): array
+  {
+    $array = [];
+    for ($i = 1; $i <= $amount; ++$i)
+    {
+      $program_entity = $this->createMock(Program::class);
+      $program_entity->expects($this->atLeastOnce())
+        ->method('getId')->willReturn($i);
+      $program_entity->expects($this->any())
+        ->method('getUser')
+        ->willReturn($this->createMock(User::class))
+      ;
+      array_push($array, $program_entity);
+    }
+    $program_entity = $this->createMock(Program::class);
+    $program_entity->expects($this->atLeastOnce())
+      ->method('getId')->willReturn($i);
+    $program_entity->expects($this->atLeastOnce())
+      ->method('isInitialVersion')->willReturn(true);
+    $program_entity->expects($this->any())
+      ->method('getUser')
+      ->willReturn($this->createMock(User::class))
+    ;
+
+    array_push($array, $program_entity);
+
+    return $array;
+  }
+
+  private function getProgramEntityAndParents(?int $entityReturn = 123, ?int $firstParentReturn = 3570, ?int $secParentReturn = 16267): array
+  {
+    $program_entity = $this->createMock(Program::class);
+    $program_entity->expects($this->atLeastOnce())
+      ->method('getId')->willReturn($entityReturn);
+    $program_entity->expects($this->atLeastOnce())
+      ->method('isInitialVersion')->willReturn(true);
+    $program_entity->expects($this->any())
+      ->method('getUser')
+      ->willReturn($this->createMock(User::class))
+    ;
+
+    $first_parent_entity = $this->createMock(Program::class);
+    $first_parent_entity->expects($this->atLeastOnce())
+      ->method('getId')->willReturn($firstParentReturn);
+    $first_parent_entity->expects($this->any())
+      ->method('getUser')
+      ->willReturn($this->createMock(User::class))
+    ;
+
+    $second_parent_entity = $this->createMock(Program::class);
+    $second_parent_entity->expects($this->atLeastOnce())
+      ->method('getId')
+      ->willReturn($secParentReturn)
+    ;
+    $second_parent_entity->expects($this->any())
+      ->method('getUser')
+      ->willReturn($this->createMock(User::class))
+    ;
+
+    $array = [];
+    array_push($array, $program_entity, $first_parent_entity, $second_parent_entity);
+
+    return $array;
   }
 }


### PR DESCRIPTION
duplicates are removed
new function to remove cp errors in RemixManagerTest.php & ProgramManagerTest.php, AsyncHttpClientTest.php, ExtractedCatrobatFileTest.php

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
no further tests because refactoring phpunit tests

### Tests - additional information
`TODO: add additional information about testruns here`
