### PR TITLE
Add translation infrastructure and translateComment API

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -879,3 +879,8 @@ services:
     class: App\Translation\ItranslateApi
     arguments:
       - '@eight_points_guzzle.client.itranslate'
+
+  App\Translation\TranslationDelegate:
+    class: App\Translation\TranslationDelegate
+    arguments:
+      - '@App\Translation\ItranslateApi'

--- a/src/Catrobat/Controller/Web/CommentsController.php
+++ b/src/Catrobat/Controller/Web/CommentsController.php
@@ -8,8 +8,12 @@ use App\Entity\CommentNotification;
 use App\Entity\ProgramManager;
 use App\Entity\User;
 use App\Entity\UserComment;
+use App\Translation\TranslationDelegate;
 use Exception;
+use InvalidArgumentException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -110,5 +114,47 @@ class CommentsController extends AbstractController
     }
 
     return new Response(Response::HTTP_OK);
+  }
+
+  /**
+   * @Route("/translate/comment/{id}", name="translate_comment", methods={"GET"})
+   */
+  public function translateCommentAction(Request $request, int $id, TranslationDelegate $translation_delegate): Response
+  {
+    if (!$request->query->has('target_language')) {
+      return new Response('Target language is required', Response::HTTP_BAD_REQUEST);
+    }
+
+    $em = $this->getDoctrine()->getManager();
+    $comment = $em->getRepository(UserComment::class)->find($id);
+
+    if (null === $comment) {
+      return new Response('No comment found for this id', Response::HTTP_NOT_FOUND);
+    }
+
+    $source_language = $request->query->get('source_language');
+    $target_language = $request->query->get('target_language');
+
+    if ($source_language === $target_language) {
+      return new Response('Source and target languages are the same', Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    try {
+      $translation_result = $translation_delegate->translate($comment->getText(), $source_language, $target_language);
+    } catch (InvalidArgumentException $exception) {
+      return new Response($exception->getMessage(), Response::HTTP_BAD_REQUEST);
+    }
+
+    if (null === $translation_result) {
+      return new Response('Translation unavailable', Response::HTTP_SERVICE_UNAVAILABLE);
+    }
+
+    return new JsonResponse([
+      'id' => $comment->getId(),
+      'source_language' => $source_language ?? $translation_result->detected_source_language,
+      'target_language' => $target_language,
+      'translation' => $translation_result->translation,
+      'provider' => $translation_result->provider,
+    ]);
   }
 }

--- a/src/Translation/ItranslateApi.php
+++ b/src/Translation/ItranslateApi.php
@@ -70,7 +70,7 @@ class ItranslateApi implements TranslationApiInterface
 
   private function transformLanguageCode(?string $language): ?string
   {
-    if (null == $language) {
+    if (null === $language) {
       return null;
     }
 

--- a/src/Translation/TranslationApiInterface.php
+++ b/src/Translation/TranslationApiInterface.php
@@ -10,7 +10,7 @@ interface TranslationApiInterface
    * or 5-character BCP 47 locale code formed by
    *     - lowercase 2-character ISO-639-1 language code
    *     - a hyphen
-   *     - uppercase 2-character ISO 3166 country code.
+   *     - uppercase 2-character ISO-3166-1 country code.
    *
    * The concrete implementations do NOT check the validity of the language code formats.
    * The underlying API might return errors if supplied invalid language code.

--- a/src/Translation/TranslationDelegate.php
+++ b/src/Translation/TranslationDelegate.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Translation;
+
+use InvalidArgumentException;
+use Symfony\Component\Intl\Countries;
+use Symfony\Component\Intl\Languages;
+
+class TranslationDelegate
+{
+  private array $apis;
+
+  public function __construct(TranslationApiInterface ...$apis)
+  {
+    $this->apis = $apis;
+  }
+
+  /**
+   * @throws InvalidArgumentException
+   */
+  public function translate(string $text, ?string $source_language, string $target_language): ?TranslationResult
+  {
+    $this->validateLanguage($source_language);
+    $this->validateLanguage($target_language);
+
+    foreach ($this->apis as $api) {
+      $translation = $api->translate($text, $source_language, $target_language);
+
+      if (null != $translation) {
+        return $translation;
+      }
+    }
+
+    return null;
+  }
+
+  private function validateLanguage(?string $language): void
+  {
+    if (2 == strlen($language)) {
+      if (strtolower($language) != $language) {
+        throw new InvalidArgumentException('2-character language code has to be lower case');
+      }
+
+      if (!Languages::exists($language)) {
+        throw new InvalidArgumentException('2-character language code is invalid');
+      }
+    } elseif (5 == strlen($language)) {
+      if ('-' != $language[2]) {
+        throw new InvalidArgumentException('Invalid 5-character language code format');
+      }
+
+      $language_code = substr($language, 0, 2);
+      $country_code = substr($language, 3, 2);
+
+      if (strtolower($language_code) != $language_code) {
+        throw new InvalidArgumentException('5-character language code has to contain lower case language code');
+      }
+
+      if (!Languages::exists($language_code)) {
+        throw new InvalidArgumentException('language code in 5-character language code is invalid');
+      }
+
+      if (strtoupper($country_code) != $country_code) {
+        throw new InvalidArgumentException('5-character language code has to contain upper case country code');
+      }
+
+      if (!Countries::exists($country_code)) {
+        throw new InvalidArgumentException('country code in 5-character language code is invalid');
+      }
+    } elseif (null !== $language) {
+      throw new InvalidArgumentException('language has to be null, 2-character or 5-character language code');
+    }
+  }
+}

--- a/tests/phpUnit/Translation/TranslationDelegateTest.php
+++ b/tests/phpUnit/Translation/TranslationDelegateTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Translation;
+
+use App\Translation\TranslationApiInterface;
+use App\Translation\TranslationDelegate;
+use App\Translation\TranslationResult;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @covers \App\Translation\TranslationDelegate
+ */
+class TranslationDelegateTest extends TestCase
+{
+  public function testSingleApi(): void
+  {
+    $api = $this->createMock(TranslationApiInterface::class);
+    $expected_result = new TranslationResult();
+    $api->expects($this->once())
+      ->method('translate')
+      ->willReturn($expected_result)
+    ;
+
+    $translation_delegate = new TranslationDelegate($api);
+
+    $actual_result = $translation_delegate->translate('test', 'en', 'fr');
+
+    $this->assertEquals($expected_result, $actual_result);
+  }
+
+  public function testTryNextApiIfFirstFails(): void
+  {
+    $api1 = $this->createMock(TranslationApiInterface::class);
+    $api2 = $this->createMock(TranslationApiInterface::class);
+
+    $api1->expects($this->once())
+      ->method('translate')
+      ->willReturn(null)
+    ;
+
+    $expected_result = new TranslationResult();
+    $api2->expects($this->once())
+      ->method('translate')
+      ->willReturn($expected_result)
+    ;
+
+    $translation_delegate = new TranslationDelegate($api1, $api2);
+
+    $actual_result = $translation_delegate->translate('test', 'en', 'fr');
+
+    $this->assertEquals($expected_result, $actual_result);
+  }
+
+  public function testAllApiFails(): void
+  {
+    $api1 = $this->createMock(TranslationApiInterface::class);
+    $api2 = $this->createMock(TranslationApiInterface::class);
+
+    $api1->expects($this->once())
+      ->method('translate')
+      ->willReturn(null)
+    ;
+
+    $api2->expects($this->once())
+      ->method('translate')
+      ->willReturn(null)
+    ;
+
+    $translation_delegate = new TranslationDelegate($api1, $api2);
+
+    $result = $translation_delegate->translate('test', 'en', 'fr');
+
+    $this->assertNull($result);
+  }
+
+  /**
+   * @dataProvider provideInvalidLanguageCode
+   */
+  public function testInvalidLanguageCode(string $invalid_code): void
+  {
+    $this->expectException(InvalidArgumentException::class);
+    $translation_delegate = new TranslationDelegate();
+
+    $translation_delegate->translate('test', $invalid_code, $invalid_code);
+  }
+
+  public function provideInvalidLanguageCode(): array
+  {
+    return [
+      [''],
+      ['x'],
+      ['xx'],
+      ['EN'], // need to be lowercase en
+      ['xxxxx'],
+      ['en-XX'],
+      ['EN-US'], // need to be lowercase en
+      ['en-us'], // need to be uppercase US
+      ['xx-US'],
+    ];
+  }
+}


### PR DESCRIPTION
- Add TranslationDelegate to handle multiple translation APIs and for error handling
- More features like statistics and caching can be added to TranslationDelegate
- Add translateComment API endpoint
- Add relevant tests
- Fix bug with php == and ===

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description

This PR is part of adding translation functionality to projects and comments on Catroweb. For more info, join the discussion on #uwaterloo-project slack channel.

### Tests - additional information

