### PR TITLE
SHARE-514 Automatic extension-type tag "Multiplayer"

### DIFF
--- a/src/DB/Entity/Project/Extension.php
+++ b/src/DB/Entity/Project/Extension.php
@@ -22,6 +22,7 @@ class Extension implements \Stringable
   final public const RASPBERRY_PI = 'raspberry_pi';
   final public const EMBROIDERY = 'embroidery';
   final public const MINDSTORMS = 'mindstorms';
+  final public const MULTIPLAYER = 'multiplayer';
 
   /**
    * @ORM\Id

--- a/src/Project/Extension/ProjectExtensionManager.php
+++ b/src/Project/Extension/ProjectExtensionManager.php
@@ -29,8 +29,19 @@ class ProjectExtensionManager
     $this->addPhiroExtensions($program, $code_xml);
     $this->addEmbroideryExtensions($program, $code_xml);
     $this->addMindstormsExtensions($program, $code_xml);
+    $this->addMultiplayerExtensions($program, $code_xml);
 
     $this->saveProject($program, $flush);
+  }
+
+  public function addMultiplayerExtensions(Program $program, string $code_xml): void
+  {
+    if ($this->isMultiplayerProject($code_xml, $program->getId())) {
+      $extension = $this->getExtension(Extension::MULTIPLAYER);
+      if (!is_null($extension)) {
+        $program->addExtension($extension);
+      }
+    }
   }
 
   public function addArduinoExtensions(Program $program, string $code_xml): void
@@ -76,6 +87,11 @@ class ProjectExtensionManager
   protected function isAnArduinoProject(string $code_xml): bool
   {
     return str_contains($code_xml, '<brick type="Arduino');
+  }
+
+  protected function isMultiplayerProject(string $code_xml, string $id): bool
+  {
+    return str_contains($code_xml, '<programMultiplayerVariableList>') && str_contains($code_xml, '</programMultiplayerVariableList>');
   }
 
   protected function isAnEmbroideryProject(string $code_xml): bool

--- a/src/Project/Extension/ProjectExtensionManager.php
+++ b/src/Project/Extension/ProjectExtensionManager.php
@@ -36,7 +36,7 @@ class ProjectExtensionManager
 
   public function addMultiplayerExtensions(Program $program, string $code_xml): void
   {
-    if ($this->isMultiplayerProject($code_xml, $program->getId())) {
+    if ($this->isMultiplayerProject($code_xml)) {
       $extension = $this->getExtension(Extension::MULTIPLAYER);
       if (!is_null($extension)) {
         $program->addExtension($extension);
@@ -89,7 +89,7 @@ class ProjectExtensionManager
     return str_contains($code_xml, '<brick type="Arduino');
   }
 
-  protected function isMultiplayerProject(string $code_xml, string $id): bool
+  protected function isMultiplayerProject(string $code_xml): bool
   {
     return str_contains($code_xml, '<programMultiplayerVariableList>') && str_contains($code_xml, '</programMultiplayerVariableList>');
   }

--- a/src/System/Commands/DBUpdater/UpdateProjectExtensionsCommand.php
+++ b/src/System/Commands/DBUpdater/UpdateProjectExtensionsCommand.php
@@ -71,6 +71,13 @@ class UpdateProjectExtensionsCommand extends Command
     ++$count;
     $this->entity_manager->persist($extension);
 
+    $extension = $this->getOrCreateExtension(Extension::MULTIPLAYER)
+      ->setTitleLtmCode(self::EXTENSION_LTM_PREFIX.'multiplayer.title')
+      ->setEnabled(true)
+    ;
+    ++$count;
+    $this->entity_manager->persist($extension);
+
     $this->entity_manager->flush();
     $output->writeln("{$count} Extensions in the Database have been inserted/updated");
 

--- a/tests/BehatFeatures/web/project/extensions_db_updater_command.feature
+++ b/tests/BehatFeatures/web/project/extensions_db_updater_command.feature
@@ -6,13 +6,13 @@ Feature: Tags are inserted/update to the database by a symfony command
 
   Scenario: Running the command adds all tags to the database
     Given I run the update extensions command
-    Then there should be "6" extensions in the database
+    Then there should be "7" extensions in the database
 
   Scenario: Rerunning the command just overwrites the old entries
     Given I run the update extensions command
-    Then there should be "6" extensions in the database
+    Then there should be "7" extensions in the database
     When I run the update extensions command
-    Then there should be "6" extensions in the database
+    Then there should be "7" extensions in the database
 
   Scenario: Rerunning the command must keep all project extensions
     Given there are users:
@@ -20,11 +20,11 @@ Feature: Tags are inserted/update to the database by a symfony command
       | 1  | Achiever |
       | 2  | Catrobat |
     And I run the update extensions command
-    Then there should be "6" extensions in the database
+    Then there should be "7" extensions in the database
     And there are programs:
       | id | name    | owned by | extensions            |
       | 1  | Minions | Catrobat | embroidery,mindstorms |
     Then the project with name "Minions" should have 2 extensions
     When I run the update extensions command
-    Then there should be "6" extensions in the database
+    Then there should be "7" extensions in the database
     And the project with name "Minions" should have 2 extensions

--- a/tests/PhpUnit/Project/Extension/ProjectExtensionManagerTest.php
+++ b/tests/PhpUnit/Project/Extension/ProjectExtensionManagerTest.php
@@ -49,7 +49,15 @@ class ProjectExtensionManagerTest extends DefaultTestCase
 
     $this->object = $this->getMockBuilder(ProjectExtensionManager::class)
       ->disableOriginalConstructor()
-      ->onlyMethods(['addArduinoExtensions', 'addPhiroExtensions', 'addEmbroideryExtensions', 'addMindstormsExtensions', 'getExtension', 'saveProject'])
+      ->onlyMethods([
+        'addArduinoExtensions',
+        'addPhiroExtensions',
+        'addEmbroideryExtensions',
+        'addMindstormsExtensions',
+        'addMultiplayerExtensions',
+        'getExtension',
+        'saveProject'
+      ])
       ->getMockForAbstractClass()
     ;
 
@@ -58,6 +66,7 @@ class ProjectExtensionManagerTest extends DefaultTestCase
     $this->object->expects($this->once())->method('addPhiroExtensions');
     $this->object->expects($this->once())->method('addEmbroideryExtensions');
     $this->object->expects($this->once())->method('addMindstormsExtensions');
+    $this->object->expects($this->once())->method('addMultiplayerExtensions');
     $this->object->expects($this->once())->method('saveProject');
 
     $this->object->addExtensions($this->extracted_catrobat_file_with_extensions, $program);

--- a/tests/PhpUnit/Project/Extension/ProjectExtensionManagerTest.php
+++ b/tests/PhpUnit/Project/Extension/ProjectExtensionManagerTest.php
@@ -56,7 +56,7 @@ class ProjectExtensionManagerTest extends DefaultTestCase
         'addMindstormsExtensions',
         'addMultiplayerExtensions',
         'getExtension',
-        'saveProject'
+        'saveProject',
       ])
       ->getMockForAbstractClass()
     ;

--- a/translations/catroweb.en.yaml
+++ b/translations/catroweb.en.yaml
@@ -893,6 +893,8 @@ extensions:
       title: Embroidery
     mindstorms:
       title: Mindstorms
+    multiplayer:
+      title: Multiplayer
 
 studio:
   details:


### PR DESCRIPTION
One would want to automatically detect projects that are using the new feature "Multiplayer". This commit adds the "Multiplayer" Extension and detects automatically projects that use this feature and shows it in the project page.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no warnings and errors 
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [ ] Perform a self-review of the changes
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
