### PR TITLE
SHARE-442 Surveys

### DIFF
--- a/config/packages/sonata_admin.yaml
+++ b/config/packages/sonata_admin.yaml
@@ -129,6 +129,13 @@ sonata_admin:
                     - catrowebadmin.block.users.storeduserdata
                     - catrowebadmin.block.users.reported
 
+            sonata.admin.group.survey:
+                label: Survey
+                label_catalogue: Catrobat
+                icon: '<i class="fa fa-bar-chart"></i>'
+                items:
+                    - catrowebadmin.block.survey
+
             sonata.admin.group.tools:
                 label:           Tools
                 label_catalogue: Catrobat

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -650,7 +650,7 @@ services:
   # ===== Apk Generation
 
   catrowebadmin.block.apk.pending:
-    class: App\Admin\PendingApkRequestsAdmin
+    class: App\Admin\ApkPendingAdmin
     tags:
       - { name: sonata.admin, manager_type: orm, label: "Pending" }
     arguments:
@@ -660,7 +660,7 @@ services:
     public: true
 
   catrowebadmin.block.apk.list:
-    class: App\Admin\ApkListAdmin
+    class: App\Admin\ApkReadyAdmin
     tags:
       - { name: sonata.admin, manager_type: orm, label: "Ready" }
     arguments:
@@ -702,6 +702,21 @@ services:
       - App\Entity\User
       - ~
     public: true
+
+
+  # ===== Survey
+
+  catrowebadmin.block.survey:
+    class: App\Admin\AllSurveysAdmin
+    tags:
+      - { name: sonata.admin, manager_type: orm, label: "All Surveys", pager_type: "simple",
+          icon: '<i class="fa fa-cogs"></i>' }
+    arguments:
+      - ~
+      - App\Entity\Survey
+      - ~
+    public: true
+
 
   # ===== Tools
 

--- a/migrations/2021/Version20210129204240.php
+++ b/migrations/2021/Version20210129204240.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210129204240 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE survey (id INT AUTO_INCREMENT NOT NULL, language_code VARCHAR(255) NOT NULL, url VARCHAR(255) NOT NULL, active TINYINT(1) DEFAULT \'1\' NOT NULL, UNIQUE INDEX UNIQ_AD5F9BFC451CDAD4 (language_code), UNIQUE INDEX UNIQ_AD5F9BFCF47645AE (url), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE survey');
+    }
+}

--- a/migrations/2021/Version20210130075021.php
+++ b/migrations/2021/Version20210130075021.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210130075021 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX UNIQ_AD5F9BFCF47645AE ON survey');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_AD5F9BFCF47645AE ON survey (url)');
+    }
+}

--- a/src/Admin/AllExtensionsAdmin.php
+++ b/src/Admin/AllExtensionsAdmin.php
@@ -30,39 +30,39 @@ class AllExtensionsAdmin extends AbstractAdmin
   ];
 
   /**
-   * @param FormMapper $formMapper
+   * @param FormMapper $form
    *
    * Fields to be shown on create/edit forms
    */
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
-    $formMapper
+    $form
       ->add('name', TextType::class, ['label' => 'Extension name'])
       ->add('prefix', TextType::class)
     ;
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper
+    $filter
       ->add('name')
       ->add('prefix')
     ;
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->addIdentifier('id')
       ->add('name')
       ->add('prefix')

--- a/src/Admin/AllProgramsAdmin.php
+++ b/src/Admin/AllProgramsAdmin.php
@@ -67,22 +67,20 @@ class AllProgramsAdmin extends AbstractAdmin
 
   /**
    * @param mixed $object
-   *
-   * @return string
    */
-  public function getThumbnailImageUrl($object)
+  public function getThumbnailImageUrl($object): string
   {
     return '/'.$this->screenshot_repository->getThumbnailWebPath($object->getId());
   }
 
   /**
-   * @param FormMapper $formMapper
+   * @param FormMapper $form
    *
    * Fields to be shown on create/edit forms
    */
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
-    $formMapper
+    $form
       ->add('name', TextType::class, ['label' => 'Program name'])
       ->add('description')
       ->add('user', EntityType::class, ['class' => User::class])
@@ -95,13 +93,13 @@ class AllProgramsAdmin extends AbstractAdmin
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper
+    $filter
       ->add('id')
       ->add('name')
       ->add('user.username', null, ['label' => 'Username'])
@@ -114,11 +112,11 @@ class AllProgramsAdmin extends AbstractAdmin
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
     $flavor_options = $this->parameter_bag->get('flavors');
 
@@ -127,7 +125,7 @@ class AllProgramsAdmin extends AbstractAdmin
     {
       $choices[$flavor] = $flavor;
     }
-    $listMapper
+    $list
       ->add('uploaded_at', null, ['label' => 'Upload Time'])
       ->add('user')
       ->addIdentifier('name', 'string', ['sortable' => false])

--- a/src/Admin/AllSurveysAdmin.php
+++ b/src/Admin/AllSurveysAdmin.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Admin;
+
+use App\Entity\Survey;
+use Doctrine\ORM\EntityManagerInterface;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType;
+use Sonata\AdminBundle\Route\RouteCollection;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType as SymfonyChoiceType;
+
+class AllSurveysAdmin extends AbstractAdmin
+{
+  /**
+   * @var string
+   */
+  protected $baseRouteName = 'admin_catrobat_adminbundle_allsurveysadmin';
+
+  /**
+   * @var string
+   */
+  protected $baseRoutePattern = 'all_surveys';
+
+  protected EntityManagerInterface $entity_manager;
+
+  public function __construct($code, $class, $baseControllerName, EntityManagerInterface $entity_manager)
+  {
+    parent::__construct($code, $class, $baseControllerName);
+
+    $this->entity_manager = $entity_manager;
+  }
+
+  /**
+   * @param FormMapper $form
+   *
+   * Fields to be shown on create/edit forms
+   */
+  protected function configureFormFields(FormMapper $form): void
+  {
+    $survey_repo = $this->entity_manager->getRepository(Survey::class);
+    $existing_surveys = $survey_repo->findAll();
+
+    $remaining_choices = Survey::getISO_639_1_Codes();
+
+    /** @var Survey $existing_survey */
+    foreach ($existing_surveys as $existing_survey)
+    {
+      unset($remaining_choices[$existing_survey->getLanguageCode()]);
+    }
+
+    $form
+      ->add('language_code', ChoiceFieldMaskType::class, [
+        'choices' => array_flip($remaining_choices),
+      ])
+      ->add('url')
+      ->add('active')
+    ;
+  }
+
+  /**
+   * @param DatagridMapper $filter
+   *
+   * Fields to be shown on filter forms
+   */
+  protected function configureDatagridFilters(DatagridMapper $filter): void
+  {
+    $filter
+      ->add('language_code', null, [
+        'label' => 'Language Code',
+        'field_type' => SymfonyChoiceType::class,
+        'field_options' => ['choices' => array_flip(Survey::getISO_639_1_Codes()),
+        ],
+      ])
+      ->add('url')
+      ->add('active')
+    ;
+  }
+
+  /**
+   * @param ListMapper $list
+   *
+   * Fields to be shown on lists
+   */
+  protected function configureListFields(ListMapper $list): void
+  {
+    $list
+      ->add('language_code', 'choice', [
+        'choices' => Survey::getISO_639_1_Codes(),
+      ])
+      ->add('url', 'string', [
+        'sortable' => false,
+        'editable' => true,
+      ])
+      ->add('active', 'boolean', [
+        'sortable' => true,
+        'editable' => true,
+      ])
+      ->add('_action', null, [
+        'label' => 'Action',
+        'actions' => [
+          'delete' => [],
+        ],
+      ])
+    ;
+  }
+
+  protected function configureRoutes(RouteCollection $collection): void
+  {
+    $collection->remove('export')->remove('acl');
+  }
+}

--- a/src/Admin/ApkPendingAdmin.php
+++ b/src/Admin/ApkPendingAdmin.php
@@ -4,31 +4,30 @@ namespace App\Admin;
 
 use App\Catrobat\Services\ScreenshotRepository;
 use App\Entity\Program;
-use Doctrine\ORM\QueryBuilder;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Route\RouteCollection;
-use Sonata\CoreBundle\Form\Type\DateTimeRangePickerType;
-use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
+use Sonata\Form\Type\DateTimeRangePickerType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as SymfonyChoiceType;
 
-class PendingApkRequestsAdmin extends AbstractAdmin
+class ApkPendingAdmin extends AbstractAdmin
 {
   /**
    * @override
    *
    * @var string
    */
-  protected $baseRouteName = 'admin_catrobat_apk_pending_requests';
+  protected $baseRouteName = 'admin_catrobat_apk_pending';
 
   /**
    * @override
    *
    * @var string
    */
-  protected $baseRoutePattern = 'apk_pending_requests';
+  protected $baseRoutePattern = 'apk_pending';
 
   /**
    * @override
@@ -43,7 +42,7 @@ class PendingApkRequestsAdmin extends AbstractAdmin
   private ScreenshotRepository $screenshot_repository;
 
   /**
-   * PendingApkRequestsAdmin constructor.
+   * ApkPendingAdmin constructor.
    *
    * @param mixed $code
    * @param mixed $class
@@ -57,24 +56,17 @@ class PendingApkRequestsAdmin extends AbstractAdmin
 
   /**
    * @param Program $object
-   *
-   * @return string
    */
-  public function getThumbnailImageUrl($object)
+  public function getThumbnailImageUrl($object): string
   {
     return '/'.$this->screenshot_repository->getThumbnailWebPath($object->getId());
   }
 
   protected function configureQuery(ProxyQueryInterface $query): ProxyQueryInterface
   {
+    /** @var ProxyQuery $query */
     $query = parent::configureQuery($query);
 
-    if (!$query instanceof ProxyQuery)
-    {
-      return $query;
-    }
-
-    /** @var QueryBuilder $qb */
     $qb = $query->getQueryBuilder();
 
     $qb->andWhere(
@@ -86,13 +78,13 @@ class PendingApkRequestsAdmin extends AbstractAdmin
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper
+    $filter
       ->add('id')
       ->add('user.username', null, ['label' => 'User'])
       ->add('name')
@@ -109,13 +101,13 @@ class PendingApkRequestsAdmin extends AbstractAdmin
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->add('id')
       ->add('user', null, [
         'route' => [

--- a/src/Admin/ApkReadyAdmin.php
+++ b/src/Admin/ApkReadyAdmin.php
@@ -4,7 +4,6 @@ namespace App\Admin;
 
 use App\Catrobat\Services\ScreenshotRepository;
 use App\Entity\Program;
-use Doctrine\ORM\QueryBuilder;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -12,17 +11,17 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 
-class ApkListAdmin extends AbstractAdmin
+class ApkReadyAdmin extends AbstractAdmin
 {
   /**
    * @var string
    */
-  protected $baseRouteName = 'admin_catrobat_apk_list';
+  protected $baseRouteName = 'admin_catrobat_apk_ready';
 
   /**
    * @var string
    */
-  protected $baseRoutePattern = 'apk_list';
+  protected $baseRoutePattern = 'apk_ready';
 
   /**
    * @var array
@@ -35,7 +34,7 @@ class ApkListAdmin extends AbstractAdmin
   private ScreenshotRepository $screenshot_repository;
 
   /**
-   * ApkListAdmin constructor.
+   * ApkReadyAdmin constructor.
    *
    * @param mixed $code
    * @param mixed $class
@@ -54,14 +53,9 @@ class ApkListAdmin extends AbstractAdmin
 
   protected function configureQuery(ProxyQueryInterface $query): ProxyQueryInterface
   {
+    /** @var ProxyQuery $query */
     $query = parent::configureQuery($query);
 
-    if (!$query instanceof ProxyQuery)
-    {
-      return $query;
-    }
-
-    /** @var QueryBuilder $qb */
     $qb = $query->getQueryBuilder();
 
     $qb->andWhere(
@@ -73,13 +67,13 @@ class ApkListAdmin extends AbstractAdmin
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper
+    $filter
       ->add('id')
       ->add('user.username', null, ['label' => 'User'])
       ->add('name')
@@ -88,13 +82,13 @@ class ApkListAdmin extends AbstractAdmin
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->addIdentifier('id')
       ->add('user', null, [
         'route' => [

--- a/src/Admin/ApproveProgramsAdmin.php
+++ b/src/Admin/ApproveProgramsAdmin.php
@@ -8,7 +8,6 @@ use App\Catrobat\Services\ScreenshotRepository;
 use App\Entity\Program;
 use App\Entity\ProgramManager;
 use App\Entity\User;
-use Doctrine\ORM\QueryBuilder;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -16,6 +15,7 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Sonata\Form\Type\DateTimeRangePickerType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -23,6 +23,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 class ApproveProgramsAdmin extends AbstractAdmin
 {
   use ProgramsTrait;
+
   /**
    * @var string
    */
@@ -59,20 +60,16 @@ class ApproveProgramsAdmin extends AbstractAdmin
 
   /**
    * @param mixed|Program $object
-   *
-   * @return string
    */
-  public function getThumbnailImageUrl($object)
+  public function getThumbnailImageUrl($object): string
   {
     return '/'.$this->screenshot_repository->getThumbnailWebPath($object->getId());
   }
 
   /**
    * @param mixed $object
-   *
-   * @return array
    */
-  public function getContainingImageUrls($object)
+  public function getContainingImageUrls($object): array
   {
     /*
      * @var $extractedFileRepository ExtractedFileRepository
@@ -98,10 +95,8 @@ class ApproveProgramsAdmin extends AbstractAdmin
 
   /**
    * @param mixed $object
-   *
-   * @return array
    */
-  public function getContainingSoundUrls($object)
+  public function getContainingSoundUrls($object): array
   {
     /*
      * @var $extractedFileRepository ExtractedFileRepository
@@ -126,10 +121,8 @@ class ApproveProgramsAdmin extends AbstractAdmin
 
   /**
    * @param mixed|Program $object
-   *
-   * @return array
    */
-  public function getContainingStrings($object)
+  public function getContainingStrings($object): array
   {
     if (null == $this->extractedProgram)
     {
@@ -147,10 +140,8 @@ class ApproveProgramsAdmin extends AbstractAdmin
 
   /**
    * @param mixed|Program $object
-   *
-   * @return array
    */
-  public function getContainingCodeObjects($object)
+  public function getContainingCodeObjects($object): array
   {
     if (null == $this->extractedProgram)
     {
@@ -169,14 +160,9 @@ class ApproveProgramsAdmin extends AbstractAdmin
 
   protected function configureQuery(ProxyQueryInterface $query): ProxyQueryInterface
   {
+    /** @var ProxyQuery $query */
     $query = parent::configureQuery($query);
 
-    if (!$query instanceof \Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery)
-    {
-      return $query;
-    }
-
-    /** @var QueryBuilder $qb */
     $qb = $query->getQueryBuilder();
 
     $qb->andWhere(
@@ -186,10 +172,10 @@ class ApproveProgramsAdmin extends AbstractAdmin
     return $query;
   }
 
-  protected function configureShowFields(ShowMapper $showMapper): void
+  protected function configureShowFields(ShowMapper $show): void
   {
-    // Here we set the fields of the ShowMapper variable, $showMapper (but this can be called anything)
-    $showMapper
+    // Here we set the fields of the ShowMapper variable, $show (but this can be called anything)
+    $show
       /*
        * The default option is to just display the value as text (for boolean this will be 1 or 0)
        */
@@ -210,26 +196,26 @@ class ApproveProgramsAdmin extends AbstractAdmin
   }
 
   /**
-   * @param FormMapper $formMapper
+   * @param FormMapper $form
    *
    * Fields to be shown on create/edit forms
    */
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
-    $formMapper
+    $form
       ->add('name', TextType::class, ['label' => 'Program name'])
       ->add('user', EntityType::class, ['class' => User::class])
     ;
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper
+    $filter
       ->add('id')
       ->add('name')
       ->add('user.username', null, ['label' => 'User'])
@@ -239,13 +225,13 @@ class ApproveProgramsAdmin extends AbstractAdmin
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->add('uploaded_at', null, ['label' => 'Upload Time'])
       ->add('id', null, ['sortable' => false])
       ->add('user')
@@ -268,10 +254,8 @@ class ApproveProgramsAdmin extends AbstractAdmin
 
   /**
    * @param mixed $paths
-   *
-   * @return array
    */
-  private function encodeFileNameOfPathsArray($paths)
+  private function encodeFileNameOfPathsArray($paths): array
   {
     $encoded_paths = [];
     foreach ($paths as $path)

--- a/src/Admin/CategoriesAdmin.php
+++ b/src/Admin/CategoriesAdmin.php
@@ -32,13 +32,13 @@ class CategoriesAdmin extends AbstractAdmin
   ];
 
   /**
-   * @param FormMapper $formMapper
+   * @param FormMapper $form
    *
    * Fields to be shown on create/edit forms
    */
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
-    $formMapper
+    $form
       ->add('name', TextType::class, ['label' => 'Name'])
       ->add('alias', TextType::class, ['label' => 'Alias'])
       ->add('programs', null, [
@@ -55,13 +55,13 @@ class CategoriesAdmin extends AbstractAdmin
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper
+    $filter
       ->add('name', null, ['label' => 'Starter Category'])
       ->add('alias', null, ['label' => 'Category Alias'])
       ->add('programs', null, ['admin_code' => 'catrowebadmin.block.programs.all'])
@@ -70,13 +70,13 @@ class CategoriesAdmin extends AbstractAdmin
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->add('name', null, ['label' => 'Starter Category', 'sortable' => false])
       ->add('alias', null, ['label' => 'Category Alias', 'sortable' => false])
       ->add('programs', EntityType::class, ['admin_code' => 'catrowebadmin.block.programs.all'])

--- a/src/Admin/ClickStatisticsAdmin.php
+++ b/src/Admin/ClickStatisticsAdmin.php
@@ -40,13 +40,13 @@ class ClickStatisticsAdmin extends AbstractAdmin
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper
+    $filter
       ->add('id')
       ->add('type')
       ->add('program.name')
@@ -60,13 +60,13 @@ class ClickStatisticsAdmin extends AbstractAdmin
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->addIdentifier('id')
       ->add('type')
       ->add('user', EntityType::class, ['class' => User::class])

--- a/src/Admin/EmailUserMessageAdmin.php
+++ b/src/Admin/EmailUserMessageAdmin.php
@@ -20,25 +20,25 @@ class EmailUserMessageAdmin extends AbstractAdmin
    */
   protected $baseRoutePattern = 'mail';
 
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
   }
 

--- a/src/Admin/ExampleProgramAdmin.php
+++ b/src/Admin/ExampleProgramAdmin.php
@@ -9,7 +9,6 @@ use App\Entity\Program;
 use App\Entity\ProgramManager;
 use App\Repository\FlavorRepository;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\QueryBuilder;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -17,7 +16,7 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Object\Metadata;
 use Sonata\AdminBundle\Object\MetadataInterface;
-use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
@@ -71,10 +70,8 @@ class ExampleProgramAdmin extends AbstractAdmin
 
   /**
    * @param ExampleProgram $object
-   *
-   * @return string
    */
-  public function getExampleImageUrl($object)
+  public function getExampleImageUrl($object): string
   {
     return '../../'.$this->example_image_repository->getWebPath($object->getId(), $object->getImageType(), false);
   }
@@ -113,14 +110,9 @@ class ExampleProgramAdmin extends AbstractAdmin
 
   protected function configureQuery(ProxyQueryInterface $query): ProxyQueryInterface
   {
+    /** @var ProxyQuery $query */
     $query = parent::configureQuery($query);
 
-    if (!$query instanceof ProxyQuery)
-    {
-      return $query;
-    }
-
-    /** @var QueryBuilder $qb */
     $qb = $query->getQueryBuilder();
 
     $qb->andWhere(
@@ -131,11 +123,11 @@ class ExampleProgramAdmin extends AbstractAdmin
   }
 
   /**
-   * @param FormMapper $formMapper
+   * @param FormMapper $form
    *
    * Fields to be shown on create/edit forms
    */
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
     /** @var ExampleProgram $example_project */
     $example_project = $this->getSubject();
@@ -151,7 +143,7 @@ class ExampleProgramAdmin extends AbstractAdmin
       $id_value = $this->getSubject()->getProgram()->getId();
     }
 
-    $formMapper
+    $form
       ->add('file', FileType::class, $file_options)
       ->add('program_id', TextType::class, ['mapped' => false, 'data' => $id_value])
       ->add('flavor', null, ['class' => Flavor::class, 'choices' => $this->getFlavors(), 'required' => true])
@@ -163,27 +155,27 @@ class ExampleProgramAdmin extends AbstractAdmin
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper
+    $filter
       ->add('program.name')
     ;
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
     unset($this->listModes['mosaic']);
 
-    $listMapper
+    $list
       ->addIdentifier('id')
       ->add('Example Image', 'string', ['template' => 'Admin/example_image.html.twig'])
       ->add('program', EntityType::class, [
@@ -194,7 +186,7 @@ class ExampleProgramAdmin extends AbstractAdmin
       ->add('flavor', 'string')
       ->add('priority', 'integer')
       ->add('for_ios', null, ['label' => 'iOS only'])
-      ->add('active', null)
+      ->add('active')
       ->add('_action', 'actions', [
         'actions' => [
           'edit' => [],

--- a/src/Admin/FeaturedProgramAdmin.php
+++ b/src/Admin/FeaturedProgramAdmin.php
@@ -143,11 +143,11 @@ class FeaturedProgramAdmin extends AbstractAdmin
   }
 
   /**
-   * @param FormMapper $formMapper
+   * @param FormMapper $form
    *
    * Fields to be shown on create/edit forms
    */
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
     /** @var FeaturedProgram $featured_project */
     $featured_project = $this->getSubject();
@@ -173,7 +173,7 @@ class FeaturedProgramAdmin extends AbstractAdmin
         $use_url = false;
       }
     }
-    $formMapper
+    $form
       ->add('file', FileType::class, $file_options,
         ['help' => 'The featured image must be of size 1024 x 400'])
       ->add('Use_Url', CheckboxType::class, ['mapped' => false, 'required' => false,
@@ -188,13 +188,13 @@ class FeaturedProgramAdmin extends AbstractAdmin
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper
+    $filter
       ->add('program.name')
       ->add('for_ios')
       ->add('active')
@@ -204,14 +204,14 @@ class FeaturedProgramAdmin extends AbstractAdmin
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
     unset($this->listModes['mosaic']);
-    $listMapper
+    $list
       ->addIdentifier('id', null, [
         'sortable' => false,
       ])
@@ -227,7 +227,7 @@ class FeaturedProgramAdmin extends AbstractAdmin
       ])
       ->add('priority', 'integer')
       ->add('for_ios', null, ['label' => 'iOS only'])
-      ->add('active', null)
+      ->add('active')
       ->add('_action', 'actions', [
         'actions' => [
           'edit' => [],

--- a/src/Admin/GoogleCloudMessagingAdmin.php
+++ b/src/Admin/GoogleCloudMessagingAdmin.php
@@ -21,29 +21,29 @@ class GoogleCloudMessagingAdmin extends AbstractAdmin
   protected $baseRoutePattern = 'gcm';
 
   /**
-   * @param FormMapper $formMapper
+   * @param FormMapper $form
    *
    * Fields to be shown on create/edit forms
    */
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
   }
 

--- a/src/Admin/MediaPackageAdmin.php
+++ b/src/Admin/MediaPackageAdmin.php
@@ -21,35 +21,35 @@ class MediaPackageAdmin extends AbstractAdmin
   protected $baseRoutePattern = 'media_package';
 
   /**
-   * @param FormMapper $formMapper
+   * @param FormMapper $form
    *
    * Fields to be shown on create/edit forms
    */
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
-    $formMapper
+    $form
       ->add('name', TextType::class, ['label' => 'Name'])
       ->add('name_url', TextType::class, ['label' => 'Url'])
     ;
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->addIdentifier('name')
       ->add('name_url', null, ['label' => 'Url'])
       ->add('_action', 'actions', [

--- a/src/Admin/MediaPackageCategoriesAdmin.php
+++ b/src/Admin/MediaPackageCategoriesAdmin.php
@@ -23,13 +23,13 @@ class MediaPackageCategoriesAdmin extends AbstractAdmin
   protected $baseRoutePattern = 'media_package_category';
 
   /**
-   * @param FormMapper $formMapper
+   * @param FormMapper $form
    *
    * Fields to be shown on create/edit forms
    */
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
-    $formMapper
+    $form
       ->add('name', TextType::class, ['label' => 'Name'])
       ->add('package', EntityType::class, [
         'class' => MediaPackage::class,
@@ -40,22 +40,22 @@ class MediaPackageCategoriesAdmin extends AbstractAdmin
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->addIdentifier('id')
       ->add('name')
       ->add('package', EntityType::class, ['class' => MediaPackage::class])

--- a/src/Admin/MediaPackageFileAdmin.php
+++ b/src/Admin/MediaPackageFileAdmin.php
@@ -131,16 +131,16 @@ class MediaPackageFileAdmin extends AbstractAdmin
   }
 
   /**
-   * @param FormMapper $formMapper
+   * @param FormMapper $form
    *
    * Fields to be shown on create/edit forms
    */
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
     $file_options = [
       'required' => (null === $this->getSubject()->getId()), ];
 
-    $formMapper
+    $form
       ->add('name', TextType::class, ['label' => 'Name'])
       ->add('file', FileType::class, $file_options)
       ->add('category', EntityType::class, [
@@ -153,13 +153,13 @@ class MediaPackageFileAdmin extends AbstractAdmin
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->addIdentifier('id')
       ->add('name')
       ->add('file', 'string', ['template' => 'Admin/mediapackage_file.html.twig'])

--- a/src/Admin/NotificationAdmin.php
+++ b/src/Admin/NotificationAdmin.php
@@ -23,27 +23,27 @@ class NotificationAdmin extends AbstractAdmin
   protected $baseRoutePattern = 'subscriptions';
 
   /**
-   * @param FormMapper $formMapper
+   * @param FormMapper $form
    *
    * Fields to be shown on create/edit forms
    */
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
     if ($this->isCurrentRoute('create'))
     {
-      $formMapper
+      $form
         ->add('id', EntityType::class, ['class' => User::class, 'label' => 'User'])
       ;
     }
 
     if ($this->isCurrentRoute('edit'))
     {
-      $formMapper
+      $form
         ->add('user', EntityType::class, ['class' => User::class, 'label' => 'User'])
       ;
     }
 
-    $formMapper
+    $form
       ->add('upload', null, ['label' => 'Email bei Upload', 'required' => false])
       ->add('report', null,
         ['label' => 'Email bei Inappropriate Report', 'required' => false])
@@ -51,13 +51,13 @@ class NotificationAdmin extends AbstractAdmin
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper
+    $filter
       ->add('user')
       ->add('user.email')
       ->add('upload')
@@ -66,13 +66,13 @@ class NotificationAdmin extends AbstractAdmin
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->add('user', EntityType::class, ['class' => User::class])
       ->add('user.email')
       ->add('upload', null, ['editable' => true])

--- a/src/Admin/ProgramDownloadStatisticsAdmin.php
+++ b/src/Admin/ProgramDownloadStatisticsAdmin.php
@@ -43,13 +43,13 @@ class ProgramDownloadStatisticsAdmin extends AbstractAdmin
   }
 
   /**
-   * @param FormMapper $formMapper
+   * @param FormMapper $form
    *
    * Fields to be shown on create/edit forms
    */
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
-    $formMapper
+    $form
       ->add('program', EntityType::class, ['class' => Program::class],
         ['admin_code' => 'catrowebadmin.block.programs.all'])
       ->add('user', EntityType::class, ['class' => User::class])
@@ -70,13 +70,13 @@ class ProgramDownloadStatisticsAdmin extends AbstractAdmin
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper
+    $filter
       ->add('id')
       ->add('program.name')
       ->add('program.id')
@@ -97,13 +97,13 @@ class ProgramDownloadStatisticsAdmin extends AbstractAdmin
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->addIdentifier('id')
       ->add('program', null, ['admin_code' => 'catrowebadmin.block.programs.all'])
       ->add('recommended_by_page_id')

--- a/src/Admin/ProgramsTrait.php
+++ b/src/Admin/ProgramsTrait.php
@@ -4,6 +4,7 @@ namespace App\Admin;
 
 use App\Entity\Program;
 use App\Entity\User;
+use Sonata\AdminBundle\Exception\ModelManagerException;
 use Sonata\DoctrineORMAdminBundle\Model\ModelManager;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -11,6 +12,8 @@ trait ProgramsTrait
 {
   /**
    * @param mixed $program
+   *
+   * @throws ModelManagerException
    */
   public function preUpdate($program): void
   {

--- a/src/Admin/ReportedCommentsAdmin.php
+++ b/src/Admin/ReportedCommentsAdmin.php
@@ -3,7 +3,6 @@
 namespace App\Admin;
 
 use App\Entity\Program;
-use Doctrine\ORM\QueryBuilder;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -26,14 +25,9 @@ class ReportedCommentsAdmin extends AbstractAdmin
 
   protected function configureQuery(ProxyQueryInterface $query): ProxyQueryInterface
   {
+    /** @var ProxyQuery $query */
     $query = parent::configureQuery($query);
 
-    if (!$query instanceof ProxyQuery)
-    {
-      return $query;
-    }
-
-    /** @var QueryBuilder $qb */
     $qb = $query->getQueryBuilder();
 
     $qb->andWhere(
@@ -44,22 +38,22 @@ class ReportedCommentsAdmin extends AbstractAdmin
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->add('id')
       ->add('program', EntityType::class,
         [

--- a/src/Admin/ReportedProgramsAdmin.php
+++ b/src/Admin/ReportedProgramsAdmin.php
@@ -8,7 +8,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
-use Sonata\CoreBundle\Form\Type\DateTimeRangePickerType;
+use Sonata\Form\Type\DateTimeRangePickerType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as SymfonyChoiceType;
 
@@ -20,13 +20,13 @@ class ReportedProgramsAdmin extends AbstractAdmin
   protected $datagridValues = ['_sort_order' => 'DESC'];
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper
+    $filter
       ->add('time', 'doctrine_orm_datetime_range',
         [
           'field_type' => DateTimeRangePickerType::class,
@@ -48,13 +48,13 @@ class ReportedProgramsAdmin extends AbstractAdmin
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->add('time')
       ->add('state', 'choice',
         [

--- a/src/Admin/ReportedUsersAdmin.php
+++ b/src/Admin/ReportedUsersAdmin.php
@@ -4,7 +4,6 @@ namespace App\Admin;
 
 use App\Entity\User;
 use Doctrine\ORM\Query\Expr\Join;
-use Doctrine\ORM\QueryBuilder;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -28,14 +27,9 @@ class ReportedUsersAdmin extends AbstractAdmin
 
   protected function configureQuery(ProxyQueryInterface $query): ProxyQueryInterface
   {
+    /** @var ProxyQuery $query */
     $query = parent::configureQuery($query);
 
-    if (!$query instanceof ProxyQuery)
-    {
-      return $query;
-    }
-
-    /** @var QueryBuilder $qb */
     $qb = $query->getQueryBuilder();
 
     $rootAlias = $qb->getRootAliases()[0];
@@ -67,16 +61,16 @@ class ReportedUsersAdmin extends AbstractAdmin
     return $query;
   }
 
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
-    $formMapper
+    $form
       ->add('user', EntityType::class, ['class' => User::class])
       ;
   }
 
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->add(
           'getReportedCommentsCount',
           null,
@@ -101,13 +95,13 @@ class ReportedUsersAdmin extends AbstractAdmin
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper->add('username', null, [
+    $filter->add('username', null, [
       'show_filter' => true,
     ])
       ->add('email')

--- a/src/Admin/RudewordAdmin.php
+++ b/src/Admin/RudewordAdmin.php
@@ -45,37 +45,37 @@ class RudewordAdmin extends AbstractAdmin
   }
 
   /**
-   * @param FormMapper $formMapper
+   * @param FormMapper $form
    *
    * Fields to be shown on create/edit forms
    */
-  protected function configureFormFields(FormMapper $formMapper): void
+  protected function configureFormFields(FormMapper $form): void
   {
-    $formMapper
+    $form
       ->add('word')
     ;
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper
+    $filter
       ->add('word')
     ;
   }
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->add('id', null, ['sortable' => false])
       ->add('word', null, ['sortable' => true])
       ->add('_action', 'actions', ['actions' => [

--- a/src/Admin/StoredUserDataAdmin.php
+++ b/src/Admin/StoredUserDataAdmin.php
@@ -20,13 +20,13 @@ class StoredUserDataAdmin extends AbstractAdmin
   protected $baseRoutePattern = 'stored_userdata';
 
   /**
-   * @param ListMapper $listMapper
+   * @param ListMapper $list
    *
    * Fields to be shown on lists
    */
-  protected function configureListFields(ListMapper $listMapper): void
+  protected function configureListFields(ListMapper $list): void
   {
-    $listMapper
+    $list
       ->addIdentifier('username')
       ->add('email')
       ->add('_action', 'actions', [
@@ -40,13 +40,13 @@ class StoredUserDataAdmin extends AbstractAdmin
   }
 
   /**
-   * @param DatagridMapper $datagridMapper
+   * @param DatagridMapper $filter
    *
    * Fields to be shown on filter forms
    */
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filter): void
   {
-    $datagridMapper->add('username', null, [
+    $filter->add('username', null, [
       'show_filter' => true,
     ])
       ->add('email')

--- a/src/Admin/UserAdmin.php
+++ b/src/Admin/UserAdmin.php
@@ -99,9 +99,9 @@ class UserAdmin extends BaseUserAdmin
     ;
   }
 
-  protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
+  protected function configureDatagridFilters(DatagridMapper $filterMapper): void
   {
-    $datagridMapper
+    $filterMapper
       ->add('username')
       ->add('email')
       ->add('groups')

--- a/src/Entity/Survey.php
+++ b/src/Entity/Survey.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="survey")
+ */
+class Survey
+{
+  /**
+   * @ORM\Id
+   * @ORM\Column(type="integer")
+   * @ORM\GeneratedValue(strategy="AUTO")
+   */
+  protected ?int $id = null;
+
+  /**
+   * @ORM\Column(type="string", length=255, unique=true)
+   */
+  protected ?string $language_code = null;
+
+  /**
+   * @ORM\Column(type="string", length=255)
+   */
+  protected ?string $url = null;
+
+  /**
+   * @ORM\Column(type="boolean", options={"default": true}, nullable=false)
+   */
+  protected bool $active = true;
+
+  public function getId(): ?int
+  {
+    return $this->id;
+  }
+
+  public function setId(?int $id): void
+  {
+    $this->id = $id;
+  }
+
+  public function getLanguageCode(): ?string
+  {
+    return $this->language_code;
+  }
+
+  public function setLanguageCode(?string $language_code): void
+  {
+    $this->language_code = $language_code;
+  }
+
+  public function getUrl(): ?string
+  {
+    return $this->url;
+  }
+
+  public function setUrl(?string $url): void
+  {
+    $this->url = $url;
+  }
+
+  public function isActive(): bool
+  {
+    return $this->active;
+  }
+
+  public function setActive(bool $active): void
+  {
+    $this->active = $active;
+  }
+
+  public static function getISO_639_1_Codes(): array
+  {
+    return [
+      'ab' => 'Abkhazian',
+      'aa' => 'Afar',
+      'af' => 'Afrikaans',
+      'ak' => 'Akan',
+      'sq' => 'Albanian',
+      'am' => 'Amharic',
+      'ar' => 'Arabic',
+      'an' => 'Aragonese',
+      'hy' => 'Armenian',
+      'as' => 'Assamese',
+      'av' => 'Avaric',
+      'ae' => 'Avestan',
+      'ay' => 'Aymara',
+      'az' => 'Azerbaijani',
+      'bm' => 'Bambara',
+      'ba' => 'Bashkir',
+      'eu' => 'Basque',
+      'be' => 'Belarusian',
+      'bn' => 'Bengali',
+      'bh' => 'Bihari languages',
+      'bi' => 'Bislama',
+      'bs' => 'Bosnian',
+      'br' => 'Breton',
+      'bg' => 'Bulgarian',
+      'my' => 'Burmese',
+      'ca' => 'Catalan, Valencian',
+      'km' => 'Central Khmer',
+      'ch' => 'Chamorro',
+      'ce' => 'Chechen',
+      'ny' => 'Chichewa, Chewa, Nyanja',
+      'zh' => 'Chinese',
+      'cu' => 'Church Slavonic, Old Bulgarian, Old Church Slavonic',
+      'cv' => 'Chuvash',
+      'kw' => 'Cornish',
+      'co' => 'Corsican',
+      'cr' => 'Cree',
+      'hr' => 'Croatian',
+      'cs' => 'Czech',
+      'da' => 'Danish',
+      'dv' => 'Divehi, Dhivehi, Maldivian',
+      'nl' => 'Dutch, Flemish',
+      'dz' => 'Dzongkha',
+      'en' => 'English',
+      'eo' => 'Esperanto',
+      'et' => 'Estonian',
+      'ee' => 'Ewe',
+      'fo' => 'Faroese',
+      'fj' => 'Fijian',
+      'fi' => 'Finnish',
+      'fr' => 'French',
+      'ff' => 'Fulah',
+      'gd' => 'Gaelic, Scottish Gaelic',
+      'gl' => 'Galician',
+      'lg' => 'Ganda',
+      'ka' => 'Georgian',
+      'de' => 'German',
+      'ki' => 'Gikuyu, Kikuyu',
+      'el' => 'Greek (Modern)',
+      'kl' => 'Greenlandic, Kalaallisut',
+      'gn' => 'Guarani',
+      'gu' => 'Gujarati',
+      'ht' => 'Haitian, Haitian Creole',
+      'ha' => 'Hausa',
+      'he' => 'Hebrew',
+      'hz' => 'Herero',
+      'hi' => 'Hindi',
+      'ho' => 'Hiri Motu',
+      'hu' => 'Hungarian',
+      'is' => 'Icelandic',
+      'io' => 'Ido',
+      'ig' => 'Igbo',
+      'id' => 'Indonesian',
+      'ia' => 'Interlingua (International Auxiliary Language Association)',
+      'ie' => 'Interlingue',
+      'iu' => 'Inuktitut',
+      'ik' => 'Inupiaq',
+      'ga' => 'Irish',
+      'it' => 'Italian',
+      'ja' => 'Japanese',
+      'jv' => 'Javanese',
+      'kn' => 'Kannada',
+      'kr' => 'Kanuri',
+      'ks' => 'Kashmiri',
+      'kk' => 'Kazakh',
+      'rw' => 'Kinyarwanda',
+      'kv' => 'Komi',
+      'kg' => 'Kongo',
+      'ko' => 'Korean',
+      'kj' => 'Kwanyama, Kuanyama',
+      'ku' => 'Kurdish',
+      'ky' => 'Kyrgyz',
+      'lo' => 'Lao',
+      'la' => 'Latin',
+      'lv' => 'Latvian',
+      'lb' => 'Letzeburgesch, Luxembourgish',
+      'li' => 'Limburgish, Limburgan, Limburger',
+      'ln' => 'Lingala',
+      'lt' => 'Lithuanian',
+      'lu' => 'Luba-Katanga',
+      'mk' => 'Macedonian',
+      'mg' => 'Malagasy',
+      'ms' => 'Malay',
+      'ml' => 'Malayalam',
+      'mt' => 'Maltese',
+      'gv' => 'Manx',
+      'mi' => 'Maori',
+      'mr' => 'Marathi',
+      'mh' => 'Marshallese',
+      'ro' => 'Moldovan, Moldavian, Romanian',
+      'mn' => 'Mongolian',
+      'na' => 'Nauru',
+      'nv' => 'Navajo, Navaho',
+      'nd' => 'Northern Ndebele',
+      'ng' => 'Ndonga',
+      'ne' => 'Nepali',
+      'se' => 'Northern Sami',
+      'no' => 'Norwegian',
+      'nb' => 'Norwegian Bokmål',
+      'nn' => 'Norwegian Nynorsk',
+      'ii' => 'Nuosu, Sichuan Yi',
+      'oc' => 'Occitan (post 1500)',
+      'oj' => 'Ojibwa',
+      'or' => 'Oriya',
+      'om' => 'Oromo',
+      'os' => 'Ossetian, Ossetic',
+      'pi' => 'Pali',
+      'pa' => 'Panjabi, Punjabi',
+      'ps' => 'Pashto, Pushto',
+      'fa' => 'Persian',
+      'pl' => 'Polish',
+      'pt' => 'Portuguese',
+      'qu' => 'Quechua',
+      'rm' => 'Romansh',
+      'rn' => 'Rundi',
+      'ru' => 'Russian',
+      'sm' => 'Samoan',
+      'sg' => 'Sango',
+      'sa' => 'Sanskrit',
+      'sc' => 'Sardinian',
+      'sr' => 'Serbian',
+      'sn' => 'Shona',
+      'sd' => 'Sindhi',
+      'si' => 'Sinhala, Sinhalese',
+      'sk' => 'Slovak',
+      'sl' => 'Slovenian',
+      'so' => 'Somali',
+      'st' => 'Sotho, Southern',
+      'nr' => 'South Ndebele',
+      'es' => 'Spanish, Castilian',
+      'su' => 'Sundanese',
+      'sw' => 'Swahili',
+      'ss' => 'Swati',
+      'sv' => 'Swedish',
+      'tl' => 'Tagalog',
+      'ty' => 'Tahitian',
+      'tg' => 'Tajik',
+      'ta' => 'Tamil',
+      'tt' => 'Tatar',
+      'te' => 'Telugu',
+      'th' => 'Thai',
+      'bo' => 'Tibetan',
+      'ti' => 'Tigrinya',
+      'to' => 'Tonga (Tonga Islands)',
+      'ts' => 'Tsonga',
+      'tn' => 'Tswana',
+      'tr' => 'Turkish',
+      'tk' => 'Turkmen',
+      'tw' => 'Twi',
+      'ug' => 'Uighur, Uyghur',
+      'uk' => 'Ukrainian',
+      'ur' => 'Urdu',
+      'uz' => 'Uzbek',
+      've' => 'Venda',
+      'vi' => 'Vietnamese',
+      'vo' => 'Volap_k',
+      'wa' => 'Walloon',
+      'cy' => 'Welsh',
+      'fy' => 'Western Frisian',
+      'wo' => 'Wolof',
+      'xh' => 'Xhosa',
+      'yi' => 'Yiddish',
+      'yo' => 'Yoruba',
+      'za' => 'Zhuang, Chuang',
+      'zu' => 'Zulu',
+    ];
+  }
+}

--- a/templates/Admin/standard_layout.html.twig
+++ b/templates/Admin/standard_layout.html.twig
@@ -52,7 +52,7 @@
             {% if _tab_menu is not empty %}
               {{ _tab_menu|raw }}
             {% endif %}
-            {% if app.request.requesturi == '/admin/apk_pending_requests/list' %}
+            {% if app.request.requesturi == '/admin/apk_pending/list' %}
               <a class="btn btn-sm btn-default navbar-btn" href="{{ admin.generateUrl('resetAllApk') }}">Reset all</a>
               <a class="btn btn-sm btn-default navbar-btn" href="{{ admin.generateUrl('rebuildAllApk') }}">Rebuild
                                                                                                            all</a>

--- a/tests/behat/context/ApiContext.php
+++ b/tests/behat/context/ApiContext.php
@@ -113,6 +113,7 @@ class ApiContext implements KernelAwareContext
 
   private array $user_structure = ['id', 'username',
     'projects', 'followers', 'following', ];
+
   private array $user_structure_extended = ['id', 'username', 'email', 'country',
     'projects', 'followers', 'following', ];
 
@@ -120,6 +121,8 @@ class ApiContext implements KernelAwareContext
 
   private array $media_file_structure = ['id', 'name', 'flavor', 'package', 'category',
     'author', 'extension', 'download_url', ];
+
+  private array $survey_structure = ['url'];
 
   private array $new_uploaded_projects = [];
 
@@ -1812,6 +1815,23 @@ class ApiContext implements KernelAwareContext
     {
       Assert::assertArrayHasKey($key, $user, 'User should contain '.$key);
       Assert::assertEquals($this->checkUserFieldsValue($user, $key), true);
+    }
+  }
+
+  /**
+   * @Then /^the response should have the survey model structure$/
+   */
+  public function responseShouldHaveSurveyModelStructure(): void
+  {
+    $response = $this->getKernelBrowser()->getResponse();
+    $survey = json_decode($response->getContent(), true);
+
+    Assert::assertEquals(count($this->survey_structure), count($survey),
+      'Number of survey fields should be '.count($this->survey_structure));
+    foreach ($this->survey_structure as $key)
+    {
+      Assert::assertArrayHasKey($key, $survey, 'Survey should contain '.$key);
+      Assert::assertEquals($this->checkSurveyFieldsValue($survey, $key), true);
     }
   }
 
@@ -3516,6 +3536,21 @@ class ApiContext implements KernelAwareContext
       'following' => function ($following)
       {
         Assert::assertIsInt($following);
+      },
+    ];
+
+    Assert::assertArrayHasKey($key, $fields);
+    call_user_func($fields[$key], $user[$key]);
+
+    return true;
+  }
+
+  private function checkSurveyFieldsValue(array $user, string $key): bool
+  {
+    $fields = [
+      'url' => function ($username)
+      {
+        Assert::assertIsString($username);
       },
     ];
 

--- a/tests/behat/context/CatrowebBrowserContext.php
+++ b/tests/behat/context/CatrowebBrowserContext.php
@@ -2530,6 +2530,22 @@ class CatrowebBrowserContext extends BrowserContext
   }
 
   /**
+   * @Then /^I should see the survey table:$/
+   *
+   * @throws ResponseTextException
+   */
+  public function seeSurveyTable(TableNode $table): void
+  {
+    $survey_stats = $table->getHash();
+    foreach ($survey_stats as $survey_stat)
+    {
+      $this->assertSession()->pageTextContains($survey_stat['Language Code']);
+      $this->assertSession()->pageTextContains($survey_stat['Url']);
+      $this->assertSession()->pageTextContains($survey_stat['Active']);
+    }
+  }
+
+  /**
    * @Then /^I should see the media package categories table:$/
    *
    * @throws ResponseTextException

--- a/tests/behat/context/DataFixturesContext.php
+++ b/tests/behat/context/DataFixturesContext.php
@@ -24,6 +24,7 @@ use App\Entity\ProgramLike;
 use App\Entity\RemixNotification;
 use App\Entity\RudeWord;
 use App\Entity\StarterCategory;
+use App\Entity\Survey;
 use App\Entity\Tag;
 use App\Entity\User;
 use App\Entity\UserComment;
@@ -274,6 +275,27 @@ class DataFixturesContext implements KernelAwareContext
 
     Assert::assertInstanceOf(User::class, $user);
     Assert::assertEquals($country_code, $user->getCountry());
+  }
+
+  // -------------------------------------------------------------------------------------------------------------------
+  //  Surveys
+  // -------------------------------------------------------------------------------------------------------------------
+
+  /**
+   * @Given /^there are surveys:$/
+   */
+  public function thereAreSurveys(TableNode $table): void
+  {
+    $em = $this->getManager();
+    foreach ($table->getHash() as $survey_config)
+    {
+      $survey = new Survey();
+      $survey->setLanguageCode($survey_config['language code']);
+      $survey->setUrl($survey_config['url']);
+      $em->persist($survey);
+    }
+    $em->flush();
+    $this->getManager()->flush();
   }
 
   // -------------------------------------------------------------------------------------------------------------------

--- a/tests/behat/features/api/utility/survey.feature
+++ b/tests/behat/features/api/utility/survey.feature
@@ -1,0 +1,39 @@
+@api @utility
+Feature: There must be a simple way to check the status/health of the catroweb API/services
+
+  Background:
+    Given there are surveys:
+      | language code | url                 |
+      | en            | www.catrosurvey.com |
+      | de            | www.catrosurvey.at  |
+
+  Scenario: The request header must be set
+    When I request "GET" "/api/survey/unknown"
+    Then the response status code should be "406"
+    And the response content must be empty
+
+  Scenario: A survey request can only return a survey if it exists
+    Given I have a request header "HTTP_ACCEPT" with value "application/json"
+    When I request "GET" "/api/survey/unknown"
+    Then the response status code should be "404"
+    And the response content must be empty
+
+  Scenario: A survey request returns the correct survey
+    Given I have a request header "HTTP_ACCEPT" with value "application/json"
+    When I request "GET" "/api/survey/en"
+    Then the response status code should be "200"
+    Then the response should have the survey model structure
+    Then I should get the json object:
+    """
+      { "url": "www.catrosurvey.com" }
+    """
+
+  Scenario: A survey request returns the correct survey 2
+    Given I have a request header "HTTP_ACCEPT" with value "application/json"
+    When I request "GET" "/api/survey/de"
+    Then the response status code should be "200"
+    Then the response should have the survey model structure
+    Then I should get the json object:
+    """
+      { "url": "www.catrosurvey.at" }
+    """

--- a/tests/behat/features/web/admin/apk_generation_pending.feature
+++ b/tests/behat/features/web/admin/apk_generation_pending.feature
@@ -5,82 +5,66 @@ Feature: APK-Generation Pending in Admin Area
   Background:
     Given there are admins:
       | name     | password | token      | email                | id |
-      | Adminius | 123456   | eeeeeeeeee | admin@pocketcode.org |  0 |
+      | Adminius | 123456   | eeeeeeeeee | admin@pocketcode.org | 0  |
     And there are users:
       | name     | password | token      | email               | id |
-      | Superman | 123456   | cccccccccc | dev1@pocketcode.org |  1 |
-      | Gregor   | 123456   | dddddddddd | dev2@pocketcode.org |  2 |
+      | Superman | 123456   | cccccccccc | dev1@pocketcode.org | 1  |
+      | Gregor   | 123456   | dddddddddd | dev2@pocketcode.org | 2  |
     And there are programs:
-      | id | name      | description              | owned by | apk request time | apk_status |
-      | 1  | program 1 | my superman description  | Superman | 27.05.2020 10:00 | ready      |
-      | 2  | program 2 | abcef                    | Gregor   | 27.05.2020 11:00 | none       |
-      | 3  | program 3 | hello                    | Adminius |                  | none       |
+      | id | name      | description       | owned by | apk request time | apk_status |
+      | 1  | program 1 | ready program     | Superman |                  | ready      |
+      | 2  | program 2 | none program      | Gregor   |                  | none       |
+      | 3  | program 3 | pending program 1 | Adminius | 27.05.2020 10:00 | pending    |
+      | 4  | program 4 | pending program 2 | Adminius | 27.05.2020 11:00 | pending    |
 
   Scenario: List should be complete and sorted after Apk Request Time DESC
     Given I log in as "Adminius" with the password "123456"
-    And I am on "/admin/apk_pending_requests/list"
+    And I am on "/admin/apk_pending/list"
     And I wait for the page to be loaded
     Then I should see the pending apk table:
-      | Id | User     | Name      | Apk Request Time   | Apk Status |
-      | 2  | Gregor   | program 2 | May 27, 2020 11:00 | none       |
-      | 1  | Superman | program 1 | May 27, 2020 10:00 | ready      |
-      | 3  | Adminius | program 3 |                    | none       |
+      | Id | User     | Name              | Apk Request Time | Apk Status |
+      | 3  | Adminius | program 3 |                  | pending    |
+      | 4  | Adminius | program 4 |                  | pending    |
 
   Scenario: The rebuild button should rebuild apk and set state to pending
     Given I log in as "Adminius" with the password "123456"
-    And I am on "/admin/apk_pending_requests/list"
+    And I am on "/admin/apk_pending/list"
     And I wait for the page to be loaded
-    Then I am on "/admin/apk_pending_requests/3/rebuildApk"
+    Then I am on "/admin/apk_pending/3/rebuildApk"
     And I wait for the page to be loaded
     And I should see the pending apk table:
-      | Id | User     | Name      | Apk Request Time   | Apk Status |
-      | 3  | Adminius | program 3 |                    | pending    |
-      | 2  | Gregor   | program 2 | May 27, 2020 11:00 | none       |
-      | 1  | Superman | program 1 | May 27, 2020 10:00 | ready      |
+      | Id | User     | Name              | Apk Request Time | Apk Status |
+      | 3  | Adminius | program 3 |                  | pending    |
+      | 4  | Adminius | program 4 |                  | pending    |
 
   Scenario: The reset button should reset the apk status and the request time
     Given I log in as "Adminius" with the password "123456"
-    And I am on "/admin/apk_pending_requests/list"
+    And I am on "/admin/apk_pending/list"
     And I wait for the page to be loaded
-    And I am on "/admin/apk_pending_requests/3/rebuildApk"
+    Then I am on "/admin/apk_pending/3/resetStatus"
     And I wait for the page to be loaded
-    And I am on "/admin/apk_pending_requests/2/rebuildApk"
+    And I am on "/admin/apk_pending/list"
     And I wait for the page to be loaded
-    Then I am on "/admin/apk_pending_requests/3/resetStatus"
-    And I wait for the page to be loaded
-    And I should see the pending apk table:
-      | Id | User     | Name      | Apk Request Time   | Apk Status |
-      | 2  | Gregor   | program 2 |                    | pending    |
-      | 1  | Superman | program 1 | May 27, 2020 10:00 | ready      |
-      | 3  | Adminius | program 3 |                    | none       |
-    And I should not see "May 27, 2020 11:00"
+    And I should not see "program 3"
 
   Scenario: The reset all button should reset all programs
     Given I log in as "Adminius" with the password "123456"
-    And I am on "/admin/apk_pending_requests/list"
+    And I am on "/admin/apk_pending/list"
     And I wait for the page to be loaded
-    And I am on "/admin/apk_pending_requests/2/rebuildApk"
+    Then I am on "/admin/apk_pending/resetAllApk"
     And I wait for the page to be loaded
-    Then I am on "/admin/apk_pending_requests/resetAllApk"
-    And I wait for the page to be loaded
-    And I should see the pending apk table:
-      | Id | User     | Name      | Apk Request Time   | Apk Status |
-      | 1  | Superman | program 1 |                    | none       |
-      | 2  | Gregor   | program 2 |                    | none       |
-      | 3  | Adminius | program 3 |                    | none       |
-    And I should not see "May 27, 2020 10:00"
-    And I should not see "May 27, 2020 11:00"
+    And I should not see "program 3"
+    And I should not see "program 4"
 
   Scenario: The rebuild all button should rebuild all programs
     Given I log in as "Adminius" with the password "123456"
-    And I am on "/admin/apk_pending_requests/list"
+    And I am on "/admin/apk_pending/list"
     And I wait for the page to be loaded
-    Then I am on "/admin/apk_pending_requests/rebuildAllApk"
+    Then I am on "/admin/apk_pending/rebuildAllApk"
     And I wait for the page to be loaded
     And I should see the pending apk table:
-      | Id | User     | Name      | Apk Request Time   | Apk Status |
-      | 3  | Adminius | program 3 |                    | pending    |
-      | 2  | Gregor   | program 2 |                    | pending    |
-      | 1  | Superman | program 1 |                    | pending    |
+      | Id | User     | Name              | Apk Request Time | Apk Status |
+      | 3  | Adminius | program 3 |                  | pending    |
+      | 4  | Adminius | program 4 |                  | pending    |
     And I should not see "May 27, 2020 10:00"
     And I should not see "May 27, 2020 11:00"

--- a/tests/behat/features/web/admin/apk_generation_ready.feature
+++ b/tests/behat/features/web/admin/apk_generation_ready.feature
@@ -18,7 +18,7 @@ Feature: APK-Generation Pending in Admin Area
 
   Scenario: List should be complete and sorted after Apk Request Time DESC
     Given I log in as "Adminius" with the password "123456"
-    And I am on "/admin/apk_list/list"
+    And I am on "/admin/apk_ready/list"
     And I wait for the page to be loaded
     Then I should see the ready apks table:
       | Id | User     | Name      | Apk Request Time   |
@@ -28,38 +28,28 @@ Feature: APK-Generation Pending in Admin Area
 
   Scenario: The Rebuild button should rebuild apk and set state to pending. Entry shouldn't be in list anymore
     Given I log in as "Adminius" with the password "123456"
-    And I am on "/admin/apk_list/list"
+    And I am on "/admin/apk_ready/list"
     And I wait for the page to be loaded
-    Then I am on "/admin/apk_list/3/rebuildApk"
+    Then I am on "/admin/apk_ready/3/rebuildApk"
     And I wait for the page to be loaded
-    And I should see the ready apks table:
-      | Id | User     | Name      | Apk Request Time   |
-      | 2  | Gregor   | program 2 | June 2, 2020 11:00 |
-      | 1  | Superman | program 1 | June 2, 2020 10:00 |
-    And I should not see "Adminius"
-    And I am on "/admin/apk_pending_requests/list"
+    When I am on "/admin/apk_ready/list"
     And I wait for the page to be loaded
-    Then I should see the pending apk table:
-      | Id | User     | Name      | Apk Request Time   | Apk Status |
-      | 3  | Adminius | program 3 |                    | pending    |
-      | 2  | Gregor   | program 2 | June 2, 2020 11:00 | ready      |
-      | 1  | Superman | program 1 | June 2, 2020 10:00 | ready      |
+    Then I should not see "program 3"
+    And I wait for the page to be loaded
+    When I am on "/admin/apk_pending/list"
+    And I wait for the page to be loaded
+    Then I should see "program 3"
 
   Scenario: The Reset button should reset the apk status, the request time and entry shouldn't be in list anymore
     Given I log in as "Adminius" with the password "123456"
-    And I am on "/admin/apk_list/list"
+    And I am on "/admin/apk_ready/list"
     And I wait for the page to be loaded
-    And I am on "/admin/apk_list/3/resetStatus"
+    And I am on "/admin/apk_ready/3/resetStatus"
     And I wait for the page to be loaded
-    And I should see the ready apks table:
-      | Id | User     | Name      | Apk Request Time   |
-      | 2  | Gregor   | program 2 | June 2, 2020 11:00 |
-      | 1  | Superman | program 1 | June 2, 2020 10:00 |
-    And I should not see "Adminius"
-    And I am on "/admin/apk_pending_requests/list"
+    When I am on "/admin/apk_ready/list"
     And I wait for the page to be loaded
-    Then I should see the pending apk table:
-      | Id | User     | Name      | Apk Request Time   | Apk Status |
-      | 3  | Adminius | program 3 |                    | none       |
-      | 2  | Gregor   | program 2 | June 2, 2020 11:00 | ready      |
-      | 1  | Superman | program 1 | June 2, 2020 10:00 | ready      |
+    Then I should not see "program 3"
+    And I wait for the page to be loaded
+    When I am on "/admin/apk_pending/list"
+    And I wait for the page to be loaded
+    Then I should not see "program 3"

--- a/tests/behat/features/web/admin/survey.feature
+++ b/tests/behat/features/web/admin/survey.feature
@@ -1,0 +1,43 @@
+@admin
+Feature: Surveys can be added, removed, and updated in the Admin interface
+
+
+  Background:
+    Given there are admins:
+      | name     | password |
+      | Adminius | 123456   |
+    And there are surveys:
+      | language code | url                |
+      | en            | www.catrosurvey.at |
+
+  Scenario: List should be complete
+    Given I log in as "Adminius" with the password "123456"
+    And I am on "/admin/all_surveys/list"
+    And I wait for the page to be loaded
+    Then I should see the survey table:
+      | Language Code | Url                | Active |
+      | English       | www.catrosurvey.at | yes    |
+
+  Scenario: I can add new surveys
+    Given I log in as "Adminius" with the password "123456"
+    And I am on "/admin/all_surveys/create"
+    And I wait for the page to be loaded
+    Then I should see "Language Code"
+    Then I should see "Url"
+    Then I should see "Active"
+    Then I should see "Create"
+
+  Scenario: I can delete entries
+    Given I log in as "Adminius" with the password "123456"
+    And I am on "/admin/all_surveys/list"
+    And I wait for the page to be loaded
+    Then I should see the survey table:
+      | Language Code | Url                | Active |
+      | English       | www.catrosurvey.at | yes    |
+    When I go to "/admin/all_surveys/1/delete"
+    And I wait for the page to be loaded
+    And I click ".btn-danger"
+    And I wait for the page to be loaded
+    And I am on "/admin/all_surveys/list"
+    And I wait for the page to be loaded
+    Then I should not see "www.catrosurvey.at"

--- a/tests/phpUnit/Api/SurveyApiTest.php
+++ b/tests/phpUnit/Api/SurveyApiTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Api;
+
+use App\Api\UtilityApi;
+use App\Entity\Survey;
+use OpenAPI\Server\Model\SurveyResponse;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\phpUnit\CatrowebPhpUnit\CatrowebTestCase;
+
+/**
+ * @covers \App\Api\UtilityApi
+ *
+ * @internal
+ */
+class SurveyApiTest extends CatrowebTestCase
+{
+  /**
+   * @var UtilityApi|MockObject
+   */
+  private $utility_api;
+
+  public function setUp(): void
+  {
+    $this->utility_api = $this->getMockBuilder(UtilityApi::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['getActiveSurvey'])
+      ->getMock()
+    ;
+  }
+
+  public function testClassExists(): void
+  {
+    $this->assertTrue(class_exists(UtilityApi::class));
+    $this->assertInstanceOf(UtilityApi::class, $this->utility_api);
+  }
+
+  /**
+   * @dataProvider dataProvider_GetSurvey
+   */
+  public function testGetSurveyResponse(?array $survey_data, int $expected_code, ?string $expected_url): void
+  {
+    $response_code = Response::HTTP_NOT_IMPLEMENTED;
+    $response_headers = [];
+
+    $survey = null;
+    if (null !== $survey_data)
+    {
+      $survey = new Survey();
+      $survey->setLanguageCode($survey_data['language_code']);
+      $survey->setUrl($survey_data['url']);
+    }
+    $this->utility_api->expects($this->once())
+      ->method('getActiveSurvey')
+      ->willReturn($survey)
+    ;
+
+    /** @var SurveyResponse|null $survey_response */
+    $survey_response = $this->utility_api->surveyLangCodeGet(
+      'language_code',
+      $response_code,
+      $response_headers
+    );
+
+    Assert::assertEquals($expected_code, $response_code);
+    if (null !== $expected_url)
+    {
+      Assert::assertEquals($expected_url, $survey_response->getUrl());
+    }
+  }
+
+  public function dataProvider_GetSurvey(): array
+  {
+    return [
+      '404' => [
+        'survey_data' => null,
+        'expected_code' => Response::HTTP_NOT_FOUND,
+        'expected_response' => null,
+      ],
+      '200' => [
+        'survey_data' => [
+          'language_code' => 'de',
+          'url' => 'www.survey.catrob.at',
+        ],
+        'expected_code' => Response::HTTP_OK,
+        'expected_response' => 'www.survey.catrob.at',
+      ],
+    ];
+  }
+}

--- a/tests/phpUnit/Api/UtilityApiTest.php
+++ b/tests/phpUnit/Api/UtilityApiTest.php
@@ -19,14 +19,4 @@ class UtilityApiTest extends WebTestCase
     $client->request('GET', '/api/health', [], [], []);
     $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
   }
-
-  public function testGetSurvey(): void
-  {
-    $client = static::createClient();
-
-    $client->request('GET', '/api/survey/de', [], [], ['HTTP_ACCEPT' => 'application/json']);
-    $this->assertResponseStatusCodeSame(Response::HTTP_OK);
-    $response = $client->getResponse()->getContent();
-    $this->assertStringContainsString('url', $response);
-  }
 }


### PR DESCRIPTION
- implement GET survey/{lang_code}
- add Admin interface for surveys:
  - You can find it under survey> All surveys
  - Language codes are automatically mapped in the background. In other words, the "full text" version of the code is in the admin interface. Say "English" instead of "en"
  - Entries can be deleted with the action button
  - The URL can be edited directly inline
  - Active can also be edited inline
  - Entries that are inactive (active == false) are not found by the API!
  - With "New" new entries can be added.
  - URL must be set, otherwise there is no further validation.
  - The language code is already mapped and only options that are not yet used are displayed. The language code must be unique.
  - Filters are available for language code, url, active (language code is already pre-mapped so that nothing can go wrong)

<br>

- Unit tests for GET survey/{lang_code}
- Behat tests for
  - GET surevey/{lang_code}
  - Survey Admin interface


<br>


- Fixed Admin interface deprecations throughout the admin interface