### PR TITLE
SHARE-421 code statistics should be open by default

### DIFF
--- a/templates/Program/code_statistics.html.twig
+++ b/templates/Program/code_statistics.html.twig
@@ -12,15 +12,15 @@
   <div class="accordion" id="accordionStatistics">
     <div class="card">
 
-      <div class="card-header collapsed d-flex justify-content-between expansion-header" id="statisticsGeneral"
+      <div class="card-header d-flex justify-content-between expansion-header" id="statisticsGeneral"
            data-toggle="collapse"
-           data-target="#collapseGeneral" aria-expanded="false"
+           aria-expanded="true"
            aria-controls="collapseGeneral">
         {{ "codeStatistics.general"|trans({}, "catroweb") }}
-        <i class="material-icons rotate-left">chevron_left</i>
+        <i class="material-icons rotate-left" style="visibility: hidden">chevron_left</i>
       </div>
 
-      <div id="collapseGeneral" class="collapse" aria-labelledby="statisticsGeneral"
+      <div id="collapseGeneral" class="collapse show" aria-labelledby="statisticsGeneral"
            data-parent="#accordionStatistics">
         <div class="card-body">
           <table class="table center table-striped">
@@ -42,14 +42,15 @@
         </div>
       </div>
 
-      <div class="card-header collapsed d-flex justify-content-between expansion-header" id="statisticsBricks"
-           data-toggle="collapse" data-target="#collapseBricks" aria-expanded="false"
+      <div class="card-header d-flex justify-content-between expansion-header" id="statisticsBricks"
+           data-toggle="collapse"
+           aria-expanded="true"
            aria-controls="collapseBricks">
         {{ "codeStatistics.bricks"|trans({}, "catroweb") }}
-        <i class="material-icons rotate-left">chevron_left</i>
+        <i class="material-icons rotate-left" style="visibility: hidden">chevron_left</i>
       </div>
 
-      <div id="collapseBricks" class="collapse" aria-labelledby="statisticsBricks"
+      <div id="collapseBricks" class="collapse show" aria-labelledby="statisticsBricks"
            data-parent="#accordionStatistics">
         <div class="card-body">
           <table class="table center table-striped">

--- a/tests/behat/features/web/code-statistics/project_code_statistics.feature
+++ b/tests/behat/features/web/code-statistics/project_code_statistics.feature
@@ -30,26 +30,6 @@ Feature: As a visitor I want to see code statistics on the project page
     And I click "#top-app-bar__title"
     Then I should be on "/app/project/1/code_statistics"
 
-  Scenario: The code statistics should use an accordion principle
-    Given I have a project zip "CodeStatistics/code_statistics_compound_blocks.catrobat"
-    And I upload this generated program with id "1", API version 1
-    And I am on "/app/project/1/code_statistics"
-    And I wait for the page to be loaded
-    Then the element "#statisticsGeneral" should be visible
-    And the element "#statisticsBricks" should be visible
-    And the element "#total-number-of-scenes" should not be visible
-    And the element "#total-number-of-event-brick" should not be visible
-    When I click "#statisticsGeneral"
-    Then the element "#statisticsGeneral" should be visible
-    And the element "#statisticsBricks" should be visible
-    And the element "#total-number-of-scenes" should be visible
-    And the element "#total-number-of-event-brick" should not be visible
-    When I click "#statisticsBricks"
-    Then the element "#statisticsGeneral" should be visible
-    And the element "#statisticsBricks" should be visible
-    And the element "#total-number-of-scenes" should not be visible
-    And the element "#total-number-of-event-brick" should be visible
-
   Scenario: On a project page there should be correct stats for all code bricks
     Given I have a project zip "CodeStatistics/code_statistics_compound_blocks.catrobat"
     When I upload this generated program with id "1", API version 1


### PR DESCRIPTION
The code statistics cards are not collapsable anymore and open by default.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
