### PR TITLE
Custom Translation Feature - Show Translation

### DIFF
--- a/assets/js/custom/ProgramCredits.js
+++ b/assets/js/custom/ProgramCredits.js
@@ -1,7 +1,7 @@
 import $ from 'jquery'
 /* global Routing */
 
-export function ProgramCredits (programId, defaultText, translationSaved, translationDeleted, myProgram,
+export function ProgramCredits (programId, usersLanguage, defaultText, translationSaved, translationDeleted, myProgram,
   creditsSelect, closeEditorDialog, keepOrDiscardDialog, customTranslationSnackbar, customTranslationApi) {
   const credits = $('#credits')
   const editCreditsUI = $('#edit-credits-ui')
@@ -17,6 +17,8 @@ export function ProgramCredits (programId, defaultText, translationSaved, transl
   const showMoreToggle = $('#descriptionShowMoreToggle')
   const descriptionHeadline = $('#description-headline')
 
+  const noop = () => {}
+
   let languages = {}
   let previousCreditsIndex = 0
   let lastSavedCredits = credits.text().trim()
@@ -24,6 +26,13 @@ export function ProgramCredits (programId, defaultText, translationSaved, transl
   $(document).ready(function () {
     if (myProgram) {
       getLanguages()
+    } else {
+      customTranslationApi.getCustomTranslation(
+        programId,
+        usersLanguage.substring(0, 2),
+        setCredits,
+        noop
+      )
     }
   })
 
@@ -56,6 +65,10 @@ export function ProgramCredits (programId, defaultText, translationSaved, transl
 
     creditsSelect.layoutOptions()
     resetCreditsEditor()
+  }
+
+  function setCredits (value) {
+    credits.text(value)
   }
 
   function getCustomTranslationSuccess (data) {

--- a/assets/js/custom/ProgramDescription.js
+++ b/assets/js/custom/ProgramDescription.js
@@ -1,8 +1,8 @@
 import $ from 'jquery'
 /* global Routing */
 
-export function ProgramDescription (programId, showMoreButtonText, showLessButtonText, defaultText,
-  translationSaved, translationDeleted, myProgram, descriptionSelect, closeEditorDialog,
+export function ProgramDescription (programId, usersLanguage, showMoreButtonText, showLessButtonText,
+  defaultText, translationSaved, translationDeleted, myProgram, descriptionSelect, closeEditorDialog,
   keepOrDiscardDialog, customTranslationSnackbar, customTranslationApi) {
   const description = $('#description')
   const editDescriptionUI = $('#edit-description-ui')
@@ -22,6 +22,8 @@ export function ProgramDescription (programId, showMoreButtonText, showLessButto
   let previousDescriptionIndex = 0
   let lastSavedDescription = description.text().trim()
 
+  const noop = () => {}
+
   initShowMore()
 
   function initShowMore () {
@@ -34,6 +36,13 @@ export function ProgramDescription (programId, showMoreButtonText, showLessButto
   $(document).ready(function () {
     if (myProgram) {
       getLanguages()
+    } else {
+      customTranslationApi.getCustomTranslation(
+        programId,
+        usersLanguage.substring(0, 2),
+        setDescription,
+        noop
+      )
     }
   })
 
@@ -66,6 +75,10 @@ export function ProgramDescription (programId, showMoreButtonText, showLessButto
 
     descriptionSelect.layoutOptions()
     resetDescriptionEditor()
+  }
+
+  function setDescription (value) {
+    description.text(value)
   }
 
   function getCustomTranslationSuccess (data) {

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -24,6 +24,7 @@ const $projectShare = $('.js-project-share')
 const $projectReport = $('.js-project-report')
 const $projectDescriptionCredits = $('.js-project-description-credits')
 const $projectComments = $('.js-project-comments')
+const $appLanguage = $('#app-language')
 
 const closeEditorDialog = new ProgramEditorDialog(
   $projectDescriptionCredits.data('trans-close-editor'),
@@ -104,6 +105,7 @@ Program(
 
 ProgramDescription(
   $projectDescriptionCredits.data('project-id'),
+  $appLanguage.data('app-language'),
   $projectDescriptionCredits.data('trans-more-info'),
   $projectDescriptionCredits.data('trans-less-info'),
   $projectDescriptionCredits.data('trans-default'),
@@ -119,6 +121,7 @@ ProgramDescription(
 
 ProgramCredits(
   $projectDescriptionCredits.data('project-id'),
+  $appLanguage.data('app-language'),
   $projectDescriptionCredits.data('trans-default'),
   $projectDescriptionCredits.data('trans-translation-saved'),
   $projectDescriptionCredits.data('trans-translation-deleted'),

--- a/tests/behat/context/CatrowebBrowserContext.php
+++ b/tests/behat/context/CatrowebBrowserContext.php
@@ -326,6 +326,10 @@ class CatrowebBrowserContext extends BrowserContext
         $this->assertSession()->cookieEquals('hl', 'de_DE');
         break;
 
+      case 'French':
+        $this->assertSession()->cookieEquals('hl', 'fr_FR');
+        break;
+
       default:
         Assert::assertTrue(false);
     }

--- a/tests/behat/features/web/translation/show_custom_translation.feature
+++ b/tests/behat/features/web/translation/show_custom_translation.feature
@@ -1,0 +1,41 @@
+@web @project_page
+Feature: Projects should show a previously defined custom translation for user's language
+
+  Background:
+    Given there are users:
+      | id | name      |
+      | 1  | Catrobat  |
+    And there are projects:
+      | id | name      | owned by  | description    | credit     |
+      | 1  | project 1 | Catrobat  | my description | my credits |
+    And there are project custom translations:
+      | project_id | language | name            | description            | credit             |
+      | 1          | de       | translated name | translated description | translated credits |
+
+  Scenario: Viewing a previously entered custom description and credits translation
+    Given I am on "/app/project/1"
+    Then the selected language should be "English"
+    And I wait for the page to be loaded
+    And I should see "my description"
+    And I should see "my credits"
+    But I should not see "translated description"
+    And I should not see "translated credits"
+    Then I switch the language to "Deutsch"
+    And I wait for the page to be loaded
+    Then the selected language should be "Deutsch"
+    And I should see "translated description"
+    And I should see "translated credits"
+    But I should not see "my description"
+    And I should not see "my credits"
+
+  Scenario: Should not see custom description and credits when not defined
+    Given I am on "/app/project/1"
+    Then the selected language should be "English"
+    And I wait for the page to be loaded
+    And I should see "my description"
+    And I should see "my credits"
+    Then I switch the language to "French"
+    And I wait for the page to be loaded
+    Then the selected language should be "French"
+    And I should see "my description"
+    And I should see "my credits"


### PR DESCRIPTION
Automatically show a custom translation for the program description and/or credits to the user based on the user's preferred language. If there is not a custom translation defined for the user's language, then just show the default description and/or credits.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
If there is a custom translation defined for the language the user has selected in the footer, the translation is automatically shown in the description and/or credits when the page loads. However, the custom translation is not shown if the user is the program owner.

### Tests - additional information
There are new tests that verify that the custom translation is automatically shown if there is a translation matching the user's language and does not show if there is not a matching translation.
