### PR TITLE
Disable Cancel and Submit Buttons in Project Editor

### DIFF
--- a/assets/js/components/ProjectEditor.js
+++ b/assets/js/components/ProjectEditor.js
@@ -15,6 +15,8 @@ export function ProjectEditor (projectDescriptionCredits, programId, textFields)
   this.languageSelectorList = $('#edit-language-selector-list')
   this.selectedLanguage = $('#edit-selected-language')
   this.textLoadingSpinner = $('#edit-loading-spinner')
+  this.saveButton = $('#edit-submit-button')
+  this.cancelButton = $('#edit-cancel-button')
 
   this.languageSelect = new MDCSelect(document.querySelector('#edit-language-selector'))
   this.languages = {}
@@ -43,9 +45,9 @@ export function ProjectEditor (projectDescriptionCredits, programId, textFields)
   this.translationDeleted = projectDescriptionCredits.data('trans-translation-deleted')
   this.cannotDelete = projectDescriptionCredits.data('trans-cannot-delete')
 
-  $('#edit-submit-button').on('click', () => { this.save() })
+  this.saveButton.on('click', () => { this.save() })
 
-  $('#edit-cancel-button').on('click', () => { this.cancelChanges() })
+  this.cancelButton.on('click', () => { this.cancelChanges() })
 
   $('#edit-delete-button').on('click', () => { this.deleteTranslation() })
 
@@ -61,6 +63,8 @@ export function ProjectEditor (projectDescriptionCredits, programId, textFields)
       this.keepOrDiscardDialog.show(keepOrDiscardChangesResult)
     }
   })
+
+  $('.mdc-text-field__input').change(checkTextFields)
 
   $(document).ready(getLanguages)
 
@@ -174,6 +178,15 @@ export function ProjectEditor (projectDescriptionCredits, programId, textFields)
     return true
   }
 
+  function checkTextFields () {
+    disableButtons(self.areChangesSaved())
+  }
+
+  function disableButtons (disable) {
+    self.saveButton.attr('disabled', disable)
+    self.cancelButton.attr('disabled', disable)
+  }
+
   function keepOrDiscardChangesResult (result) {
     if (result.isConfirmed) {
       self.previousIndex = self.languageSelect.selectedIndex
@@ -264,6 +277,8 @@ export function ProjectEditor (projectDescriptionCredits, programId, textFields)
     for (const textField of this.textFields) {
       textField.getNewText(this.languageSelect.value)
     }
+
+    disableButtons(true)
   }
 
   // end region

--- a/tests/BehatFeatures/web/project-details/project_credits.feature
+++ b/tests/BehatFeatures/web/project-details/project_credits.feature
@@ -29,7 +29,8 @@ Feature: As a project owner, I should be able to give credits for my project.
     When I click "#edit-default-button"
     And I wait for AJAX to finish
     Then the element "#edit-credits-text" should be visible
-    And I fill in "edit-credits-text" with "This is a credit"
+    When I fill in "edit-credits-text" with "This is a credit"
+    Then the element "#edit-submit-button" should not be disabled
     When I click "#edit-submit-button"
     And I wait for AJAX to finish
     Then I should see "This is a credit"

--- a/tests/BehatFeatures/web/project-details/project_description.feature
+++ b/tests/BehatFeatures/web/project-details/project_description.feature
@@ -23,7 +23,8 @@ Feature: Projects should have descriptions that can be changed by the project ow
     And I wait for AJAX to finish
     Then the element "#edit-description-text" should be visible
     When I fill in "edit-description-text" with "This is a new description"
-    And I click "#edit-submit-button"
+    Then the element "#edit-submit-button" should not be disabled
+    When I click "#edit-submit-button"
     And I wait for AJAX to finish
     Then the element "#description" should be visible
     And the element "#edit-text-ui" should not be visible

--- a/tests/BehatFeatures/web/project-details/project_editor.feature
+++ b/tests/BehatFeatures/web/project-details/project_editor.feature
@@ -44,10 +44,12 @@ Feature: As a project owner, I should be able to provide and edit name, descript
     And I wait for AJAX to finish
     Then the element "#edit-text-ui" should be visible
     And the element "#edit-submit-button" should be visible
+    And the element "#edit-submit-button" should be disabled
     When I fill in "edit-name-text" with "This is a new name"
     And I fill in "edit-description-text" with "This is a new description"
-    When I fill in "edit-credits-text" with "This is a new credit"
-    And I click "#edit-submit-button"
+    And I fill in "edit-credits-text" with "This is a new credit"
+    Then the element "#edit-submit-button" should not be disabled
+    When I click "#edit-submit-button"
     And I wait for AJAX to finish
     Then the element "#edit-text-ui" should not be visible
     And the element "#edit-text-navigation" should not be visible
@@ -68,10 +70,12 @@ Feature: As a project owner, I should be able to provide and edit name, descript
     And I wait for AJAX to finish
     Then the element "#edit-text-ui" should be visible
     And the element "#edit-submit-button" should be visible
+    And the element "#edit-submit-button" should be disabled
     When I fill in "edit-name-text" with "This is a new name"
     And I fill in "edit-description-text" with "This is a new description"
     And I fill in "edit-credits-text" with "This is a new credit"
-    And I click "#edit-submit-button"
+    Then the element "#edit-submit-button" should not be disabled
+    When I click "#edit-submit-button"
     And I wait for AJAX to finish
     Then the element "#edit-text-ui" should not be visible
     And the element "#edit-text-navigation" should not be visible
@@ -92,10 +96,12 @@ Feature: As a project owner, I should be able to provide and edit name, descript
     And I wait for AJAX to finish
     Then the element "#edit-text-ui" should be visible
     And the element "#edit-cancel-button" should be visible
+    And the element "#edit-cancel-button" should be disabled
     When I fill in "edit-name-text" with "This is a new name"
     And I fill in "edit-description-text" with "This is a new description"
     And I fill in "edit-credits-text" with "This is a new credit"
-    And I click "#edit-cancel-button"
+    Then the element "#edit-cancel-button" should not be disabled
+    When I click "#edit-cancel-button"
     Then I should see "project 2"
     And I should see "description 2"
     And I should see "credit 2"

--- a/tests/BehatFeatures/web/project-details/project_name.feature
+++ b/tests/BehatFeatures/web/project-details/project_name.feature
@@ -24,7 +24,8 @@ Feature: Projects should have a name that can be changed by the project owner
     Then the element "#edit-name-text" should be visible
     And the element "#edit-submit-button" should be visible
     When I fill in "edit-name-text" with "This is a new name"
-    And I click "#edit-submit-button"
+    Then the element "#edit-submit-button" should not be disabled
+    When I click "#edit-submit-button"
     And I wait for AJAX to finish
     Then the element "#name" should be visible
     And the element "#edit-text-navigation" should not be visible

--- a/tests/BehatFeatures/web/translation/credits_custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/credits_custom_translation.feature
@@ -29,6 +29,8 @@ Feature: Projects should have credits where a custom translation can be defined
     When I click ".swal2-confirm"
     Then the "edit-credits-text" field should contain "This is a credit translation"
     And the "#edit-selected-language" element should contain "Russian"
+    And the element "#edit-submit-button" should not be disabled
+    And the element "#edit-cancel-button" should not be disabled
 
   Scenario: Adding a custom credits translation, then changing the language while discarding changes
     Given I log in as "Catrobat"
@@ -49,6 +51,8 @@ Feature: Projects should have credits where a custom translation can be defined
     And I wait for AJAX to finish
     Then the "edit-credits-text" field should contain ""
     And the "#edit-selected-language" element should contain "Russian"
+    And the element "#edit-submit-button" should be disabled
+    And the element "#edit-cancel-button" should be disabled
 
   Scenario: Adding a custom credits translation, then changing the language but going back to unsaved changes
     Given I log in as "Catrobat"
@@ -69,6 +73,8 @@ Feature: Projects should have credits where a custom translation can be defined
     And I wait for AJAX to finish
     Then the "edit-credits-text" field should contain "This is a credit translation"
     And the "#edit-selected-language" element should contain "French"
+    And the element "#edit-submit-button" should not be disabled
+    And the element "#edit-cancel-button" should not be disabled
   
   Scenario: Credit text field should be disabled if there is not a default credit defined
     Given I log in as "Catrobat"
@@ -85,6 +91,8 @@ Feature: Projects should have credits where a custom translation can be defined
     And I wait for AJAX to finish
     Then the element "#edit-credits-text" should be disabled
     And I should see "No notes and credits available."
+    And the element "#edit-submit-button" should be disabled
+    And the element "#edit-cancel-button" should be disabled
 
   Scenario: Adding a default credit, then changing the language without saving and keeping the unsaved changes
     Given I log in as "Catrobat"

--- a/tests/BehatFeatures/web/translation/custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/custom_translation.feature
@@ -30,6 +30,8 @@ Feature: Projects should have an editor a custom translation can be defined
     And the element "#edit-cancel-button" should be visible
     And the element "#edit-submit-button" should be visible
     And the element "#edit-delete-button" should not be visible
+    And the element "#edit-submit-button" should be disabled
+    And the element "#edit-cancel-button" should be disabled
 
   Scenario: Adding a custom translation
     Given I log in as "Catrobat"
@@ -43,10 +45,14 @@ Feature: Projects should have an editor a custom translation can be defined
     And I wait for AJAX to finish
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
-    Then I fill in "edit-name-text" with "This is a name translation"
+    Then the element "#edit-submit-button" should be disabled
+    And the element "#edit-cancel-button" should be disabled
+    When I fill in "edit-name-text" with "This is a name translation"
     And I fill in "edit-description-text" with "This is a description translation"
     And I fill in "edit-credits-text" with "This is a credit translation"
-    And I click "#edit-submit-button"
+    Then the element "#edit-submit-button" should not be disabled
+    And the element "#edit-cancel-button" should not be disabled 
+    When I click "#edit-submit-button"
     And I wait for AJAX to finish
     Then the element "#edit-text-navigation" should be visible
     And the element "#edit-fr-button" should exist
@@ -79,6 +85,8 @@ Feature: Projects should have an editor a custom translation can be defined
     And the element "#edit-cancel-button" should be visible
     And the element "#edit-delete-button" should be visible
     And the element "#edit-language-selector" should not be visible
+    And the element "#edit-submit-button" should be disabled
+    And the element "#edit-cancel-button" should be disabled
     And the "edit-name-text" field should contain "name translation"
     And the "edit-description-text" field should contain "description translation"
     And the "edit-credits-text" field should contain "credit translation"

--- a/tests/BehatFeatures/web/translation/description_custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/description_custom_translation.feature
@@ -29,6 +29,8 @@ Feature: Projects should have descriptions where a custom translation can be def
     When I click ".swal2-confirm"
     Then the "edit-description-text" field should contain "This is a description translation"
     And the "#edit-selected-language" element should contain "Russian"
+    And the element "#edit-submit-button" should not be disabled
+    And the element "#edit-cancel-button" should not be disabled
 
   Scenario: Adding a custom description translation, then changing the language while discarding changes
     Given I log in as "Catrobat"
@@ -49,6 +51,8 @@ Feature: Projects should have descriptions where a custom translation can be def
     And I wait for AJAX to finish
     Then the "edit-description-text" field should contain ""
     And the "#edit-selected-language" element should contain "Russian"
+    And the element "#edit-submit-button" should be disabled
+    And the element "#edit-cancel-button" should be disabled
 
   Scenario: Adding a custom description translation, then changing the language but going back to unsaved changes
     Given I log in as "Catrobat"
@@ -69,6 +73,8 @@ Feature: Projects should have descriptions where a custom translation can be def
     And I wait for AJAX to finish
     Then the "edit-description-text" field should contain "This is a description translation"
     And the "#edit-selected-language" element should contain "French"
+    And the element "#edit-submit-button" should not be disabled
+    And the element "#edit-cancel-button" should not be disabled
 
   Scenario: Description text field should be disabled if there is not a default description defined
     Given I log in as "Catrobat"
@@ -84,6 +90,8 @@ Feature: Projects should have descriptions where a custom translation can be def
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
     Then the element "#edit-description-text" should be disabled
+    And the element "#edit-submit-button" should be disabled
+    And the element "#edit-cancel-button" should be disabled
 
   Scenario: Adding a default description, then changing the language without saving and keeping the unsaved changes
     Given I log in as "Catrobat"

--- a/tests/BehatFeatures/web/translation/name_custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/name_custom_translation.feature
@@ -28,6 +28,8 @@ Feature: Projects should have a name where a custom translation can be defined
     When I click ".swal2-confirm"
     Then the "edit-name-text" field should contain "This is a name translation"
     And the "#edit-selected-language" element should contain "Russian"
+    And the element "#edit-submit-button" should not be disabled
+    And the element "#edit-cancel-button" should not be disabled
 
   Scenario: Adding a custom name translation, then changing the language while discarding changes
     Given I log in as "Catrobat"
@@ -48,6 +50,8 @@ Feature: Projects should have a name where a custom translation can be defined
     And I wait for AJAX to finish
     Then the "edit-name-text" field should contain ""
     And the "#edit-selected-language" element should contain "Russian"
+    And the element "#edit-submit-button" should be disabled
+    And the element "#edit-cancel-button" should be disabled
 
   Scenario: Adding a custom name translation, then changing the language but going back to unsaved changes
     Given I log in as "Catrobat"
@@ -67,3 +71,5 @@ Feature: Projects should have a name where a custom translation can be defined
     When I click ".swal2-close"
     Then the "edit-name-text" field should contain "This is a name translation"
     And the "#edit-selected-language" element should contain "French"
+    And the element "#edit-submit-button" should not be disabled
+    And the element "#edit-cancel-button" should not be disabled


### PR DESCRIPTION
Disable the cancel and submit buttons in the project editor when there are no changes to undo or save.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
Additional information on the custom translation feature can be found here: [catrobat custom translations](https://docs.google.com/document/d/1IU-12Np7yajbz2Gt9rkfm2jasQlt7trhliu1gqE1k4Y/edit?usp=sharing)

### Tests - additional information
Added new checks to make sure that cancel and save buttons are disabled and enabled in the correct situation.
