### PR TITLE
Elasticsearch analyzer settings was not applied

### DIFF
--- a/config/packages/fos_elastica.php
+++ b/config/packages/fos_elastica.php
@@ -30,7 +30,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
           'settings' => [
             'analysis' => [
               'analyzer' => [
-                'my_analyzer' => [
+                'default' => [
                   'type' => 'custom',
                   'tokenizer' => 'standard',
                   'filter' => [
@@ -77,7 +77,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
           'settings' => [
             'analysis' => [
               'analyzer' => [
-                'my_analyzer' => [
+                'default' => [
                   'type' => 'custom',
                   'tokenizer' => 'standard',
                   'filter' => [


### PR DESCRIPTION
renaming the analyzer from 'my_analyzer' to 'default' works

The current elasticsearch settings can be queried using http://elasticsearch:9200/app_program/_settings?pretty. You should see 'default' as the analyser in this response. You may need to run `bin/console fos:elastica:populate` for the changes to take effect.

Test: the elision filter should make search results for "l'appli" and "appli" the same, ie., omitting certain prefixes in languages.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no warnings and errors 
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [ ] Perform a self-review of the changes
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`
