### PR TITLE
Usability improvement on ProjectEditor.js

### DIFF
--- a/assets/js/components/ProjectEditor.js
+++ b/assets/js/components/ProjectEditor.js
@@ -16,7 +16,6 @@ export function ProjectEditor (projectDescriptionCredits, programId, textFields)
   this.selectedLanguage = $('#edit-selected-language')
   this.textLoadingSpinner = $('#edit-loading-spinner')
   this.saveButton = $('#edit-submit-button')
-  this.cancelButton = $('#edit-cancel-button')
 
   this.languageSelect = new MDCSelect(document.querySelector('#edit-language-selector'))
   this.languages = {}
@@ -47,8 +46,6 @@ export function ProjectEditor (projectDescriptionCredits, programId, textFields)
 
   this.saveButton.on('click', () => { this.save() })
 
-  this.cancelButton.on('click', () => { this.cancelChanges() })
-
   $('#edit-delete-button').on('click', () => { this.deleteTranslation() })
 
   this.languageSelect.listen('MDCSelect:change', () => {
@@ -64,7 +61,9 @@ export function ProjectEditor (projectDescriptionCredits, programId, textFields)
     }
   })
 
-  $('.mdc-text-field__input').change(checkTextFields)
+  $('.mdc-text-field__input').on('input', function () {
+    disableButtons(self.areChangesSaved())
+  })
 
   $(document).ready(getLanguages)
 
@@ -169,22 +168,11 @@ export function ProjectEditor (projectDescriptionCredits, programId, textFields)
   }
 
   this.areChangesSaved = () => {
-    for (const textField of this.textFields) {
-      if (!textField.areChangesSaved()) {
-        return false
-      }
-    }
-
-    return true
-  }
-
-  function checkTextFields () {
-    disableButtons(self.areChangesSaved())
+    return this.textFields.every(textField => textField.areChangesSaved())
   }
 
   function disableButtons (disable) {
     self.saveButton.attr('disabled', disable)
-    self.cancelButton.attr('disabled', disable)
   }
 
   function keepOrDiscardChangesResult (result) {
@@ -232,12 +220,6 @@ export function ProjectEditor (projectDescriptionCredits, programId, textFields)
         }
       }
     })
-  }
-
-  this.cancelChanges = () => {
-    for (const textField of this.textFields) {
-      textField.cancelChanges()
-    }
   }
 
   this.deleteTranslation = () => {

--- a/assets/js/components/ProjectEditorTextField.js
+++ b/assets/js/components/ProjectEditorTextField.js
@@ -89,10 +89,6 @@ export function ProjectEditorTextField (projectDescriptionCredits, programId, pr
     }
   }
 
-  this.cancelChanges = () => {
-    this.editText.val(this.lastSavedText)
-  }
-
   this.delete = (languageSelected) => {
     hideError()
     return this.customTranslationApi.deleteCustomTranslation(

--- a/templates/Program/program_editor.html.twig
+++ b/templates/Program/program_editor.html.twig
@@ -99,11 +99,6 @@
             {{ "programs.delete"|trans({}, "catroweb") }}
           </button>
 
-          <button id="edit-cancel-button" class="btn btn-primary" style="padding: 10px;">
-            <i class="material-icons align-bottom">cancel</i>
-            {{ "cancel"|trans({}, "catroweb") }}
-          </button>
-
           <button id="edit-submit-button" class="btn btn-primary" style="padding: 10px;">
             <i class="material-icons align-bottom">done</i>
             {{ "programs.save"|trans({}, "catroweb") }}

--- a/tests/BehatFeatures/web/project-details/project_editor.feature
+++ b/tests/BehatFeatures/web/project-details/project_editor.feature
@@ -82,26 +82,3 @@ Feature: As a project owner, I should be able to provide and edit name, descript
     And I should see "This is a new name"
     And I should see "This is a new description"
     And I should see "This is a new credit"
-  
-  Scenario: Canceling changes for all fields is possible with cancel button
-    Given I log in as "OtherUser"
-    And I go to "/app/project/2"
-    And I wait for the page to be loaded
-    Then the element "#edit-program-button" should be visible
-    When I click "#edit-program-button"
-    And I wait for AJAX to finish
-    Then the element "#edit-text-navigation" should be visible
-    And I should see "Default"
-    When I click "#edit-default-button"
-    And I wait for AJAX to finish
-    Then the element "#edit-text-ui" should be visible
-    And the element "#edit-cancel-button" should be visible
-    And the element "#edit-cancel-button" should be disabled
-    When I fill in "edit-name-text" with "This is a new name"
-    And I fill in "edit-description-text" with "This is a new description"
-    And I fill in "edit-credits-text" with "This is a new credit"
-    Then the element "#edit-cancel-button" should not be disabled
-    When I click "#edit-cancel-button"
-    Then I should see "project 2"
-    And I should see "description 2"
-    And I should see "credit 2"

--- a/tests/BehatFeatures/web/translation/credits_custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/credits_custom_translation.feature
@@ -30,7 +30,6 @@ Feature: Projects should have credits where a custom translation can be defined
     Then the "edit-credits-text" field should contain "This is a credit translation"
     And the "#edit-selected-language" element should contain "Russian"
     And the element "#edit-submit-button" should not be disabled
-    And the element "#edit-cancel-button" should not be disabled
 
   Scenario: Adding a custom credits translation, then changing the language while discarding changes
     Given I log in as "Catrobat"
@@ -52,7 +51,6 @@ Feature: Projects should have credits where a custom translation can be defined
     Then the "edit-credits-text" field should contain ""
     And the "#edit-selected-language" element should contain "Russian"
     And the element "#edit-submit-button" should be disabled
-    And the element "#edit-cancel-button" should be disabled
 
   Scenario: Adding a custom credits translation, then changing the language but going back to unsaved changes
     Given I log in as "Catrobat"
@@ -74,8 +72,7 @@ Feature: Projects should have credits where a custom translation can be defined
     Then the "edit-credits-text" field should contain "This is a credit translation"
     And the "#edit-selected-language" element should contain "French"
     And the element "#edit-submit-button" should not be disabled
-    And the element "#edit-cancel-button" should not be disabled
-  
+
   Scenario: Credit text field should be disabled if there is not a default credit defined
     Given I log in as "Catrobat"
     And I go to "/app/project/2"
@@ -92,7 +89,6 @@ Feature: Projects should have credits where a custom translation can be defined
     Then the element "#edit-credits-text" should be disabled
     And I should see "No notes and credits available."
     And the element "#edit-submit-button" should be disabled
-    And the element "#edit-cancel-button" should be disabled
 
   Scenario: Adding a default credit, then changing the language without saving and keeping the unsaved changes
     Given I log in as "Catrobat"

--- a/tests/BehatFeatures/web/translation/custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/custom_translation.feature
@@ -27,11 +27,9 @@ Feature: Projects should have an editor a custom translation can be defined
     And the element "#edit-credits-text" should be visible
     And the element "#edit-text-ui" should be visible
     And the element "#edit-language-selector" should be visible
-    And the element "#edit-cancel-button" should be visible
     And the element "#edit-submit-button" should be visible
     And the element "#edit-delete-button" should not be visible
     And the element "#edit-submit-button" should be disabled
-    And the element "#edit-cancel-button" should be disabled
 
   Scenario: Adding a custom translation
     Given I log in as "Catrobat"
@@ -46,12 +44,10 @@ Feature: Projects should have an editor a custom translation can be defined
     Then I choose "French" from selector "#edit-language-selector"
     And I wait for AJAX to finish
     Then the element "#edit-submit-button" should be disabled
-    And the element "#edit-cancel-button" should be disabled
     When I fill in "edit-name-text" with "This is a name translation"
     And I fill in "edit-description-text" with "This is a description translation"
     And I fill in "edit-credits-text" with "This is a credit translation"
     Then the element "#edit-submit-button" should not be disabled
-    And the element "#edit-cancel-button" should not be disabled 
     When I click "#edit-submit-button"
     And I wait for AJAX to finish
     Then the element "#edit-text-navigation" should be visible
@@ -82,11 +78,9 @@ Feature: Projects should have an editor a custom translation can be defined
     And the element "#edit-description-text" should be visible
     And the element "#edit-credits-text" should be visible
     And the element "#edit-submit-button" should be visible
-    And the element "#edit-cancel-button" should be visible
     And the element "#edit-delete-button" should be visible
     And the element "#edit-language-selector" should not be visible
     And the element "#edit-submit-button" should be disabled
-    And the element "#edit-cancel-button" should be disabled
     And the "edit-name-text" field should contain "name translation"
     And the "edit-description-text" field should contain "description translation"
     And the "edit-credits-text" field should contain "credit translation"

--- a/tests/BehatFeatures/web/translation/description_custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/description_custom_translation.feature
@@ -30,7 +30,6 @@ Feature: Projects should have descriptions where a custom translation can be def
     Then the "edit-description-text" field should contain "This is a description translation"
     And the "#edit-selected-language" element should contain "Russian"
     And the element "#edit-submit-button" should not be disabled
-    And the element "#edit-cancel-button" should not be disabled
 
   Scenario: Adding a custom description translation, then changing the language while discarding changes
     Given I log in as "Catrobat"
@@ -52,7 +51,6 @@ Feature: Projects should have descriptions where a custom translation can be def
     Then the "edit-description-text" field should contain ""
     And the "#edit-selected-language" element should contain "Russian"
     And the element "#edit-submit-button" should be disabled
-    And the element "#edit-cancel-button" should be disabled
 
   Scenario: Adding a custom description translation, then changing the language but going back to unsaved changes
     Given I log in as "Catrobat"
@@ -74,7 +72,6 @@ Feature: Projects should have descriptions where a custom translation can be def
     Then the "edit-description-text" field should contain "This is a description translation"
     And the "#edit-selected-language" element should contain "French"
     And the element "#edit-submit-button" should not be disabled
-    And the element "#edit-cancel-button" should not be disabled
 
   Scenario: Description text field should be disabled if there is not a default description defined
     Given I log in as "Catrobat"
@@ -91,7 +88,6 @@ Feature: Projects should have descriptions where a custom translation can be def
     And I wait for AJAX to finish
     Then the element "#edit-description-text" should be disabled
     And the element "#edit-submit-button" should be disabled
-    And the element "#edit-cancel-button" should be disabled
 
   Scenario: Adding a default description, then changing the language without saving and keeping the unsaved changes
     Given I log in as "Catrobat"

--- a/tests/BehatFeatures/web/translation/name_custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/name_custom_translation.feature
@@ -29,7 +29,6 @@ Feature: Projects should have a name where a custom translation can be defined
     Then the "edit-name-text" field should contain "This is a name translation"
     And the "#edit-selected-language" element should contain "Russian"
     And the element "#edit-submit-button" should not be disabled
-    And the element "#edit-cancel-button" should not be disabled
 
   Scenario: Adding a custom name translation, then changing the language while discarding changes
     Given I log in as "Catrobat"
@@ -51,7 +50,6 @@ Feature: Projects should have a name where a custom translation can be defined
     Then the "edit-name-text" field should contain ""
     And the "#edit-selected-language" element should contain "Russian"
     And the element "#edit-submit-button" should be disabled
-    And the element "#edit-cancel-button" should be disabled
 
   Scenario: Adding a custom name translation, then changing the language but going back to unsaved changes
     Given I log in as "Catrobat"
@@ -72,4 +70,3 @@ Feature: Projects should have a name where a custom translation can be defined
     Then the "edit-name-text" field should contain "This is a name translation"
     And the "#edit-selected-language" element should contain "French"
     And the element "#edit-submit-button" should not be disabled
-    And the element "#edit-cancel-button" should not be disabled


### PR DESCRIPTION
- immediate enabling of buttons while typing
- remove cancel button, which should have the same function as back button

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
![image](https://user-images.githubusercontent.com/37479705/164789494-037068b6-4e9d-42d7-8d55-b77059587e2f.png)

### Tests - additional information
`TODO: add additional information about testruns here`
