### PR TITLE
SHARE-520 Constraint issue Delete User

### DIFF
--- a/src/DB/Entity/User/User.php
+++ b/src/DB/Entity/User/User.php
@@ -62,6 +62,19 @@ class User extends BaseUser
   protected Collection $programs;
 
   /**
+   * Requests to change the password issued by this user.
+   * When this user is deleted, all the reset-password requests issued by him should be deleted too.
+   *
+   * @ORM\OneToMany(
+   *     targetEntity=ResetPasswordRequest::class,
+   *     mappedBy="user",
+   *     fetch="EXTRA_LAZY",
+   *     cascade={"remove"}
+   * )
+   */
+  protected Collection $reset_password_requests;
+
+  /**
    * Notifications which are available for this user (shown upon login).
    * When this user is deleted, all notifications for him should also be deleted.
    *


### PR DESCRIPTION
Deletion of a user, when priorly a reset-password request was issued, was not possible due to a violation of the foreign key constraint. When a user gets removed from the database, so should it's reset-password requests.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no warnings and errors 
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [ ] Perform a self-review of the changes
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
