### PR TITLE
Fix coverage reports in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -115,6 +115,7 @@ jobs:
           files: tests/TestReports/CoverageReports/PhpUnit/coverage.xml
           flags: phpunit # optional
           name: codecov-umbrella # optional
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Behat:
@@ -216,7 +217,7 @@ jobs:
         #   the pipe status, which contains the correct exit code.
         run: |
           docker exec app.catroweb chmod -R 777 var
-          docker exec app.catroweb bin/behat -s ${{ matrix.testSuite }} -f pretty \
+          docker exec app.catroweb bin/behat -s ${{ matrix.testSuite }} -f pretty --xdebug \
           |& tee tests/TestReports/Behat/${{ matrix.testSuite }}.log; \
           TEST_RUN_EXIT_CODE=${PIPESTATUS[0]}
           echo "test-run-exit-code=$TEST_RUN_EXIT_CODE" > $GITHUB_ENV
@@ -268,7 +269,7 @@ jobs:
           files: tests/TestReports/CoverageReports/Behat/coverage.xml
           flags: behat # optional
           name: codecov-umbrella # optional
-          # fail_ci_if_error: true # optional (default = false)
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Rerun Behat Tests (1st Attempt)
         if: env.test-run-exit-code != '0'


### PR DESCRIPTION
Due to:  Disable Xdebug unless `--xdebug` is specified on the CLI, to improve performance by @carlos-granados in [#1560](https://github.com/Behat/Behat/pull/1560)  -> https://github.com/Behat/Behat/blob/2444547e6661a1406b4b312a40b92d47a3b86684/CHANGELOG.md?plain=1#L143