### PR TITLE
SHARE-459 License to play one column on mobile

### DIFF
--- a/templates/PrivacyAndTerms/licenseToPlay.html.twig
+++ b/templates/PrivacyAndTerms/licenseToPlay.html.twig
@@ -1,25 +1,27 @@
 {% extends 'Default/base.html.twig' %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ asset('css/'~themeAssets()~'/licensetoplay.css') }}" media="screen"/>
+  <link rel="stylesheet" href="{{ asset('css/'~themeAssets()~'/multi_column_article.css') }}" media="screen"/>
 {% endblock %}
 
 {% block body %}
-  <h1>{{ "licenseToPlay.title"|trans({}, "catroweb") }}</h1>
-  <div class="standard-col-text size-large">
-    <p>{{ "licenseToPlay.text1"|trans({}, "catroweb") }}</p>
-    <p>{{ "licenseToPlay.text2"|trans({}, "catroweb") }}</p>
-    <p>
-      <b>{{ "licenseToPlay.text3"|trans({}, "catroweb") }}</b>
-    </p>
-    <ul>
-      <li>{{ "licenseToPlay.list1.item1"|trans({}, "catroweb") }}</li>
-      <li>{{ "licenseToPlay.list1.item2"|trans({}, "catroweb") }}</li>
-    </ul>
-    <p>{{ "licenseToPlay.text4"|trans({}, "catroweb") }}</p>
-    <p>{{ "licenseToPlay.text5"|trans({}, "catroweb") }}</p>
-    <p>{{ "licenseToPlay.text6"|trans({'%link-termsOfUse%': '<a href="' ~ url('termsOfUse') ~ '">' ~ url('termsOfUse') ~ '</a>'}, "catroweb")|raw }}</p>
-    <p>{{ "licenseToPlay.version"|trans({}, "catroweb") }}</p>
+    <div class="col-12">
+        <div class="article-columns">
+          <h1 class="mb-4">{{ "licenseToPlay.title"|trans({}, "catroweb") }}</h1>
+          <p>{{ "licenseToPlay.text1"|trans({}, "catroweb") }}</p>
+          <p>{{ "licenseToPlay.text2"|trans({}, "catroweb") }}</p>
+          <p>
+            <b>{{ "licenseToPlay.text3"|trans({}, "catroweb") }}</b>
+          </p>
+          <ul>
+            <li>{{ "licenseToPlay.list1.item1"|trans({}, "catroweb") }}</li>
+            <li>{{ "licenseToPlay.list1.item2"|trans({}, "catroweb") }}</li>
+          </ul>
+          <p>{{ "licenseToPlay.text4"|trans({}, "catroweb") }}</p>
+          <p>{{ "licenseToPlay.text5"|trans({}, "catroweb") }}</p>
+          <p>{{ "licenseToPlay.text6"|trans({'%link-termsOfUse%': '<a href="' ~ url('termsOfUse') ~ '">' ~ url('termsOfUse') ~ '</a>'}, "catroweb")|raw }}</p>
+          <p>{{ "licenseToPlay.version"|trans({}, "catroweb") }}</p>
+        </div>
   </div>
 {% endblock %}
 


### PR DESCRIPTION
"License to play" page is now shown in single column layout on small screens and mobiles.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
