### PR TITLE
Emails switch provider to sendInBlue

### DIFF
--- a/.env
+++ b/.env
@@ -116,3 +116,8 @@ MAILER_DSN='null://null'
 ###< symfony/mailer ###
 
 BUGSNAG_API_KEY=''
+
+###> symfony/sendinblue-mailer ###
+# MAILER_DSN=sendinblue+api://KEY@default
+# MAILER_DSN=sendinblue+smtp://USERNAME:PASSWORD@default
+###< symfony/sendinblue-mailer ###

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "symfony/polyfill-iconv": "^1.27",
         "symfony/process": "6.2.*",
         "symfony/routing": "6.2.*",
+        "symfony/sendinblue-mailer": "6.2.*",
         "symfony/translation": "6.2.*",
         "symfony/twig-bundle": "6.2.*",
         "symfony/validator": "6.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94657ca549115be9a781033b4380f3cf",
+    "content-hash": "5b504d857f82567fe38adf53bddcb1a9",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -12029,6 +12029,74 @@
             "time": "2023-01-30T15:46:28+00:00"
         },
         {
+            "name": "symfony/sendinblue-mailer",
+            "version": "v6.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/sendinblue-mailer.git",
+                "reference": "5e57ba90e6cc08d0538b6782fb0cb885e7bbedb1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/sendinblue-mailer/zipball/5e57ba90e6cc08d0538b6782fb0cb885e7bbedb1",
+                "reference": "5e57ba90e6cc08d0538b6782fb0cb885e7bbedb1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/mailer": "^5.4|^6.0"
+            },
+            "conflict": {
+                "symfony/mime": "<6.2"
+            },
+            "require-dev": {
+                "symfony/http-client": "^5.4|^6.0"
+            },
+            "type": "symfony-mailer-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\Bridge\\Sendinblue\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Sendinblue Mailer Bridge",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/sendinblue-mailer/tree/v6.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-01T08:38:09+00:00"
+        },
+        {
             "name": "symfony/serializer",
             "version": "v6.2.5",
             "source": {
@@ -18399,5 +18467,5 @@
         "ext-posix": "8.2",
         "ext-zip": "8.2"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -25,7 +25,7 @@ services:
       # Which means changes to those files are synced between the host and container. No rebuild needed!
       #
       # Make sure the content of the following dirs/files is not changed in the Dockerfile, else the changes will just
-      # be discarded. Otherwise feel free to add every file that is modified regularly.
+      # be discarded. Otherwise, feel free to add every file that is modified regularly.
       #
       - ./../assets:/var/www/catroweb/assets:cached
       #

--- a/src/System/Mail/MailerAdapter.php
+++ b/src/System/Mail/MailerAdapter.php
@@ -21,8 +21,8 @@ class MailerAdapter
   public function send(string $to, string $subject, string $template, array $context = []): void
   {
     $email = $this->buildEmail($to, $subject, $template, $context);
-    $signedEmail = $this->signEmail($email);
-    $this->sendEmail($signedEmail, $to);
+    // $email = $this->signEmail($email); // Signing is currently disabled due to sendinblue
+    $this->sendEmail($email, $to);
   }
 
   protected function buildEmail(string $to, string $subject, string $template, array $context): Message

--- a/symfony.lock
+++ b/symfony.lock
@@ -920,6 +920,15 @@
     "symfony/security-http": {
         "version": "v5.4.8"
     },
+    "symfony/sendinblue-mailer": {
+        "version": "6.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "5.2",
+            "ref": "ae1cf494ce06b9a4578a8445c610402a1676ee8d"
+        }
+    },
     "symfony/service-contracts": {
         "version": "v2.0.1"
     },


### PR DESCRIPTION
Using their API reduces our overhead with all the mail configurations for the security policies.