### PR TITLE
Add target _blank to Scratch project links in Description

### DIFF
--- a/templates/Project/Description.html.twig
+++ b/templates/Project/Description.html.twig
@@ -22,9 +22,9 @@
           {% endif %}
           {% if project.isScratchProgram() %}
             {{ 'projectImportedFromScratch'|trans({}, 'catroweb') }}
-            <a href={{ 'https://scratch.mit.edu/projects/' ~ project.getScratchId() }}>
-              {{ 'scratchImportedProjectLinkHere'|trans({}, 'catroweb') }}
-            </a>
+            <a href={{ 'https://scratch.mit.edu/projects/' ~ project.getScratchId() }} target="_blank" rel="noopener noreferrer">
+  {{ 'scratchImportedProjectLinkHere'|trans({}, 'catroweb') }}
+	   </a>
           {% endif %}
         {% else %}
           {{ 'noCredits'|trans({}, 'catroweb') }}


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) and [wiki pages](https://github.com/Catrobat/catroweb-Symfony/wiki/) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-XXXX Add target _blank to Scratch project links`
- [x] Choose the proper base branch (_develop_)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI)
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description

This PR updates `Description.html.twig` so that external Scratch project links open in a new tab (`target="_blank"`) and adds `rel="noopener noreferrer"` for security.  
It is a tiny frontend-only change and does not affect any backend logic.
