### PR TITLE
SHARE-577 Add "Share" option to project overview context menu

### DIFF
--- a/assets/js/custom/own_project_list.js
+++ b/assets/js/custom/own_project_list.js
@@ -5,6 +5,8 @@ import { MDCMenuSurfaceFoundation } from '@material/menu-surface'
 import Swal from 'sweetalert2'
 import { ApiDeleteFetch, ApiFetch } from '../api/ApiHelper'
 import ProjectApi from '../api/ProjectApi'
+import Clipboard from 'clipboard'
+import { showSnackbar } from '../components/snackbar'
 
 require('../../styles/components/own_project_list.scss')
 
@@ -69,6 +71,9 @@ export class OwnProjectList {
         // Set public/private
         self._actionToggleVisibility(self.projectActionMenu.projectId)
       } else if (event.detail.index === 1) {
+        // Share
+        self._actionShareProject(self.projectActionMenu.projectId)
+      } else if (event.detail.index === 2) {
         // Delete
         self._actionDeleteProject(self.projectActionMenu.projectId)
       } else {
@@ -324,6 +329,49 @@ export class OwnProjectList {
         ).run()
       }
     })
+  }
+
+  _actionShareProject(id) {
+    const clipboardSuccessMessage =
+      myProfileConfiguration.messages.clipboardSuccessMessage
+    const clipboardFailMessage = myProfileConfiguration.messages.clipboardFailMessage
+    const shareSuccessMessage = myProfileConfiguration.messages.shareSuccessMessage
+    const shareFailMessage = myProfileConfiguration.messages.shareFailMessage
+    const projectUrl = this.projectsData[id].project_url
+    const titleMessage = myProfileConfiguration.messages.displayName
+    const textMessage = myProfileConfiguration.messages.checkoutMessage
+
+    const shareButton = document.querySelector('#project-share-action')
+
+    if (navigator.share) {
+      shareButton.addEventListener('click', function () {
+        navigator
+          .share({
+            title: titleMessage,
+            text: textMessage,
+            url: projectUrl,
+          })
+          .then(() => {
+            showSnackbar('#share-snackbar', shareSuccessMessage)
+          })
+          .catch((e) => {
+            console.error(e)
+            showSnackbar('#share-snackbar', shareFailMessage)
+          })
+      })
+    } else {
+      const cb = new Clipboard('#project-share-action', {
+        text: function () {
+          return projectUrl
+        },
+      })
+      cb.on('success', function () {
+        showSnackbar('#share-snackbar', clipboardSuccessMessage)
+      })
+      cb.on('error', function () {
+        showSnackbar('#share-snackbar', clipboardFailMessage)
+      })
+    }
   }
 
   _actionToggleVisibility(id) {

--- a/assets/js/custom/own_project_list.js
+++ b/assets/js/custom/own_project_list.js
@@ -5,6 +5,8 @@ import { MDCMenuSurfaceFoundation } from '@material/menu-surface'
 import Swal from 'sweetalert2'
 import { ApiDeleteFetch, ApiFetch } from '../api/ApiHelper'
 import ProjectApi from '../api/ProjectApi'
+import Clipboard from 'clipboard'
+import { showSnackbar } from '../components/snackbar'
 
 require('../../styles/components/own_project_list.scss')
 
@@ -69,6 +71,9 @@ export class OwnProjectList {
         // Set public/private
         self._actionToggleVisibility(self.projectActionMenu.projectId)
       } else if (event.detail.index === 1) {
+        // Share
+        self._actionShareProject(self.projectActionMenu.projectId)
+      } else if (event.detail.index === 2) {
         // Delete
         self._actionDeleteProject(self.projectActionMenu.projectId)
       } else {
@@ -324,6 +329,51 @@ export class OwnProjectList {
         ).run()
       }
     })
+  }
+
+  _actionShareProject(id) {
+    const clipboardSuccessMessage =
+      myProfileConfiguration.messages.clipboardSuccessMessage
+    const clipboardFailMessage =
+      myProfileConfiguration.messages.clipboardFailMessage
+    const shareSuccessMessage =
+      myProfileConfiguration.messages.shareSuccessMessage
+    const shareFailMessage = myProfileConfiguration.messages.shareFailMessage
+    const projectUrl = this.projectsData[id].project_url
+    const titleMessage = myProfileConfiguration.messages.displayName
+    const textMessage = myProfileConfiguration.messages.checkoutMessage
+
+    const shareButton = document.querySelector('#project-share-action')
+
+    if (navigator.share) {
+      shareButton.addEventListener('click', function () {
+        navigator
+          .share({
+            title: titleMessage,
+            text: textMessage,
+            url: projectUrl,
+          })
+          .then(() => {
+            showSnackbar('#share-snackbar', shareSuccessMessage)
+          })
+          .catch((e) => {
+            console.error(e)
+            showSnackbar('#share-snackbar', shareFailMessage)
+          })
+      })
+    } else {
+      const cb = new Clipboard('#project-share-action', {
+        text: function () {
+          return projectUrl
+        },
+      })
+      cb.on('success', function () {
+        showSnackbar('#share-snackbar', clipboardSuccessMessage)
+      })
+      cb.on('error', function () {
+        showSnackbar('#share-snackbar', clipboardFailMessage)
+      })
+    }
   }
 
   _actionToggleVisibility(id) {

--- a/templates/UserManagement/Profile/myProfile.html.twig
+++ b/templates/UserManagement/Profile/myProfile.html.twig
@@ -126,6 +126,10 @@
               data-text-private="{{ 'project.setPrivateAction'|trans({}, 'catroweb') }}"
               data-text-public="{{ 'project.setPublicAction'|trans({}, 'catroweb') }}"></span>
       </li>
+      <li class="mdc-list-item" role="menuitem" id="project-share-action">
+        <span class="mdc-list-item__ripple"></span>
+        <span class="mdc-list-item__text">{{ 'project.shareAction'|trans({}, 'catroweb') }}</span>
+      </li>
       <li class="mdc-list-item" role="menuitem">
         <span class="mdc-list-item__ripple"></span>
         <span class="mdc-list-item__text">{{ 'project.deleteAction'|trans({}, 'catroweb') }}</span>
@@ -165,6 +169,12 @@
       }
     },
     messages: {
+      clipboardSuccessMessage: '{{ 'clipboard.success_project'|trans({}, 'catroweb')|escape('js')|raw }}',
+      clipboardFailMessage: '{{ 'clipboard.fail'|trans({}, 'catroweb')|escape('js')|raw }}',
+      shareSuccessMessage: '{{ 'share.success'|trans({}, 'catroweb')|escape('js')|raw }}',
+      shareFailMessage: '{{ 'share.error'|trans({}, 'catroweb')|escape('js')|raw }}',
+      checkoutMessage: '{{ 'checkOutProject'|trans({}, 'catroweb')|escape('js')|raw }}',
+      displayName: '{{ 'flavor.pocketcode'|trans({}, 'catroweb')|escape('js')|raw }}',
       unspecifiedErrorText: '{{ 'myprofile.unspecifiedError'|trans({}, 'catroweb')|escape('js')|raw }}',
       deleteProjectNotFoundText: '{{ 'project.deleteNotFoundError'|trans({}, 'catroweb')|escape('js')|raw }}',
       security: {

--- a/translations/catroweb.de_DE.yaml
+++ b/translations/catroweb.de_DE.yaml
@@ -109,6 +109,7 @@ project:
   recommended: Empfohlene Projekte
   scratchremixes: Scratch remixes
   noProjects: Derzeit gibt es keine Projekte.
+  shareAction: Teilen
   deleteAction: Projekt löschen
   deleteConfirmation: |+
     Bist du dir sicher?

--- a/translations/catroweb.en.yaml
+++ b/translations/catroweb.en.yaml
@@ -114,6 +114,7 @@ project:
   recommended: Recommended projects
   scratchremixes: Scratch remixes
   noProjects: There are currently no projects.
+  shareAction: Share
   deleteAction: Delete project
   deleteConfirmation: |+
     Are you sure?


### PR DESCRIPTION
Added a "Share" option to the project overview context menu to make it easier to access the share link. This new button is inserted between the existing "Set public" and "Delete project" options and leads to the same result as clicking the share button in the toolbar on the project page.
