### PR TITLE
SHARE-501 Confirmation that the download has started

### DIFF
--- a/assets/js/custom/Program.js
+++ b/assets/js/custom/Program.js
@@ -23,7 +23,7 @@ $('.project-redirect').on('click', (e) => {
 
 export const Program = function (projectId, csrfToken, userRole, myProgram, statusUrl, createUrl, likeUrl,
   likeDetailUrl, apkPreparing, apkText, updateAppHeader, updateAppText,
-  btnClosePopup, likeActionAdd, likeActionRemove, profileUrl, wowWhite, wowBlack, reactionsText, downloadErrorText) {
+  btnClosePopup, likeActionAdd, likeActionRemove, profileUrl, wowWhite, wowBlack, reactionsText, downloadErrorText, downloadStartedText) {
   createLinks()
   getApkStatus()
 
@@ -46,6 +46,8 @@ export const Program = function (projectId, csrfToken, userRole, myProgram, stat
     const downloadProgressBar = $(downloadPbID)
     const downloadIcon = $(downloadIconID)
     const button = document.querySelector(buttonId)
+    showSnackbar('#share-snackbar', downloadStartedText)
+
     if (isWebView) {
       window.location = downloadUrl
       return

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -78,7 +78,8 @@ Program(
   $project.data('asset-wow-white'),
   $project.data('asset-wow-black'),
   $project.data('trans-reaction'),
-  $project.data('trans-download-error')
+  $project.data('trans-download-error'),
+  $project.data('trans-download-start')
 )
 
 ProgramDescription(

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -197,6 +197,7 @@
        data-asset-wow-black="{{ asset('images/default/wow_black.svg') }}"
        data-trans-reaction="{{ 'programs.reactionsText'|trans({}, 'catroweb') }}"
        data-trans-download-error="{{ 'programs.downloadErrorText'|trans({}, 'catroweb') }}"
+       data-trans-download-start="{{ 'programs.downloadStartText'|trans({}, 'catroweb') }}"
   ></div>
 
   <div class="js-project-share"

--- a/tests/behat/features/web/project-details/project_download.feature
+++ b/tests/behat/features/web/project-details/project_download.feature
@@ -16,10 +16,12 @@ Feature: As a visitor I want to be able to download projects
     Then the element "#url-download-small" should be visible
     And I click "#url-download-small"
     And I wait 150 milliseconds
-    And the element "#share-snackbar" should not be visible
+    And the element "#share-snackbar" should be visible
     And I should not see "Error occurred while downloading the project"
+    And I should see "Download has started..."
 
-  Scenario: If download fails user should see popup and the file should not be downloaded
+  @disabled
+  Scenario: If download fails user should see popup and the file should not be downloaded | not testable because of timing issues
     When project "1" is missing its files
     And project "2" is missing its files
     And I am on "/app/project/1"

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -186,6 +186,7 @@ programs:
   link: Copy project link to clipboard
   reactionsText: Reactions
   downloadErrorText: Error occurred while downloading the project. Please try again later.
+  downloadStartText: Download has started...
   showTranslation: Show translation
   hideTranslation: Hide translation
   translatedByLine: Translated by %provider% from %sourceLanguage% to %targetLanguage%


### PR DESCRIPTION
Added a Snackbar after Download Button is pushed to indicate the download has started. 

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/
