### PR TITLE
Add Custom Translation Navigation Screen

### DIFF
--- a/assets/js/api/CustomTranslationApi.js
+++ b/assets/js/api/CustomTranslationApi.js
@@ -53,4 +53,13 @@ export class CustomTranslationApi {
       })
     })
   }
+
+  getCustomTranslationLanguages (programId, successCallback, errorCallback = () => {}) {
+    $.ajax({
+      url: '../translate/custom/project/' + programId + '/list',
+      type: 'get',
+      success: successCallback,
+      error: errorCallback
+    })
+  }
 }

--- a/assets/js/components/ProjectEditorNavigation.js
+++ b/assets/js/components/ProjectEditorNavigation.js
@@ -1,0 +1,138 @@
+import $ from 'jquery'
+import { CustomTranslationApi } from '../api/CustomTranslationApi'
+import { showDefaultTopBarTitle, showCustomTopBarTitle } from '../layout/top_bar'
+
+export function ProjectEditorNavigation (projectDescriptionCredits, programId, programEditor) {
+  const self = this
+
+  this.programId = programId
+  this.programEditor = programEditor
+
+  this.body = $('body')
+  this.editTextNavigation = $('#edit-text-navigation')
+  this.navigationLanguageList = $('#navigation-language-list')
+
+  this.languages = {}
+
+  this.customTranslationApi = new CustomTranslationApi()
+
+  this.translationsText = projectDescriptionCredits.data('trans-translations')
+  this.defaultText = projectDescriptionCredits.data('trans-default')
+  this.translationTitleText = projectDescriptionCredits.data('trans-translation-title')
+  this.editDefaultText = projectDescriptionCredits.data('trans-edit-default')
+  this.editTranslationText = projectDescriptionCredits.data('trans-edit-translation')
+  this.createTranslationText = projectDescriptionCredits.data('trans-create-translation')
+
+  $('#add-translation-button').on('click', () => { this.openEditor(null, true, false, this.createTranslationText) })
+
+  $(document).ready(getLanguages)
+
+  $(document).on('click', '.edit-defined-translation', function () {
+    const language = $(this).data('value')
+    const languageName = $(this).data('language')
+
+    if (language === 'default') {
+      self.openEditor(language, false, false, self.editDefaultText)
+    } else {
+      self.openEditor(language, false, true, self.translationTitleText.replace('%language%', languageName))
+    }
+  })
+
+  this.show = () => {
+    window.history.pushState(
+      { type: 'ProjectEditorNavigation', id: programId, full: true },
+      $(this).text(),
+      '#navigation'
+    )
+
+    $(window).on('popstate', this.popStateHandler)
+    showCustomTopBarTitle(this.translationsText, function () {
+      window.history.back()
+    })
+
+    this.body.addClass('overflow-hidden')
+    this.editTextNavigation.removeClass('d-none')
+  }
+
+  // region private
+
+  this.popStateHandler = () => {
+    this.close()
+  }
+
+  this.close = () => {
+    $(window).off('popstate', this.popStateHandler)
+    showDefaultTopBarTitle()
+
+    this.body.removeClass('overflow-hidden')
+    this.editTextNavigation.addClass('d-none')
+  }
+
+  this.openEditor = (language, showLanguageSelect, showDeleteButton, headerText) => {
+    $(window).off('popstate', this.popStateHandler)
+
+    this.programEditor.show(
+      this.reopenNavigation,
+      language,
+      showLanguageSelect,
+      showDeleteButton,
+      headerText
+    )
+  }
+
+  this.reopenNavigation = () => {
+    $(window).on('popstate', this.popStateHandler)
+
+    showCustomTopBarTitle(this.translationsText, function () {
+      window.history.back()
+    })
+
+    this.editTextNavigation.removeClass('d-none')
+
+    this.getTranslations()
+  }
+
+  function getLanguages () {
+    $.ajax({
+      url: '../languages',
+      type: 'get',
+      success: function (data) {
+        self.languages = data
+        self.getTranslations()
+      }
+    })
+  }
+
+  this.getTranslations = () => {
+    this.customTranslationApi.getCustomTranslationLanguages(
+      this.programId,
+      this.showTranslations
+    )
+  }
+
+  this.showTranslations = (translationLanguages) => {
+    this.navigationLanguageList.empty()
+    this.navigationLanguageList.append(
+      '<li>' +
+        '<div id="edit-default-button" class="text-icon-aligned edit-defined-translation" data-value="default">' +
+          '<span class="language-code"></span>' +
+          '<span class="language-name">' + this.defaultText + '</span>' +
+          '<span data-bs-toggle="tooltip" title="' + this.editDefaultText + '" class="catro-icon-button material-icons trailing-icon " style="font-size: 1.75rem;">edit</span>' +
+        '</div>' +
+      '</li>'
+    )
+
+    for (const language of translationLanguages) {
+      this.navigationLanguageList.append(
+        `<li>\
+          <div id="edit-${language}-button" class="text-icon-aligned edit-defined-translation" data-value="${language}" data-language="${this.languages[language]}">\
+            <span class="language-code">${language}</span>\
+            <span class="language-name">${this.languages[language]}</span>\
+            <span data-bs-toggle="tooltip" title="${this.editTranslationText.replace('%language%', this.languages[language])}" class="catro-icon-button material-icons trailing-icon " style="font-size: 1.75rem;">edit</span>\
+          </div>\
+        </li>`)
+    }
+  }
+
+  // end region
+}

--- a/assets/js/custom/ProgramName.js
+++ b/assets/js/custom/ProgramName.js
@@ -1,6 +1,6 @@
 import $ from 'jquery'
 
-export function ProgramName (programId, usersLanguage, myProgram, customTranslationApi, editor) {
+export function ProgramName (programId, usersLanguage, myProgram, customTranslationApi, editorNavigation) {
   const name = $('#name')
   const editProgramButton = $('#edit-program-button')
 
@@ -17,6 +17,6 @@ export function ProgramName (programId, usersLanguage, myProgram, customTranslat
   }
 
   editProgramButton.on('click', () => {
-    editor.show()
+    editorNavigation.show()
   })
 }

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -12,6 +12,7 @@ import { ProgramDescription } from './custom/ProgramDescription'
 import { ProgramCredits } from './custom/ProgramCredits'
 import { ProgramComments } from './custom/ProgramComments'
 import { CustomTranslationApi } from './api/CustomTranslationApi'
+import { ProjectEditorNavigation } from './components/ProjectEditorNavigation'
 import { ProjectEditor } from './components/ProjectEditor'
 import { ProjectEditorTextField } from './components/ProjectEditorTextField'
 import { ProgramName } from './custom/ProgramName'
@@ -26,7 +27,7 @@ const $projectDescriptionCredits = $('.js-project-description-credits')
 const $projectComments = $('.js-project-comments')
 const $appLanguage = $('#app-language')
 
-let editor = null
+let editorNavigation = null
 
 if ($project.data('my-program')) {
   new MDCTextField(document.querySelector('.comment-message'))
@@ -52,14 +53,16 @@ if ($project.data('my-program')) {
     $projectDescriptionCredits.data('has-credits')
   )
 
-  const showLanguageSelect = $projectDescriptionCredits.data('has-description') || $projectDescriptionCredits.data('has-credits')
-
-  editor = new ProjectEditor(
+  const projectEditor = new ProjectEditor(
     $projectDescriptionCredits,
     $projectDescriptionCredits.data('project-id'),
-    [nameEditorTextField, descriptionEditorTextField, creditsEditorTextField],
-    showLanguageSelect,
-    $projectDescriptionCredits.data('trans-default')
+    [nameEditorTextField, descriptionEditorTextField, creditsEditorTextField]
+  )
+
+  editorNavigation = new ProjectEditorNavigation(
+    $projectDescriptionCredits,
+    $projectDescriptionCredits.data('project-id'),
+    projectEditor
   )
 }
 
@@ -121,7 +124,7 @@ ProgramName(
   $appLanguage.data('app-language'),
   $project.data('my-program'),
   new CustomTranslationApi('name'),
-  editor
+  editorNavigation
 )
 
 ProgramDescription(

--- a/assets/styles/custom/program.scss
+++ b/assets/styles/custom/program.scss
@@ -625,6 +625,39 @@ input[type="number"] {
   background: #fff;
 }
 
+.translation-list {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+.edit-defined-translation {
+  padding: 1rem 2rem;
+  border-bottom: solid;
+  border-color: grey;
+  cursor: pointer;
+}
+
+.language-code {
+  width: 3rem;
+  color: grey;
+}
+
+.language-name {
+  font-weight: bold;
+}
+
+.add-translation-button {
+  position: fixed;
+  width: 60px;
+  height: 60px;
+  bottom: 40px;
+  right: 40px;
+  text-align: center;
+  font-size: 40px;
+  padding-top: 8px;
+  box-shadow: 2px 2px 3px #999;
+}
+
 @media only screen and (min-width: 768px) {
   .sign-app-form {
     label {

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -118,6 +118,8 @@
 
   {% include 'Program/program_description.html.twig' %}
 
+  {% include 'Program/program_editor_navigation.html.twig' %}
+
   {% include 'Program/program_editor.html.twig' %}
 
   {% include 'Program/program_tags.html.twig' %}
@@ -274,7 +276,12 @@
        data-trans-keep="{{ "programs.btnKeep"|trans({}, "catroweb") }}"
        data-trans-delete="{{ "programs.delete"|trans({}, "catroweb") }}"
        data-trans-default="{{ "programs.default"|trans({}, "catroweb") }}"
-       data-trans-save-on-language-change="{{ "programs.saveOnLanguageChange"|trans({}, "catroweb") }}"\
+       data-trans-save-on-language-change="{{ "programs.saveOnLanguageChange"|trans({}, "catroweb") }}"
+       data-trans-translation-title="{{ "programs.translationTitle"|trans({}, "catroweb") }}"
+       data-trans-edit-default="{{ "programs.editDefault"|trans({}, "catroweb") }}"
+       data-trans-edit-translation="{{ "programs.editTranslation"|trans({}, "catroweb") }}"
+       data-trans-create-translation="{{ "programs.createTranslation"|trans({}, "catroweb") }}"
+       data-trans-translations="{{ "programs.translations"|trans({}, "catroweb") }}"
        data-path-edit-program-name="{{ path('edit_program_name', {'id': program.id}) }}"
        data-path-edit-program-description="{{ path('edit_program_description', {'id': program.id}) }}"
        data-path-edit-program-credits="{{ path('edit_program_credits', {'id': program.id}) }}"

--- a/templates/Program/program_editor_navigation.html.twig
+++ b/templates/Program/program_editor_navigation.html.twig
@@ -1,0 +1,12 @@
+<div class="row">
+  <div class="col">
+    {% if app.user and my_program %}
+      <div id="edit-text-navigation" class="d-none mb-5 full-screen">
+        <ul id="navigation-language-list" class="translation-list">
+        </ul>
+        <i id="add-translation-button" class="add-translation-button material-icons catro-round-icon-button"
+          data-bs-toggle="tooltip" title="{{ 'programs.createTranslation'|trans({}, 'catroweb') }}">add</i>
+      </div>
+    {% endif %}
+  </div>
+</div>

--- a/tests/BehatFeatures/web/project-details/project_credits.feature
+++ b/tests/BehatFeatures/web/project-details/project_credits.feature
@@ -25,6 +25,9 @@ Feature: As a project owner, I should be able to give credits for my project.
     And the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then I should see "Default"
+    When I click "#edit-default-button"
+    And I wait for AJAX to finish
     Then the element "#edit-credits-text" should be visible
     And I fill in "edit-credits-text" with "This is a credit"
     When I click "#edit-submit-button"
@@ -38,12 +41,16 @@ Feature: As a project owner, I should be able to give credits for my project.
     Then the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then I should see "Default"
+    When I click "#edit-default-button"
+    And I wait for AJAX to finish
     Then I fill in "edit-credits-text" with "These are new notes and credits"
     And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-confirm"
     And I wait for AJAX to finish
     Then the element "#credits" should be visible
+    And the element "#edit-text-navigation" should not be visible
     And the element "#edit-text-ui" should not be visible
     And I should see "These are new notes and credits"
 
@@ -54,11 +61,17 @@ Feature: As a project owner, I should be able to give credits for my project.
     Then the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then I should see "Default"
+    When I click "#edit-default-button"
+    And I wait for AJAX to finish
     Then I fill in "edit-credits-text" with "These are new notes and credits"
     And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-deny"
+    Then the element "#edit-text-navigation" should be visible
+    When I click "#top-app-bar__back__btn-back"
     Then the element "#credits" should be visible
+    And the element "#edit-text-navigation" should not be visible
     And the element "#edit-text-ui" should not be visible
     And I should see "No notes and credits available."
 
@@ -68,6 +81,9 @@ Feature: As a project owner, I should be able to give credits for my project.
     And I wait for the page to be loaded
     Then the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then I should see "Default"
+    When I click "#edit-default-button"
     And I wait for AJAX to finish
     Then I fill in "edit-credits-text" with "These are new notes and credits"
     And I click "#top-app-bar__back__btn-back"

--- a/tests/BehatFeatures/web/project-details/project_description.feature
+++ b/tests/BehatFeatures/web/project-details/project_description.feature
@@ -18,6 +18,9 @@ Feature: Projects should have descriptions that can be changed by the project ow
     Then the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then I should see "Default"
+    When I click "#edit-default-button"
+    And I wait for AJAX to finish
     Then the element "#edit-description-text" should be visible
     When I fill in "edit-description-text" with "This is a new description"
     And I click "#edit-submit-button"
@@ -33,12 +36,16 @@ Feature: Projects should have descriptions that can be changed by the project ow
     Then the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then I should see "Default"
+    When I click "#edit-default-button"
+    And I wait for AJAX to finish
     Then I fill in "edit-description-text" with "This is a new description"
     And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-confirm"
     And I wait for AJAX to finish
     Then the element "#description" should be visible
+    And the element "#edit-text-navigation" should not be visible
     And the element "#edit-text-ui" should not be visible
     And I should see "This is a new description"
 
@@ -49,11 +56,17 @@ Feature: Projects should have descriptions that can be changed by the project ow
     Then the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then I should see "Default"
+    When I click "#edit-default-button"
+    And I wait for AJAX to finish
     Then I fill in "edit-description-text" with "This is a new description"
     And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-deny"
+    Then the element "#edit-text-navigation" should be visible
+    When I click "#top-app-bar__back__btn-back"
     Then the element "#description" should be visible
+    And the element "#edit-text-navigation" should not be visible
     And the element "#edit-text-ui" should not be visible
     And I should see "my description"
 
@@ -63,6 +76,9 @@ Feature: Projects should have descriptions that can be changed by the project ow
     And I wait for the page to be loaded
     Then the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then I should see "Default"
+    When I click "#edit-default-button"
     And I wait for AJAX to finish
     Then I fill in "edit-description-text" with "This is a new description"
     And I click "#top-app-bar__back__btn-back"

--- a/tests/BehatFeatures/web/project-details/project_editor.feature
+++ b/tests/BehatFeatures/web/project-details/project_editor.feature
@@ -27,6 +27,7 @@ Feature: As a project owner, I should be able to provide and edit name, descript
     Given I am on "/app/project/1"
     And I wait for the page to be loaded
     Then the element "#edit-program-button" should not exist
+    And the element "#edit-text-navigation" should not exist
     And the element "#edit-text-ui" should not exist
 
   Scenario: Creating all fields is possible if it's my project
@@ -36,6 +37,11 @@ Feature: As a project owner, I should be able to provide and edit name, descript
     Then the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then the element "#edit-text-navigation" should be visible
+    And I should see "Default"
+    And the element "#edit-default-button" should be visible
+    When I click "#edit-default-button"
+    And I wait for AJAX to finish
     Then the element "#edit-text-ui" should be visible
     And the element "#edit-submit-button" should be visible
     When I fill in "edit-name-text" with "This is a new name"
@@ -44,6 +50,7 @@ Feature: As a project owner, I should be able to provide and edit name, descript
     And I click "#edit-submit-button"
     And I wait for AJAX to finish
     Then the element "#edit-text-ui" should not be visible
+    And the element "#edit-text-navigation" should not be visible
     And I should see "This is a new name"
     And I should see "This is a new description"
     And I should see "This is a new credit"
@@ -55,6 +62,10 @@ Feature: As a project owner, I should be able to provide and edit name, descript
     Then the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then the element "#edit-text-navigation" should be visible
+    And I should see "Default"
+    When I click "#edit-default-button"
+    And I wait for AJAX to finish
     Then the element "#edit-text-ui" should be visible
     And the element "#edit-submit-button" should be visible
     When I fill in "edit-name-text" with "This is a new name"
@@ -63,6 +74,7 @@ Feature: As a project owner, I should be able to provide and edit name, descript
     And I click "#edit-submit-button"
     And I wait for AJAX to finish
     Then the element "#edit-text-ui" should not be visible
+    And the element "#edit-text-navigation" should not be visible
     And I should see "This is a new name"
     And I should see "This is a new description"
     And I should see "This is a new credit"
@@ -73,6 +85,10 @@ Feature: As a project owner, I should be able to provide and edit name, descript
     And I wait for the page to be loaded
     Then the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then the element "#edit-text-navigation" should be visible
+    And I should see "Default"
+    When I click "#edit-default-button"
     And I wait for AJAX to finish
     Then the element "#edit-text-ui" should be visible
     And the element "#edit-cancel-button" should be visible

--- a/tests/BehatFeatures/web/project-details/project_name.feature
+++ b/tests/BehatFeatures/web/project-details/project_name.feature
@@ -18,12 +18,16 @@ Feature: Projects should have a name that can be changed by the project owner
     Then the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then I should see "Default"
+    When I click "#edit-default-button"
+    And I wait for AJAX to finish
     Then the element "#edit-name-text" should be visible
     And the element "#edit-submit-button" should be visible
     When I fill in "edit-name-text" with "This is a new name"
     And I click "#edit-submit-button"
     And I wait for AJAX to finish
     Then the element "#name" should be visible
+    And the element "#edit-text-navigation" should not be visible
     And the element "#edit-text-ui" should not be visible
     And I should see "This is a new name"
   
@@ -34,12 +38,16 @@ Feature: Projects should have a name that can be changed by the project owner
     Then the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then I should see "Default"
+    When I click "#edit-default-button"
+    And I wait for AJAX to finish
     Then I fill in "edit-name-text" with "This is a new name"
     And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-confirm"
     And I wait for AJAX to finish
     Then the element "#name" should be visible
+    And the element "#edit-text-navigation" should not be visible
     And the element "#edit-text-ui" should not be visible
     And I should see "This is a new name"
 
@@ -50,11 +58,17 @@ Feature: Projects should have a name that can be changed by the project owner
     Then the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then I should see "Default"
+    When I click "#edit-default-button"
+    And I wait for AJAX to finish
     Then I fill in "edit-name-text" with "This is a new name"
     And I click "#top-app-bar__back__btn-back"
     And I should see "Do you want to save your changes?"
     When I click ".swal2-deny"
+    Then the element "#edit-text-navigation" should be visible
+    When I click "#top-app-bar__back__btn-back"
     Then the element "#name" should be visible
+    And the element "#edit-text-navigation" should not be visible
     And the element "#edit-text-ui" should not be visible
     And I should see "project 1"
 
@@ -64,6 +78,9 @@ Feature: Projects should have a name that can be changed by the project owner
     And I wait for the page to be loaded
     Then the element "#edit-program-button" should be visible
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then I should see "Default"
+    When I click "#edit-default-button"
     And I wait for AJAX to finish
     Then I fill in "edit-name-text" with "This is a new name"
     And I click "#top-app-bar__back__btn-back"

--- a/tests/BehatFeatures/web/translation/credits_custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/credits_custom_translation.feature
@@ -11,12 +11,15 @@ Feature: Projects should have credits where a custom translation can be defined
       | 2  | project 2 | Catrobat |            |
     And I wait 1000 milliseconds
 
-  Scenario: Editing custom translation, then changing the language and keeping the unsaved changes
+  Scenario: Adding a custom credits translation, then changing the language and keeping the unsaved changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then the element "#add-translation-button" should be visible
+    When I click "#add-translation-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
@@ -27,12 +30,15 @@ Feature: Projects should have credits where a custom translation can be defined
     Then the "edit-credits-text" field should contain "This is a credit translation"
     And the "#edit-selected-language" element should contain "Russian"
 
-  Scenario: Editing custom translation, then changing the language while discarding changes
+  Scenario: Adding a custom credits translation, then changing the language while discarding changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then the element "#add-translation-button" should be visible
+    When I click "#add-translation-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
@@ -44,12 +50,15 @@ Feature: Projects should have credits where a custom translation can be defined
     Then the "edit-credits-text" field should contain ""
     And the "#edit-selected-language" element should contain "Russian"
 
-  Scenario: Editing custom translation, then changing the language but going back to unsaved changes
+  Scenario: Adding a custom credits translation, then changing the language but going back to unsaved changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then the element "#add-translation-button" should be visible
+    When I click "#add-translation-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
@@ -60,7 +69,7 @@ Feature: Projects should have credits where a custom translation can be defined
     And I wait for AJAX to finish
     Then the "edit-credits-text" field should contain "This is a credit translation"
     And the "#edit-selected-language" element should contain "French"
-
+  
   Scenario: Credit text field should be disabled if there is not a default credit defined
     Given I log in as "Catrobat"
     And I go to "/app/project/2"
@@ -68,10 +77,14 @@ Feature: Projects should have credits where a custom translation can be defined
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then the element "#add-translation-button" should be visible
+    When I click "#add-translation-button"
+    And I wait for AJAX to finish
     Then the element "#edit-credits-text" should not be disabled
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
     Then the element "#edit-credits-text" should be disabled
+    And I should see "No notes and credits available."
 
   Scenario: Adding a default credit, then changing the language without saving and keeping the unsaved changes
     Given I log in as "Catrobat"
@@ -79,6 +92,9 @@ Feature: Projects should have credits where a custom translation can be defined
     And I wait for the page to be loaded
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then the element "#add-translation-button" should be visible
+    When I click "#add-translation-button"
     And I wait for AJAX to finish
     Then I fill in "edit-credits-text" with "This is a default credit"
     When I choose "French" from selector "#edit-language-selector"

--- a/tests/BehatFeatures/web/translation/custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/custom_translation.feature
@@ -17,12 +17,19 @@ Feature: Projects should have an editor a custom translation can be defined
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then the element "#edit-text-navigation" should be visible
+    And the element "#edit-default-button" should be visible
+    And the element "#add-translation-button" should be visible
+    When I click "#add-translation-button"
+    And I wait for AJAX to finish
     Then the element "#edit-name-text" should be visible
     And the element "#edit-description-text" should be visible
     And the element "#edit-credits-text" should be visible
     And the element "#edit-text-ui" should be visible
     And the element "#edit-language-selector" should be visible
+    And the element "#edit-cancel-button" should be visible
     And the element "#edit-submit-button" should be visible
+    And the element "#edit-delete-button" should not be visible
 
   Scenario: Adding a custom translation
     Given I log in as "Catrobat"
@@ -31,6 +38,9 @@ Feature: Projects should have an editor a custom translation can be defined
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then the element "#edit-text-navigation" should be visible
+    When I click "#add-translation-button"
+    And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
     Then I fill in "edit-name-text" with "This is a name translation"
@@ -38,6 +48,10 @@ Feature: Projects should have an editor a custom translation can be defined
     And I fill in "edit-credits-text" with "This is a credit translation"
     And I click "#edit-submit-button"
     And I wait for AJAX to finish
+    Then the element "#edit-text-navigation" should be visible
+    And the element "#edit-fr-button" should exist
+    And I should see "French"
+    When I click "#top-app-bar__back__btn-back"
     Then I should see "project 1"
     And I should see "my description"
     And I should see "my credits"
@@ -52,11 +66,20 @@ Feature: Projects should have an editor a custom translation can be defined
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
     And I wait for AJAX to finish
-    Then the element "#edit-credits-text" should be visible
-    And the element "#edit-language-selector" should be visible
-    Then I choose "French" from selector "#edit-language-selector"
+    Then the element "#edit-text-navigation" should be visible
+    And the element "#edit-fr-button" should be visible
+    And I should see "French"
+    When I click "#edit-fr-button"
     And I wait for AJAX to finish
-    Then the "edit-name-text" field should contain "name translation"
+    Then the element "#edit-text-ui" should be visible
+    And the element "#edit-name-text" should be visible
+    And the element "#edit-description-text" should be visible
+    And the element "#edit-credits-text" should be visible
+    And the element "#edit-submit-button" should be visible
+    And the element "#edit-cancel-button" should be visible
+    And the element "#edit-delete-button" should be visible
+    And the element "#edit-language-selector" should not be visible
+    And the "edit-name-text" field should contain "name translation"
     And the "edit-description-text" field should contain "description translation"
     And the "edit-credits-text" field should contain "credit translation"
 
@@ -70,8 +93,8 @@ Feature: Projects should have an editor a custom translation can be defined
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
     And I wait for AJAX to finish
-    Then the element "#edit-language-selector" should be visible
-    Then I choose "French" from selector "#edit-language-selector"
+    Then the element "#edit-fr-button" should be visible
+    When I click "#edit-fr-button"
     And I wait for AJAX to finish
     When I click "#edit-delete-button"
     Then should see "Are you sure you want to delete the translation?"

--- a/tests/BehatFeatures/web/translation/description_custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/description_custom_translation.feature
@@ -11,12 +11,15 @@ Feature: Projects should have descriptions where a custom translation can be def
       | 2  | project 2 | Catrobat |                |
     And I wait 1000 milliseconds
 
-  Scenario: Editing custom translation, then changing the language and keeping the unsaved changes
+  Scenario: Adding a custom description translation, then changing the language and keeping the unsaved changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then the element "#add-translation-button" should be visible
+    When I click "#add-translation-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
@@ -27,12 +30,15 @@ Feature: Projects should have descriptions where a custom translation can be def
     Then the "edit-description-text" field should contain "This is a description translation"
     And the "#edit-selected-language" element should contain "Russian"
 
-  Scenario: Editing custom translation, then changing the language while discarding changes
+  Scenario: Adding a custom description translation, then changing the language while discarding changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then the element "#add-translation-button" should be visible
+    When I click "#add-translation-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
@@ -44,12 +50,15 @@ Feature: Projects should have descriptions where a custom translation can be def
     Then the "edit-description-text" field should contain ""
     And the "#edit-selected-language" element should contain "Russian"
 
-  Scenario: Editing custom translation, then changing the language but going back to unsaved changes
+  Scenario: Adding a custom description translation, then changing the language but going back to unsaved changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then the element "#add-translation-button" should be visible
+    When I click "#add-translation-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
@@ -68,17 +77,23 @@ Feature: Projects should have descriptions where a custom translation can be def
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
     And I wait for AJAX to finish
+    Then the element "#add-translation-button" should be visible
+    When I click "#add-translation-button"
+    And I wait for AJAX to finish
     Then the element "#edit-description-text" should not be disabled
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
     Then the element "#edit-description-text" should be disabled
-  
+
   Scenario: Adding a default description, then changing the language without saving and keeping the unsaved changes
     Given I log in as "Catrobat"
     And I go to "/app/project/2"
     And I wait for the page to be loaded
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then the element "#add-translation-button" should be visible
+    When I click "#add-translation-button"
     And I wait for AJAX to finish
     Then I fill in "edit-description-text" with "This is a default description"
     When I choose "French" from selector "#edit-language-selector"

--- a/tests/BehatFeatures/web/translation/name_custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/name_custom_translation.feature
@@ -10,12 +10,15 @@ Feature: Projects should have a name where a custom translation can be defined
       | 1  | project 1 | Catrobat |
     And I wait 1000 milliseconds
 
-  Scenario: Editing custom translation, then changing the language and keeping the unsaved changes
+  Scenario: Adding a custom name translation, then changing the language and keeping the unsaved changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then the element "#add-translation-button" should be visible
+    When I click "#add-translation-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
@@ -26,12 +29,15 @@ Feature: Projects should have a name where a custom translation can be defined
     Then the "edit-name-text" field should contain "This is a name translation"
     And the "#edit-selected-language" element should contain "Russian"
 
-  Scenario: Editing custom translation, then changing the language while discarding changes
+  Scenario: Adding a custom name translation, then changing the language while discarding changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then the element "#add-translation-button" should be visible
+    When I click "#add-translation-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
@@ -43,12 +49,15 @@ Feature: Projects should have a name where a custom translation can be defined
     Then the "edit-name-text" field should contain ""
     And the "#edit-selected-language" element should contain "Russian"
 
-  Scenario: Editing custom translation, then changing the language but going back to unsaved changes
+  Scenario: Adding a custom name translation, then changing the language but going back to unsaved changes
     Given I log in as "Catrobat"
     And I go to "/app/project/1"
     And I wait for the page to be loaded
     And I wait 10000 milliseconds
     When I click "#edit-program-button"
+    And I wait for AJAX to finish
+    Then the element "#add-translation-button" should be visible
+    When I click "#add-translation-button"
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -205,6 +205,11 @@ programs:
   confrimDelete: Are you sure you want to delete the translation?
   default: Default
   save: Save
+  translationTitle: '%language% translation'
+  editDefault: Edit default
+  editTranslation: Edit %language% translation
+  translations: Translations
+  createTranslation: Create translation
 
 remixGraph:
   title: Remixes


### PR DESCRIPTION
Add a navigation screen to allow users to navigate between different defined translations. Also, separate adding and editing a custom translation into two different processes.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
The new navigation screen displays buttons that link to each defined translation. Then a separate button to add a new custom translation. When the user adds a new translation, they can select which language they want to define and cancel or save any additions. When a user edits an existing translation, they cannot change the language, but they can delete the translation and cancel or save any changes.

Also, with this change, most of the functionality in the following document is implemented.
[catrobat custom translations](https://docs.google.com/document/d/1IU-12Np7yajbz2Gt9rkfm2jasQlt7trhliu1gqE1k4Y/edit?usp=sharing)

### Tests - additional information
All tests that are impacted by this change have been updated.
