### PR TITLE
Add Google translate provider

### DIFF
--- a/.env
+++ b/.env
@@ -128,3 +128,7 @@ FB_OAUTH_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8
 ###> translation ###
 ITRANSLATE_API_KEY=''
 ###< translation ###
+
+###> google cloud ###
+GOOGLE_APPLICATION_CREDENTIALS='/var/www/catroweb/google_cloud_key.json'
+###< google cloud ###

--- a/assets/js/custom/Translation.js
+++ b/assets/js/custom/Translation.js
@@ -4,7 +4,8 @@ export class Translation {
   constructor (translatedByLine) {
     this.translatedByLine = translatedByLine
     this.providerMap = {
-      itranslate: 'iTranslate'
+      itranslate: 'iTranslate',
+      google: 'Google Translate'
     }
     this.displayLanguageMap = {}
     this.translatedByLineMap = {}

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "friendsofsymfony/rest-bundle": "^2.8",
         "gesdinet/jwt-refresh-token-bundle": "^1.0.0",
         "google/apiclient": "^2.11",
+        "google/cloud-translate": "^1.12",
         "hwi/oauth-bundle": "^1.4",
         "incenteev/composer-parameter-handler": "^2.1",
         "lexik/jwt-authentication-bundle": "^2.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "faeebd983c55212fe63a7488739ee4e1",
+    "content-hash": "31080df1f61f047d43e440583ee1bf6d",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -2900,6 +2900,353 @@
                 "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.18.0"
             },
             "time": "2021-08-24T18:03:18+00:00"
+        },
+        {
+            "name": "google/cloud-core",
+            "version": "v1.43.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-cloud-php-core.git",
+                "reference": "93fc44af3ebf60a35fbc70e13e6113b1122ba495"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/93fc44af3ebf60a35fbc70e13e6113b1122ba495",
+                "reference": "93fc44af3ebf60a35fbc70e13e6113b1122ba495",
+                "shasum": ""
+            },
+            "require": {
+                "google/auth": "^1.18",
+                "guzzlehttp/guzzle": "^5.3|^6.0|^7.0",
+                "guzzlehttp/promises": "^1.3",
+                "guzzlehttp/psr7": "^1.7|^2.0",
+                "monolog/monolog": "^1.1|^2.0",
+                "php": ">=5.5",
+                "psr/http-message": "1.0.*",
+                "rize/uri-template": "~0.3"
+            },
+            "require-dev": {
+                "erusev/parsedown": "^1.6",
+                "google/common-protos": "^1.0",
+                "google/gax": "^1.9",
+                "opis/closure": "^3",
+                "phpdocumentor/reflection": "^3.0",
+                "phpunit/phpunit": "^4.8|^5.0",
+                "squizlabs/php_codesniffer": "2.*"
+            },
+            "suggest": {
+                "opis/closure": "May be used to serialize closures to process jobs in the batch daemon. Please require version ^3.",
+                "symfony/lock": "Required for the Spanner cached based session pool. Please require the following commit: 3.3.x-dev#1ba6ac9"
+            },
+            "bin": [
+                "bin/google-cloud-batch"
+            ],
+            "type": "library",
+            "extra": {
+                "component": {
+                    "id": "cloud-core",
+                    "target": "googleapis/google-cloud-php-core.git",
+                    "path": "Core",
+                    "entry": "src/ServiceBuilder.php"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\Cloud\\Core\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Google Cloud PHP shared dependency, providing functionality useful to all components.",
+            "support": {
+                "source": "https://github.com/googleapis/google-cloud-php-core/tree/v1.43.2"
+            },
+            "time": "2022-01-12T16:19:20+00:00"
+        },
+        {
+            "name": "google/cloud-translate",
+            "version": "v1.12.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-cloud-php-translate.git",
+                "reference": "2e770c18a865bd4aeab76a8c22d54fee555376d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-translate/zipball/2e770c18a865bd4aeab76a8c22d54fee555376d0",
+                "reference": "2e770c18a865bd4aeab76a8c22d54fee555376d0",
+                "shasum": ""
+            },
+            "require": {
+                "google/cloud-core": "^1.39",
+                "google/gax": "^1.1"
+            },
+            "require-dev": {
+                "erusev/parsedown": "^1.6",
+                "phpdocumentor/reflection": "^3.0",
+                "phpunit/phpunit": "^4.8|^5.0",
+                "squizlabs/php_codesniffer": "2.*"
+            },
+            "suggest": {
+                "ext-grpc": "The gRPC extension enables use of the performant gRPC transport",
+                "ext-protobuf": "Provides a significant increase in throughput over the pure PHP protobuf implementation. See https://cloud.google.com/php/grpc for installation instructions."
+            },
+            "type": "library",
+            "extra": {
+                "component": {
+                    "id": "cloud-translate",
+                    "target": "googleapis/google-cloud-php-translate.git",
+                    "path": "Translate",
+                    "entry": "src/TranslateClient.php"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\Cloud\\Translate\\": "src",
+                    "GPBMetadata\\Google\\Cloud\\Translate\\": "metadata"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Cloud Translation Client for PHP",
+            "support": {
+                "source": "https://github.com/googleapis/google-cloud-php-translate/tree/v1.12.3"
+            },
+            "time": "2022-01-12T16:19:20+00:00"
+        },
+        {
+            "name": "google/common-protos",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/common-protos-php.git",
+                "reference": "a1bcb7b37f1fa1c92d65c3c6339fc701a65916ee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/common-protos-php/zipball/a1bcb7b37f1fa1c92d65c3c6339fc701a65916ee",
+                "reference": "a1bcb7b37f1fa1c92d65c3c6339fc701a65916ee",
+                "shasum": ""
+            },
+            "require": {
+                "google/protobuf": "^3.6.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36",
+                "sami/sami": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Google\\": "src",
+                    "GPBMetadata\\Google\\": "metadata"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Google API Common Protos for PHP",
+            "homepage": "https://github.com/googleapis/common-protos-php",
+            "keywords": [
+                "google"
+            ],
+            "support": {
+                "issues": "https://github.com/googleapis/common-protos-php/issues",
+                "source": "https://github.com/googleapis/common-protos-php/tree/2.0.0"
+            },
+            "time": "2022-01-13T20:17:53+00:00"
+        },
+        {
+            "name": "google/gax",
+            "version": "v1.11.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/gax-php.git",
+                "reference": "79af83504a30cbada97531208b823d041f73abb9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/79af83504a30cbada97531208b823d041f73abb9",
+                "reference": "79af83504a30cbada97531208b823d041f73abb9",
+                "shasum": ""
+            },
+            "require": {
+                "google/auth": "^1.18.0",
+                "google/common-protos": "^1.0||^2.0",
+                "google/grpc-gcp": "^0.2",
+                "google/protobuf": "^3.12.2",
+                "grpc/grpc": "^1.13",
+                "guzzlehttp/promises": "^1.3",
+                "guzzlehttp/psr7": "^1.7.0||^2",
+                "php": ">=5.5"
+            },
+            "conflict": {
+                "ext-protobuf": "<3.7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36",
+                "squizlabs/php_codesniffer": "3.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Google\\ApiCore\\": "src",
+                    "GPBMetadata\\ApiCore\\": "metadata/ApiCore"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Google API Core for PHP",
+            "homepage": "https://github.com/googleapis/gax-php",
+            "keywords": [
+                "google"
+            ],
+            "support": {
+                "issues": "https://github.com/googleapis/gax-php/issues",
+                "source": "https://github.com/googleapis/gax-php/tree/v1.11.2"
+            },
+            "time": "2022-01-20T16:21:48+00:00"
+        },
+        {
+            "name": "google/grpc-gcp",
+            "version": "v0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GoogleCloudPlatform/grpc-gcp-php.git",
+                "reference": "2465c2273e11ada1e95155aa1e209f3b8f03c314"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GoogleCloudPlatform/grpc-gcp-php/zipball/2465c2273e11ada1e95155aa1e209f3b8f03c314",
+                "reference": "2465c2273e11ada1e95155aa1e209f3b8f03c314",
+                "shasum": ""
+            },
+            "require": {
+                "google/auth": "^1.3",
+                "google/protobuf": "^v3.3.0",
+                "grpc/grpc": "^v1.13.0",
+                "php": ">=5.5.0",
+                "psr/cache": "^1.0.1||^2.0.0||^3.0.0"
+            },
+            "require-dev": {
+                "google/cloud-spanner": "^1.7",
+                "phpunit/phpunit": "4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Grpc\\Gcp\\": "src/"
+                },
+                "classmap": [
+                    "src/generated/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "gRPC GCP library for channel management",
+            "support": {
+                "issues": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/issues",
+                "source": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/tree/v0.2.0"
+            },
+            "time": "2021-09-27T22:57:18+00:00"
+        },
+        {
+            "name": "google/protobuf",
+            "version": "v3.19.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/protocolbuffers/protobuf-php.git",
+                "reference": "c6d35bfdf41f8cb9dcf71ebc3631f8b9d80aa040"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/c6d35bfdf41f8cb9dcf71ebc3631f8b9d80aa040",
+                "reference": "c6d35bfdf41f8cb9dcf71ebc3631f8b9d80aa040",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4.8.0"
+            },
+            "suggest": {
+                "ext-bcmath": "Need to support JSON deserialization"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Google\\Protobuf\\": "src/Google/Protobuf",
+                    "GPBMetadata\\Google\\Protobuf\\": "src/GPBMetadata/Google/Protobuf"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "proto library for PHP",
+            "homepage": "https://developers.google.com/protocol-buffers/",
+            "keywords": [
+                "proto"
+            ],
+            "support": {
+                "issues": "https://github.com/protocolbuffers/protobuf-php/issues",
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.19.3"
+            },
+            "time": "2022-01-11T17:40:06+00:00"
+        },
+        {
+            "name": "grpc/grpc",
+            "version": "1.42.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/grpc/grpc-php.git",
+                "reference": "9fa44f104cb92e924d4da547323a97f3d8aca6d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/9fa44f104cb92e924d4da547323a97f3d8aca6d4",
+                "reference": "9fa44f104cb92e924d4da547323a97f3d8aca6d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "google/auth": "^v1.3.0"
+            },
+            "suggest": {
+                "ext-protobuf": "For better performance, install the protobuf C extension.",
+                "google/protobuf": "To get started using grpc quickly, install the native protobuf library."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Grpc\\": "src/lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "gRPC library for PHP",
+            "homepage": "https://grpc.io",
+            "keywords": [
+                "rpc"
+            ],
+            "support": {
+                "source": "https://github.com/grpc/grpc-php/tree/v1.42.0"
+            },
+            "time": "2021-11-19T08:13:51+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -5873,6 +6220,64 @@
                 "source": "https://github.com/reactphp/promise/tree/v2.8.0"
             },
             "time": "2020-05-12T15:16:56+00:00"
+        },
+        {
+            "name": "rize/uri-template",
+            "version": "0.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rize/UriTemplate.git",
+                "reference": "2a874863c48d643b9e2e254ab288ec203060a0b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rize/UriTemplate/zipball/2a874863c48d643b9e2e254ab288ec203060a0b8",
+                "reference": "2a874863c48d643b9e2e254ab288ec203060a0b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Rize\\": "src/Rize"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marut K",
+                    "homepage": "http://twitter.com/rezigned"
+                }
+            ],
+            "description": "PHP URI Template (RFC 6570) supports both expansion & extraction",
+            "keywords": [
+                "RFC 6570",
+                "template",
+                "uri"
+            ],
+            "support": {
+                "issues": "https://github.com/rize/UriTemplate/issues",
+                "source": "https://github.com/rize/UriTemplate/tree/0.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/rezigned",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://opencollective.com/rize-uri-template",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2021-10-09T06:30:16+00:00"
         },
         {
             "name": "rosell-dk/exec-with-fallback",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -893,11 +893,19 @@ services:
     arguments:
       - '@eight_points_guzzle.client.itranslate'
 
+  App\Translation\GoogleTranslateApi:
+    class: App\Translation\GoogleTranslateApi
+    arguments:
+      - '@Google\Cloud\Translate\V2\TranslateClient'
+
+  Google\Cloud\Translate\V2\TranslateClient:
+
   App\Translation\TranslationDelegate:
     class: App\Translation\TranslationDelegate
     arguments:
       - '@App\Repository\ProjectCustomTranslationRepository'
       - '@App\Translation\ItranslateApi'
+      - '@App\Translation\GoogleTranslateApi'
 
   App\Translation\MachineTranslationListener:
     class: App\Translation\MachineTranslationListener

--- a/src/Translation/GoogleTranslateApi.php
+++ b/src/Translation/GoogleTranslateApi.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Translation;
+
+use Google\Cloud\Core\Exception\ServiceException;
+use Google\Cloud\Translate\V2\TranslateClient;
+use Psr\Log\LoggerInterface;
+
+class GoogleTranslateApi implements TranslationApiInterface
+{
+  private const LONG_LANGUAGE_CODE = [
+    'zh-CN',
+    'zh-TW',
+  ];
+
+  private TranslateClient $client;
+  private LoggerInterface $logger;
+  private TranslationApiHelper $helper;
+
+  public function __construct(TranslateClient $client, LoggerInterface $logger)
+  {
+    $this->client = $client;
+    $this->logger = $logger;
+    $this->helper = new TranslationApiHelper(self::LONG_LANGUAGE_CODE);
+  }
+
+  public function translate(string $text, ?string $source_language, string $target_language): ?TranslationResult
+  {
+    $target_language = $this->helper->transformLanguageCode($target_language);
+    $source_language = $this->helper->transformLanguageCode($source_language);
+
+    try {
+      $result = $this->client->translate($text, [
+        'source' => $source_language,
+        'target' => $target_language,
+        'format' => 'text',
+      ]);
+    } catch (ServiceException $e) {
+      $this->logger->error("Google translate client exception, source: {$source_language}, target: {$target_language}, text: {$text}, message: {$e->getMessage()}");
+
+      return null;
+    }
+
+    if (null === $result) {
+      return null;
+    }
+
+    $translation_result = new TranslationResult();
+    $translation_result->provider = 'google';
+    if (null == $source_language) {
+      $translation_result->detected_source_language = $result['source'];
+    }
+    $translation_result->translation = $result['text'];
+
+    return $translation_result;
+  }
+}

--- a/src/Translation/ItranslateApi.php
+++ b/src/Translation/ItranslateApi.php
@@ -18,18 +18,20 @@ class ItranslateApi implements TranslationApiInterface
   private Client $client;
   private string $api_key;
   private LoggerInterface $logger;
+  private TranslationApiHelper $helper;
 
   public function __construct(Client $client, LoggerInterface $logger)
   {
     $this->client = $client;
     $this->logger = $logger;
     $this->api_key = $_ENV['ITRANSLATE_API_KEY'];
+    $this->helper = new TranslationApiHelper(self::LONG_LANGUAGE_CODE);
   }
 
   public function translate(string $text, ?string $source_language, string $target_language): ?TranslationResult
   {
-    $target_language = $this->transformLanguageCode($target_language);
-    $source_language = $this->transformLanguageCode($source_language);
+    $target_language = $this->helper->transformLanguageCode($target_language);
+    $source_language = $this->helper->transformLanguageCode($source_language);
 
     try {
       $response = $this->client->request(
@@ -73,22 +75,5 @@ class ItranslateApi implements TranslationApiInterface
     $translation_result->translation = $result['target']['text'];
 
     return $translation_result;
-  }
-
-  private function transformLanguageCode(?string $language): ?string
-  {
-    if (null === $language) {
-      return null;
-    }
-
-    if (2 == strlen($language)) {
-      return $language;
-    }
-
-    if (in_array($language, self::LONG_LANGUAGE_CODE, true)) {
-      return $language;
-    }
-
-    return substr($language, 0, 2);
   }
 }

--- a/src/Translation/TranslationApiHelper.php
+++ b/src/Translation/TranslationApiHelper.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Translation;
+
+class TranslationApiHelper
+{
+  private array $long_language_code;
+
+  public function __construct(array $long_language_code)
+  {
+    $this->long_language_code = $long_language_code;
+  }
+
+  public function transformLanguageCode(?string $language): ?string
+  {
+    if (null === $language) {
+      return null;
+    }
+
+    if (2 == strlen($language)) {
+      return $language;
+    }
+
+    if (in_array($language, $this->long_language_code, true)) {
+      return $language;
+    }
+
+    return substr($language, 0, 2);
+  }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -289,6 +289,27 @@
     "google/auth": {
         "version": "v1.7.1"
     },
+    "google/cloud-core": {
+        "version": "v1.43.1"
+    },
+    "google/cloud-translate": {
+        "version": "v1.12.2"
+    },
+    "google/common-protos": {
+        "version": "1.4.0"
+    },
+    "google/gax": {
+        "version": "v1.10.0"
+    },
+    "google/grpc-gcp": {
+        "version": "v0.2.0"
+    },
+    "google/protobuf": {
+        "version": "v3.19.2"
+    },
+    "grpc/grpc": {
+        "version": "1.42.0"
+    },
     "guzzlehttp/guzzle": {
         "version": "6.5.2"
     },
@@ -542,6 +563,9 @@
     },
     "react/promise": {
         "version": "v2.8.0"
+    },
+    "rize/uri-template": {
+        "version": "0.3.4"
     },
     "rosell-dk/image-mime-type-guesser": {
         "version": "0.3"

--- a/tests/phpUnit/Translation/GoogleTranslateApiTest.php
+++ b/tests/phpUnit/Translation/GoogleTranslateApiTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Translation;
+
+use App\Translation\GoogleTranslateApi;
+use Google\Cloud\Core\Exception\ServiceException;
+use Google\Cloud\Translate\V2\TranslateClient;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class GoogleTranslateApiTest extends TestCase
+{
+  private GoogleTranslateApi $api;
+
+  /**
+   * @var MockObject|TranslateClient
+   */
+  private $client;
+
+  protected function setUp(): void
+  {
+    $this->client = $this->createMock(TranslateClient::class);
+    $this->api = new GoogleTranslateApi($this->client, $this->createMock(LoggerInterface::class));
+  }
+
+  public function testSuccessDetectedLanguage(): void
+  {
+    $response = [
+      'source' => 'en',
+      'text' => 'translated',
+    ];
+    $this->client->expects($this->once())->method('translate')->willReturn($response);
+
+    $result = $this->api->translate('testing', null, 'fr');
+
+    $this->assertEquals('en', $result->detected_source_language);
+    $this->assertEquals('translated', $result->translation);
+  }
+
+  public function testSuccessSpecifiedLanguage(): void
+  {
+    $response = [
+      'source' => 'en',
+      'text' => 'test',
+    ];
+    $this->client->expects($this->once())->method('translate')->willReturn($response);
+
+    $result = $this->api->translate('testing', 'en', 'fr');
+
+    $this->assertNull($result->detected_source_language);
+    $this->assertEquals('test', $result->translation);
+  }
+
+  public function testNullResponse(): void
+  {
+    $this->client->expects($this->once())->method('translate')->willReturn(null);
+    $result = $this->api->translate('testing', null, 'fr');
+    $this->assertNull($result);
+  }
+
+  public function testExceptionThrown(): void
+  {
+    $exception = $this->createMock(ServiceException::class);
+    $this->client->expects($this->once())->method('translate')->willThrowException($exception);
+    $result = $this->api->translate('testing', null, 'fr');
+    $this->assertNull($result);
+  }
+}

--- a/tests/phpUnit/Translation/ItranslateApiTest.php
+++ b/tests/phpUnit/Translation/ItranslateApiTest.php
@@ -30,63 +30,6 @@ class ItranslateApiTest extends TestCase
     $this->api = new ItranslateApi($this->httpClient, $this->createMock(LoggerInterface::class));
   }
 
-  public function testShortenLanguageCode(): void
-  {
-    $this->httpClient
-      ->expects($this->once())
-      ->method('request')
-      ->with('POST', '/translate/v1',
-        $this->callback(function ($subject) {
-          $this->assertEquals('fr', $subject['json']['source']['dialect']);
-          $this->assertEquals('fr', $subject['json']['target']['dialect']);
-
-          return true;
-        }
-      ))
-      ->willReturn($this->mockGenericResponse())
-    ;
-
-    $this->api->translate('testing', 'fr-FR', 'fr-FR');
-  }
-
-  public function testLongLanguageCode(): void
-  {
-    $this->httpClient
-      ->expects($this->once())
-      ->method('request')
-      ->with('POST', '/translate/v1',
-        $this->callback(function ($subject) {
-          $this->assertEquals('zh-CN', $subject['json']['source']['dialect']);
-          $this->assertEquals('pt-BR', $subject['json']['target']['dialect']);
-
-          return true;
-        }
-      ))
-      ->willReturn($this->mockGenericResponse())
-    ;
-
-    $this->api->translate('testing', 'zh-CN', 'pt-BR');
-  }
-
-  public function testShortLanguageCode(): void
-  {
-    $this->httpClient
-      ->expects($this->once())
-      ->method('request')
-      ->with('POST', '/translate/v1',
-        $this->callback(function ($subject) {
-          $this->assertEquals('fr', $subject['json']['source']['dialect']);
-          $this->assertEquals('en', $subject['json']['target']['dialect']);
-
-          return true;
-        }
-      ))
-      ->willReturn($this->mockGenericResponse())
-    ;
-
-    $this->api->translate('testing', 'fr', 'en');
-  }
-
   public function testDetectLanguageCode(): void
   {
     $this->httpClient

--- a/tests/phpUnit/Translation/TranslationApiHelperTest.php
+++ b/tests/phpUnit/Translation/TranslationApiHelperTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Translation;
+
+use App\Translation\TranslationApiHelper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class TranslationApiHelperTest extends TestCase
+{
+  private const LONG_LANGUAGE_CODE = [
+    'aa-bb',
+    'cc-dd',
+  ];
+
+  private TranslationApiHelper $helper;
+
+  protected function setUp(): void
+  {
+    $this->helper = new TranslationApiHelper(self::LONG_LANGUAGE_CODE);
+  }
+
+  public function testDetectLanguageCode(): void
+  {
+    $this->assertnull($this->helper->transformLanguageCode(null));
+  }
+
+  public function testShortenLanguageCode(): void
+  {
+    $this->assertEquals('zz', $this->helper->transformLanguageCode('zz-zz'));
+  }
+
+  public function testShortLanguageCode(): void
+  {
+    $this->assertEquals('zz', $this->helper->transformLanguageCode('zz'));
+  }
+
+  public function testLongLanguageCode(): void
+  {
+    $this->assertEquals('aa-bb', $this->helper->transformLanguageCode('aa-bb'));
+    $this->assertEquals('cc-dd', $this->helper->transformLanguageCode('cc-dd'));
+  }
+}


### PR DESCRIPTION
---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description

Rationale:

The plan is for google translate to fill the gap of iTranslate, since it provides significantly less free quota. For one, it supports more languages. Then, it might also provide better translation for shorter text. There will be more changes coming to fully take advantages of google translate.

---

This PR adds a new dependency as `google/cloud-translate`. The google translate api still uses http and guzzle under the hood, but it requires new access token every time, generated from the key file pointed by the `.env` file. This is more complicated than iTranslate, which just uses the same token all the time. 

The `google/cloud-translate` library handles generating this token automatically (in addition to handling retries and using a more efficient grpc encoding). This token can also be generated by the `gcloud` cli tool, but that's even more complicated and only recommended for manual testing, as it requires installing a new program to the system. 

Deployment note:

Google api requires a google cloud account and a credit card to work. But with the correct quota set per month, there shouldn't be any charges. I can share my credentials for initial testing. See slack for details.

### Tests - additional information
`TODO: add additional information about testruns here`
