### PR TITLE
SHARE-528 Default notification icon broken

### DIFF
--- a/assets/styles/notifications_overview.scss
+++ b/assets/styles/notifications_overview.scss
@@ -103,6 +103,7 @@
 
 .notification-avatar-round {
   border-radius: 100%;
+  width: 100%;
 }
 
 .chip-selected {


### PR DESCRIPTION
In current version the default notification icon sometimes was bigger than the others, therefore I added the width property to fix the issue.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [X] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no warnings and errors 
- [X] Verify to commit no other files than the intentionally changed ones
- [X] Include reasonable and readable tests verifying the added or changed behavior
- [X] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [X] Perform a self-review of the changes
- [X] Stick to the project’s git workflow (rebase and squash your commits)
- [X] Verify that your changes do not have any conflicts with the base branch
- [X] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [X] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [X] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
