### PR TITLE
Translate Program Comment Section

### DIFF
--- a/assets/css/custom/program.scss
+++ b/assets/css/custom/program.scss
@@ -260,6 +260,26 @@ table td:nth-child(1) {
   @include force-word-break();
 }
 
+.comment-translation-loading-spinner {
+  padding-left: 1em;
+}
+
+.comment-translation-wrapper {
+  display: block;
+  padding-top: 0.4em;
+  clear: both;
+  @include force-word-break();
+}
+
+.comment-translation-credit {
+  font-size: small;
+  color: #808080;
+}
+
+.comment-text-translation {
+  display: block;
+}
+
 .single-comment {
   min-height: 80px;
   padding-top: 10px;

--- a/assets/js/custom/TranslateWithLink.js
+++ b/assets/js/custom/TranslateWithLink.js
@@ -1,0 +1,35 @@
+/* eslint-env jquery */
+
+// eslint-disable-next-line no-unused-vars
+function TranslateWithLink (hasDescription, hasCredit) {
+  const elementsToTranslate = [document.getElementById('name')]
+
+  if (hasDescription) {
+    elementsToTranslate.push(document.getElementById('description'))
+  }
+  if (hasCredit) {
+    elementsToTranslate.push(document.getElementById('credits'))
+  }
+
+  createTranslateLink(
+    document.getElementById('translate-program'),
+    elementsToTranslate,
+    document.documentElement.lang
+  )
+
+  function createTranslateLink (buttonElement, textElements, targetLang) {
+    let text = ''
+    if (Array.isArray(textElements)) {
+      const array = []
+      for (let i = 0; i < textElements.length; i++) {
+        array.push(textElements[i].innerText)
+      }
+
+      text = array.join('\n\n')
+    } else {
+      text = textElements.innerText
+    }
+
+    buttonElement.setAttribute('href', 'https://translate.google.com/?q=' + encodeURIComponent(text) + '&sl=auto&tl=' + targetLang)
+  }
+}

--- a/assets/js/custom/Translation.js
+++ b/assets/js/custom/Translation.js
@@ -1,40 +1,140 @@
 /* eslint-env jquery */
 
 // eslint-disable-next-line no-unused-vars
-function Translation (hasDescription, hasCredit) {
-  const elementsToTranslate = [document.getElementById('name')]
-
-  if (hasDescription) {
-    elementsToTranslate.push(document.getElementById('description'))
+function Translation (translatedByLine) {
+  const providerMap = {
+    itranslate: 'iTranslate'
   }
-  if (hasCredit) {
-    elementsToTranslate.push(document.getElementById('credits'))
-  }
+  let displayLanguageMap = {}
+  let translatedByLineMap = {}
+  let targetLanguage = null
 
-  translation(
-    document.getElementById('translate-program'),
-    elementsToTranslate,
-    document.documentElement.lang
-  )
-
-  $('.comment-translate-button').each(function () {
-    const commentId = $(this).attr('id').substring('comment-translate-button-'.length)
-    translation(this, document.getElementById('comment-text-' + commentId), document.documentElement.lang)
+  $(document).ready(function () {
+    setTargetLanguage()
+    getDisplayLanguageMap()
+    splitTranslatedByLine()
   })
 
-  function translation (buttonElement, textElements, targetLang) {
-    let text = ''
-    if (Array.isArray(textElements)) {
-      const array = []
-      for (let i = 0; i < textElements.length; i++) {
-        array.push(textElements[i].innerText)
-      }
+  $(document).on('click', '.comment-translation-button', function () {
+    const commentId = $(this).attr('id').substring('comment-translation-button-'.length)
 
-      text = array.join('\n\n')
+    $(this).hide()
+
+    if (isTranslationNotAvailable(commentId)) {
+      $('#comment-translation-loading-spinner-' + commentId).show()
+      translateComment(commentId)
     } else {
-      text = textElements.innerText
+      openTranslatedComment(commentId)
+    }
+  })
+
+  $(document).on('click', '.remove-comment-translation-button', function () {
+    const commentId = $(this).attr('id').substring('remove-comment-translation-button-'.length)
+    $(this).hide()
+    $('#comment-translation-button-' + commentId).show()
+    $('#comment-translation-wrapper-' + commentId).slideUp()
+    $('#comment-text-wrapper-' + commentId).slideDown()
+  })
+
+  function setTargetLanguage () {
+    const decodedCookie = document.cookie
+      .split(';')
+      .map(v => v.split('='))
+      .reduce((acc, v) => {
+        acc[decodeURIComponent(v[0].trim())] = decodeURIComponent(v[1].trim())
+        return acc
+      }, {})
+
+    if (decodedCookie.hl !== undefined) {
+      targetLanguage = decodedCookie.hl.replace('_', '-')
+    } else {
+      targetLanguage = document.documentElement.lang
+    }
+  }
+
+  function getDisplayLanguageMap () {
+    $.ajax({
+      url: '../languages',
+      type: 'get',
+      success: function (data) {
+        displayLanguageMap = data
+      }
+    })
+  }
+
+  function splitTranslatedByLine () {
+    let firstLanguage = '%sourceLanguage%'
+    let secondLanguage = '%targetLanguage%'
+    if (!isSourceLanguageFirst()) {
+      firstLanguage = '%targetLanguage%'
+      secondLanguage = '%sourceLanguage%'
     }
 
-    buttonElement.setAttribute('href', 'https://translate.google.com/?q=' + encodeURIComponent(text) + '&sl=auto&tl=' + targetLang)
+    translatedByLineMap = {
+      before: translatedByLine.substring(0, translatedByLine.indexOf(firstLanguage)),
+      between: translatedByLine.substring(translatedByLine.indexOf(firstLanguage) + firstLanguage.length, translatedByLine.indexOf(secondLanguage)),
+      after: translatedByLine.substring(translatedByLine.indexOf(secondLanguage) + secondLanguage.length)
+    }
+  }
+
+  function isTranslationNotAvailable (commentId) {
+    return $('#comment-text-translation-' + commentId).attr('lang') !== targetLanguage
+  }
+
+  function isSourceLanguageFirst () {
+    return translatedByLine.indexOf('%sourceLanguage%') < translatedByLine.indexOf('%targetLanguage%')
+  }
+
+  function openGoogleTranslatePage (commentId) {
+    const text = document.getElementById('comment-text-' + commentId).innerText
+    window.open(
+      'https://translate.google.com/?q=' + encodeURIComponent(text) + '&sl=auto&tl=' + targetLanguage,
+      '_self'
+    )
+  }
+
+  function setTranslatedCommentData (commentId, data) {
+    $('#comment-text-translation-' + commentId).text(data.translation)
+    $('#comment-text-translation-' + commentId).attr('lang', data.target_language)
+
+    $('#comment-translation-before-languages-' + commentId).text(translatedByLineMap.before.replace('%provider%', providerMap[data.provider]))
+    $('#comment-translation-between-languages-' + commentId).text(translatedByLineMap.between.replace('%provider%', providerMap[data.provider]))
+    $('#comment-translation-after-languages-' + commentId).text(translatedByLineMap.after.replace('%provider%', providerMap[data.provider]))
+
+    if (isSourceLanguageFirst()) {
+      $('#comment-translation-first-language-' + commentId).text(displayLanguageMap[data.source_language])
+      $('#comment-translation-second-language-' + commentId).text(displayLanguageMap[data.target_language])
+    } else {
+      $('#comment-translation-first-language-' + commentId).text(displayLanguageMap[data.target_language])
+      $('#comment-translation-second-language-' + commentId).text(displayLanguageMap[data.source_language])
+    }
+  }
+
+  function openTranslatedComment (commentId) {
+    $('#comment-translation-loading-spinner-' + commentId).hide()
+    $('#remove-comment-translation-button-' + commentId).show()
+    $('#comment-translation-wrapper-' + commentId).slideDown()
+    $('#comment-text-wrapper-' + commentId).slideUp()
+  }
+
+  function commentNotTranslated (commentId) {
+    $('#comment-translation-loading-spinner-' + commentId).hide()
+    $('#comment-translation-button-' + commentId).show()
+    openGoogleTranslatePage(commentId)
+  }
+
+  function translateComment (commentId) {
+    $.ajax({
+      url: '../translate/comment/' + commentId,
+      type: 'get',
+      data: { target_language: targetLanguage },
+      success: function (data) {
+        setTranslatedCommentData(commentId, data)
+        openTranslatedComment(commentId)
+      },
+      error: function () {
+        commentNotTranslated(commentId)
+      }
+    })
   }
 }

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -83,3 +83,8 @@ services:
   App\Catrobat\Services\TestEnv\DataFixtures\UserDataFixtures:
     class: App\Catrobat\Services\TestEnv\DataFixtures\UserDataFixtures
     public: true
+
+  # ======== Mocking translation API services
+
+  App\Translation\TranslationDelegate:
+    class: App\Translation\TestEnv\FakeTranslationDelegate

--- a/src/Translation/TestEnv/FakeTranslationDelegate.php
+++ b/src/Translation/TestEnv/FakeTranslationDelegate.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Translation\TestEnv;
+
+use App\Translation\TranslationDelegate;
+use App\Translation\TranslationResult;
+use InvalidArgumentException;
+
+class FakeTranslationDelegate extends TranslationDelegate
+{
+  /**
+   * @throws InvalidArgumentException
+   */
+  public function translate(string $text, ?string $source_language, string $target_language): ?TranslationResult
+  {
+    $translation_result = new TranslationResult();
+    $translation_result->provider = 'itranslate';
+    if (null == $source_language) {
+      $translation_result->detected_source_language = 'en';
+    }
+    $translation_result->translation = 'Fixed translation text';
+
+    return $translation_result;
+  }
+}

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -298,11 +298,18 @@
   </script>
   <script src="{{ asset('js/PasswordVisibilityToggler.min.js') }}"></script>
 
+  <script src=" {{ asset( 'js/TranslateWithLink.min.js') }}"></script>
+  <script>
+    new TranslateWithLink(
+      {% if program.description %} true, {% else %} false, {% endif %}
+      {% if program.credits %} true {% else %} false {% endif %}
+    )
+  </script>
+
   <script src=" {{ asset( 'js/Translation.min.js') }}"></script>
   <script>
     new Translation(
-      {% if program.description %} true, {% else %} false, {% endif %}
-      {% if program.credits %} true {% else %} false {% endif %}
+      '{{ 'programs.translatedByLine'|trans({}, 'catroweb') }}'
     )
   </script>
 {% endblock %}

--- a/templates/Program/programComments.html.twig
+++ b/templates/Program/programComments.html.twig
@@ -51,11 +51,23 @@
             <div class="date">
               {{ comment.uploadDate.format('Y-m-d') }}
             </div>
-            <a id="comment-translate-button-{{ comment.id }}" class="comment-translate-button">
+            <span id="comment-translation-button-{{ comment.id }}" class="comment-translation-button catro-icon-button"
+                data-toggle="tooltip" title="{{ 'programs.showTranslation'|trans({}, 'catroweb') }}">
               <i class="ml-3 material-icons">
                 translate
               </i>
-            </a>
+            </span>
+            <span id="comment-translation-loading-spinner-{{ comment.id }}" class="comment-translation-loading-spinner" style="display: none;">
+              <i class="material-icons">
+                {% include 'Default/loadingSpinner.html.twig' with {'size': 'small'} %}
+              </i>
+            </span>
+            <span id="remove-comment-translation-button-{{ comment.id }}" class="remove-comment-translation-button catro-icon-button" style="display: none"
+                data-toggle="tooltip" title="Hide Translation">
+                <i class="ml-3 material-icons" data-toggle="tooltip" title="{{ 'programs.hideTranslation'|trans({}, 'catroweb') }}">
+                  close
+                </i>
+            </span>
             {% if not(app.user) or (app.user and comment.username != app.user.username) %}
               {#  Everybody, but the comment owner must be able to report a comment  #}
               <a id="comment-report-button-{{ comment.id }}" class="comment-report-button"
@@ -71,8 +83,18 @@
               </a>
             {% endif %}
           </div>
-          <div class="comment-text">
+          <div id="comment-text-wrapper-{{ comment.id }}" class="comment-text">
             <p id="comment-text-{{ comment.id }}">{{ comment.text }}</p>
+          </div>
+          <div id="comment-translation-wrapper-{{ comment.id }}" class="comment-translation-wrapper" style="display: none">
+            <div id="comment-translation-credit-wrapper-{{ comment.id }}">
+              <span id="comment-translation-before-languages-{{ comment.id }}" class="comment-translation-credit"></span>
+              <span id="comment-translation-first-language-{{ comment.id }}" class="comment-translation-credit"></span>
+              <span id="comment-translation-between-languages-{{ comment.id }}" class="comment-translation-credit"></span>
+              <span id="comment-translation-second-language-{{ comment.id }}" class="comment-translation-credit"></span>
+              <span id="comment-translation-after-languages-{{ comment.id }}" class="comment-translation-credit"></span>
+            </div>
+            <p id="comment-text-translation-{{ comment.id }}" class="comment-text-translation" lang=""></p>
           </div>
         </div>
       </div>

--- a/tests/behat/features/web/translation/translate_comments.feature
+++ b/tests/behat/features/web/translation/translate_comments.feature
@@ -16,7 +16,45 @@ Feature: Project title, description and credits should be translatable via a but
   Scenario: Translate button should translate the corresponding comment
     Given I am on "/app/project/1"
     And I wait for the page to be loaded
-    Then the element "#comment-translate-button-1" should exist
-    Then the element "#comment-translate-button-2" should exist
-    And the element "#comment-translate-button-1" should have a attribute "href" with value "https://translate.google.com/?q=c1"
-    And the element "#comment-translate-button-2" should have a attribute "href" with value "https://translate.google.com/?q=c2"
+    Then the element "#comment-translation-button-1" should exist
+    When I click "#comment-translation-button-1"
+    And I wait for AJAX to finish
+    Then the element "#remove-comment-translation-button-1" should be visible
+    And the element "#comment-translation-wrapper-1" should be visible
+    Then the "#comment-text-translation-1" element should contain "Fixed translation text"
+    When I click "#remove-comment-translation-button-1"
+    Then the element "#comment-translation-button-1" should be visible
+    And the element "#comment-text-wrapper-1" should be visible
+    And the "#comment-text-1" element should contain "c1"
+  
+  Scenario: Comment should only be translated by API once
+    Given I am on "/app/project/1"
+    And I wait for the page to be loaded
+    Then the element "#comment-translation-button-2" should exist
+    When I click "#comment-translation-button-2"
+    And I wait for AJAX to finish
+    Then the element "#remove-comment-translation-button-2" should be visible
+    And the element "#comment-translation-wrapper-2" should be visible
+    And the "#comment-text-translation-2" element should contain "Fixed translation text"
+    When I click "#remove-comment-translation-button-2"
+    Then the element "#comment-translation-button-2" should be visible
+    And the element "#comment-text-wrapper-2" should be visible
+    When I click "#comment-translation-button-2"
+    Then the element "#remove-comment-translation-button-2" should be visible
+    And the element "#comment-translation-wrapper-2" should be visible
+    And the "#comment-text-translation-2" element should contain "Fixed translation text"
+
+  Scenario: Translation provider should have correct provider, source language, and target language
+    Given I am on "/app/project/1"
+    And I wait for the page to be loaded
+    Then the element "#comment-translation-button-1" should exist
+    When I click "#comment-translation-button-1"
+    And I wait for AJAX to finish
+    Then the element "#remove-comment-translation-button-1" should be visible
+    And the element "#comment-translation-wrapper-1" should be visible
+    Then the "#comment-translation-before-languages-1" element should contain "Translated by iTranslate from"
+    And the "#comment-translation-first-language-1" element should contain "English"
+    And the "#comment-translation-between-languages-1" element should contain "to"
+    And the "#comment-translation-second-language-1" element should contain "English"
+    And the "#comment-translation-after-languages-1" element should contain ""
+    

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -182,6 +182,9 @@ programs:
   link: Copy project link to clipboard
   reactionsText: Reactions
   downloadErrorText: Error occurred while downloading the project. Please try again later.
+  showTranslation: Show translation
+  hideTranslation: Hide translation
+  translatedByLine: Translated by %provider% from %sourceLanguage% to %targetLanguage%
 
 remixGraph:
   title: Remixes


### PR DESCRIPTION
---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
The program comment section has been updated to utilize the new iTranslate API and languages API to translate user-generated content. Now, when the translate button is selected, a new translation section will appear with the original content translated to the user's preferred language using the iTranslate API. Within the new translation section, there is also a statement which displays the translation provider, the source language, and the target language. There is also logic to handle different orderings of the provider, source language, and target language to support various languages with different grammars.

Additional information on the UI design can be found in the original mockup document through the following link.
https://docs.google.com/document/d/1ELqaGX_zIUMP5p8bcGcGhIe8gDj55ITANxYYuFRgePQ/edit?usp=sharing

### Tests - additional information
Updated the Behat translation tests for comment sections to select the translation button and check if the new translation section opens as intended. These new tests replace the previous tests which checked if the href attribute was updated properly.
