### PR TITLE
SHARE-402 "Open project" on remix graph now working

### DIFF
--- a/assets/js/custom/RemixGraphHandler.js
+++ b/assets/js/custom/RemixGraphHandler.js
@@ -35,8 +35,8 @@ function RemixGraphHandler (programId, remixOk, remixBy, remixOpen, remixPath, r
     const remixGraphTranslations = {
       ok: self.remixOk,
       by: self.remixBy,
-      open: self.remixPath,
-      showPaths: self.remixOpen,
+      open: self.remixOpen,
+      showPaths: self.remixPath,
       programNotAvailableErrorTitle: self.remixNotAvailableTitle,
       programNotAvailableErrorDescription: self.remixNotAvailableDescription,
       programNotAvailable: self.remixNotAvailable,

--- a/assets/js/custom/remixgraph.visualization.js
+++ b/assets/js/custom/remixgraph.visualization.js
@@ -122,7 +122,7 @@ const _InternalRemixGraph = function () {
 
     const selectedNodeId = selectedNodes[0]
     const idParts = selectedNodeId.split('_')
-    const nodeId = parseInt(idParts[1])
+    const nodeId = idParts[1]
 
     if ($.inArray(nodeId, self.unavailableNodes) !== -1) {
       Swal.fire({
@@ -180,7 +180,7 @@ const _InternalRemixGraph = function () {
           const queryString = (idParts[0] === CATROBAT_NODE_PREFIX)
             ? ('?rec_by_page_id=' + self.recommendedByPageID + '&rec_by_program_id=' + self.programID)
             : ''
-          window.location = newUrlPrefix + nodeId + queryString
+          window.location = newUrlPrefix + '/' + nodeId + queryString
         }
       }
     }


### PR DESCRIPTION
When a user clicks on the "Open" button in the context menu of a remix graph node, the user now gets forwarded to the selected project's page.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
