### PR TITLE
Add logging for ItranslateApi in case of error

### DIFF
--- a/src/Translation/ItranslateApi.php
+++ b/src/Translation/ItranslateApi.php
@@ -4,6 +4,7 @@ namespace App\Translation;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
+use Psr\Log\LoggerInterface;
 
 class ItranslateApi implements TranslationApiInterface
 {
@@ -16,10 +17,12 @@ class ItranslateApi implements TranslationApiInterface
 
   private Client $client;
   private string $api_key;
+  private LoggerInterface $logger;
 
-  public function __construct(Client $client)
+  public function __construct(Client $client, LoggerInterface $logger)
   {
     $this->client = $client;
+    $this->logger = $logger;
     $this->api_key = $_ENV['ITRANSLATE_API_KEY'];
   }
 
@@ -46,12 +49,16 @@ class ItranslateApi implements TranslationApiInterface
         ]
       );
     } catch (GuzzleException $e) {
+      $this->logger->error("Itranslate Guzzle client exception, source: {$source_language}, target: {$target_language}, text: {$text}, message: {$e->getMessage()}");
+
       return null;
     }
 
     $statusCode = $response->getStatusCode();
 
     if (200 != $statusCode) {
+      $this->logger->error("Itranslate returned status code {$statusCode}, source: {$source_language}, target: {$target_language}, text: {$text}, body: {$response->getBody()}");
+
       return null;
     }
 

--- a/tests/phpUnit/Translation/ItranslateApiTest.php
+++ b/tests/phpUnit/Translation/ItranslateApiTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * @internal
@@ -26,7 +27,7 @@ class ItranslateApiTest extends TestCase
   protected function setUp(): void
   {
     $this->httpClient = $this->createMock(Client::class);
-    $this->api = new ItranslateApi($this->httpClient);
+    $this->api = new ItranslateApi($this->httpClient, $this->createMock(LoggerInterface::class));
   }
 
   public function testShortenLanguageCode(): void


### PR DESCRIPTION
Following https://github.com/Catrobat/Catroweb/pull/1639#discussion_r635784118

Log error whenever an error occurs with guzzle client or http code is not 200.
These logs should show up in admin console.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
No tests
