### PR TITLE
 Remove global border-radius from all <img> elements

### DIFF
--- a/assets/catblocks/main.css
+++ b/assets/catblocks/main.css
@@ -64,8 +64,8 @@
   background: none !important;
 }
 
-img {
-  border-radius: 10% !important;
+.rounded-img {
+  border-radius: 10%;
 }
 
 .list-group-item {


### PR DESCRIPTION
Title: Remove global border-radius from all <img> elements
Description:

Removed img { border-radius: 10% !important; } from global CSS

This rule caused unintended rounding on thumbnails, icons, charts, and UI elements

Styles are now consistent and component-safe
