### PR TITLE
Google Translate: fix unicode string length count

### DIFF
--- a/src/Translation/GoogleTranslateApi.php
+++ b/src/Translation/GoogleTranslateApi.php
@@ -180,7 +180,7 @@ class GoogleTranslateApi implements TranslationApiInterface
       return 0;
     }
 
-    if (strlen($text) <= $this->short_text_length) {
+    if (mb_strlen($text) <= $this->short_text_length) {
       return 1;
     }
 

--- a/tests/PhpUnit/Translation/GoogleTranslateApiTest.php
+++ b/tests/PhpUnit/Translation/GoogleTranslateApiTest.php
@@ -79,11 +79,13 @@ class GoogleTranslateApiTest extends TestCase
 
   public function testLongText(): void
   {
-    $this->assertEquals(0.5, $this->api->getPreference('testing', null, 'en'));
+    $this->assertEquals(0.5, $this->api->getPreference('test12', null, 'en'));
+    $this->assertEquals(0.5, $this->api->getPreference('Невтии', null, 'en'));
   }
 
   public function testShortText(): void
   {
-    $this->assertEquals(1, $this->api->getPreference('test', null, 'en'));
+    $this->assertEquals(1, $this->api->getPreference('test1', null, 'en'));
+    $this->assertEquals(1, $this->api->getPreference('Невти', null, 'en'));
   }
 }


### PR DESCRIPTION
Google translate count unicode character as one character

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
