### PR TITLE
Add ETag caching to /languages api

### DIFF
--- a/src/Catrobat/Controller/Web/DefaultController.php
+++ b/src/Catrobat/Controller/Web/DefaultController.php
@@ -202,6 +202,15 @@ class DefaultController extends AbstractController
   public function languagesAction(Request $request): Response
   {
     $display_locale = $request->getLocale();
+
+    $response = new JsonResponse();
+    $response->setEtag($display_locale);
+    $response->setPublic();
+
+    if ($response->isNotModified($request)) {
+      return $response;
+    }
+
     $all_locales = Locales::getNames($display_locale);
 
     $all_locales = array_filter($all_locales, function ($key) {
@@ -213,6 +222,6 @@ class DefaultController extends AbstractController
       $locales[str_replace('_', '-', $key)] = $value;
     }
 
-    return JsonResponse::create($locales);
+    return $response->setData($locales);
   }
 }

--- a/tests/behat/context/ApiContext.php
+++ b/tests/behat/context/ApiContext.php
@@ -640,6 +640,7 @@ class ApiContext implements KernelAwareContext
 
   /**
    * @Given /^I have a request header "([^"]*)" with value "([^"]*)"$/
+   * @Given /^I have a request header "([^"]*)" with value '([^']*)'$/
    */
   public function iHaveARequestHeaderWithValue(string $name, string $value): void
   {

--- a/tests/behat/features/api/translation/GET_languages/display_language.feature
+++ b/tests/behat/features/api/translation/GET_languages/display_language.feature
@@ -2,8 +2,7 @@
 Feature: display language list should be returned in user's language
 
   Scenario: When the user has no preferred language, language names should be in English
-    Given I have a request header "HTTP_ACCEPT" with value "application/json"
-    And I request "GET" "/app/languages"
+    Given I request "GET" "/app/languages"
     Then the response status code should be "200"
     Then the response should have language list structure
     Then the response should contain the following languages:
@@ -13,7 +12,6 @@ Feature: display language list should be returned in user's language
 
   Scenario: When the user uses French, languages names should be in French
     Given I set request language to "French"
-    And I have a request header "HTTP_ACCEPT" with value "application/json"
     And I request "GET" "/app/languages"
     Then the response status code should be "200"
     Then the response should have language list structure
@@ -24,7 +22,6 @@ Feature: display language list should be returned in user's language
 
   Scenario: When the user uses German, languages names should be in German
     Given I set request language to "Deutsch"
-    And I have a request header "HTTP_ACCEPT" with value "application/json"
     And I request "GET" "/app/languages"
     Then the response status code should be "200"
     Then the response should have language list structure
@@ -32,3 +29,21 @@ Feature: display language list should be returned in user's language
       | Language Code | Display Name                  |
       | en-US         | Englisch (Vereinigte Staaten) |
       | fr-FR         | Französisch (Frankreich)      |
+
+  Scenario: Display language list should be cached with etag
+    Given I set request language to "French"
+    And I request "GET" "/app/languages"
+    Then the response status code should be "200"
+    And the response Header should contain the key "ETAG" with the value '"fr_FR"'
+
+  Scenario: Cached response is valid when it matches user's language
+    Given I set request language to "French"
+    And I have a request header "HTTP_IF_NONE_MATCH" with value '"fr_FR"'
+    And I request "GET" "/app/languages"
+    Then the response status code should be "304"
+
+  Scenario: Cached response is not valid when user changes language
+    Given I set request language to "French"
+    And I have a request header "HTTP_IF_NONE_MATCH" with value '"en"'
+    And I request "GET" "/app/languages"
+    Then the response status code should be "200"


### PR DESCRIPTION
User's language code is used as ETag.
304 response after first quest to languages api.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description

### Tests - additional information