### PR TITLE
Add ETag caching to project and comment translation api

### DIFF
--- a/src/Catrobat/Controller/Web/ProgramController.php
+++ b/src/Catrobat/Controller/Web/ProgramController.php
@@ -477,13 +477,21 @@ class ProgramController extends AbstractController
       return new Response('Source and target languages are the same', Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 
+    $response = new JsonResponse();
+    $response->setEtag(md5($project->getName().$project->getDescription().$project->getCredits()).$target_language);
+    $response->setPublic();
+
+    if ($response->isNotModified($request)) {
+      return $response;
+    }
+
     $translation_result = $this->translation_delegate->translateProject($project, $source_language, $target_language);
 
     if (null === $translation_result) {
       return new Response('Translation unavailable', Response::HTTP_SERVICE_UNAVAILABLE);
     }
 
-    return new JsonResponse([
+    return $response->setData([
       'id' => $project->getId(),
       'source_language' => $source_language ?? $translation_result[0]->detected_source_language,
       'target_language' => $target_language,

--- a/tests/behat/features/api/translation/GET_comments_machine_translation/caching.feature
+++ b/tests/behat/features/api/translation/GET_comments_machine_translation/caching.feature
@@ -1,0 +1,34 @@
+@api
+Feature: Comment translation should be cached
+
+  Background:
+    Given there are users:
+      | id | name     |
+      | 1  | Catrobat |
+    And there are projects:
+      | id | name     | owned by | description   | credit   |
+      | 1  | project1 | Catrobat | mydescription | mycredit |
+    And there are comments:
+      | id | program_id | user_id | text |
+      | 1  | 1          | 1       | c1   |
+
+  Scenario: Comment translation should include etag
+    Given I request "GET" "/app/translate/comment/1?target_language=fr"
+    Then the response status code should be "200"
+    And the response Header should contain the key "ETAG" with the value '"a9f7e97965d6cf799a529102a973b8b9fr"'
+
+  Scenario: Comment translation should be cached when comment is not modified
+    Given I have a request header "HTTP_IF_NONE_MATCH" with value '"a9f7e97965d6cf799a529102a973b8b9fr"'
+    And I request "GET" "/app/translate/comment/1?target_language=fr"
+    Then the response status code should be "304"
+
+  Scenario: Comment translation should not be cached when comment is changed
+    Given I have a request header "HTTP_IF_NONE_MATCH" with value '"different value"'
+    And I request "GET" "/app/translate/comment/1?target_language=fr"
+    Then the response status code should be "200"
+
+  Scenario: Comment translation should not be cached when target language changes
+    Given I have a request header "HTTP_IF_NONE_MATCH" with value '"a9f7e97965d6cf799a529102a973b8b9fr"'
+    And I request "GET" "/app/translate/comment/1?target_language=es"
+    Then the response status code should be "200"
+    And the response Header should contain the key "ETAG" with the value '"a9f7e97965d6cf799a529102a973b8b9es"'

--- a/tests/behat/features/api/translation/GET_project_machine_translation/caching.feature
+++ b/tests/behat/features/api/translation/GET_project_machine_translation/caching.feature
@@ -1,0 +1,31 @@
+@api
+Feature: Project translation should be cached
+
+  Background:
+    Given there are users:
+      | id | name     |
+      | 1  | Catrobat |
+    And there are projects:
+      | id | name     | owned by | description   | credit   |
+      | 1  | project1 | Catrobat | mydescription | mycredit |
+
+  Scenario: Project translation should include etag
+    Given I request "GET" "/app/translate/project/1?target_language=fr"
+    Then the response status code should be "200"
+    And the response Header should contain the key "ETAG" with the value '"c7e50946e88cbd9d1d5989809aefcb84fr"'
+
+  Scenario: Project translation should be cached when project is not modified
+    Given I have a request header "HTTP_IF_NONE_MATCH" with value '"c7e50946e88cbd9d1d5989809aefcb84fr"'
+    And I request "GET" "/app/translate/project/1?target_language=fr"
+    Then the response status code should be "304"
+
+  Scenario: Project translation should not be cached when project is changed
+    Given I have a request header "HTTP_IF_NONE_MATCH" with value '"different value"'
+    And I request "GET" "/app/translate/project/1?target_language=fr"
+    Then the response status code should be "200"
+
+  Scenario: Project translation should not be cached when target language changes
+    Given I have a request header "HTTP_IF_NONE_MATCH" with value '"c7e50946e88cbd9d1d5989809aefcb84fr"'
+    And I request "GET" "/app/translate/project/1?target_language=es"
+    Then the response status code should be "200"
+    And the response Header should contain the key "ETAG" with the value '"c7e50946e88cbd9d1d5989809aefcb84es"'

--- a/tests/behat/features/web/translation/translate_comments.feature
+++ b/tests/behat/features/web/translation/translate_comments.feature
@@ -1,5 +1,5 @@
 @web @project_page
-Feature: Project title, description and credits should be translatable via a button
+Feature: Project comments should be translatable via a button
 
   Background:
     Given there are users:


### PR DESCRIPTION
- project etag = md5 of (title, description, credit) and target language
- comment etag = md5 of text plus target language
- Integration tests

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
