### PR TITLE
Add /languages api for localized language names

### DIFF
--- a/src/Catrobat/Controller/Web/DefaultController.php
+++ b/src/Catrobat/Controller/Web/DefaultController.php
@@ -12,6 +12,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Intl\Locales;
 use Symfony\Component\Routing\Annotation\Route;
 
 class DefaultController extends AbstractController
@@ -167,5 +168,25 @@ class DefaultController extends AbstractController
       'first_login' => $user_first_login,
       'user_id' => $user_id,
     ]);
+  }
+
+  /**
+   * @Route("/languages", name="languages", methods={"GET"})
+   */
+  public function languagesAction(Request $request): Response
+  {
+    $display_locale = $request->getLocale();
+    $all_locales = Locales::getNames($display_locale);
+
+    $all_locales = array_filter($all_locales, function ($key) {
+      return 2 == strlen($key) || 5 == strlen($key);
+    }, ARRAY_FILTER_USE_KEY);
+
+    $locales = [];
+    foreach ($all_locales as $key => $value) {
+      $locales[str_replace('_', '-', $key)] = $value;
+    }
+
+    return JsonResponse::create($locales);
   }
 }


### PR DESCRIPTION
---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description

Our intention is for this api to have 2 uses.

1. Show localized language names in translation results.

For example, next to the translated text, show "Translated by iTranslate from French to English", where the language names will be in the language that the user speaks. ("Translated by {} from {} to {}" will be in a string template in `translations` directory)

2. Show a list of languages for the user to choose for translation

This is different from the language selector currently in the footer, where each language name is shown in that language, i.e., English, français...
Here, the list would be English, French..., or if the user speak French, anglais, français...

--- 

The api actually returns all available languages with language code of length 2 or 5 characters. This may include languages not supported by the translation api used. The api will just return an error in that case and the ui should properly handle this case, either by trying another api or showing some error.

---

I put this endpoint in `DefaultController`, but if you think `DefaultController` shouldn't be used as a dumping ground for random apis, say so.

### Tests - additional information

No tests. This api is essentially static.
