### PR TITLE
Invalidate translation cache when project is edited

### DIFF
--- a/src/DB/Entity/Project/Program.php
+++ b/src/DB/Entity/Project/Program.php
@@ -360,6 +360,11 @@ class Program
   private Collection $custom_translations;
 
   /**
+   * No ORM entry.
+   */
+  private bool $should_invalidate_translation_cache = false;
+
+  /**
    * Program constructor.
    */
   public function __construct()
@@ -440,6 +445,7 @@ class Program
   public function setName(string $name): Program
   {
     $this->name = $name;
+    $this->should_invalidate_translation_cache = true;
 
     return $this;
   }
@@ -452,6 +458,7 @@ class Program
   public function setDescription(?string $description): Program
   {
     $this->description = $description;
+    $this->should_invalidate_translation_cache = true;
 
     return $this;
   }
@@ -464,6 +471,7 @@ class Program
   public function setCredits(?string $credits): Program
   {
     $this->credits = $credits;
+    $this->should_invalidate_translation_cache = true;
 
     return $this;
   }
@@ -980,5 +988,10 @@ class Program
     $this->rand = $rand;
 
     return $this;
+  }
+
+  public function shouldInvalidateTranslationCache(): bool
+  {
+    return $this->should_invalidate_translation_cache;
   }
 }

--- a/src/DB/Entity/Translation/ProjectMachineTranslation.php
+++ b/src/DB/Entity/Translation/ProjectMachineTranslation.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\HasLifecycleCallbacks;
 
 /**
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="App\DB\EntityRepository\Project\ProjectMachineTranslationRepository")
  * @ORM\Table(name="project_machine_translation")
  * @HasLifecycleCallbacks
  */

--- a/src/DB/EntityRepository/Project/ProjectMachineTranslationRepository.php
+++ b/src/DB/EntityRepository/Project/ProjectMachineTranslationRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\DB\EntityRepository\Project;
+
+use App\DB\Entity\Project\Program;
+use App\DB\Entity\Translation\ProjectMachineTranslation;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
+use Doctrine\Persistence\ManagerRegistry;
+
+class ProjectMachineTranslationRepository extends ServiceEntityRepository
+{
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, ProjectMachineTranslation::class);
+  }
+
+  /**
+   * @throws OptimisticLockException
+   * @throws ORMException
+   */
+  public function invalidateCachedTranslation(Program $project): void
+  {
+    /** @var ProjectMachineTranslation[] $entries */
+    $entries = $this->findBy(['project' => $project]);
+
+    foreach ($entries as $entry) {
+      $entry->invalidateCachedTranslation();
+      $this->getEntityManager()->persist($entry);
+    }
+    $this->getEntityManager()->flush();
+  }
+}

--- a/src/Project/EventListener/ProjectPostUpdateNotifier.php
+++ b/src/Project/EventListener/ProjectPostUpdateNotifier.php
@@ -5,6 +5,7 @@ namespace App\Project\EventListener;
 use App\DB\Entity\Project\Program;
 use App\DB\Entity\Project\Tag;
 use App\DB\Entity\User\User;
+use App\DB\EntityRepository\Project\ProjectMachineTranslationRepository;
 use App\DB\EntityRepository\Project\TagRepository;
 use App\User\Achievements\AchievementManager;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
@@ -14,17 +15,21 @@ class ProjectPostUpdateNotifier
 {
   protected AchievementManager $achievement_manager;
   protected TagRepository $tag_repository;
+  private ProjectMachineTranslationRepository $machine_translation_repository;
 
-  public function __construct(AchievementManager $achievement_manager, TagRepository $tag_repository)
+  public function __construct(AchievementManager $achievement_manager, TagRepository $tag_repository,
+                              ProjectMachineTranslationRepository $machine_translation_repository)
   {
     $this->achievement_manager = $achievement_manager;
     $this->tag_repository = $tag_repository;
+    $this->machine_translation_repository = $machine_translation_repository;
   }
 
   public function postUpdate(Program $project, LifecycleEventArgs $event): void
   {
     $user = $project->getUser();
     $this->addCodingJam092021Achievement($project, $user);
+    $this->invalidateTranslationCacheIfNecessary($project);
   }
 
   /**
@@ -47,6 +52,13 @@ class ProjectPostUpdateNotifier
         $program->addTag($coding_jam_09_2021_tag);
       }
       $this->achievement_manager->unlockAchievementCodingJam092021($user);
+    }
+  }
+
+  private function invalidateTranslationCacheIfNecessary(Program $project): void
+  {
+    if ($project->shouldInvalidateTranslationCache()) {
+      $this->machine_translation_repository->invalidateCachedTranslation($project);
     }
   }
 }

--- a/src/System/Testing/Behat/Context/DataFixturesContext.php
+++ b/src/System/Testing/Behat/Context/DataFixturesContext.php
@@ -1385,8 +1385,12 @@ class DataFixturesContext implements KernelAwareContext
       $target_language = $config['target_language'];
       $provider = $config['provider'];
       $usage_count = $config['usage_count'];
+      $cached_name = $config['cached_name'] ?? null;
+      $cached_description = $config['cached_description'] ?? null;
+      $cached_credits = $config['cached_credits'] ?? null;
 
       $project_machine_translation = new ProjectMachineTranslation($project, $source_language, $target_language, $provider, $usage_count);
+      $project_machine_translation->setCachedTranslation($cached_name, $cached_description, $cached_credits);
       $this->getManager()->persist($project_machine_translation);
     }
     $this->getManager()->flush();

--- a/tests/BehatFeatures/web/translation/credits_custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/credits_custom_translation.feature
@@ -8,6 +8,7 @@ Feature: Projects should have credits where a custom translation can be defined
     And there are projects:
       | id | name      | owned by | credit     |
       | 1  | project 1 | Catrobat | my credits |
+    And I wait 1000 milliseconds
 
   Scenario: Custom translation editor should be visible
     Given I log in as "Catrobat"
@@ -25,6 +26,7 @@ Feature: Projects should have credits where a custom translation can be defined
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
@@ -41,6 +43,7 @@ Feature: Projects should have credits where a custom translation can be defined
     And I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
     Then the element "#edit-text" should be visible
@@ -53,6 +56,7 @@ Feature: Projects should have credits where a custom translation can be defined
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
@@ -68,6 +72,7 @@ Feature: Projects should have credits where a custom translation can be defined
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
@@ -84,6 +89,7 @@ Feature: Projects should have credits where a custom translation can be defined
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-credits-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"

--- a/tests/BehatFeatures/web/translation/description_custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/description_custom_translation.feature
@@ -8,6 +8,7 @@ Feature: Projects should have descriptions where a custom translation can be def
     And there are projects:
       | id | name      | owned by | description    |
       | 1  | project 1 | Catrobat | my description |
+    And I wait 1000 milliseconds
 
   Scenario: Custom translation editor should be visible
     Given I log in as "Catrobat"
@@ -25,6 +26,7 @@ Feature: Projects should have descriptions where a custom translation can be def
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-description-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
@@ -41,6 +43,7 @@ Feature: Projects should have descriptions where a custom translation can be def
     And I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-description-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
@@ -51,6 +54,7 @@ Feature: Projects should have descriptions where a custom translation can be def
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-description-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
@@ -66,6 +70,7 @@ Feature: Projects should have descriptions where a custom translation can be def
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-description-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
@@ -82,6 +87,7 @@ Feature: Projects should have descriptions where a custom translation can be def
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-description-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"

--- a/tests/BehatFeatures/web/translation/invalidate_machine_translation_cache.feature
+++ b/tests/BehatFeatures/web/translation/invalidate_machine_translation_cache.feature
@@ -1,0 +1,78 @@
+@web
+Feature: Invalidate project cached machine translation
+
+  Background:
+    Given there are users:
+      | id | name     |
+      | 1  | Catrobat |
+      | 2  | Alice    |
+    And there are projects:
+      | id | name     | owned by | description  | credit  |
+      | 1  | project1 | Catrobat | description1 | credit1 |
+      | 2  | project2 | Catrobat | description2 | credit2 |
+
+  Scenario Outline: Invalidate cached translation when project is edited
+    Given there are project machine translations:
+      | project_id | source_language | target_language | provider   | usage_count | cached_name         | cached_description      | cached_credits     |
+      | 1          | en              | fr-FR           | itranslate | 16          | translated project1 | translated description1 | translated credit1 |
+    And I POST login with user "Catrobat" and password "123456"
+    When I have a request parameter "value" with value "new value"
+    And I request "PUT" "/app/<url>/1"
+    Then there should be project machine translations:
+      | project_id | source_language | target_language | provider   | usage_count |
+      | 1          | en              | fr-FR           | itranslate | 16          |
+
+    Examples:
+      | url                    |
+      | editProjectName        |
+      | editProjectDescription |
+      | editProjectCredits     |
+
+  Scenario Outline: Edits should not invalidate cached translation when not logged in
+    Given there are project machine translations:
+      | project_id | source_language | target_language | provider   | usage_count | cached_name         | cached_description      | cached_credits     |
+      | 1          | en              | fr-FR           | itranslate | 16          | translated project1 | translated description1 | translated credit1 |
+    When I have a request parameter "value" with value "new value"
+    And I request "PUT" "/app/<url>/1"
+    Then there should be project machine translations:
+      | project_id | source_language | target_language | provider   | usage_count | cached_name         | cached_description      | cached_credits     |
+      | 1          | en              | fr-FR           | itranslate | 16          | translated project1 | translated description1 | translated credit1 |
+
+    Examples:
+      | url                    |
+      | editProjectName        |
+      | editProjectDescription |
+      | editProjectCredits     |
+
+  Scenario Outline: Nothing happens when other project properties are changed
+    Given there are project machine translations:
+      | project_id | source_language | target_language | provider   | usage_count | cached_name         | cached_description      | cached_credits     |
+      | 1          | en              | fr-FR           | itranslate | 16          | translated project1 | translated description1 | translated credit1 |
+    And I log in as "<user>"
+    When I go to "<url>"
+    Then there should be project machine translations:
+      | project_id | source_language | target_language | provider   | usage_count | cached_name         | cached_description      | cached_credits     |
+      | 1          | en              | fr-FR           | itranslate | 16          | translated project1 | translated description1 | translated credit1 |
+
+    Examples:
+      | user     | url                            |
+      | Catroweb | /app/userDeleteProject/1           |
+      | Catroweb | /app/userToggleProjectVisibility/1 |
+      | Alice    | /app/project/like/1                |
+
+  Scenario Outline: Nothing happens when other projects are edited
+    Given there are project machine translations:
+      | project_id | source_language | target_language | provider   | usage_count | cached_name         | cached_description      | cached_credits     |
+      | 1          | en              | fr-FR           | itranslate | 16          | translated project1 | translated description1 | translated credit1 |
+    And I POST login with user "Catrobat" and password "123456"
+    When I have a request parameter "value" with value "new value"
+    And I request "PUT" "/app/<url>/2"
+    Then there should be project machine translations:
+      | project_id | source_language | target_language | provider   | usage_count | cached_name         | cached_description      | cached_credits     |
+      | 1          | en              | fr-FR           | itranslate | 16          | translated project1 | translated description1 | translated credit1 |
+
+    Examples:
+      | url                    |
+      | editProjectName        |
+      | editProjectDescription |
+      | editProjectCredits     |

--- a/tests/BehatFeatures/web/translation/name_custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/name_custom_translation.feature
@@ -8,6 +8,7 @@ Feature: Projects should have a name where a custom translation can be defined
     And there are projects:
       | id | name      | owned by |
       | 1  | project 1 | Catrobat |
+    And I wait 1000 milliseconds
 
   Scenario: Custom translation editor should be visible
     Given I log in as "Catrobat"
@@ -24,6 +25,7 @@ Feature: Projects should have a name where a custom translation can be defined
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-name-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
@@ -40,6 +42,7 @@ Feature: Projects should have a name where a custom translation can be defined
     And I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-name-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
@@ -50,6 +53,7 @@ Feature: Projects should have a name where a custom translation can be defined
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-name-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
@@ -65,6 +69,7 @@ Feature: Projects should have a name where a custom translation can be defined
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-name-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
@@ -81,6 +86,7 @@ Feature: Projects should have a name where a custom translation can be defined
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
+    And I wait 10000 milliseconds
     When I click "#edit-name-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"

--- a/tests/BehatFeatures/web/translation/persist_machine_translation.feature
+++ b/tests/BehatFeatures/web/translation/persist_machine_translation.feature
@@ -1,5 +1,5 @@
 @web
-Feature: Persist project and comment translation
+Feature: Persist project and comment machine translation
 
   Background:
     Given there are users:


### PR DESCRIPTION
Design consideration:
There are different ways to do this:
 - i could have called invalidate directly from the edit api function
 - i could have emitted an event from the edit api 
     - these two have the same problem: when new openapi are created, like POST /project/{id}, you'd have to remember to copy over this code for invalidating
 - i used the `postUpdate` in the existing event listener


---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
