### PR TITLE
FIX: MyProfile Image Upload, Home Category TopAppBar

### DIFF
--- a/assets/js/components/project_list.js
+++ b/assets/js/components/project_list.js
@@ -165,11 +165,11 @@ export class ProjectList {
       if (self.isFullView) {
         window.history.back() // to remove pushed state
       } else {
+        self.openFullView()
         window.history.pushState(
           { type: 'ProjectList', id: self.container.id, full: true },
           $(this).text(), '#' + self.container.id
         )
-        self.openFullView()
       }
     })
 

--- a/assets/js/layout/top_bar.js
+++ b/assets/js/layout/top_bar.js
@@ -7,7 +7,7 @@ require('../../styles/layout/top_bar.scss')
  * Define elements
  */
 const topAppBarElement = document.querySelector('.mdc-top-app-bar')
-new MDCTopAppBar(topAppBarElement)
+const mdcObject = new MDCTopAppBar(topAppBarElement)
 
 const $title = $('#top-app-bar__title')
 const $toggleSidebarButton = $('#top-app-bar__btn-sidebar-toggle')
@@ -69,6 +69,7 @@ export function showCustomTopBarTitle (title, onBack) {
   $backButton.hide()
 
   $('.mdc-top-app-bar').css('top', 0)
+  mdcObject.setScrollTarget(document.createElement('div'))
   if (typeof onBack === 'function') {
     $backButton = $('<button/>', {
       id: 'top-app-bar__back__btn-back',
@@ -87,6 +88,7 @@ export function showDefaultTopBarTitle () {
   $title.attr('href', defaultAppBarHref)
   $toggleSidebarButton.show()
   if ($backButton) $backButton.hide()
+  mdcObject.setScrollTarget(window) // reset to default
 }
 
 function submitSearchForm (event) {

--- a/assets/js/my_profile.js
+++ b/assets/js/my_profile.js
@@ -82,14 +82,17 @@ class OwnProfile {
   addProfilePictureChangeListenerToInput (input) {
     const self = this
     input.onchange = () => {
-      const loadingSpinner = document.getElementById('profile-loading-spinner-template').content.cloneNode(true)
+      let loadingSpinner
       if (this.avatarElement) {
-        this.avatarElement.appendChild(loadingSpinner)
+        const loadingSpinnerTemplate = document.getElementById('profile-loading-spinner-template').content
+        this.avatarElement.appendChild(loadingSpinnerTemplate.cloneNode(true))
+        loadingSpinner = this.avatarElement.getElementsByClassName(loadingSpinnerTemplate.children[0].className)[0]
       }
       const reader = new window.FileReader()
       reader.onerror = () => {
         if (loadingSpinner && self.avatarElement && loadingSpinner.parentElement === this.avatarElement) {
           this.avatarElement.removeChild(loadingSpinner)
+          loadingSpinner = null
         }
         MessageDialogs.showErrorMessage(myProfileConfiguration.messages.profilePictureInvalid)
       }
@@ -100,6 +103,7 @@ class OwnProfile {
         }, function () {
           if (loadingSpinner && self.avatarElement && loadingSpinner.parentElement === self.avatarElement) {
             self.avatarElement.removeChild(loadingSpinner)
+            loadingSpinner = null
           }
         })
       }


### PR DESCRIPTION
Fix two issues:
- Remove loading spinner on image upload error on MyProfile page
- TopAppBar should be always visible when opening a project category in full view on the home page

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no warnings and errors 
- [X] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [X] Perform a self-review of the changes
- [X] Stick to the project’s git workflow (rebase and squash your commits)
- [X] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/
