### PR TITLE
SHARE-466 Invisible Loading Spinners (on Buttons)

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -23,6 +23,7 @@
     "function-linear-gradient-no-nonstandard-direction": null,
 
     "declaration-no-important": null,
-    "no-invalid-position-at-import-rule": null
+    "no-invalid-position-at-import-rule": null,
+    "selector-class-pattern": "^[a-z][a-z0-9\\-\\_]*[a-z0-9]$"
   }
 }

--- a/assets/css/base/_buttons.scss
+++ b/assets/css/base/_buttons.scss
@@ -4,4 +4,10 @@
   text-overflow: ellipsis;
   text-transform: uppercase;
   white-space: nowrap;
+
+  &:hover {
+    .mdc-circular-progress__indeterminate-circle-graphic {
+      stroke: #fff;
+    }
+  }
 }


### PR DESCRIPTION
When hovering the color of the circular progress loading spinner is now the same as the text and therefore visible again.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
