### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check_for_new_bricks.yaml
+++ b/.github/workflows/check_for_new_bricks.yaml
@@ -12,6 +12,9 @@
 #
 name: Check for new bricks
 
+permissions:
+  contents: read
+
 #
 # This check is independent of a pull request, hence, it is executed once a day on a schedule.
 # In case, an additional run is required, a manual dispatch trigger is also enabled.

--- a/.github/workflows/code_quality.yaml
+++ b/.github/workflows/code_quality.yaml
@@ -32,6 +32,9 @@
 #
 name: 'Static analysis'
 
+permissions:
+  contents: read
+
 # Run-on every creation, update and merge of a pull request.
 # However, prevent checks to be initiated twice if the pull request origins from a branch on the official repository.
 # For example, this happens with dependabot.

--- a/.github/workflows/container_tests.yaml
+++ b/.github/workflows/container_tests.yaml
@@ -15,6 +15,9 @@
 #
 name: 'Docker Container tests'
 
+permissions:
+  contents: read
+
 # Run-on every creation, update and merge of a pull request.
 # However, prevent checks to be initiated twice if the pull request origins from a branch on the official repository.
 # For example, this happens with dependabot.

--- a/.github/workflows/sync_crowdin.yaml
+++ b/.github/workflows/sync_crowdin.yaml
@@ -14,6 +14,9 @@
 #
 name: Synchronize Crowdin
 
+permissions:
+  contents: read
+
 #
 # New base strings could be uploaded on the merge of a new feature.
 # However, the translation download process is independent from a pull request.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,9 @@
 #
 name: 'Dynamic analysis'
 
+permissions:
+  contents: read
+
 # Run-on every creation, update and merge of a pull request.
 # However, prevent checks to be initiated twice if the pull request is a branch on the same repository. (E.g dependabot)
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Catrobat/Catroweb/security/code-scanning/1](https://github.com/Catrobat/Catroweb/security/code-scanning/1)

In general, to fix this issue we should explicitly specify the minimal required permissions for the `GITHUB_TOKEN` in this workflow, either globally at the root level or per job. Since this workflow has a single job and only needs to read repository contents (for `actions/checkout` and the PHP script), the token can be limited to `contents: read`.

The best fix without changing existing functionality is to add a `permissions:` block that restricts `contents` to `read`. This can be added at the workflow root (right after `name:` and before `on:`) so it applies to all jobs, or inside the `check_for_new_catroid_bricks` job. Root-level is cleaner and future-proof for additional jobs. No imports or other code changes are needed; we only adjust the YAML to include:

```yaml
permissions:
  contents: read
```

Concretely, in `.github/workflows/check_for_new_bricks.yaml`:
- Insert a new `permissions:` section after line 13 (`name: Check for new bricks`) and before line 15 (`# This check is independent...`).
- Ensure correct indentation (top-level) so it applies to the whole workflow.
No other lines or behavior need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
