### PR TITLE
Architecture refactor of custom translation editor

### DIFF
--- a/assets/js/components/ProjectEditor.js
+++ b/assets/js/components/ProjectEditor.js
@@ -1,15 +1,10 @@
 import $ from 'jquery'
 import { MDCSelect } from '@material/select'
 import { ProgramEditorDialog } from '../custom/ProgramEditorDialog'
-import { showSnackbar } from './snackbar'
 import { showCustomTopBarTitle } from '../layout/top_bar'
+import { DIALOG } from './ProjectEditorModel'
 
-export function ProjectEditor (projectDescriptionCredits, programId, textFields) {
-  const self = this
-
-  this.programId = programId
-  this.textFields = textFields
-
+export function ProjectEditor (projectDescriptionCredits, programId, model) {
   this.body = $('body')
   this.editTextUI = $('#edit-text-ui')
   this.languageSelectorList = $('#edit-language-selector-list')
@@ -18,8 +13,6 @@ export function ProjectEditor (projectDescriptionCredits, programId, textFields)
   this.saveButton = $('#edit-submit-button')
 
   this.languageSelect = new MDCSelect(document.querySelector('#edit-language-selector'))
-  this.languages = {}
-  this.previousIndex = 0
 
   this.closeEditorDialog = new ProgramEditorDialog(
     projectDescriptionCredits.data('trans-close-editor-prompt'),
@@ -40,50 +33,33 @@ export function ProjectEditor (projectDescriptionCredits, programId, textFields)
   )
 
   this.defaultText = projectDescriptionCredits.data('trans-default')
-  this.translationUpdated = projectDescriptionCredits.data('trans-translation-updated')
-  this.translationDeleted = projectDescriptionCredits.data('trans-translation-deleted')
-  this.cannotDelete = projectDescriptionCredits.data('trans-cannot-delete')
 
-  this.saveButton.on('click', () => { this.save() })
+  this.saveButton.on('click', model.save)
 
-  $('#edit-delete-button').on('click', () => { this.deleteTranslation() })
+  $('#edit-delete-button').on('click', model.deleteTranslation)
 
   this.languageSelect.listen('MDCSelect:change', () => {
-    if (!this.editTextUI.is(':visible') || this.languageSelect.selectedIndex === this.previousIndex) {
+    if (!this.editTextUI.is(':visible')) {
       return
     }
 
-    if (this.areChangesSaved()) {
-      this.previousIndex = this.languageSelect.selectedIndex
-      this.getNewText()
-    } else {
-      this.keepOrDiscardDialog.show(keepOrDiscardChangesResult)
-    }
+    model.setLanguage(this.languageSelect.value, this.languageSelect.selectedIndex)
   })
 
-  $('.mdc-text-field__input').on('input', function () {
-    disableButtons(self.areChangesSaved())
-  })
-
-  $(document).ready(getLanguages)
+  $('.mdc-text-field__input').on('input', model.onInput)
 
   this.show = (navigationCallback, language, showLanguageSelect, showDeleteButton, headerText) => {
     this.navigationCallback = navigationCallback
     this.showLanguageSelect = showLanguageSelect
     this.showDeleteButton = showDeleteButton
 
-    if (language !== null) {
-      this.languageSelect.value = language
-      this.languageSelect.emit('change')
-    }
+    model.show(language)
 
-    this.getNewText()
-
-    const langaugeSelectElement = $('#edit-language-selector')
+    const languageSelectElement = $('#edit-language-selector')
     if (this.showLanguageSelect) {
-      langaugeSelectElement.removeClass('d-none')
+      languageSelectElement.removeClass('d-none')
     } else {
-      langaugeSelectElement.addClass('d-none')
+      languageSelectElement.addClass('d-none')
     }
 
     const deleteButtonElement = $('#edit-delete-button')
@@ -99,7 +75,7 @@ export function ProjectEditor (projectDescriptionCredits, programId, textFields)
       '#editor'
     )
 
-    $(window).on('popstate', this.popStateHandler)
+    $(window).on('popstate', model.popStateHandler)
     showCustomTopBarTitle(headerText, function () {
       window.history.back()
     })
@@ -109,173 +85,58 @@ export function ProjectEditor (projectDescriptionCredits, programId, textFields)
   }
 
   // region private
-  this.popStateHandler = function () {
-    if (self.areChangesSaved()) {
-      self.close()
-    } else {
-      self.closeEditorDialog.show(closeEditorDialogResult)
-    }
-  }
-
   this.close = () => {
-    $(window).off('popstate', this.popStateHandler)
-
-    if (this.reloadScreen) {
-      window.location.reload()
-    }
+    $(window).off('popstate', model.popStateHandler)
 
     this.editTextUI.addClass('d-none')
 
-    this.reset()
+    model.reset()
     this.navigationCallback()
   }
 
-  this.reset = () => {
-    this.languageSelect.selectedIndex = 0
-    this.previousIndex = 0
-    this.getNewText()
-  }
-
-  function getLanguages () {
-    $.ajax({
-      url: '../languages',
-      type: 'get',
-      success: function (data) {
-        self.languages = data
-        self.filterLanguages()
-        self.populateSelector()
-      }
-    })
-  }
-
-  this.filterLanguages = () => {
-    const specialLanguages = [
-      'zh-CN',
-      'zh-TW',
-      'pt-BR',
-      'pt-PT'
-    ]
-
-    for (const language in this.languages) {
-      if (!specialLanguages.includes(language) && language.length !== 2) {
-        delete this.languages[language]
-      }
-    }
-  }
-
-  this.populateSelector = () => {
+  model.setOnLanguageList((languages) => {
     this.languageSelectorList.empty()
     this.languageSelectorList.append('<li class="mdc-list-item" data-value="default" role="option" tabindex="-1">' +
       '<span class="mdc-list-item__ripple"></span>' +
       '<span class="mdc-list-item__text">' + this.defaultText + '</span>' +
       '</li>')
 
-    for (const language in this.languages) {
+    for (const language in languages) {
       this.languageSelectorList.append(`<li class="mdc-list-item" data-value="${language}" role="option" tabindex="-1">\
         <span class="mdc-list-item__ripple"></span>\
-        <span class="mdc-list-item__text">${this.languages[language]}</span>\
+        <span class="mdc-list-item__text">${languages[language]}</span>\
         </li>`)
     }
 
     this.languageSelect.layoutOptions()
-    this.reset()
-  }
+  })
 
-  this.areChangesSaved = () => {
-    return this.textFields.every(textField => textField.areChangesSaved())
-  }
-
-  function disableButtons (disable) {
-    self.saveButton.attr('disabled', disable)
-  }
-
-  function keepOrDiscardChangesResult (result) {
-    if (result.isConfirmed) {
-      self.previousIndex = self.languageSelect.selectedIndex
-      for (const textField of self.textFields) {
-        textField.getNewTextKeepChanges(self.languageSelect.value)
-      }
-    } else if (result.isDenied) {
-      self.previousIndex = self.languageSelect.selectedIndex
-      self.getNewText()
-    } else if (result.isDismissed) {
-      self.languageSelect.selectedIndex = self.previousIndex
+  model.setOnDialog((dialog) => {
+    switch (dialog) {
+      case DIALOG.KEEP_CHANGES:
+        this.keepOrDiscardDialog.show(model.keepChangesResult)
+        break
+      case DIALOG.CLOSE_EDITOR:
+        this.closeEditorDialog.show(model.closeEditorResult)
+        break
+      case DIALOG.CONFIRM_DELETE:
+        this.confirmDeleteDialog.show(model.deleteTranslationResult)
+        break
     }
-  }
+  })
 
-  function closeEditorDialogResult (result) {
-    if (result.isConfirmed) {
-      self.save()
-    } else if (result.isDenied) {
-      self.close()
-    }
-  }
+  model.setOnButtonEnabled((enabled) => this.saveButton.attr('disabled', !enabled))
 
-  this.save = () => {
-    Promise.all([
-      this.textFields[0].save(this.languageSelect.value),
-      this.textFields[1].save(this.languageSelect.value),
-      this.textFields[2].save(this.languageSelect.value)
-    ]).then(function (results) {
-      if (self.languageSelect.value === '' || self.languageSelect.value === 'default') {
-        self.reloadScreen = true
-      }
+  model.setOnLanguageSelected((languageIndex) => {
+    this.languageSelect.selectedIndex = languageIndex
+  })
 
-      const updatedText = self.translationUpdated.replace('%language%', self.selectedLanguage.text())
-      showSnackbar('#share-snackbar', updatedText)
+  model.setOnClose(() => this.close())
 
-      if (results.length === self.textFields.length) {
-        self.close()
-      }
-    }).catch(function (reason) {
-      for (const error of reason) {
-        if (error === 401) {
-          window.location.href = '../login'
-        }
-      }
-    })
-  }
+  model.setOnReload(() => window.location.reload())
 
-  this.deleteTranslation = () => {
-    const languageSelected = this.languageSelect.value
-    if (languageSelected === '' || languageSelected === 'default') {
-      showSnackbar('#share-snackbar', this.cannotDelete)
-    } else {
-      this.confirmDeleteDialog.show(deleteTranslationResult)
-    }
-  }
-
-  function deleteTranslationResult (result) {
-    if (result.isDenied) {
-      const languageSelected = self.languageSelect.value
-      Promise.all([
-        self.textFields[0].delete(languageSelected),
-        self.textFields[1].delete(languageSelected),
-        self.textFields[2].delete(languageSelected)
-      ]).then(function (results) {
-        const deletedText = self.translationDeleted.replace('%language%', self.selectedLanguage.text())
-        showSnackbar('#share-snackbar', deletedText)
-
-        if (results.length === self.textFields.length) {
-          self.close()
-        }
-      }).catch(function (reason) {
-        for (const error of reason) {
-          if (error === 401) {
-            window.location.href = '../login'
-          }
-        }
-      })
-    }
-  }
-
-  self.getNewText = () => {
-    for (const textField of this.textFields) {
-      textField.getNewText(this.languageSelect.value)
-    }
-
-    disableButtons(true)
-  }
-
+  model.setOnUnauthorized(() => {
+    window.location.href = '../login'
+  })
   // end region
 }

--- a/assets/js/components/ProjectEditorTextField.js
+++ b/assets/js/components/ProjectEditorTextField.js
@@ -1,185 +1,45 @@
 import $ from 'jquery'
 import { MDCTextField } from '@material/textfield'
-import { CustomTranslationApi } from '../api/CustomTranslationApi'
 
-export function ProjectEditorTextField (projectDescriptionCredits, programId, programSection, hasDefaultText) {
-  const self = this
-  this.programId = programId
-  this.programSection = programSection
-  this.hasDefaultText = hasDefaultText
-  this.customTranslationApi = new CustomTranslationApi(programSection)
-
-  this.editText = $('#edit-' + this.programSection + '-text')
-  this.editTextError = $('#edit-' + this.programSection + '-text-error')
-  this.textLoadingSpinner = $('#edit-' + this.programSection + '-loading-spinner')
+export function ProjectEditorTextField (model) {
+  this.editText = $('#edit-' + model.programSection + '-text')
+  this.editTextError = $('#edit-' + model.programSection + '-text-error')
+  this.textLoadingSpinner = $('#edit-' + model.programSection + '-loading-spinner')
   this.selectedLanguage = $('#edit-selected-language')
 
-  this.initialText = $('#' + this.programSection).text().trim()
+  new MDCTextField(document.querySelector('#edit-' + model.programSection + '-mdc-text-field'))
 
-  new MDCTextField(document.querySelector('#edit-' + this.programSection + '-mdc-text-field'))
+  this.editText.on('input', () => {
+    model.setText(this.editText.val().trim())
+  })
 
-  this.pathEditName = projectDescriptionCredits.data('path-edit-program-name')
-  this.pathEditDescription = projectDescriptionCredits.data('path-edit-program-description')
-  this.pathEditCredits = projectDescriptionCredits.data('path-edit-program-credits')
+  model.setOnTextChanged((text) => {
+    this.editText.val(text)
+  })
 
-  this.setText = () => {
-    this.editText.val(this.initialText)
-    this.lastSavedText = this.initialText
-  }
-
-  this.areChangesSaved = () => {
-    return this.editText.val().trim() === this.lastSavedText.trim()
-  }
-
-  this.save = (languageSelected) => {
-    hideError()
-    const newText = this.editText.val().trim()
-    if (this.areChangesSaved() || this.shouldDisable(languageSelected)) {
-      // Return without saving
-    } else if (languageSelected === '' || languageSelected === 'default') {
-      let url
-      if (this.programSection === 'name') {
-        url = this.pathEditName
-      } else if (this.programSection === 'description') {
-        url = this.pathEditDescription
-      } else if (this.programSection === 'credits') {
-        url = this.pathEditCredits
-      }
-
-      return new Promise(function (resolve, reject) {
-        $.ajax({
-          url: url,
-          type: 'put',
-          data: { value: newText },
-          success: function (data) {
-            const statusCode = parseInt(data.statusCode)
-            if (statusCode === 527 || statusCode === 707) {
-              showError(data)
-              reject(statusCode)
-            } else {
-              resolve(statusCode)
-            }
-          },
-          error: function (error) {
-            if (error.status === 422) {
-              error.message = error.responseText
-              showError(error)
-              reject(error.status)
-            } else if (error.status === 401) {
-              reject(error.status)
-            }
-          }
-        })
-      })
-    } else if (newText === '') {
-      return this.customTranslationApi.deleteCustomTranslation(
-        this.programId,
-        languageSelected,
-        hideError,
-        showError
-      )
+  model.setOnError((message) => {
+    if (message !== '') {
+      this.editText.addClass('danger')
+      this.editTextError.show()
+      this.editTextError.text(message)
     } else {
-      return this.customTranslationApi.saveCustomTranslation(
-        this.programId,
-        newText,
-        languageSelected,
-        hideError,
-        showError
-      )
+      this.editTextError.hide()
     }
-  }
+  })
 
-  this.delete = (languageSelected) => {
-    hideError()
-    return this.customTranslationApi.deleteCustomTranslation(
-      this.programId,
-      languageSelected,
-      hideError,
-      showError
-    )
-  }
-
-  this.getNewText = (language) => {
-    hideError()
-    if (language === 'default') {
+  model.setOnEnabled((enabled) => {
+    if (enabled === true) {
       this.editText.removeAttr('disabled')
-      this.editText.val(this.initialText)
-      this.lastSavedText = this.initialText
-      return
-    } else if (this.shouldDisable(language)) {
-      this.lastSavedText = this.initialText
-      this.editText.val(this.initialText)
-      this.editText.attr('disabled', '')
-      return
-    }
-
-    this.editText.attr('disabled', '')
-    this.editText.val('')
-    this.textLoadingSpinner.show()
-
-    this.customTranslationApi.getCustomTranslation(
-      this.programId,
-      language,
-      getCustomTranslationSuccess,
-      getCustomTranslationError
-    )
-  }
-
-  this.getNewTextKeepChanges = (language) => {
-    if (this.shouldDisable(language)) {
-      this.lastSavedText = this.initialText
-      this.editText.val(this.initialText)
-      this.editText.attr('disabled', '')
-    } else if (language === 'default') {
-      this.editText.removeAttr('disabled')
-      this.lastSavedText = this.initialText
     } else {
-      this.customTranslationApi.getCustomTranslation(
-        this.programId,
-        language,
-        setLastSavedText,
-        setLastSavedTextError
-      )
+      this.editText.attr('disabled', '')
     }
-  }
+  })
 
-  // region private
-  this.shouldDisable = (languageSelected) => {
-    // User should not be able to define custom translation if field is not defined in default language
-    return !this.hasDefaultText && !(languageSelected === '' || languageSelected === 'default')
-  }
-
-  function showError (error) {
-    self.editText.addClass('danger')
-    self.editTextError.show()
-    self.editTextError.text(error.message)
-  }
-
-  function hideError () {
-    self.editTextError.hide()
-  }
-
-  function getCustomTranslationSuccess (data) {
-    self.textLoadingSpinner.hide()
-    self.editText.val(data)
-    self.lastSavedText = data
-    self.editText.removeAttr('disabled')
-  }
-
-  function getCustomTranslationError () {
-    self.textLoadingSpinner.hide()
-    self.editText.val('')
-    self.lastSavedText = ''
-    self.editText.removeAttr('disabled')
-  }
-
-  function setLastSavedText (data) {
-    self.lastSavedText = data
-  }
-
-  function setLastSavedTextError () {
-    self.lastSavedText = ''
-  }
-
-  // end region
+  model.setOnLoading((loading) => {
+    if (loading === true) {
+      this.textLoadingSpinner.show()
+    } else {
+      this.textLoadingSpinner.hide()
+    }
+  })
 }

--- a/assets/js/components/ProjectEditorTextFieldModel.js
+++ b/assets/js/components/ProjectEditorTextFieldModel.js
@@ -1,0 +1,199 @@
+import $ from 'jquery'
+import { CustomTranslationApi } from '../api/CustomTranslationApi'
+
+export function ProjectEditorTextFieldModel (projectDescriptionCredits, programId, programSection, hasDefaultLanguage, initialText) {
+  const self = this
+  this.text = ''
+  this.lastSavedText = ''
+  this.error = ''
+  this.enabled = true
+
+  this.programId = programId
+  this.programSection = programSection
+  this.hasDefaultLanguage = hasDefaultLanguage
+  this.initialText = initialText
+
+  this.customTranslationApi = new CustomTranslationApi(programSection)
+
+  this.pathEditName = projectDescriptionCredits.data('path-edit-program-name')
+  this.pathEditDescription = projectDescriptionCredits.data('path-edit-program-description')
+  this.pathEditCredits = projectDescriptionCredits.data('path-edit-program-credits')
+
+  this.setOnTextChanged = (onTextChanged) => {
+    this.onTextChanged = onTextChanged
+  }
+
+  this.setOnError = (onError) => {
+    this.onError = onError
+  }
+
+  this.setOnEnabled = (onEnabled) => {
+    this.onEnabled = onEnabled
+  }
+
+  this.setOnLoading = (onLoading) => {
+    this.onLoading = onLoading
+  }
+
+  this.save = (language) => {
+    this.clearError()
+
+    if (this.areChangesSaved() || !this.enabled) {
+      return null
+    } else if (language === '' || language === 'default') {
+      let url
+      if (this.programSection === 'name') {
+        url = this.pathEditName
+      } else if (this.programSection === 'description') {
+        url = this.pathEditDescription
+      } else if (this.programSection === 'credits') {
+        url = this.pathEditCredits
+      }
+
+      return new Promise((resolve, reject) => {
+        $.ajax({
+          url: url,
+          type: 'put',
+          data: { value: this.text },
+          success: function (data) {
+            const statusCode = parseInt(data.statusCode)
+            if (statusCode === 527 || statusCode === 707) {
+              self.setError(data.message)
+              reject(statusCode)
+            } else {
+              resolve(statusCode)
+            }
+          },
+          error: function (error) {
+            if (error.status === 422) {
+              self.setError(error.responseText)
+              reject(error.status)
+            } else if (error.status === 401) {
+              reject(error.status)
+            }
+          }
+        })
+      })
+    } else if (this.text === '') {
+      return this.delete(language)
+    } else {
+      return this.customTranslationApi.saveCustomTranslation(
+        this.programId,
+        this.text,
+        language,
+        this.clearError,
+        this.setError
+      )
+    }
+  }
+
+  this.delete = (language) => {
+    this.clearError()
+
+    return this.customTranslationApi.deleteCustomTranslation(
+      this.programId,
+      language,
+      this.clearError,
+      this.setError
+    )
+  }
+
+  this.setText = (text) => {
+    this.text = text
+  }
+
+  this.fetchText = (language) => {
+    this.clearError()
+
+    if (language === 'default') {
+      this.setEnabled(true)
+      this.setText(this.initialText)
+      this.onTextChanged(this.initialText)
+      this.lastSavedText = this.initialText
+    } else if (this.shouldDisable(language)) {
+      this.setEnabled(false)
+      this.setText(this.initialText)
+      this.onTextChanged(this.initialText)
+      this.lastSavedText = this.initialText
+    } else {
+      this.setEnabled(false)
+      this.onTextChanged('')
+      this.setLoading(true)
+
+      function getCustomTranslationSuccess (data) {
+        self.setLoading(false)
+        self.setText(data)
+        self.onTextChanged(data)
+        self.lastSavedText = data
+        self.setEnabled(true)
+      }
+
+      function getCustomTranslationError () {
+        self.setLoading(false)
+        self.setText('')
+        self.onTextChanged('')
+        self.lastSavedText = ''
+        self.setEnabled(true)
+      }
+
+      this.customTranslationApi.getCustomTranslation(
+        this.programId,
+        language,
+        getCustomTranslationSuccess,
+        getCustomTranslationError
+      )
+    }
+  }
+
+  this.fetchTextKeepChanges = (language) => {
+    if (this.shouldDisable(language)) {
+      this.setEnabled(false)
+      this.onTextChanged(this.initialText)
+      this.lastSavedText = this.initialText
+    } else if (language === 'default') {
+      this.setEnabled(true)
+      this.lastSavedText = this.initialText
+    } else {
+      this.customTranslationApi.getCustomTranslation(
+        this.programId,
+        language,
+        (data) => {
+          self.lastSavedText = data
+        },
+        () => {
+          self.lastSavedText = ''
+        }
+      )
+    }
+  }
+
+  this.areChangesSaved = () => {
+    return this.text === this.lastSavedText
+  }
+
+  // region private
+  this.setError = (error) => {
+    this.error = error
+    this.onError(error)
+  }
+
+  this.clearError = () => {
+    this.setError('')
+  }
+
+  this.setEnabled = (enabled) => {
+    this.enabled = enabled
+    this.onEnabled(enabled)
+  }
+
+  this.setLoading = (loading) => {
+    this.loading = loading
+    this.onLoading(loading)
+  }
+
+  this.shouldDisable = (languageSelected) => {
+    // User should not be able to define custom translation if field is not defined in default language
+    return !this.hasDefaultLanguage && languageSelected !== '' && languageSelected !== 'default'
+  }
+  // end region
+}

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -16,6 +16,8 @@ import { ProjectEditorNavigation } from './components/ProjectEditorNavigation'
 import { ProjectEditor } from './components/ProjectEditor'
 import { ProjectEditorTextField } from './components/ProjectEditorTextField'
 import { ProgramName } from './custom/ProgramName'
+import { ProjectEditorTextFieldModel } from './components/ProjectEditorTextFieldModel'
+import { ProjectEditorModel } from './components/ProjectEditorModel'
 
 require('../styles/custom/profile.scss')
 require('../styles/custom/program.scss')
@@ -32,31 +34,41 @@ let editorNavigation = null
 if ($project.data('my-program')) {
   new MDCTextField(document.querySelector('.comment-message'))
 
-  const nameEditorTextField = new ProjectEditorTextField(
+  const nameEditorTextFieldModel = new ProjectEditorTextFieldModel(
     $projectDescriptionCredits,
     $projectDescriptionCredits.data('project-id'),
     'name',
-    true
+    true,
+    $('#name').text().trim()
   )
+  new ProjectEditorTextField(nameEditorTextFieldModel)
 
-  const descriptionEditorTextField = new ProjectEditorTextField(
+  const descriptionEditorTextFieldModel = new ProjectEditorTextFieldModel(
     $projectDescriptionCredits,
     $projectDescriptionCredits.data('project-id'),
     'description',
-    $projectDescriptionCredits.data('has-description')
+    $projectDescriptionCredits.data('has-description'),
+    $('#description').text().trim()
   )
+  new ProjectEditorTextField(descriptionEditorTextFieldModel)
 
-  const creditsEditorTextField = new ProjectEditorTextField(
+  const creditsEditorTextFieldModel = new ProjectEditorTextFieldModel(
     $projectDescriptionCredits,
     $projectDescriptionCredits.data('project-id'),
     'credits',
-    $projectDescriptionCredits.data('has-credits')
+    $projectDescriptionCredits.data('has-credits'),
+    $('#credits').text().trim()
   )
+  new ProjectEditorTextField(creditsEditorTextFieldModel)
 
+  const projectEditorModel = new ProjectEditorModel(
+    $projectDescriptionCredits.data('project-id'),
+    [nameEditorTextFieldModel, descriptionEditorTextFieldModel, creditsEditorTextFieldModel]
+  )
   const projectEditor = new ProjectEditor(
     $projectDescriptionCredits,
     $projectDescriptionCredits.data('project-id'),
-    [nameEditorTextField, descriptionEditorTextField, creditsEditorTextField]
+    projectEditorModel
   )
 
   editorNavigation = new ProjectEditorNavigation(

--- a/templates/Program/program.html.twig
+++ b/templates/Program/program.html.twig
@@ -265,11 +265,7 @@
        data-has-credits={% if program.credits %} true {% else %} false {% endif %}
        data-trans-more-info="{{ "more-information"|trans({}, "catroweb") }}"
        data-trans-less-info="{{ "less-information"|trans({}, "catroweb") }}"
-       data-trans-translation-updated="{{ "programs.translationUpdated"|trans({}, "catroweb") }}"
-       data-trans-translation-deleted="{{ "programs.translationDeleted"|trans({}, "catroweb") }}"
-       data-trans-cannot-delete="{{ "programs.cannotDelete"|trans({}, "catroweb") }}"
        data-trans-confirm-delete="{{ "programs.confrimDelete"|trans({}, "catroweb") }}"
-       data-trans-close-editor="{{ "programs.closeEditor"|trans({}, "catroweb") }}"
        data-trans-close-editor-prompt="{{ "programs.closeEditorPrompt"|trans({}, "catroweb") }}"
        data-trans-save="{{ "programs.save"|trans({}, "catroweb") }}"
        data-trans-discard="{{ "programs.btnDiscard"|trans({}, "catroweb") }}"

--- a/templates/Program/program_editor.html.twig
+++ b/templates/Program/program_editor.html.twig
@@ -5,7 +5,7 @@
         <div class="mt-3">
           <span class="h2" id="edit-name-headline">{{ 'name'|trans({}, 'catroweb') }}</span>
         </div>
-        <div id="edit-name-error" style="display:none;" class="alert alert-danger"></div>
+        <div id="edit-name-text-error" style="display:none;" class="alert alert-danger"></div>
         <label id="edit-name-mdc-text-field"
             class="mdc-text-field mdc-text-field--filled mdc-text-field--textarea mdc-text-field--no-label">
           <span class="mdc-text-field__ripple"></span>

--- a/translations/catroweb.en.yml
+++ b/translations/catroweb.en.yml
@@ -199,10 +199,7 @@ programs:
   showTranslation: Show translation
   hideTranslation: Hide translation
   translatedByLine: Translated by %provider% from %sourceLanguage% to %targetLanguage%
-  translationUpdated: Changes for the translation to %language% updated
   googleTranslate: Google Translate
-  translationDeleted: Custom translation to %language% deleted
-  cannotDelete: Cannot delete default name, description, or credits
   confrimDelete: Are you sure you want to delete the translation?
   default: Default
   save: Save


### PR DESCRIPTION
- separate business logic from ui in ProjectEditor and ProjectEditorTextField
- Remove snackbars
- remove unused function
- program_editor.html.twig error text bug fix

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
