### PR TITLE
Refactor project text editor

### DIFF
--- a/assets/js/api/CustomTranslationApi.js
+++ b/assets/js/api/CustomTranslationApi.js
@@ -5,7 +5,7 @@ export class CustomTranslationApi {
     this.programSection = programSection
   }
 
-  getCustomTranslation (programId, language, successCallback, errorCallback) {
+  getCustomTranslation (programId, language, successCallback, errorCallback = () => {}) {
     $.ajax({
       url: '../translate/custom/project/' + programId + '?field=' + this.programSection + '&language=' + language,
       type: 'get',

--- a/assets/js/components/ProjectTextEditor.js
+++ b/assets/js/components/ProjectTextEditor.js
@@ -1,0 +1,239 @@
+import $ from 'jquery'
+import { MDCSelect } from '@material/select'
+import { ProgramEditorDialog } from '../custom/ProgramEditorDialog'
+import { CustomTranslationApi } from '../api/CustomTranslationApi'
+
+/* global Routing */
+export function ProjectTextEditor (projectDescriptionCredits, defaultText, programId) {
+  const self = this
+  this.defaultText = defaultText
+  this.programId = programId
+
+  this.editTextUI = $('#edit-text-ui')
+  this.editText = $('#edit-text')
+  this.editTextError = $('#edit-text-error')
+  this.languageSelectorList = $('#edit-language-selector-list')
+  this.selectedLanguage = $('#edit-selected-language')
+  this.textLoadingSpinner = $('#edit-loading-spinner')
+
+  this.languageSelect = new MDCSelect(document.querySelector('#edit-language-selector'))
+  this.languages = {}
+  this.previousIndex = 0
+
+  this.translationSaved = projectDescriptionCredits.data('trans-translation-saved')
+  this.translationDeleted = projectDescriptionCredits.data('trans-translation-deleted')
+
+  this.closeEditorDialog = new ProgramEditorDialog(
+    projectDescriptionCredits.data('trans-close-editor-prompt'),
+    projectDescriptionCredits.data('trans-save'),
+    projectDescriptionCredits.data('trans-discard')
+  )
+
+  this.keepOrDiscardDialog = new ProgramEditorDialog(
+    projectDescriptionCredits.data('trans-save-on-language-change'),
+    projectDescriptionCredits.data('trans-keep'),
+    projectDescriptionCredits.data('trans-discard')
+  )
+
+  $('#edit-submit-button').on('click', () => { this.save() })
+  $('#edit-close-button').on('click', () => {
+    if (this.areChangesSaved()) {
+      this.close()
+    } else {
+      this.closeEditorDialog.show(closeEditorDialogResult)
+    }
+  })
+
+  this.languageSelect.listen('MDCSelect:change', () => {
+    if (!this.editText.is(':visible') || this.languageSelect.selectedIndex === this.previousIndex) {
+      return
+    }
+
+    if (this.areChangesSaved()) {
+      this.previousIndex = this.languageSelect.selectedIndex
+      this.getCustomTranslation()
+    } else {
+      this.keepOrDiscardDialog.show(keepOrDiscardChangesResult)
+    }
+  })
+
+  $(document).ready(getLanguages)
+
+  this.show = (config, initialText, closedCallback) => {
+    this.programSection = config.programSection
+    this.customTranslationApi = new CustomTranslationApi(config.programSection)
+    this.editText.val(initialText)
+    this.lastSavedText = initialText
+    this.editText.maxLength = config.maxLength
+    this.snackbar = config.snackbar
+    this.closedCallback = closedCallback
+    $('#edit-headline').text(config.headline)
+    $('#edit-close-button').attr('title', config.closeText)
+    $('#edit-text-instruction').text(config.instruction)
+
+    const langaugeSelectElement = $('#edit-language-selector')
+    if (config.showLanguageSelect) {
+      langaugeSelectElement.removeClass('d-none')
+    } else {
+      langaugeSelectElement.addClass('d-none')
+    }
+
+    this.editTextUI.removeClass('d-none')
+  }
+
+  // region private
+  this.close = () => {
+    this.editTextUI.addClass('d-none')
+    this.reset()
+    this.closedCallback()
+  }
+
+  this.reset = () => {
+    this.languageSelect.selectedIndex = 0
+    this.previousIndex = 0
+  }
+
+  function getLanguages () {
+    $.ajax({
+      url: '../languages',
+      type: 'get',
+      success: function (data) {
+        self.languages = data
+        self.populateSelector()
+      }
+    })
+  }
+
+  this.populateSelector = () => {
+    this.languageSelectorList.empty()
+    this.languageSelectorList.append('<li class="mdc-list-item" data-value="default" role="option" tabindex="-1">' +
+      '<span class="mdc-list-item__ripple"></span>' +
+      '<span class="mdc-list-item__text">' + this.defaultText + '</span>' +
+      '</li>')
+
+    for (const language in this.languages) {
+      if (language.length <= 2) {
+        this.languageSelectorList.append(`<li class="mdc-list-item" data-value="${language}" role="option" tabindex="-1">\
+          <span class="mdc-list-item__ripple"></span>\
+          <span class="mdc-list-item__text">${this.languages[language]}</span>\
+          </li>`)
+      }
+    }
+
+    this.languageSelect.layoutOptions()
+    this.reset()
+  }
+
+  this.areChangesSaved = () => {
+    return this.editText.val().trim() === this.lastSavedText.trim()
+  }
+
+  function keepOrDiscardChangesResult (result) {
+    if (result.isConfirmed) {
+      self.previousIndex = self.languageSelect.selectedIndex
+      self.lastSavedText = self.editText.text().trim()
+    } else if (result.isDenied) {
+      self.previousIndex = self.languageSelect.selectedIndex
+      self.getCustomTranslation()
+    } else if (result.isDismissed) {
+      self.languageSelect.selectedIndex = self.previousIndex
+    }
+  }
+
+  function closeEditorDialogResult (result) {
+    if (result.isConfirmed) {
+      self.save()
+    } else if (result.isDenied) {
+      self.close()
+    }
+  }
+
+  this.save = () => {
+    const newText = this.editText.val().trim()
+    if (this.areChangesSaved()) {
+      this.close()
+      return
+    }
+
+    const languageSelected = this.languageSelect.value
+    if (languageSelected === '' || languageSelected === 'default') {
+      let url
+      if (this.programSection === 'name') {
+        url = Routing.generate('edit_program_name', { id: this.programId, new_name: newText }, false)
+      } else if (this.programSection === 'description') {
+        url = Routing.generate('edit_program_description', { id: this.programId, new_description: newText }, false)
+      } else if (this.programSection === 'credit') {
+        url = Routing.generate('edit_program_credits', { id: this.programId, new_credits: newText }, false)
+      }
+
+      $.get(url, function (data) {
+        if (parseInt(data.statusCode) === 200) {
+          location.reload()
+        } else if (parseInt(data.statusCode) === 707 ||
+          parseInt(data.statusCode()) === 527) {
+          showError(data)
+        }
+      })
+    } else if (newText === '') {
+      this.customTranslationApi.deleteCustomTranslation(
+        this.programId,
+        languageSelected,
+        deleteCustomTranslationSuccess,
+        showError
+      )
+    } else {
+      this.customTranslationApi.saveCustomTranslation(
+        this.programId,
+        newText,
+        languageSelected,
+        saveCustomTranslationSuccess,
+        showError
+      )
+    }
+  }
+
+  function showError (error) {
+    self.editText.addClass('danger')
+    self.editTextError.show()
+    self.editTextError.text(error.message)
+  }
+
+  function deleteCustomTranslationSuccess () {
+    self.snackbar.show(self.translationDeleted, self.selectedLanguage.text())
+    self.close()
+  }
+
+  function saveCustomTranslationSuccess () {
+    self.snackbar.show(self.translationSaved, self.selectedLanguage.text())
+    self.close()
+  }
+
+  function getCustomTranslationSuccess (data) {
+    self.textLoadingSpinner.hide()
+    self.editText.val(data)
+    self.lastSavedText = data
+    self.editText.removeAttr('disabled')
+  }
+
+  function getCustomTranslationError () {
+    self.textLoadingSpinner.hide()
+    self.editText.val('')
+    self.lastSavedText = ''
+    self.editText.removeAttr('disabled')
+  }
+
+  self.getCustomTranslation = () => {
+    this.editText.attr('disabled', '')
+    this.editText.val('')
+    this.textLoadingSpinner.show()
+
+    this.customTranslationApi.getCustomTranslation(
+      this.programId,
+      this.languageSelect.value,
+      getCustomTranslationSuccess,
+      getCustomTranslationError
+    )
+  }
+
+  // end region
+}

--- a/assets/js/custom/ProgramCredits.js
+++ b/assets/js/custom/ProgramCredits.js
@@ -1,229 +1,40 @@
 import $ from 'jquery'
-/* global Routing */
 
-export function ProgramCredits (programId, usersLanguage, defaultText, translationSaved, translationDeleted, myProgram,
-  creditsSelect, closeEditorDialog, keepOrDiscardDialog, customTranslationSnackbar, customTranslationApi) {
+export function ProgramCredits (programId, usersLanguage, myProgram, editor, editorConfig, customTranslationApi) {
   const credits = $('#credits')
-  const editCreditsUI = $('#edit-credits-ui')
-  const editCredits = $('#edit-credits')
-  const editCreditsButton = $('#edit-credits-button')
-  const closeCreditsEditorButton = $('#close-credits-editor-button')
-  const creditsLoadingSpinner = $('#credits-loading-spinner')
-  const creditLanguageSelectorList = $('#credit-language-selector-list')
-  const creditsSelectedText = $('#credits-selected-text')
-  const editCreditsSubmitButton = $('#edit-credits-submit-button')
-  const editCreditsError = $('#edit-credits-error')
   const descriptionCreditsContainer = $('#description-credits-container')
   const showMoreToggle = $('#descriptionShowMoreToggle')
-  const descriptionHeadline = $('#description-headline')
-
-  const noop = () => {}
-
-  let languages = {}
-  let previousCreditsIndex = 0
-  let lastSavedCredits = credits.text().trim()
-
-  $(document).ready(function () {
-    if (myProgram) {
-      getLanguages()
-    } else {
-      customTranslationApi.getCustomTranslation(
-        programId,
-        usersLanguage.substring(0, 2),
-        setCredits,
-        noop
-      )
-    }
-  })
-
-  function getLanguages () {
-    $.ajax({
-      url: '../languages',
-      type: 'get',
-      success: function (data) {
-        languages = data
-        populateSelector()
-      }
-    })
-  }
-
-  function populateSelector () {
-    creditLanguageSelectorList.empty()
-    creditLanguageSelectorList.append('<li class="mdc-list-item" data-value="default" role="option" tabindex="-1">' +
-        '<span class="mdc-list-item__ripple"></span>' +
-        '<span class="mdc-list-item__text">' + defaultText + '</span>' +
-        '</li>')
-
-    for (const language in languages) {
-      if (language.length <= 2) {
-        creditLanguageSelectorList.append(`<li class="mdc-list-item" data-value="${language}" role="option" tabindex="-1">\
-          <span class="mdc-list-item__ripple"></span>\
-          <span class="mdc-list-item__text">${languages[language]}</span>\
-          </li>`)
-      }
-    }
-
-    creditsSelect.layoutOptions()
-    resetCreditsEditor()
-  }
-
-  function setCredits (value) {
-    credits.text(value)
-  }
-
-  function getCustomTranslationSuccess (data) {
-    creditsLoadingSpinner.hide()
-    editCredits.val(data)
-    lastSavedCredits = data
-    editCredits.removeAttr('disabled')
-  }
-
-  function getCustomTranslationError () {
-    creditsLoadingSpinner.hide()
-    editCredits.val('')
-    lastSavedCredits = ''
-    editCredits.removeAttr('disabled')
-  }
-
-  function getCustomTranslation () {
-    editCredits.attr('disabled', '')
-    editCredits.val('')
-    creditsLoadingSpinner.show()
-
-    customTranslationApi.getCustomTranslation(
-      programId,
-      creditsSelect.value,
-      getCustomTranslationSuccess,
-      getCustomTranslationError
-    )
-  }
-
-  function deleteCustomTranslationSuccess () {
-    customTranslationSnackbar.show(translationDeleted, creditsSelectedText.text())
-    closeCreditsEditor()
-  }
-
-  function saveCustomTranslationSuccess () {
-    customTranslationSnackbar.show(translationSaved, creditsSelectedText.text())
-    closeCreditsEditor()
-  }
-
-  function showCreditsError (error) {
-    editCredits.addClass('danger')
-    editCreditsError.show()
-    editCreditsError.text(error.message)
-  }
-
-  function saveCredits () {
-    const newCredits = editCredits.val().trim()
-    if (newCredits === credits.text().trim()) {
-      closeCreditsEditor()
-      return
-    }
-
-    const languageSelected = creditsSelect.value
-    if (languageSelected === '' || languageSelected === 'default') {
-      const url = Routing.generate('edit_program_credits', { id: programId, new_credits: newCredits }, false)
-
-      $.get(url, function (data) {
-        if (parseInt(data.statusCode) === 200) {
-          location.reload()
-        } else if (parseInt(data.statusCode) === 707) {
-          editCredits.addClass('danger')
-          editCreditsError.show()
-          editCreditsError.text(data.message)
-        }
-      })
-    } else if (newCredits === '') {
-      customTranslationApi.deleteCustomTranslation(
-        programId,
-        languageSelected,
-        deleteCustomTranslationSuccess,
-        showCreditsError
-      )
-    } else {
-      customTranslationApi.saveCustomTranslation(
-        programId,
-        newCredits,
-        languageSelected,
-        saveCustomTranslationSuccess,
-        showCreditsError
-      )
-    }
-  }
-
-  function keepOrDiscardChangesResult (result) {
-    if (result.isConfirmed) {
-      previousCreditsIndex = creditsSelect.selectedIndex
-      lastSavedCredits = credits.text().trim()
-    } else if (result.isDenied) {
-      previousCreditsIndex = creditsSelect.selectedIndex
-      getCustomTranslation()
-    } else if (result.isDismissed) {
-      creditsSelect.selectedIndex = previousCreditsIndex
-    }
-  }
-
-  function closeEditorDialogResult (result) {
-    if (result.isConfirmed) {
-      saveCredits()
-    } else if (result.isDenied) {
-      closeCreditsEditor()
-    }
-  }
-
-  function areChangesSaved () {
-    return editCredits.val().trim() === lastSavedCredits.trim()
-  }
-
-  function resetCreditsEditor () {
-    creditsSelect.selectedIndex = 0
-    previousCreditsIndex = 0
-    const defaultCredits = credits.text().trim()
-    editCredits.val(defaultCredits)
-    lastSavedCredits = defaultCredits
-  }
-
-  function closeCreditsEditor () {
-    descriptionCreditsContainer.show()
-    descriptionHeadline.show()
-    editCreditsUI.addClass('d-none')
-    resetCreditsEditor()
-    handleShowMore()
-  }
-
-  editCreditsButton.on('click', () => {
-    descriptionCreditsContainer.hide()
-    descriptionHeadline.hide()
-    editCreditsUI.removeClass('d-none')
-    showMoreToggle.addClass('d-none')
-  })
-
-  closeCreditsEditorButton.on('click', () => {
-    if (areChangesSaved()) {
-      closeCreditsEditor()
-    } else {
-      closeEditorDialog.show(closeEditorDialogResult)
-    }
-  })
-
-  editCreditsSubmitButton.on('click', () => {
-    saveCredits()
-  })
 
   if (myProgram) {
-    creditsSelect.listen('MDCSelect:change', () => {
-      if (!editCredits.is(':visible') || creditsSelect.selectedIndex === previousCreditsIndex) {
-        return
-      }
+    const descriptionHeadline = $('#description-headline')
 
-      if (areChangesSaved()) {
-        previousCreditsIndex = creditsSelect.selectedIndex
-        getCustomTranslation()
-      } else {
-        keepOrDiscardDialog.show(keepOrDiscardChangesResult)
-      }
+    $('#edit-credits-button').on('click', () => {
+      descriptionCreditsContainer.hide()
+      descriptionHeadline.hide()
+      showMoreToggle.addClass('d-none')
+
+      editor.show(
+        editorConfig,
+        credits.text().trim(),
+        closeCreditsEditor
+      )
     })
+
+    function closeCreditsEditor () {
+      descriptionCreditsContainer.show()
+      descriptionHeadline.show()
+      handleShowMore()
+    }
+  } else {
+    customTranslationApi.getCustomTranslation(
+      programId,
+      usersLanguage.substring(0, 2),
+      setCredits
+    )
+
+    function setCredits (value) {
+      credits.text(value)
+    }
   }
 
   function handleShowMore () {

--- a/assets/js/custom/ProgramDescription.js
+++ b/assets/js/custom/ProgramDescription.js
@@ -1,28 +1,12 @@
 import $ from 'jquery'
-/* global Routing */
 
 export function ProgramDescription (programId, usersLanguage, showMoreButtonText, showLessButtonText,
-  defaultText, translationSaved, translationDeleted, myProgram, descriptionSelect, closeEditorDialog,
-  keepOrDiscardDialog, customTranslationSnackbar, customTranslationApi) {
+  myProgram, editor, editorConfig, customTranslationApi) {
   const description = $('#description')
-  const editDescriptionUI = $('#edit-description-ui')
   const editDescriptionButton = $('#edit-description-button')
-  const closeDescriptionEditorButton = $('#close-description-editor-button')
-  const editDescription = $('#edit-description')
-  const descriptionLoadingSpinner = $('#description-loading-spinner')
-  const descriptionLanguageSelectorList = $('#description-language-selector-list')
-  const descriptionSelectedText = $('#description-selected-text')
-  const editDescriptionSubmitButton = $('#edit-description-submit-button')
-  const editDescriptionError = $('#edit-description-error')
   const descriptionCreditsContainer = $('#description-credits-container')
   const showMoreToggle = $('#descriptionShowMoreToggle')
   const descriptionShowMoreText = $('#descriptionShowMoreText')
-
-  let languages = {}
-  let previousDescriptionIndex = 0
-  let lastSavedDescription = description.text().trim()
-
-  const noop = () => {}
 
   initShowMore()
 
@@ -33,207 +17,36 @@ export function ProgramDescription (programId, usersLanguage, showMoreButtonText
     }
   }
 
-  $(document).ready(function () {
-    if (myProgram) {
-      getLanguages()
-    } else {
-      customTranslationApi.getCustomTranslation(
-        programId,
-        usersLanguage.substring(0, 2),
-        setDescription,
-        noop
+  if (myProgram) {
+    const descriptionHeadline = $('#description-headline')
+
+    editDescriptionButton.on('click', () => {
+      descriptionCreditsContainer.hide()
+      descriptionHeadline.hide()
+      showMoreToggle.addClass('d-none')
+
+      editor.show(
+        editorConfig,
+        $('#description').text().trim(),
+        closeDescriptionEditor
       )
-    }
-  })
-
-  function getLanguages () {
-    $.ajax({
-      url: '../languages',
-      type: 'get',
-      success: function (data) {
-        languages = data
-        populateSelector()
-      }
     })
-  }
 
-  function populateSelector () {
-    descriptionLanguageSelectorList.empty()
-    descriptionLanguageSelectorList.append('<li class="mdc-list-item" data-value="default" role="option" tabindex="-1">' +
-        '<span class="mdc-list-item__ripple"></span>' +
-        '<span class="mdc-list-item__text">' + defaultText + '</span>' +
-        '</li>')
-
-    for (const language in languages) {
-      if (language.length <= 2) {
-        descriptionLanguageSelectorList.append(`<li class="mdc-list-item" data-value="${language}" role="option" tabindex="-1">\
-          <span class="mdc-list-item__ripple"></span>\
-          <span class="mdc-list-item__text">${languages[language]}</span>\
-          </li>`)
-      }
+    function closeDescriptionEditor () {
+      descriptionCreditsContainer.show()
+      descriptionHeadline.show()
+      handleShowMore()
     }
-
-    descriptionSelect.layoutOptions()
-    resetDescriptionEditor()
-  }
-
-  function setDescription (value) {
-    description.text(value)
-  }
-
-  function getCustomTranslationSuccess (data) {
-    descriptionLoadingSpinner.hide()
-    editDescription.val(data)
-    lastSavedDescription = data
-    editDescription.removeAttr('disabled')
-  }
-
-  function getCustomTranslationError () {
-    descriptionLoadingSpinner.hide()
-    editDescription.val('')
-    lastSavedDescription = ''
-    editDescription.removeAttr('disabled')
-  }
-
-  function getCustomTranslation () {
-    editDescription.attr('disabled', '')
-    editDescription.val('')
-    descriptionLoadingSpinner.show()
-
+  } else {
     customTranslationApi.getCustomTranslation(
       programId,
-      descriptionSelect.value,
-      getCustomTranslationSuccess,
-      getCustomTranslationError
+      usersLanguage.substring(0, 2),
+      setDescription
     )
-  }
 
-  function deleteCustomTranslationSuccess () {
-    customTranslationSnackbar.show(translationDeleted, descriptionSelectedText.text())
-    closeDescriptionEditor()
-  }
-
-  function saveCustomTranslationSuccess () {
-    customTranslationSnackbar.show(translationSaved, descriptionSelectedText.text())
-    closeDescriptionEditor()
-  }
-
-  function showDescriptionError (error) {
-    editDescriptionError.show()
-    editDescriptionError.text(error.message)
-  }
-
-  function saveDescription () {
-    const newDescription = editDescription.val().trim()
-    if (newDescription === description.text().trim()) {
-      closeDescriptionEditor()
-      return
+    function setDescription (value) {
+      description.text(value)
     }
-
-    const languageSelected = descriptionSelect.value
-    if (languageSelected === '' || languageSelected === 'default') {
-      const url = Routing.generate('edit_program_description', { id: programId, new_description: newDescription }, false)
-      $.get(url, function (data) {
-        if (parseInt(data.statusCode) === 200) {
-          location.reload()
-        } else if (parseInt(data.statusCode) === 527) {
-          editDescription.addClass('danger')
-          editDescriptionError.show()
-          editDescriptionError.text(data.message)
-        }
-      })
-    } else if (newDescription === '') {
-      customTranslationApi.deleteCustomTranslation(
-        programId,
-        languageSelected,
-        deleteCustomTranslationSuccess,
-        showDescriptionError
-      )
-    } else {
-      customTranslationApi.saveCustomTranslation(
-        programId,
-        newDescription,
-        languageSelected,
-        saveCustomTranslationSuccess,
-        showDescriptionError
-      )
-    }
-  }
-
-  function keepOrDiscardChangesResult (result) {
-    if (result.isConfirmed) {
-      previousDescriptionIndex = descriptionSelect.selectedIndex
-      lastSavedDescription = description.text().trim()
-    } else if (result.isDenied) {
-      previousDescriptionIndex = descriptionSelect.selectedIndex
-      getCustomTranslation()
-    } else if (result.isDismissed) {
-      descriptionSelect.selectedIndex = previousDescriptionIndex
-    }
-  }
-
-  function closeEditorDialogResult (result) {
-    if (result.isConfirmed) {
-      saveDescription()
-    } else if (result.isDenied) {
-      closeDescriptionEditor()
-    }
-  }
-
-  function areChangesSaved () {
-    return editDescription.val().trim() === lastSavedDescription.trim()
-  }
-
-  function resetDescriptionEditor () {
-    descriptionSelect.selectedIndex = 0
-    previousDescriptionIndex = 0
-    const defaultDescription = description.text().trim()
-    editDescription.val(defaultDescription)
-    lastSavedDescription = defaultDescription
-  }
-
-  function closeDescriptionEditor () {
-    closeDescriptionEditorButton.hide()
-    editDescriptionButton.show()
-    descriptionCreditsContainer.show()
-    editDescriptionUI.addClass('d-none')
-    resetDescriptionEditor()
-    handleShowMore()
-  }
-
-  editDescriptionButton.on('click', () => {
-    closeDescriptionEditorButton.show()
-    editDescriptionButton.hide()
-    descriptionCreditsContainer.hide()
-    editDescriptionUI.removeClass('d-none')
-    showMoreToggle.addClass('d-none')
-  })
-
-  closeDescriptionEditorButton.on('click', () => {
-    if (areChangesSaved()) {
-      closeDescriptionEditor()
-    } else {
-      closeEditorDialog.show(closeEditorDialogResult)
-    }
-  })
-
-  editDescriptionSubmitButton.on('click', () => {
-    saveDescription()
-  })
-
-  if (myProgram) {
-    descriptionSelect.listen('MDCSelect:change', () => {
-      if (!editDescription.is(':visible') || descriptionSelect.selectedIndex === previousDescriptionIndex) {
-        return
-      }
-
-      if (areChangesSaved()) {
-        previousDescriptionIndex = descriptionSelect.selectedIndex
-        getCustomTranslation()
-      } else {
-        keepOrDiscardDialog.show(keepOrDiscardChangesResult)
-      }
-    })
   }
 
   showMoreToggle.on('click', () => {

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -1,5 +1,4 @@
 import { MDCTextField } from '@material/textfield'
-import { MDCSelect } from '@material/select'
 import $ from 'jquery'
 import './components/fullscreen_list_modal'
 import { TranslateProgram } from './custom/TranslateProgram'
@@ -12,9 +11,9 @@ import { ProgramReport } from './custom/ProgramReport'
 import { ProgramDescription } from './custom/ProgramDescription'
 import { ProgramCredits } from './custom/ProgramCredits'
 import { ProgramComments } from './custom/ProgramComments'
-import { ProgramEditorDialog } from './custom/ProgramEditorDialog'
 import { CustomTranslationSnackbar } from './custom/CustomTranslationSnackbar'
 import { CustomTranslationApi } from './api/CustomTranslationApi'
+import { ProjectTextEditor } from './components/ProjectTextEditor'
 
 require('../styles/custom/profile.scss')
 require('../styles/custom/program.scss')
@@ -26,28 +25,17 @@ const $projectDescriptionCredits = $('.js-project-description-credits')
 const $projectComments = $('.js-project-comments')
 const $appLanguage = $('#app-language')
 
-const closeEditorDialog = new ProgramEditorDialog(
-  $projectDescriptionCredits.data('trans-close-editor'),
-  $projectDescriptionCredits.data('trans-save'),
-  $projectDescriptionCredits.data('trans-discard')
-)
-
-const keepOrDiscardDialog = new ProgramEditorDialog(
-  $projectDescriptionCredits.data('trans-save-on-language-change'),
-  $projectDescriptionCredits.data('trans-keep'),
-  $projectDescriptionCredits.data('trans-discard')
-)
-
-let descriptionSelect = null
-let creditsSelect = null
+let editor = null
 
 if ($project.data('my-program')) {
-  new MDCTextField(document.querySelector('.description'))
-  new MDCTextField(document.querySelector('.credits'))
+  new MDCTextField(document.querySelector('#edit-mdc-text-field'))
   new MDCTextField(document.querySelector('.comment-message'))
 
-  descriptionSelect = new MDCSelect(document.querySelector('#description-language-selector'))
-  creditsSelect = new MDCSelect(document.querySelector('#credits-language-selector'))
+  editor = new ProjectTextEditor(
+    $projectDescriptionCredits,
+    $projectDescriptionCredits.data('trans-default'),
+    $projectDescriptionCredits.data('project-id')
+  )
 }
 
 shareProject(
@@ -103,33 +91,43 @@ Program(
   $project.data('trans-download-start')
 )
 
+const descriptionEditorConfig = {
+  maxLength: $projectDescriptionCredits.data('max-length'),
+  programSection: 'description',
+  snackbar: new CustomTranslationSnackbar($projectDescriptionCredits.data('trans-description')),
+  headline: $projectDescriptionCredits.data('trans-description'),
+  closeText: $projectDescriptionCredits.data('trans-close-description-editor'),
+  instruction: '',
+  showLanguageSelect: $projectDescriptionCredits.data('has-description')
+}
+
 ProgramDescription(
   $projectDescriptionCredits.data('project-id'),
   $appLanguage.data('app-language'),
   $projectDescriptionCredits.data('trans-more-info'),
   $projectDescriptionCredits.data('trans-less-info'),
-  $projectDescriptionCredits.data('trans-default'),
-  $projectDescriptionCredits.data('trans-translation-saved'),
-  $projectDescriptionCredits.data('trans-translation-deleted'),
   $project.data('my-program'),
-  descriptionSelect,
-  closeEditorDialog,
-  keepOrDiscardDialog,
-  new CustomTranslationSnackbar($projectDescriptionCredits.data('trans-description')),
+  editor,
+  descriptionEditorConfig,
   new CustomTranslationApi('description')
 )
+
+const creditsEditorConfig = {
+  maxLength: $projectDescriptionCredits.data('max-length'),
+  programSection: 'credit',
+  snackbar: new CustomTranslationSnackbar($projectDescriptionCredits.data('trans-notes-and-credits')),
+  headline: $projectDescriptionCredits.data('trans-notes-and-credits'),
+  closeText: $projectDescriptionCredits.data('trans-close-credits-editor'),
+  instruction: $projectDescriptionCredits.data('trans-notes-and-credits-description'),
+  showLanguageSelect: $projectDescriptionCredits.data('has-credits')
+}
 
 ProgramCredits(
   $projectDescriptionCredits.data('project-id'),
   $appLanguage.data('app-language'),
-  $projectDescriptionCredits.data('trans-default'),
-  $projectDescriptionCredits.data('trans-translation-saved'),
-  $projectDescriptionCredits.data('trans-translation-deleted'),
   $project.data('my-program'),
-  creditsSelect,
-  closeEditorDialog,
-  keepOrDiscardDialog,
-  new CustomTranslationSnackbar($projectDescriptionCredits.data('trans-notes-and-credits')),
+  editor,
+  creditsEditorConfig,
   new CustomTranslationApi('credit')
 )
 

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -246,19 +246,25 @@
   ></div>
   <div class="js-project-description-credits"
        data-project-id="{{ program.id }}"
+       data-max-length={{ max_description_size }}
+       data-has-description={% if program.description %} true {% else %} false {% endif %}
+       data-has-credits={% if program.credits %} true {% else %} false {% endif %}
        data-trans-more-info="{{ "more-information"|trans({}, "catroweb") }}"
        data-trans-less-info="{{ "less-information"|trans({}, "catroweb") }}"
        data-trans-description="{{ "description"|trans({}, "catroweb") }}"
        data-trans-notes-and-credits="{{ "credits"|trans({}, "catroweb") }}"
        data-trans-translation-saved="{{ "programs.translationSaved"|trans({}, "catroweb") }}"
        data-trans-translation-deleted="{{ "programs.translationDeleted"|trans({}, "catroweb") }}"
-       data-trans-close-editor="{{ "programs.closeEditorPrompt"|trans({}, "catroweb") }}"
-       data-trans-save="{{ "programs.saveDescription"|trans({}, "catroweb") }}"
+       data-trans-close-description-editor="{{ "programs.closeDescriptionEditor"|trans({}, "catroweb") }}"
+       data-trans-close-credits-editor="{{ "programs.closeCreditsEditor"|trans({}, "catroweb") }}"
+       data-trans-close-editor-prompt="{{ "programs.closeEditorPrompt"|trans({}, "catroweb") }}"
+       data-trans-save="{{ "programs.save"|trans({}, "catroweb") }}"
        data-trans-discard="{{ "programs.btnDiscard"|trans({}, "catroweb") }}"
        data-trans-cancel="{{ "cancel"|trans({}, "catroweb") }}"
        data-trans-keep="{{ "programs.btnKeep"|trans({}, "catroweb") }}"
        data-trans-default="{{ "programs.default"|trans({}, "catroweb") }}"
        data-trans-save-on-language-change="{{ "programs.saveOnLanguageChange"|trans({}, "catroweb") }}"
+       data-trans-notes-and-credits-description="{{ "notesAndCreditsDescription"|trans({}, "catroweb") }}"
   ></div>
   <div class="js-project-comments"
        data-project-id="{{ program_details.id }}"

--- a/templates/Program/program_description.html.twig
+++ b/templates/Program/program_description.html.twig
@@ -15,67 +15,6 @@
         </span>
       {% endif %}
     </div>
-    {% if app.user and my_program %}
-      <div id="edit-description-ui" class="d-none mb-5">
-        <div id="edit-description-error" style="display:none;" class="alert alert-danger"></div>
-        <label
-            class="mdc-text-field mdc-text-field--filled mdc-text-field--textarea mdc-text-field--no-label description">
-          <span class="mdc-text-field__ripple"></span>
-          <span class="mdc-text-field__resizer">
-              <span id="description-loading-spinner" style="display: none;">
-                <i class="ms-2 material-icons">
-                  {% include 'components/loading_spinner.html.twig' with {'size': 'small'} %}
-                </i>
-              </span>
-              <textarea class="mdc-text-field__input mt-2 mb-2" id="edit-description" name="edit-description"
-                        title="_edit-description"
-                        maxlength="{{ max_description_size }}" style="width: 100%;" rows="10" cols="100">
-                {% if program.description %}{{ program.description }}{% else %}{{ "noDescription"|trans({}, "catroweb") }}{% endif %}
-              </textarea>
-          </span>
-          <span class="mdc-line-ripple"></span>
-        </label>
-
-        <div class="row justify-content-between" style="margin-top: 1rem; padding-right: 0.75rem;">
-          <div class="form-group col-8">
-            <div id="description-language-selector" class="mdc-select mdc-select--outlined" {% if (program.description == null) %} style="display: none;" {% endif %}>
-              <div class="mdc-select__anchor" aria-labelledby="outlined-select-label">
-                <span class="mdc-notched-outline">
-                  <span class="mdc-notched-outline__leading"></span>
-                  <span class="mdc-notched-outline__notch">
-                    <span id="description-outlined-select-label"
-                          class="mdc-floating-label">{{ 'footer.language'|trans({}, "catroweb") }}</span>
-                  </span>
-                  <span class="mdc-notched-outline__trailing"></span>
-                </span>
-                <span class="mdc-select__selected-text-container">
-                  <span id="description-selected-text" class="mdc-select__selected-text" data-selected-value="default"></span>
-                </span>
-                <span class="mdc-select__dropdown-icon">
-                  {% include 'components/mdc_select_svg.html.twig' %}
-                </span>
-              </div>
-              <div class="mdc-select__menu mdc-menu mdc-menu-surface mdc-menu-surface--fullwidth">
-                <ul id="description-language-selector-list" class="mdc-list" role="listbox">
-                  <li class="mdc-list-item" data-value="default" role="option">
-                      <span class="mdc-list-item__ripple"></span>
-                      <span class="mdc-list-item__text">
-                        {{ "programs.default"|trans({}, "catroweb") }}
-                      </span>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          <button id="edit-description-submit-button" class="btn btn-primary p-3 col-4">
-            <i class="material-icons align-bottom">save</i>
-            {{ 'programs.saveDescription'|trans({}, 'catroweb') }}
-          </button>
-        </div>
-
-      </div>
-    {% endif %}
     <div id="description-credits-container" style="height:auto; overflow: hidden;">
       <div id="description" class="text-break">
         {% if program.description %}
@@ -117,57 +56,54 @@
 <div class="row">
   <div class="col">
     {% if app.user and my_program %}
-      <div id="edit-credits-ui" class="d-none mb-5">
-        <div class="mt-3" id="credits-headline">
-          <span class="h2">{{ "credits"|trans({}, "catroweb") }} </span>
-          {% if app.user and my_program %}
+      <div id="edit-text-ui" class="d-none mb-5">
+        <div class="mt-3">
+          <span class="h2" id="edit-headline"></span>
             <span>
-              <i data-bs-toggle="tooltip" title="{{ 'programs.closeCreditsEditor'|trans({}, 'catroweb') }}"
-                 id="close-credits-editor-button" class="ml-3 material-icons catro-icon-button align-bottom">
+              <i data-bs-toggle="tooltip"
+                 id="edit-close-button" class="ml-3 material-icons catro-icon-button align-bottom">
                 close
               </i>
             </span>
-          {% endif %}
         </div>
-        <div id="notes-and-credits-description">{{ "notesAndCreditsDescription"|trans({}, "catroweb") }}</div>
-        <div id="edit-credits-error" style="display:none;" class="alert alert-danger"></div>
-        <label
-            class="mdc-text-field mdc-text-field--filled mdc-text-field--textarea mdc-text-field--no-label description credits">
+        <div id="edit-text-instruction"></div>
+        <div id="edit-text-error" style="display:none;" class="alert alert-danger"></div>
+        <label id="edit-mdc-text-field"
+            class="mdc-text-field mdc-text-field--filled mdc-text-field--textarea mdc-text-field--no-label">
           <span class="mdc-text-field__ripple"></span>
           <span class="mdc-text-field__resizer">
-            <span id="credits-loading-spinner" style="display: none;">
+            <span id="edit-loading-spinner" style="display: none;">
               <i class="ms-2 material-icons">
                 {% include 'components/loading_spinner.html.twig' with {'size': 'small'} %}
               </i>
             </span>
-            <textarea class="mdc-text-field__input" id="edit-credits" name="edit-credits" title="_edit-credits"
-                      maxlength="{{ max_description_size }}" style="width: 100%" rows="10" cols="100">
-              {% if program.credits %}{{ program.credits }}{% else %}{{ "noCredits"|trans({}, "catroweb") }}{% endif %}
-            </textarea>          </span>
+            <textarea class="mdc-text-field__input mt-2 mb-2" id="edit-text" name="edit-text" title="_edit-text"
+                      style="width: 100%" rows="10" cols="100">
+            </textarea>
+          </span>
           <span class="mdc-line-ripple"></span>
         </label>
 
         <div class="row justify-content-between" style="margin-top: 1rem; padding-right: 0.75rem;">
           <div class="form-group col-8">
-            <div id="credits-language-selector" class="mdc-select mdc-select--outlined"  {% if (program.credits == null) %} style="display: none;" {% endif %}>
+            <div id="edit-language-selector" class="mdc-select mdc-select--outlined">
               <div class="mdc-select__anchor" aria-labelledby="outlined-select-label">
                 <span class="mdc-notched-outline">
                   <span class="mdc-notched-outline__leading"></span>
                   <span class="mdc-notched-outline__notch">
-                    <span id="credits-outlined-select-label"
-                          class="mdc-floating-label">{{ 'footer.language'|trans({}, "catroweb") }}</span>
+                    <span class="mdc-floating-label">{{ 'footer.language'|trans({}, "catroweb") }}</span>
                   </span>
                   <span class="mdc-notched-outline__trailing"></span>
                 </span>
                 <span class="mdc-select__selected-text-container">
-                  <span id="credits-selected-text" class="mdc-select__selected-text" data-selected-value="default"></span>
+                  <span id="edit-selected-language" class="mdc-select__selected-text" data-selected-value="default"></span>
                 </span>
                 <span class="mdc-select__dropdown-icon">
                   {% include 'components/mdc_select_svg.html.twig' %}
                 </span>
               </div>
               <div class="mdc-select__menu mdc-menu mdc-menu-surface mdc-menu-surface--fullwidth">
-                <ul id="credit-language-selector-list" class="mdc-list" role="listbox">
+                <ul id="edit-language-selector-list" class="mdc-list" role="listbox">
                   <li class="mdc-list-item" data-value="default" role="option">
                       <span class="mdc-list-item__ripple"></span>
                       <span class="mdc-list-item__text">
@@ -179,9 +115,9 @@
             </div>
           </div>
 
-          <button id="edit-credits-submit-button" class="btn btn-primary p-3 col-4">
+          <button id="edit-submit-button" class="btn btn-primary p-3 col-4">
             <i class="material-icons align-bottom">save</i>
-            {{ 'programs.saveCredits'|trans({}, 'catroweb') }}
+            {{ 'programs.save'|trans({}, 'catroweb') }}
           </button>
         </div>
       </div>

--- a/tests/behat/context/CatrowebBrowserContext.php
+++ b/tests/behat/context/CatrowebBrowserContext.php
@@ -888,7 +888,7 @@ class CatrowebBrowserContext extends BrowserContext
    */
   public function iWriteInTextarea($arg1): void
   {
-    $textarea = $this->getSession()->getPage()->find('css', '#edit-credits');
+    $textarea = $this->getSession()->getPage()->find('css', '#edit-text');
     Assert::assertNotNull($textarea, 'Textarea not found');
     $textarea->setValue($arg1);
   }

--- a/tests/behat/features/web/project-details/project_credits.feature
+++ b/tests/behat/features/web/project-details/project_credits.feature
@@ -39,9 +39,9 @@ Feature: As a project owner, I should be able to give credits for my project.
     And the element ".edit-credits-button" should be visible
     When I click ".edit-credits-button"
     And I wait for AJAX to finish
-    Then the element "#edit-credits" should be visible
+    Then the element "#edit-text" should be visible
     And I write "This is a credit" in textarea
-    When I click "#edit-credits-submit-button"
+    When I click "#edit-submit-button"
     And I wait for AJAX to finish
     Then I should see "This is a credit"
   
@@ -52,13 +52,13 @@ Feature: As a project owner, I should be able to give credits for my project.
     Then the element "#edit-credits-button" should be visible
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
-    Then I fill in "edit-credits" with "These are new notes and credits"
-    And I click "#close-credits-editor-button"
+    Then I fill in "edit-text" with "These are new notes and credits"
+    And I click "#edit-close-button"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-confirm"
     And I wait for AJAX to finish
     Then the element "#credits" should be visible
-    And the element "#edit-credits-ui" should not be visible
+    And the element "#edit-text-ui" should not be visible
     And I should see "These are new notes and credits"
 
   Scenario: Editing credits, closing the editor while discarding edits
@@ -68,12 +68,12 @@ Feature: As a project owner, I should be able to give credits for my project.
     Then the element "#edit-credits-button" should be visible
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
-    Then I fill in "edit-credits" with "These are new notes and credits"
-    And I click "#close-credits-editor-button"
+    Then I fill in "edit-text" with "These are new notes and credits"
+    And I click "#edit-close-button"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-deny"
     Then the element "#credits" should be visible
-    And the element "#edit-credits-ui" should not be visible
+    And the element "#edit-text-ui" should not be visible
     And I should see "No notes and credits"
 
   Scenario: Editing credits, closing the editor but going back to unsaved changes
@@ -83,9 +83,9 @@ Feature: As a project owner, I should be able to give credits for my project.
     Then the element "#edit-credits-button" should be visible
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
-    Then I fill in "edit-credits" with "These are new notes and credits"
-    And I click "#close-credits-editor-button"
+    Then I fill in "edit-text" with "These are new notes and credits"
+    And I click "#edit-close-button"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-close"
-    Then the element "#edit-credits" should be visible
-    Then the "edit-credits" field should contain "These are new notes and credits"
+    Then the element "#edit-text" should be visible
+    Then the "edit-text" field should contain "These are new notes and credits"

--- a/tests/behat/features/web/project-details/project_description.feature
+++ b/tests/behat/features/web/project-details/project_description.feature
@@ -15,14 +15,14 @@ Feature: Projects should have descriptions that can be changed by the project ow
     Given I am on "/app/project/1"
     And I wait for the page to be loaded
     Then the element "#edit-description-button" should not exist
-    And the element "#edit-description-ui" should not exist
+    And the element "#edit-text-ui" should not exist
 
   Scenario: Changing description is not possible if it's not my project
     Given I log in as "OtherUser"
     When I go to "/app/project/1"
     And I wait for the page to be loaded
     Then the element "#edit-description-button" should not exist
-    And the element "#edit-description-ui" should not exist
+    And the element "#edit-text-ui" should not exist
 
   Scenario: Changing description is possible if it's my project
     Given I log in as "OtherUser"
@@ -32,13 +32,13 @@ Feature: Projects should have descriptions that can be changed by the project ow
     When I click "#edit-description-button"
     And I wait for AJAX to finish
     Then the element "#description" should not be visible
-    But the element "#edit-description" should be visible
-    And the element "#edit-description-submit-button" should be visible
-    When I fill in "edit-description" with "This is a new description"
-    And I click "#edit-description-submit-button"
+    But the element "#edit-text" should be visible
+    And the element "#edit-submit-button" should be visible
+    When I fill in "edit-text" with "This is a new description"
+    And I click "#edit-submit-button"
     And I wait for AJAX to finish
     Then the element "#description" should be visible
-    And the element "#edit-description-ui" should not be visible
+    And the element "#edit-text-ui" should not be visible
     And I should see "This is a new description"
   
   Scenario: Editing description, closing the editor while saving edits
@@ -48,13 +48,13 @@ Feature: Projects should have descriptions that can be changed by the project ow
     Then the element "#edit-description-button" should be visible
     When I click "#edit-description-button"
     And I wait for AJAX to finish
-    Then I fill in "edit-description" with "This is a new description"
-    And I click "#close-description-editor-button"
+    Then I fill in "edit-text" with "This is a new description"
+    And I click "#edit-close-button"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-confirm"
     And I wait for AJAX to finish
     Then the element "#description" should be visible
-    And the element "#edit-description-ui" should not be visible
+    And the element "#edit-text-ui" should not be visible
     And I should see "This is a new description"
 
   Scenario: Editing description, closing the editor while discarding edits
@@ -64,12 +64,12 @@ Feature: Projects should have descriptions that can be changed by the project ow
     Then the element "#edit-description-button" should be visible
     When I click "#edit-description-button"
     And I wait for AJAX to finish
-    Then I fill in "edit-description" with "This is a new description"
-    And I click "#close-description-editor-button"
+    Then I fill in "edit-text" with "This is a new description"
+    And I click "#edit-close-button"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-deny"
     Then the element "#description" should be visible
-    And the element "#edit-description-ui" should not be visible
+    And the element "#edit-text-ui" should not be visible
     And I should see "my description"
 
   Scenario: Editing description, closing the editor but going back to unsaved changes
@@ -79,12 +79,12 @@ Feature: Projects should have descriptions that can be changed by the project ow
     Then the element "#edit-description-button" should be visible
     When I click "#edit-description-button"
     And I wait for AJAX to finish
-    Then I fill in "edit-description" with "This is a new description"
-    And I click "#close-description-editor-button"
+    Then I fill in "edit-text" with "This is a new description"
+    And I click "#edit-close-button"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-close"
-    Then the element "#edit-description" should be visible
-    Then the "edit-description" field should contain "This is a new description"
+    Then the element "#edit-text" should be visible
+    Then the "edit-text" field should contain "This is a new description"
 
   Scenario: Large Project Descriptions are only fully visible when show more was clicked
     Given there are programs with a large description:

--- a/tests/behat/features/web/translation/credits_custom_translation.feature
+++ b/tests/behat/features/web/translation/credits_custom_translation.feature
@@ -3,84 +3,94 @@ Feature: Projects should have credits where a custom translation can be defined
 
   Background:
     Given there are users:
-      | id | name      |
-      | 1  | Catrobat  |
+      | id | name     |
+      | 1  | Catrobat |
     And there are projects:
-      | id | name      | owned by  | credit     |
-      | 1  | project 1 | Catrobat  | my credits |
+      | id | name      | owned by | credit     |
+      | 1  | project 1 | Catrobat | my credits |
 
-  Scenario: Adding and viewing a custom credits translation
+  Scenario: Custom translation editor should be visible
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
-    Then the element "#edit-credits-button" should be visible
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
     Then the element "#credits" should not be visible
-    But the element "#edit-credits" should be visible
-    And the element "#credits-language-selector" should be visible
-    And the element "#edit-credits-submit-button" should be visible
-    Then I choose "French" from selector "#credits-language-selector"
-    And I wait for AJAX to finish
-    Then I fill in "edit-credits" with "This is a credit translation"
-    And I click "#edit-credits-submit-button"
-    And I wait for AJAX to finish
-    Then the element "#credits" should be visible
-    And the element "#edit-credits-ui" should not be visible
-    And I should see "my credits"
+    But the element "#edit-text" should be visible
+    And the element "#edit-text-ui" should be visible
+    And the element "#edit-language-selector" should be visible
+    And the element "#edit-submit-button" should be visible
+
+  Scenario: Adding a custom credits translation
+    Given I log in as "Catrobat"
+    And I go to "/app/project/1"
+    And I wait for the page to be loaded
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
-    Then the element "#edit-credits" should be visible
-    And the element "#credits-language-selector" should be visible
-    Then I choose "French" from selector "#credits-language-selector"
+    Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
-    Then the "edit-credits" field should contain "This is a credit translation"
+    Then I fill in "edit-text" with "This is a credit translation"
+    And I click "#edit-submit-button"
+    And I wait for AJAX to finish
+    And I should see "my credits"
+
+  Scenario: Viewing a custom description translation
+    Given there are project custom translations:
+      | project_id | language | name | description | credit                       |
+      | 1          | fr       |      |             | This is a credit translation |
+    And I log in as "Catrobat"
+    And I go to "/app/project/1"
+    And I wait for the page to be loaded
+    When I click "#edit-credits-button"
+    And I wait for AJAX to finish
+    Then the element "#edit-text" should be visible
+    And the element "#edit-language-selector" should be visible
+    Then I choose "French" from selector "#edit-language-selector"
+    And I wait for AJAX to finish
+    Then the "edit-text" field should contain "This is a credit translation"
 
   Scenario: Editing custom translation, then changing the language and keeping the unsaved changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
-    Then the element "#edit-credits-button" should be visible
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
-    Then I choose "French" from selector "#credits-language-selector"
+    Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
-    Then I fill in "edit-credits" with "This is a credit translation"
-    Then I choose "Russian" from selector "#credits-language-selector"
+    Then I fill in "edit-text" with "This is a credit translation"
+    Then I choose "Russian" from selector "#edit-language-selector"
     And I should see "Would you like to keep your current changes?"
     When I click ".swal2-confirm"
-    Then the "edit-credits" field should contain "This is a credit translation"
+    Then the "edit-text" field should contain "This is a credit translation"
     And I should see "Russian"
 
   Scenario: Editing custom translation, then changing the language while discarding changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
-    Then the element "#edit-credits-button" should be visible
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
-    Then I choose "French" from selector "#credits-language-selector"
+    Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
-    Then I fill in "edit-credits" with "This is a credit translation"
-    Then I choose "Russian" from selector "#credits-language-selector"
+    Then I fill in "edit-text" with "This is a credit translation"
+    Then I choose "Russian" from selector "#edit-language-selector"
     And I should see "Would you like to keep your current changes?"
     When I click ".swal2-deny"
     And I wait for AJAX to finish
-    Then the "edit-credits" field should contain ""
+    Then the "edit-text" field should contain ""
     And I should see "Russian"
 
   Scenario: Editing custom translation, then changing the language but going back to unsaved changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
-    Then the element "#edit-credits-button" should be visible
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
-    Then I choose "French" from selector "#credits-language-selector"
+    Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
-    Then I fill in "edit-credits" with "This is a credit translation"
-    Then I choose "Russian" from selector "#credits-language-selector"
+    Then I fill in "edit-text" with "This is a credit translation"
+    Then I choose "Russian" from selector "#edit-language-selector"
     And I should see "Would you like to keep your current changes?"
     When I click ".swal2-close"
-    Then the "edit-credits" field should contain "This is a credit translation"
+    Then the "edit-text" field should contain "This is a credit translation"
     And I should see "French"

--- a/tests/behat/features/web/translation/description_custom_translation.feature
+++ b/tests/behat/features/web/translation/description_custom_translation.feature
@@ -3,84 +3,92 @@ Feature: Projects should have descriptions where a custom translation can be def
 
   Background:
     Given there are users:
-      | id | name      |
-      | 1  | Catrobat  |
+      | id | name     |
+      | 1  | Catrobat |
     And there are projects:
-      | id | name      | owned by  | description    |
-      | 1  | project 1 | Catrobat  | my description |
+      | id | name      | owned by | description    |
+      | 1  | project 1 | Catrobat | my description |
 
-  Scenario: Adding and viewing a custom description translation
+  Scenario: Custom translation editor should be visible
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
-    Then the element "#edit-description-button" should be visible
     When I click "#edit-description-button"
     And I wait for AJAX to finish
     Then the element "#description" should not be visible
-    But the element "#edit-description" should be visible
-    And the element "#description-language-selector" should be visible
-    And the element "#edit-description-submit-button" should be visible
-    Then I choose "French" from selector "#description-language-selector"
-    And I wait for AJAX to finish
-    Then I fill in "edit-description" with "This is a description translation"
-    And I click "#edit-description-submit-button"
-    And I wait for AJAX to finish
-    Then the element "#description" should be visible
-    And the element "#edit-description-ui" should not be visible
-    And I should see "my description"
+    But the element "#edit-text" should be visible
+    And the element "#edit-text-ui" should be visible
+    And the element "#edit-language-selector" should be visible
+    And the element "#edit-submit-button" should be visible
+
+  Scenario: Adding a custom description translation
+    Given I log in as "Catrobat"
+    And I go to "/app/project/1"
+    And I wait for the page to be loaded
     When I click "#edit-description-button"
     And I wait for AJAX to finish
-    Then the element "#edit-description" should be visible
-    And the element "#description-language-selector" should be visible
-    Then I choose "French" from selector "#description-language-selector"
+    Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
-    Then the "edit-description" field should contain "This is a description translation"
+    Then I fill in "edit-text" with "This is a description translation"
+    And I click "#edit-submit-button"
+    And I wait for AJAX to finish
+    Then I should see "my description"
+
+  Scenario: Viewing a custom description translation
+    Given there are project custom translations:
+      | project_id | language | name | description                       | credit |
+      | 1          | fr       |      | This is a description translation |        |
+    And I log in as "Catrobat"
+    And I go to "/app/project/1"
+    And I wait for the page to be loaded
+    When I click "#edit-description-button"
+    And I wait for AJAX to finish
+    Then I choose "French" from selector "#edit-language-selector"
+    And I wait for AJAX to finish
+    Then the "edit-text" field should contain "This is a description translation"
 
   Scenario: Editing custom translation, then changing the language and keeping the unsaved changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
-    Then the element "#edit-description-button" should be visible
     When I click "#edit-description-button"
     And I wait for AJAX to finish
-    Then I choose "French" from selector "#description-language-selector"
+    Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
-    Then I fill in "edit-description" with "This is a description translation"
-    Then I choose "Russian" from selector "#description-language-selector"
+    Then I fill in "edit-text" with "This is a description translation"
+    Then I choose "Russian" from selector "#edit-language-selector"
     And I should see "Would you like to keep your current changes?"
     When I click ".swal2-confirm"
-    Then the "edit-description" field should contain "This is a description translation"
+    Then the "edit-text" field should contain "This is a description translation"
     And I should see "Russian"
 
   Scenario: Editing custom translation, then changing the language while discarding changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
-    Then the element "#edit-description-button" should be visible
     When I click "#edit-description-button"
     And I wait for AJAX to finish
-    Then I choose "French" from selector "#description-language-selector"
+    Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
-    Then I fill in "edit-description" with "This is a description translation"
-    Then I choose "Russian" from selector "#description-language-selector"
+    Then I fill in "edit-text" with "This is a description translation"
+    Then I choose "Russian" from selector "#edit-language-selector"
     And I should see "Would you like to keep your current changes?"
     When I click ".swal2-deny"
     And I wait for AJAX to finish
-    Then the "edit-description" field should contain ""
+    Then the "edit-text" field should contain ""
     And I should see "Russian"
 
   Scenario: Editing custom translation, then changing the language but going back to unsaved changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
-    Then the element "#edit-description-button" should be visible
     When I click "#edit-description-button"
     And I wait for AJAX to finish
-    Then I choose "French" from selector "#description-language-selector"
+    Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
-    Then I fill in "edit-description" with "This is a description translation"
-    Then I choose "Russian" from selector "#description-language-selector"
+    Then I fill in "edit-text" with "This is a description translation"
+    Then I choose "Russian" from selector "#edit-language-selector"
     And I should see "Would you like to keep your current changes?"
     When I click ".swal2-close"
-    Then the "edit-description" field should contain "This is a description translation"
+    Then the "edit-text" field should contain "This is a description translation"
     And I should see "French"

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -178,10 +178,8 @@ programs:
   deleted_popup_header: Deleted
   noAdminRights: You have no admin rights. Please Log in as an Admin.
   editDescription: Edit the project description
-  saveDescription: Save
   closeDescriptionEditor: Close description editor
   editCredits: Edit the project notes and credits
-  saveCredits: Save
   closeCreditsEditor: Close credits editor
   closeEditorPrompt: Do you want to save your changes?
   saveOnLanguageChange: Would you like to keep your current changes?
@@ -203,6 +201,7 @@ programs:
   translationSaved: Translation to %language% for the program %section% saved
   translationDeleted: Translation to %language% for the program %section% deleted
   default: Default
+  save: Save
 
 remixGraph:
   title: Remixes


### PR DESCRIPTION
Refactor the editor into a standalone, simple to reuse class.

There is now only one instance of the editor in the page to avoid duplicate in html as well.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
No UI change except some strings

Conceptually:

![Screenshot 2022-01-25 154703](https://user-images.githubusercontent.com/37479705/151058336-bae34b22-fad2-4208-b986-4587409d7a9f.png)

![Screenshot 2022-01-25 155649](https://user-images.githubusercontent.com/37479705/151058770-ed4523a4-e229-4295-abec-85d35247a0ab.png)

### Tests - additional information

No new tests, just rename some references in tests
