### PR TITLE
Fail on all issues - and fix notices

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -498,3 +498,14 @@ The main `ProjectsApi.php` delegates to these facades.
 
 - **400 Bad Request**: Query parameter validation failures (enum values in URL)
 - **422 Unprocessable Entity**: Request body validation failures (JSON body content)
+
+## PHPUnit Testing Best Practices
+
+**See [CLAUDE_PHPUNIT_MOCKING.md](CLAUDE_PHPUNIT_MOCKING.md) for comprehensive guidelines on:**
+
+- When to use `createStub()` vs `createMock()`
+- Common patterns and anti-patterns
+- Refactoring checklist for mock warnings
+- Real examples from the codebase
+
+**Quick Rule:** Use `createStub()` when you need return values. Use `createMock()` only when you verify behavior with `expects()`.

--- a/.claude/CLAUDE_PHPUNIT_MOCKING.md
+++ b/.claude/CLAUDE_PHPUNIT_MOCKING.md
@@ -1,0 +1,352 @@
+# PHPUnit Testing Best Practices - Mocks vs Stubs
+
+## Overview
+
+This document explains proper usage of test doubles in PHPUnit tests. PHPUnit 12+ strictly enforces best practices to help developers write clearer, more maintainable tests.
+
+## The Problem
+
+You may see this warning:
+
+```
+No expectations were configured for the mock object for ClassName.
+Consider refactoring your test code to use a test stub instead.
+```
+
+This means you're using `createMock()` but not actually verifying behavior with `expects()`. This is a code smell - you should use `createStub()` instead.
+
+## Mocks vs Stubs - When to Use Which
+
+### Use `createStub()` when:
+
+- You need a dependency to return specific values
+- You're **NOT** verifying that methods were called
+- The dependency is just providing data for the test
+- You only care about **WHAT** is returned, not **HOW** it's called
+
+### Use `createMock()` when:
+
+- You're **verifying behavior** (that specific methods are called)
+- You use `expects()` to assert interactions
+- The test is about **HOW** the code interacts with dependencies
+- You care about **method calls, arguments, and order**
+
+## Common Patterns
+
+### Pattern 1: Repository as Stub (No Behavior Verification)
+
+```php
+use PHPUnit\Framework\MockObject\Stub;
+
+class UserServiceTest extends TestCase
+{
+  private Stub|UserRepository $repository;
+
+  protected function setUp(): void
+  {
+    // GOOD - Using a stub for dependencies that just return data
+    $this->repository = $this->createStub(UserRepository::class);
+    $this->repository->method('find')->willReturn(new User());
+    $this->service = new UserService($this->repository);
+  }
+
+  public function testGetUserName(): void
+  {
+    // We don't care HOW the repository was called, just that we get data
+    $name = $this->service->getUserName(123);
+    $this->assertEquals('John', $name);
+  }
+}
+```
+
+### Pattern 2: Mock When Verifying Behavior
+
+```php
+use PHPUnit\Framework\MockObject\MockObject;
+
+class UserServiceTest extends TestCase
+{
+  public function testUserIsSaved(): void
+  {
+    // GOOD - Using a mock to verify the method was called correctly
+    $repository = $this->createMock(UserRepository::class);
+    $repository->expects($this->once())  // ← This is WHY we use createMock()
+      ->method('save')
+      ->with($this->isInstanceOf(User::class));
+
+    $service = new UserService($repository);
+    $service->createUser('John');
+
+    // The assertion happens via expects() - we're testing BEHAVIOR
+  }
+}
+```
+
+### Pattern 3: Mixed Approach (Stub by Default, Mock When Needed)
+
+```php
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class TranslateClientTest extends TestCase
+{
+  private Stub|TranslateClient $client;
+  private GoogleTranslateApi $api;
+
+  protected function setUp(): void
+  {
+    // Stub by default - many tests don't need to verify behavior
+    $this->client = $this->createStub(TranslateClient::class);
+    $this->api = new GoogleTranslateApi($this->client, $this->createStub(LoggerInterface::class), 5);
+  }
+
+  public function testTranslatesText(): void
+  {
+    // For this test, we need to verify the client is called correctly
+    $client = $this->createMock(TranslateClient::class);
+    $client->expects($this->once())
+      ->method('translate')
+      ->with('hello', ['target' => 'fr'])
+      ->willReturn(['text' => 'bonjour']);
+
+    $api = new GoogleTranslateApi($client, $this->createStub(LoggerInterface::class), 5);
+    $result = $api->translate('hello', null, 'fr');
+
+    $this->assertEquals('bonjour', $result->translation);
+  }
+
+  public function testGetPreference(): void
+  {
+    // This test doesn't call the client at all, so the stub from setUp() is fine
+    $preference = $this->api->getPreference('test', 'en', 'fr');
+    $this->assertEquals(1.0, $preference);
+  }
+}
+```
+
+### Pattern 4: Type Hints Show Intent
+
+```php
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+
+class MyTest extends TestCase
+{
+  // Clear signal: this is a stub (returns values, no behavior verification)
+  private Stub|UserRepository $userRepository;
+  private Stub|LoggerInterface $logger;
+
+  // Clear signal: these are mocks (behavior will be verified)
+  private MockObject|EmailService $emailService;
+  private MockObject|EventDispatcher $eventDispatcher;
+
+  protected function setUp(): void
+  {
+    // Stubs - just return values
+    $this->userRepository = $this->createStub(UserRepository::class);
+    $this->logger = $this->createStub(LoggerInterface::class);
+
+    // Mocks - we'll use expects() on these
+    $this->emailService = $this->createMock(EmailService::class);
+    $this->eventDispatcher = $this->createMock(EventDispatcher::class);
+  }
+}
+```
+
+## What NOT to Do
+
+### ❌ BAD: Creating mocks without expectations
+
+```php
+// BAD - createMock() without expects()
+protected function setUp(): void
+{
+  $this->logger = $this->createMock(LoggerInterface::class);  // ← Wrong!
+  $this->repository = $this->createMock(UserRepository::class);  // ← Wrong!
+}
+
+public function testSomething(): void
+{
+  // No expects() anywhere - these should be stubs!
+  $result = $this->service->doSomething();
+  $this->assertTrue($result);
+}
+```
+
+### ❌ BAD: Using opt-out attribute instead of proper refactoring
+
+```php
+// BAD - This hides the problem instead of fixing it
+#[AllowMockObjectsWithoutExpectations]
+public function testSomething(): void
+{
+  $logger = $this->createMock(LoggerInterface::class);  // ← Should be createStub()!
+  // ...
+}
+```
+
+### ✅ GOOD: Use the right tool for the job
+
+```php
+// GOOD - Using stubs for dependencies that just return values
+protected function setUp(): void
+{
+  $this->logger = $this->createStub(LoggerInterface::class);  // ← Correct!
+  $this->repository = $this->createStub(UserRepository::class);  // ← Correct!
+}
+
+public function testSomething(): void
+{
+  $result = $this->service->doSomething();
+  $this->assertTrue($result);
+}
+```
+
+## Refactoring Checklist
+
+When you see PHPUnit warnings about mocks without expectations:
+
+1. **Identify the dependency** - What object is triggering the warning?
+
+2. **Search for `expects()` in the test file**
+   - If NO `expects()` anywhere → Change ALL `createMock()` to `createStub()`
+   - If `expects()` in SOME tests → Use Pattern 3 (stub by default, mock in specific tests)
+
+3. **Update type hints**
+
+   ```php
+   // From:
+   private MockObject|Logger $logger;
+
+   // To:
+   private Stub|Logger $logger;
+   ```
+
+4. **Update imports** if needed
+
+   ```php
+   use PHPUnit\Framework\MockObject\Stub;
+   ```
+
+5. **Run tests** to verify everything still passes
+
+6. **Remove any `#[AllowMockObjectsWithoutExpectations]` attributes**
+
+## Examples from the Codebase
+
+### Example 1: TranslationDelegateTest (Properly Refactored)
+
+**Before:**
+
+```php
+private MockObject|ProjectCustomTranslationRepository $repository;
+
+protected function setUp(): void
+{
+  $this->repository = $this->createMock(ProjectCustomTranslationRepository::class);
+}
+
+#[AllowMockObjectsWithoutExpectations]
+public function testTranslate(): void
+{
+  // No expects() used
+  $result = $this->delegate->translate('test', 'en', 'fr');
+  $this->assertNotNull($result);
+}
+```
+
+**After:**
+
+```php
+private Stub|ProjectCustomTranslationRepository $repository;
+
+protected function setUp(): void
+{
+  $this->repository = $this->createStub(ProjectCustomTranslationRepository::class);
+}
+
+public function testTranslate(): void
+{
+  // Clean - no warning, clear intent
+  $result = $this->delegate->translate('test', 'en', 'fr');
+  $this->assertNotNull($result);
+}
+
+public function testAddTranslation(): void
+{
+  // For this test, we need to verify behavior
+  $repository = $this->createMock(ProjectCustomTranslationRepository::class);
+  $repository->expects($this->once())
+    ->method('addNameTranslation')
+    ->with($project, 'fr', 'test');
+
+  $delegate = new TranslationDelegate($repository, ...);
+  $delegate->addProjectNameCustomTranslation($project, 'fr', 'test');
+}
+```
+
+### Example 2: GoogleTranslateApiTest (Properly Refactored)
+
+**Before:**
+
+```php
+private MockObject|TranslateClient $client;
+
+protected function setUp(): void
+{
+  $this->client = $this->createMock(TranslateClient::class);
+  $this->api = new GoogleTranslateApi($this->client, ...);
+}
+
+#[AllowMockObjectsWithoutExpectations]
+public function testGetPreference(): void
+{
+  // Doesn't use $this->client at all!
+  $this->assertEquals(1.0, $this->api->getPreference('test', 'en', 'fr'));
+}
+```
+
+**After:**
+
+```php
+private Stub|TranslateClient $client;
+
+protected function setUp(): void
+{
+  $this->client = $this->createStub(TranslateClient::class);
+  $this->api = new GoogleTranslateApi($this->client, ...);
+}
+
+public function testGetPreference(): void
+{
+  // Clean - no warning
+  $this->assertEquals(1.0, $this->api->getPreference('test', 'en', 'fr'));
+}
+
+public function testTranslate(): void
+{
+  // Create a mock when we need to verify behavior
+  $client = $this->createMock(TranslateClient::class);
+  $client->expects($this->once())->method('translate')->willReturn(['text' => 'bonjour']);
+  $api = new GoogleTranslateApi($client, ...);
+
+  $result = $api->translate('hello', null, 'fr');
+  $this->assertEquals('bonjour', $result->translation);
+}
+```
+
+## Why This Matters
+
+1. **Test Clarity** - Stubs vs mocks makes intent explicit and tests easier to understand
+2. **Maintainability** - Future developers immediately understand what's being tested
+3. **Best Practices** - Aligns with modern PHP/PHPUnit standards
+4. **Faster Tests** - Stubs are lighter weight than mocks
+
+## Summary
+
+- **Stub** = "I need this dependency to return a value"
+- **Mock** = "I need to verify this dependency was used correctly"
+
+When in doubt, start with a stub. Only upgrade to a mock when you need to verify behavior with `expects()`.
+
+**Never use `#[AllowMockObjectsWithoutExpectations]` - it's a code smell that hides the real issue.**

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### Catroweb ###
 .idea/
+.phpunit.cache/
 composer.phar
 phpspec.yaml
 phpunit.xml

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
         colors="true"
         bootstrap="config/bootstrap.php"
+        cacheDirectory=".phpunit.cache"
         displayDetailsOnTestsThatTriggerDeprecations="true"
         displayDetailsOnTestsThatTriggerErrors="true"
         displayDetailsOnTestsThatTriggerNotices="true"
         displayDetailsOnTestsThatTriggerWarnings="true"
         displayDetailsOnPhpunitDeprecations="true"
+        displayDetailsOnAllIssues="true"
+        failOnDeprecation="true"
+        failOnNotice="true"
+        failOnWarning="true"
+        failOnRisky="true"
+        failOnAllIssues="true"
 >
   <php>
     <ini name="display_errors" value="1"/>
@@ -16,7 +23,7 @@
     <server name="APP_ENV" value="test" force="true"/>
     <server name="SHELL_VERBOSITY" value="-1"/>
     <server name="SYMFONY_PHPUNIT_REMOVE" value=""/>
-    <server name="SYMFONY_PHPUNIT_VERSION" value="12.1"/>
+    <server name="SYMFONY_PHPUNIT_VERSION" value="12.5"/>
   </php>
   <testsuites>
     <testsuite name="Project Test Suite">
@@ -29,8 +36,8 @@
   <source>
     <include>
       <directory suffix=".php">src/</directory>
-      <file>tests/PhpUnit/Api/Services/Base/TranslatorAwareTraitTestClass.php</file>
-      <file>tests/PhpUnit/Api/Services/Base/BearerAuthenticationTraitTestClass.php</file>
     </include>
+    <exclude>
+    </exclude>
   </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -36,6 +36,7 @@
   <source>
     <include>
       <directory suffix=".php">src/</directory>
+      <directory suffix="Class.php">tests/</directory>
     </include>
     <exclude>
     </exclude>

--- a/tests/PhpUnit/Api/AuthenticationApiTest.php
+++ b/tests/PhpUnit/Api/AuthenticationApiTest.php
@@ -14,7 +14,7 @@ use OpenAPI\Server\Model\RefreshRequest;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\Exception;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -25,7 +25,7 @@ final class AuthenticationApiTest extends DefaultTestCase
 {
   protected AuthenticationApi $authentication_api;
 
-  protected AuthenticationApiFacade|MockObject $facade;
+  protected AuthenticationApiFacade|Stub $facade;
 
   /**
    * @throws Exception
@@ -33,7 +33,7 @@ final class AuthenticationApiTest extends DefaultTestCase
   #[\Override]
   protected function setUp(): void
   {
-    $this->facade = $this->createMock(AuthenticationApiFacade::class);
+    $this->facade = $this->createStub(AuthenticationApiFacade::class);
     $this->authentication_api = new AuthenticationApi($this->facade);
   }
 
@@ -57,7 +57,7 @@ final class AuthenticationApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $login_request = $this->createMock(LoginRequest::class);
+    $login_request = $this->createStub(LoginRequest::class);
     $response = $this->authentication_api->authenticationPost($login_request, $response_code, $response_headers);
 
     $this->assertEquals(Response::HTTP_OK, $response_code);
@@ -73,7 +73,7 @@ final class AuthenticationApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $processor = $this->createMock(AuthenticationApiProcessor::class);
+    $processor = $this->createStub(AuthenticationApiProcessor::class);
     $processor->method('deleteRefreshToken')->willReturn(true);
     $this->facade->method('getProcessor')->willReturn($processor);
 
@@ -91,7 +91,7 @@ final class AuthenticationApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $refresh_request = $this->createMock(RefreshRequest::class);
+    $refresh_request = $this->createStub(RefreshRequest::class);
     $response = $this->authentication_api->authenticationRefreshPost($refresh_request, $response_code, $response_headers);
 
     $this->assertEquals(Response::HTTP_OK, $response_code);

--- a/tests/PhpUnit/Api/MediaLibraryApiTest.php
+++ b/tests/PhpUnit/Api/MediaLibraryApiTest.php
@@ -15,7 +15,7 @@ use OpenAPI\Server\Model\MediaFileResponse;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\Exception;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -26,7 +26,7 @@ final class MediaLibraryApiTest extends DefaultTestCase
 {
   protected MediaLibraryApi $media_library_api;
 
-  protected MediaLibraryApiFacade|MockObject $facade;
+  protected MediaLibraryApiFacade|Stub $facade;
 
   /**
    * @throws Exception
@@ -34,7 +34,7 @@ final class MediaLibraryApiTest extends DefaultTestCase
   #[\Override]
   protected function setUp(): void
   {
-    $this->facade = $this->createMock(MediaLibraryApiFacade::class);
+    $this->facade = $this->createStub(MediaLibraryApiFacade::class);
     $this->media_library_api = new MediaLibraryApi($this->facade);
   }
 
@@ -47,7 +47,7 @@ final class MediaLibraryApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(MediaLibraryApiLoader::class);
+    $loader = $this->createStub(MediaLibraryApiLoader::class);
     $loader->method('searchMediaLibraryFiles')->willReturn([]);
     $this->facade->method('getLoader')->willReturn($loader);
 
@@ -65,7 +65,7 @@ final class MediaLibraryApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(MediaLibraryApiLoader::class);
+    $loader = $this->createStub(MediaLibraryApiLoader::class);
     $loader->method('getMediaPackageByName')->willReturn(null);
     $this->facade->method('getLoader')->willReturn($loader);
 
@@ -84,8 +84,8 @@ final class MediaLibraryApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(MediaLibraryApiLoader::class);
-    $mediaPackage = $this->createMock(MediaPackage::class);
+    $loader = $this->createStub(MediaLibraryApiLoader::class);
+    $mediaPackage = $this->createStub(MediaPackage::class);
     $mediaPackage->method('getCategories')->willReturn(new ArrayCollection());
     $loader->method('getMediaPackageByName')->willReturn($mediaPackage);
     $this->facade->method('getLoader')->willReturn($loader);
@@ -106,7 +106,7 @@ final class MediaLibraryApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(MediaLibraryApiLoader::class);
+    $loader = $this->createStub(MediaLibraryApiLoader::class);
     $loader->method('getMediaPackageFileByID')->willReturn(null);
     $this->facade->method('getLoader')->willReturn($loader);
 
@@ -125,8 +125,8 @@ final class MediaLibraryApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(MediaLibraryApiLoader::class);
-    $loader->method('getMediaPackageFileByID')->willReturn($this->createMock(MediaPackageFile::class));
+    $loader = $this->createStub(MediaLibraryApiLoader::class);
+    $loader->method('getMediaPackageFileByID')->willReturn($this->createStub(MediaPackageFile::class));
     $this->facade->method('getLoader')->willReturn($loader);
 
     $response = $this->media_library_api->mediaFileIdGet(1, '', $response_code, $response_headers);
@@ -145,7 +145,7 @@ final class MediaLibraryApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(MediaLibraryApiLoader::class);
+    $loader = $this->createStub(MediaLibraryApiLoader::class);
     $loader->method('getMediaPackageFiles')->willReturn([]);
     $this->facade->method('getLoader')->willReturn($loader);
 

--- a/tests/PhpUnit/Api/NotificationsApiTest.php
+++ b/tests/PhpUnit/Api/NotificationsApiTest.php
@@ -13,7 +13,7 @@ use OpenAPI\Server\Model\NotificationsCountResponse;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\Exception;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -22,9 +22,9 @@ use Symfony\Component\HttpFoundation\Response;
 #[CoversClass(NotificationsApi::class)]
 class NotificationsApiTest extends DefaultTestCase
 {
-  protected MockObject|NotificationsApi $object;
+  protected NotificationsApi $object;
 
-  protected MockObject|NotificationsApiFacade $facade;
+  protected Stub|NotificationsApiFacade $facade;
 
   /**
    * @throws \ReflectionException
@@ -33,21 +33,8 @@ class NotificationsApiTest extends DefaultTestCase
   #[\Override]
   protected function setUp(): void
   {
-    $this->object = $this->getMockBuilder(NotificationsApi::class)
-      ->disableOriginalConstructor()
-      ->onlyMethods(['getAuthenticationToken'])
-      ->getMock()
-    ;
-
-    $this->facade = $this->createMock(NotificationsApiFacade::class);
-    $this->mockProperty(NotificationsApi::class, $this->object, 'facade', $this->facade);
-  }
-
-  #[Group('integration')]
-  public function testCtor(): void
-  {
+    $this->facade = $this->createStub(NotificationsApiFacade::class);
     $this->object = new NotificationsApi($this->facade);
-    $this->assertInstanceOf(NotificationsApi::class, $this->object);
   }
 
   #[Group('unit')]
@@ -70,8 +57,8 @@ class NotificationsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
-    $user = $this->createMock(User::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
+    $user = $this->createStub(User::class);
     $user->method('getId')->willReturn('1');
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->facade->method('getAuthenticationManager')->willReturn($authentication_manager);
@@ -103,8 +90,8 @@ class NotificationsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
-    $authentication_manager->method('getAuthenticatedUser')->willReturn($this->createMock(User::class));
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
+    $authentication_manager->method('getAuthenticatedUser')->willReturn($this->createStub(User::class));
     $this->facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
     $this->object->notificationsReadPut($response_code, $response_headers);

--- a/tests/PhpUnit/Api/ProjectsApiTest.php
+++ b/tests/PhpUnit/Api/ProjectsApiTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -41,11 +42,11 @@ use Symfony\Component\HttpFoundation\Response;
 #[CoversClass(ProjectsApi::class)]
 final class ProjectsApiTest extends DefaultTestCase
 {
-  protected MockObject|ProjectsApi $object;
+  protected ProjectsApi $object;
 
-  protected MockObject|ProjectsApiFacade $facade;
+  protected Stub|ProjectsApiFacade $facade;
 
-  protected MockObject|ReactionsApiFacade $reactions_facade;
+  protected Stub|ReactionsApiFacade $reactions_facade;
 
   protected mixed $full_validator;
 
@@ -58,27 +59,13 @@ final class ProjectsApiTest extends DefaultTestCase
   #[\Override]
   protected function setUp(): void
   {
-    $this->object = $this->getMockBuilder(ProjectsApi::class)
-      ->disableOriginalConstructor()
-      ->onlyMethods(['getAuthenticationToken'])
-      ->getMock()
-    ;
-
-    $this->facade = $this->createMock(ProjectsApiFacade::class);
-    $this->reactions_facade = $this->createMock(ReactionsApiFacade::class);
-    $this->mockProperty(ProjectsApi::class, $this->object, 'facade', $this->facade);
-    $this->mockProperty(ProjectsApi::class, $this->object, 'reactions_facade', $this->reactions_facade);
+    $this->facade = $this->createStub(ProjectsApiFacade::class);
+    $this->reactions_facade = $this->createStub(ReactionsApiFacade::class);
+    $this->object = new ProjectsApi($this->facade, $this->reactions_facade);
 
     ProjectsApiTest::bootKernel();
     $this->full_validator = ProjectsApiTest::getContainer()->get(ProjectsRequestValidator::class);
     $this->full_response_manager = ProjectsApiTest::getContainer()->get(ProjectsResponseManager::class);
-  }
-
-  #[Group('integration')]
-  public function testCtor(): void
-  {
-    $this->object = new ProjectsApi($this->facade, $this->reactions_facade);
-    $this->assertInstanceOf(ProjectsApi::class, $this->object);
   }
 
   /**
@@ -90,7 +77,7 @@ final class ProjectsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(ProjectsApiLoader::class);
+    $loader = $this->createStub(ProjectsApiLoader::class);
     $loader->method('findProjectByID')->willReturn(null);
     $this->facade->method('getLoader')->willReturn($loader);
 
@@ -110,8 +97,8 @@ final class ProjectsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(ProjectsApiLoader::class);
-    $loader->method('findProjectByID')->willReturn($this->createMock(Program::class));
+    $loader = $this->createStub(ProjectsApiLoader::class);
+    $loader->method('findProjectByID')->willReturn($this->createStub(Program::class));
     $this->facade->method('getLoader')->willReturn($loader);
 
     $response = $this->object->projectIdGet('id', $response_code, $response_headers);
@@ -126,11 +113,11 @@ final class ProjectsApiTest extends DefaultTestCase
   private function projectIdPut_setLoaderAndAuthManager(MockObject|Program|null $project = null, MockObject|User|null $user = null): void
   {
     if (is_null($user)) {
-      $user = $this->createMock(User::class);
+      $user = $this->createStub(User::class);
     }
 
     if (is_null($project)) {
-      $project = $this->createMock(Program::class);
+      $project = $this->createStub(Program::class);
       $project->method('getUser')->willReturn($user);
     }
 
@@ -143,7 +130,7 @@ final class ProjectsApiTest extends DefaultTestCase
    */
   private function projectIdPut_setLoader(MockObject|Program|null $project): void
   {
-    $loader = $this->createMock(ProjectsApiLoader::class);
+    $loader = $this->createStub(ProjectsApiLoader::class);
     $loader->method('findProjectByID')->willReturn($project);
     $this->facade->method('getLoader')->willReturn($loader);
   }
@@ -153,7 +140,7 @@ final class ProjectsApiTest extends DefaultTestCase
    */
   private function projectIdPut_setAuthManager(MockObject|User|null $user): void
   {
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->facade->method('getAuthenticationManager')->willReturn($authentication_manager);
   }
@@ -178,20 +165,20 @@ final class ProjectsApiTest extends DefaultTestCase
 
     $this->projectIdPut_setLoaderAndAuthManager($project, $user);
 
-    $extracted_file_repository = $this->createMock(ExtractedFileRepository::class);
+    $extracted_file_repository = $this->createStub(ExtractedFileRepository::class);
     $extracted_file_repository->method('loadProjectExtractedFile')->willReturn(null);
     $processor = new ProjectsApiProcessor(
-      $this->createMock(ProjectManager::class),
-      $this->createMock(EntityManagerInterface::class),
+      $this->createStub(ProjectManager::class),
+      $this->createStub(EntityManagerInterface::class),
       $extracted_file_repository,
-      $this->createMock(ProjectFileRepository::class),
-      $this->createMock(ScreenshotRepository::class)
+      $this->createStub(ProjectFileRepository::class),
+      $this->createStub(ScreenshotRepository::class)
     );
     $this->facade->method('getProcessor')->willReturn($processor);
 
     $this->facade->method('getRequestValidator')->willReturn($this->full_validator);
 
-    $update_project_request = $this->createMock(UpdateProjectRequest::class);
+    $update_project_request = $this->createStub(UpdateProjectRequest::class);
 
     $project_name = 'My special 🐼 project!';
     $project_description = 'Integer lobortis lacus efficitur arcu blandit hendrerit. In hac habitasse platea accumsan.';
@@ -223,7 +210,7 @@ final class ProjectsApiTest extends DefaultTestCase
 
     $this->projectIdPut_setLoader(null);
 
-    $update_project_request = $this->createMock(UpdateProjectRequest::class);
+    $update_project_request = $this->createStub(UpdateProjectRequest::class);
 
     $response = $this->object->projectIdPut('id', $update_project_request, 'en', $response_code, $response_headers);
 
@@ -240,10 +227,10 @@ final class ProjectsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $this->projectIdPut_setLoader($this->createMock(Program::class));
+    $this->projectIdPut_setLoader($this->createStub(Program::class));
     $this->projectIdPut_setAuthManager(null);
 
-    $update_project_request = $this->createMock(UpdateProjectRequest::class);
+    $update_project_request = $this->createStub(UpdateProjectRequest::class);
 
     $response = $this->object->projectIdPut('id', $update_project_request, 'en', $response_code, $response_headers);
 
@@ -271,7 +258,7 @@ final class ProjectsApiTest extends DefaultTestCase
 
     $this->projectIdPut_setLoaderAndAuthManager($project, $user);
 
-    $update_project_request = $this->createMock(UpdateProjectRequest::class);
+    $update_project_request = $this->createStub(UpdateProjectRequest::class);
 
     $response = $this->object->projectIdPut('id', $update_project_request, 'en', $response_code, $response_headers);
 
@@ -292,7 +279,7 @@ final class ProjectsApiTest extends DefaultTestCase
 
     $this->facade->method('getRequestValidator')->willReturn($this->full_validator);
 
-    $update_project_request = $this->createMock(UpdateProjectRequest::class);
+    $update_project_request = $this->createStub(UpdateProjectRequest::class);
 
     $project_name = '';
     $project_description = str_pad('a', 10_001, 'a');
@@ -325,29 +312,29 @@ final class ProjectsApiTest extends DefaultTestCase
 
     $this->projectIdPut_setLoaderAndAuthManager();
 
-    $extracted_file_repository = $this->createMock(ExtractedFileRepository::class);
-    $extracted_file = $this->createMock(ExtractedCatrobatFile::class);
+    $extracted_file_repository = $this->createStub(ExtractedFileRepository::class);
+    $extracted_file = $this->createStub(ExtractedCatrobatFile::class);
     $extracted_file_repository->method('loadProjectExtractedFile')->willReturn($extracted_file);
     $extracted_file_repository->method('saveProjectExtractedFile')->willThrowException(new \Exception(''));
 
     $processor = new ProjectsApiProcessor(
-      $this->createMock(ProjectManager::class),
-      $this->createMock(EntityManagerInterface::class),
+      $this->createStub(ProjectManager::class),
+      $this->createStub(EntityManagerInterface::class),
       $extracted_file_repository,
-      $this->createMock(ProjectFileRepository::class),
-      $this->createMock(ScreenshotRepository::class)
+      $this->createStub(ProjectFileRepository::class),
+      $this->createStub(ScreenshotRepository::class)
     );
     $this->facade->method('getProcessor')->willReturn($processor);
 
-    $validator = $this->createMock(ProjectsRequestValidator::class);
-    $validation_wrapper = $this->createMock(ValidationWrapper::class);
+    $validator = $this->createStub(ProjectsRequestValidator::class);
+    $validation_wrapper = $this->createStub(ValidationWrapper::class);
     $validation_wrapper->method('hasError')->willReturn(false);
     $validator->method('validateUpdateRequest')->willReturn($validation_wrapper);
 
     $this->facade->method('getRequestValidator')->willReturn($validator);
     $this->facade->method('getResponseManager')->willReturn($this->full_response_manager);
 
-    $update_project_request = $this->createMock(UpdateProjectRequest::class);
+    $update_project_request = $this->createStub(UpdateProjectRequest::class);
 
     $update_project_request->method('getName')->willReturn('New name');
 
@@ -370,7 +357,7 @@ final class ProjectsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(ProjectsApiLoader::class);
+    $loader = $this->createStub(ProjectsApiLoader::class);
     $loader->method('getFeaturedProjects')->willReturn([]);
     $this->facade->method('getLoader')->willReturn($loader);
 
@@ -420,8 +407,8 @@ final class ProjectsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(ProjectsApiLoader::class);
-    $loader->method('findProjectByID')->willReturn($this->createMock(Program::class));
+    $loader = $this->createStub(ProjectsApiLoader::class);
+    $loader->method('findProjectByID')->willReturn($this->createStub(Program::class));
     $loader->method('getRecommendedProjects')->willReturn([]);
     $this->facade->method('getLoader')->willReturn($loader);
 
@@ -472,7 +459,7 @@ final class ProjectsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn(null);
     $this->facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
@@ -493,8 +480,8 @@ final class ProjectsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
-    $user = $this->createMock(User::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
+    $user = $this->createStub(User::class);
     $user->method('getId')->willReturn('1');
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->facade->method('getAuthenticationManager')->willReturn($authentication_manager);
@@ -516,7 +503,7 @@ final class ProjectsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $request_validator = $this->createMock(ProjectsRequestValidator::class);
+    $request_validator = $this->createStub(ProjectsRequestValidator::class);
     $request_validator->method('validateUserExists')->willReturn(true);
     $this->facade->method('getRequestValidator')->willReturn($request_validator);
 
@@ -537,7 +524,7 @@ final class ProjectsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $request_validator = $this->createMock(ProjectsRequestValidator::class);
+    $request_validator = $this->createStub(ProjectsRequestValidator::class);
     $request_validator->method('validateUserExists')->willReturn(false);
     $this->facade->method('getRequestValidator')->willReturn($request_validator);
 
@@ -558,7 +545,7 @@ final class ProjectsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $project_report_request = $this->createMock(ProjectReportRequest::class);
+    $project_report_request = $this->createStub(ProjectReportRequest::class);
 
     $this->object->projectIdReportPost('id', $project_report_request, $response_code, $response_headers);
 
@@ -576,16 +563,16 @@ final class ProjectsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $user = $this->createMock(User::class);
+    $user = $this->createStub(User::class);
     $user->method('isVerified')->willReturn(true);
-    $processor = $this->createMock(ProjectsApiProcessor::class);
-    $processor->method('addProject')->willReturn($this->createMock(Program::class));
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $processor = $this->createStub(ProjectsApiProcessor::class);
+    $processor->method('addProject')->willReturn($this->createStub(Program::class));
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->facade->method('getAuthenticationManager')->willReturn($authentication_manager);
     $this->facade->method('getProcessor')->willReturn($processor);
 
-    $file = $this->createMock(UploadedFile::class);
+    $file = $this->createStub(UploadedFile::class);
     $response = $this->object->projectsPost('checksum', $file, 'en', '', false, $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_CREATED, $response_code);
@@ -604,21 +591,21 @@ final class ProjectsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $validator = $this->createMock(ProjectsRequestValidator::class);
-    $validation_wrapper = $this->createMock(ValidationWrapper::class);
+    $validator = $this->createStub(ProjectsRequestValidator::class);
+    $validation_wrapper = $this->createStub(ValidationWrapper::class);
     $validation_wrapper->method('hasError')->willReturn(true);
     $validator->method('validateUploadFile')->willReturn($validation_wrapper);
-    $processor = $this->createMock(ProjectsApiProcessor::class);
-    $processor->method('addProject')->willReturn($this->createMock(Program::class));
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
-    $user = $this->createMock(User::class);
+    $processor = $this->createStub(ProjectsApiProcessor::class);
+    $processor->method('addProject')->willReturn($this->createStub(Program::class));
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
+    $user = $this->createStub(User::class);
     $user->method('isVerified')->willReturn(true);
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->facade->method('getAuthenticationManager')->willReturn($authentication_manager);
     $this->facade->method('getProcessor')->willReturn($processor);
     $this->facade->method('getRequestValidator')->willReturn($validator);
 
-    $file = $this->createMock(UploadedFile::class);
+    $file = $this->createStub(UploadedFile::class);
     $response = $this->object->projectsPost('checksum', $file, 'en', '', false, $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response_code);
@@ -636,16 +623,16 @@ final class ProjectsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $processor = $this->createMock(ProjectsApiProcessor::class);
+    $processor = $this->createStub(ProjectsApiProcessor::class);
     $processor->method('addProject')->willThrowException(new \Exception());
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
-    $user = $this->createMock(User::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
+    $user = $this->createStub(User::class);
     $user->method('isVerified')->willReturn(true);
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->facade->method('getAuthenticationManager')->willReturn($authentication_manager);
     $this->facade->method('getProcessor')->willReturn($processor);
 
-    $file = $this->createMock(UploadedFile::class);
+    $file = $this->createStub(UploadedFile::class);
     $response = $this->object->projectsPost('checksum', $file, 'en', '', false, $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response_code);

--- a/tests/PhpUnit/Api/ReactionsApiTest.php
+++ b/tests/PhpUnit/Api/ReactionsApiTest.php
@@ -20,7 +20,7 @@ use OpenAPI\Server\Model\ReactionUsersResponse;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\Exception;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -29,11 +29,11 @@ use Symfony\Component\HttpFoundation\Response;
 #[CoversClass(ProjectsApi::class)]
 final class ReactionsApiTest extends DefaultTestCase
 {
-  protected MockObject|ProjectsApi $object;
+  protected ProjectsApi $object;
 
-  protected MockObject|ProjectsApiFacade $facade;
+  protected Stub|ProjectsApiFacade $facade;
 
-  protected MockObject|ReactionsApiFacade $reactions_facade;
+  protected Stub|ReactionsApiFacade $reactions_facade;
 
   /**
    * @throws \ReflectionException
@@ -42,26 +42,9 @@ final class ReactionsApiTest extends DefaultTestCase
   #[\Override]
   protected function setUp(): void
   {
-    $this->object = $this->getMockBuilder(ProjectsApi::class)
-      ->disableOriginalConstructor()
-      ->onlyMethods([])
-      ->getMock()
-    ;
-
-    $this->facade = $this->createMock(ProjectsApiFacade::class);
-    $this->reactions_facade = $this->createMock(ReactionsApiFacade::class);
-    $this->mockProperty(ProjectsApi::class, $this->object, 'facade', $this->facade);
-    $this->mockProperty(ProjectsApi::class, $this->object, 'reactions_facade', $this->reactions_facade);
-  }
-
-  #[Group('integration')]
-  public function testCtor(): void
-  {
-    $this->object = new ProjectsApi(
-      $this->createMock(ProjectsApiFacade::class),
-      $this->createMock(ReactionsApiFacade::class)
-    );
-    $this->assertInstanceOf(ProjectsApi::class, $this->object);
+    $this->facade = $this->createStub(ProjectsApiFacade::class);
+    $this->reactions_facade = $this->createStub(ReactionsApiFacade::class);
+    $this->object = new ProjectsApi($this->facade, $this->reactions_facade);
   }
 
   // ==================== projectIdReactionPost Tests ====================
@@ -75,11 +58,11 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn(null);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $reaction_request = $this->createMock(ReactionRequest::class);
+    $reaction_request = $this->createStub(ReactionRequest::class);
 
     $response = $this->object->projectIdReactionPost('id', $reaction_request, 'en', $response_code, $response_headers);
 
@@ -96,16 +79,16 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $user = $this->createMock(User::class);
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $user = $this->createStub(User::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $loader = $this->createMock(ReactionsApiLoader::class);
+    $loader = $this->createStub(ReactionsApiLoader::class);
     $loader->method('findProjectIfVisibleToCurrentUser')->willReturn(null);
     $this->reactions_facade->method('getLoader')->willReturn($loader);
 
-    $reaction_request = $this->createMock(ReactionRequest::class);
+    $reaction_request = $this->createStub(ReactionRequest::class);
 
     $response = $this->object->projectIdReactionPost('id', $reaction_request, 'en', $response_code, $response_headers);
 
@@ -122,17 +105,17 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $user = $this->createMock(User::class);
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $user = $this->createStub(User::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $project = $this->createMock(Program::class);
-    $loader = $this->createMock(ReactionsApiLoader::class);
+    $project = $this->createStub(Program::class);
+    $loader = $this->createStub(ReactionsApiLoader::class);
     $loader->method('findProjectIfVisibleToCurrentUser')->willReturn($project);
     $this->reactions_facade->method('getLoader')->willReturn($loader);
 
-    $reaction_request = $this->createMock(ReactionRequest::class);
+    $reaction_request = $this->createStub(ReactionRequest::class);
     $reaction_request->method('getType')->willReturn(null);
 
     $response = $this->object->projectIdReactionPost('id', $reaction_request, 'en', $response_code, $response_headers);
@@ -150,17 +133,17 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $user = $this->createMock(User::class);
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $user = $this->createStub(User::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $project = $this->createMock(Program::class);
-    $loader = $this->createMock(ReactionsApiLoader::class);
+    $project = $this->createStub(Program::class);
+    $loader = $this->createStub(ReactionsApiLoader::class);
     $loader->method('findProjectIfVisibleToCurrentUser')->willReturn($project);
     $this->reactions_facade->method('getLoader')->willReturn($loader);
 
-    $reaction_request = $this->createMock(ReactionRequest::class);
+    $reaction_request = $this->createStub(ReactionRequest::class);
     $reaction_request->method('getType')->willReturn('invalid_type');
 
     $response = $this->object->projectIdReactionPost('id', $reaction_request, 'en', $response_code, $response_headers);
@@ -178,21 +161,21 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $user = $this->createMock(User::class);
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $user = $this->createStub(User::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $project = $this->createMock(Program::class);
-    $loader = $this->createMock(ReactionsApiLoader::class);
+    $project = $this->createStub(Program::class);
+    $loader = $this->createStub(ReactionsApiLoader::class);
     $loader->method('findProjectIfVisibleToCurrentUser')->willReturn($project);
     $this->reactions_facade->method('getLoader')->willReturn($loader);
 
-    $processor = $this->createMock(ReactionsApiProcessor::class);
+    $processor = $this->createStub(ReactionsApiProcessor::class);
     $processor->method('addReaction')->willReturn(false);
     $this->reactions_facade->method('getProcessor')->willReturn($processor);
 
-    $reaction_request = $this->createMock(ReactionRequest::class);
+    $reaction_request = $this->createStub(ReactionRequest::class);
     $reaction_request->method('getType')->willReturn('thumbs_up');
 
     $response = $this->object->projectIdReactionPost('id', $reaction_request, 'en', $response_code, $response_headers);
@@ -210,13 +193,13 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $user = $this->createMock(User::class);
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $user = $this->createStub(User::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $project = $this->createMock(Program::class);
-    $loader = $this->createMock(ReactionsApiLoader::class);
+    $project = $this->createStub(Program::class);
+    $loader = $this->createStub(ReactionsApiLoader::class);
     $loader->method('findProjectIfVisibleToCurrentUser')->willReturn($project);
     $loader->method('getReactionCounts')->willReturn([
       'total' => 1, 'thumbs_up' => 1, 'smile' => 0, 'love' => 0, 'wow' => 0, 'active_types' => ['thumbs_up'],
@@ -224,17 +207,17 @@ final class ReactionsApiTest extends DefaultTestCase
     $loader->method('getUserReactions')->willReturn(['thumbs_up']);
     $this->reactions_facade->method('getLoader')->willReturn($loader);
 
-    $processor = $this->createMock(ReactionsApiProcessor::class);
+    $processor = $this->createStub(ReactionsApiProcessor::class);
     $processor->method('addReaction')->willReturn(true);
     $this->reactions_facade->method('getProcessor')->willReturn($processor);
 
-    $response_manager = $this->createMock(ReactionsResponseManager::class);
+    $response_manager = $this->createStub(ReactionsResponseManager::class);
     $response_manager->method('createReactionSummaryResponse')
-      ->willReturn($this->createMock(ReactionSummaryResponse::class))
+      ->willReturn($this->createStub(ReactionSummaryResponse::class))
     ;
     $this->reactions_facade->method('getResponseManager')->willReturn($response_manager);
 
-    $reaction_request = $this->createMock(ReactionRequest::class);
+    $reaction_request = $this->createStub(ReactionRequest::class);
     $reaction_request->method('getType')->willReturn('thumbs_up');
 
     $response = $this->object->projectIdReactionPost('id', $reaction_request, 'en', $response_code, $response_headers);
@@ -254,7 +237,7 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn(null);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
@@ -272,12 +255,12 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $user = $this->createMock(User::class);
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $user = $this->createStub(User::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $loader = $this->createMock(ReactionsApiLoader::class);
+    $loader = $this->createStub(ReactionsApiLoader::class);
     $loader->method('findProjectIfVisibleToCurrentUser')->willReturn(null);
     $this->reactions_facade->method('getLoader')->willReturn($loader);
 
@@ -295,13 +278,13 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $user = $this->createMock(User::class);
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $user = $this->createStub(User::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $project = $this->createMock(Program::class);
-    $loader = $this->createMock(ReactionsApiLoader::class);
+    $project = $this->createStub(Program::class);
+    $loader = $this->createStub(ReactionsApiLoader::class);
     $loader->method('findProjectIfVisibleToCurrentUser')->willReturn($project);
     $this->reactions_facade->method('getLoader')->willReturn($loader);
 
@@ -319,17 +302,17 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $user = $this->createMock(User::class);
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $user = $this->createStub(User::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $project = $this->createMock(Program::class);
-    $loader = $this->createMock(ReactionsApiLoader::class);
+    $project = $this->createStub(Program::class);
+    $loader = $this->createStub(ReactionsApiLoader::class);
     $loader->method('findProjectIfVisibleToCurrentUser')->willReturn($project);
     $this->reactions_facade->method('getLoader')->willReturn($loader);
 
-    $processor = $this->createMock(ReactionsApiProcessor::class);
+    $processor = $this->createStub(ReactionsApiProcessor::class);
     $this->reactions_facade->method('getProcessor')->willReturn($processor);
 
     $this->object->projectIdReactionDelete('id', 'thumbs_up', 'en', $response_code, $response_headers);
@@ -348,11 +331,11 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn(null);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $loader = $this->createMock(ReactionsApiLoader::class);
+    $loader = $this->createStub(ReactionsApiLoader::class);
     $loader->method('findProjectIfVisibleToCurrentUser')->willReturn(null);
     $this->reactions_facade->method('getLoader')->willReturn($loader);
 
@@ -371,13 +354,13 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $user = $this->createMock(User::class);
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $user = $this->createStub(User::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $project = $this->createMock(Program::class);
-    $loader = $this->createMock(ReactionsApiLoader::class);
+    $project = $this->createStub(Program::class);
+    $loader = $this->createStub(ReactionsApiLoader::class);
     $loader->method('findProjectIfVisibleToCurrentUser')->willReturn($project);
     $loader->method('getReactionCounts')->willReturn([
       'total' => 5, 'thumbs_up' => 2, 'smile' => 1, 'love' => 1, 'wow' => 1, 'active_types' => ['thumbs_up', 'smile', 'love', 'wow'],
@@ -385,9 +368,9 @@ final class ReactionsApiTest extends DefaultTestCase
     $loader->method('getUserReactions')->willReturn(['thumbs_up', 'love']);
     $this->reactions_facade->method('getLoader')->willReturn($loader);
 
-    $response_manager = $this->createMock(ReactionsResponseManager::class);
+    $response_manager = $this->createStub(ReactionsResponseManager::class);
     $response_manager->method('createReactionSummaryResponse')
-      ->willReturn($this->createMock(ReactionSummaryResponse::class))
+      ->willReturn($this->createStub(ReactionSummaryResponse::class))
     ;
     $this->reactions_facade->method('getResponseManager')->willReturn($response_manager);
 
@@ -406,21 +389,21 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn(null);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $project = $this->createMock(Program::class);
-    $loader = $this->createMock(ReactionsApiLoader::class);
+    $project = $this->createStub(Program::class);
+    $loader = $this->createStub(ReactionsApiLoader::class);
     $loader->method('findProjectIfVisibleToCurrentUser')->willReturn($project);
     $loader->method('getReactionCounts')->willReturn([
       'total' => 3, 'thumbs_up' => 1, 'smile' => 1, 'love' => 1, 'wow' => 0, 'active_types' => ['thumbs_up', 'smile', 'love'],
     ]);
     $this->reactions_facade->method('getLoader')->willReturn($loader);
 
-    $response_manager = $this->createMock(ReactionsResponseManager::class);
+    $response_manager = $this->createStub(ReactionsResponseManager::class);
     $response_manager->method('createReactionSummaryResponse')
-      ->willReturn($this->createMock(ReactionSummaryResponse::class))
+      ->willReturn($this->createStub(ReactionSummaryResponse::class))
     ;
     $this->reactions_facade->method('getResponseManager')->willReturn($response_manager);
 
@@ -441,11 +424,11 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn(null);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $loader = $this->createMock(ReactionsApiLoader::class);
+    $loader = $this->createStub(ReactionsApiLoader::class);
     $loader->method('findProjectIfVisibleToCurrentUser')->willReturn(null);
     $this->reactions_facade->method('getLoader')->willReturn($loader);
 
@@ -464,12 +447,12 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn(null);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $project = $this->createMock(Program::class);
-    $loader = $this->createMock(ReactionsApiLoader::class);
+    $project = $this->createStub(Program::class);
+    $loader = $this->createStub(ReactionsApiLoader::class);
     $loader->method('findProjectIfVisibleToCurrentUser')->willReturn($project);
     $loader->method('getReactionUsersPaginated')->willReturn([
       'data' => [],
@@ -478,9 +461,9 @@ final class ReactionsApiTest extends DefaultTestCase
     ]);
     $this->reactions_facade->method('getLoader')->willReturn($loader);
 
-    $response_manager = $this->createMock(ReactionsResponseManager::class);
+    $response_manager = $this->createStub(ReactionsResponseManager::class);
     $response_manager->method('createReactionUsersResponse')
-      ->willReturn($this->createMock(ReactionUsersResponse::class))
+      ->willReturn($this->createStub(ReactionUsersResponse::class))
     ;
     $this->reactions_facade->method('getResponseManager')->willReturn($response_manager);
 
@@ -499,12 +482,12 @@ final class ReactionsApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $authentication_manager = $this->createMock(AuthenticationManager::class);
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
     $authentication_manager->method('getAuthenticatedUser')->willReturn(null);
     $this->reactions_facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $project = $this->createMock(Program::class);
-    $loader = $this->createMock(ReactionsApiLoader::class);
+    $project = $this->createStub(Program::class);
+    $loader = $this->createStub(ReactionsApiLoader::class);
     $loader->method('findProjectIfVisibleToCurrentUser')->willReturn($project);
     $loader->method('getReactionUsersPaginated')->willReturn([
       'data' => [],
@@ -513,9 +496,9 @@ final class ReactionsApiTest extends DefaultTestCase
     ]);
     $this->reactions_facade->method('getLoader')->willReturn($loader);
 
-    $response_manager = $this->createMock(ReactionsResponseManager::class);
+    $response_manager = $this->createStub(ReactionsResponseManager::class);
     $response_manager->method('createReactionUsersResponse')
-      ->willReturn($this->createMock(ReactionUsersResponse::class))
+      ->willReturn($this->createStub(ReactionUsersResponse::class))
     ;
     $this->reactions_facade->method('getResponseManager')->willReturn($response_manager);
 

--- a/tests/PhpUnit/Api/SearchApiTest.php
+++ b/tests/PhpUnit/Api/SearchApiTest.php
@@ -11,7 +11,7 @@ use OpenAPI\Server\Model\SearchResponse;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\Exception;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -22,7 +22,7 @@ final class SearchApiTest extends DefaultTestCase
 {
   protected SearchApi $search_api;
 
-  protected MockObject|SearchApiFacade $facade;
+  protected SearchApiFacade|Stub $facade;
 
   /**
    * @throws Exception
@@ -30,15 +30,8 @@ final class SearchApiTest extends DefaultTestCase
   #[\Override]
   protected function setUp(): void
   {
-    $this->facade = $this->createMock(SearchApiFacade::class);
+    $this->facade = $this->createStub(SearchApiFacade::class);
     $this->search_api = new SearchApi($this->facade);
-  }
-
-  #[Group('integration')]
-  public function testCtor(): void
-  {
-    $this->search_api = new SearchApi($this->facade);
-    $this->assertInstanceOf(SearchApi::class, $this->search_api);
   }
 
   /**

--- a/tests/PhpUnit/Api/Services/Base/AbstractResponseManagerTest.php
+++ b/tests/PhpUnit/Api/Services/Base/AbstractResponseManagerTest.php
@@ -10,7 +10,9 @@ use OpenAPI\Server\Model\ProjectResponse;
 use OpenAPI\Server\Service\JmsSerializer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Exception;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @internal
@@ -18,27 +20,24 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[CoversClass(AbstractResponseManager::class)]
 final class AbstractResponseManagerTest extends DefaultTestCase
 {
-  protected AbstractResponseManager|MockObject $object;
+  protected AbstractResponseManagerTestClass $object;
 
-  /** @noinspection PhpMultipleClassDeclarationsInspection */
+  /**
+   * @throws Exception
+   */
   #[\Override]
   protected function setUp(): void
   {
-    $this->object = $this->getMockBuilder(AbstractResponseManager::class)
-      ->disableOriginalConstructor()
-      ->onlyMethods([])
-      ->getMock()
-    ;
+    $translator = $this->createStub(TranslatorInterface::class);
+    $serializer = new JmsSerializer();
+    $cache = $this->createStub(CacheItemPoolInterface::class);
+
+    $this->object = new AbstractResponseManagerTestClass($translator, $serializer, $cache);
   }
 
-  /**
-   * @throws \ReflectionException
-   */
   #[Group('integration')]
   public function testAddResponseHashToHeaders(): void
   {
-    $this->mockProperty(AbstractResponseManager::class, $this->object, 'serializer', new JmsSerializer());
-
     $responseHeaders = [];
     $response = new ProjectResponse(['id' => '1']);
     $this->object->addResponseHashToHeaders($responseHeaders, $response);

--- a/tests/PhpUnit/Api/Services/Base/AbstractResponseManagerTestClass.php
+++ b/tests/PhpUnit/Api/Services/Base/AbstractResponseManagerTestClass.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Api\Services\Base;
+
+use App\Api\Services\Base\AbstractResponseManager;
+
+class AbstractResponseManagerTestClass extends AbstractResponseManager
+{
+}

--- a/tests/PhpUnit/Api/Services/Base/BearerAuthenticationTraitTest.php
+++ b/tests/PhpUnit/Api/Services/Base/BearerAuthenticationTraitTest.php
@@ -10,7 +10,6 @@ use App\System\Testing\PhpUnit\DefaultTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @internal
@@ -18,16 +17,12 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[CoversClass(BearerAuthenticationTraitTestClass::class)]
 final class BearerAuthenticationTraitTest extends DefaultTestCase
 {
-  protected MockObject|BearerAuthenticationTraitTestClass $object;
+  protected BearerAuthenticationTraitTestClass $object;
 
   #[\Override]
   protected function setUp(): void
   {
-    $this->object = $this->getMockBuilder(BearerAuthenticationTraitTestClass::class)
-      ->onlyMethods([])
-      ->onlyMethods([])
-      ->getMock()
-    ;
+    $this->object = new BearerAuthenticationTraitTestClass();
   }
 
   #[Group('integration')]

--- a/tests/PhpUnit/Api/Services/Base/TranslatorAwareTraitTest.php
+++ b/tests/PhpUnit/Api/Services/Base/TranslatorAwareTraitTest.php
@@ -19,16 +19,12 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[CoversClass(TranslatorAwareTraitTestClass::class)]
 final class TranslatorAwareTraitTest extends DefaultTestCase
 {
-  protected MockObject|TranslatorAwareTraitTestClass $object;
+  protected TranslatorAwareTraitTestClass|MockObject $object;
 
   #[\Override]
   protected function setUp(): void
   {
-    $this->object = $this->getMockBuilder(TranslatorAwareTraitTestClass::class)
-      ->onlyMethods([])
-      ->onlyMethods([])
-      ->getMock()
-    ;
+    $this->object = new TranslatorAwareTraitTestClass();
   }
 
   #[Group('integration')]
@@ -74,7 +70,7 @@ final class TranslatorAwareTraitTest extends DefaultTestCase
   #[Group('unit')]
   public function testTransFailureHandling(): void
   {
-    $translator = $this->createMock(Translator::class);
+    $translator = $this->createStub(Translator::class);
     $translator->method('trans')
       ->willReturnCallback(function () {
         static $callCount = 0;

--- a/tests/PhpUnit/Api/Services/Projects/ProjectsRequestValidatorTest.php
+++ b/tests/PhpUnit/Api/Services/Projects/ProjectsRequestValidatorTest.php
@@ -4,252 +4,273 @@ declare(strict_types=1);
 
 namespace Tests\PhpUnit\Api\Services\Projects;
 
-use App\Api\Services\Base\AbstractRequestValidator;
 use App\Api\Services\Projects\ProjectsRequestValidator;
-use App\Api\Services\ValidationWrapper;
-use App\System\Testing\PhpUnit\DefaultTestCase;
+use App\User\UserManager;
 use OpenAPI\Server\Model\UpdateProjectRequest;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\MockObject\Exception;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @internal
  */
 #[CoversClass(ProjectsRequestValidator::class)]
-final class ProjectsRequestValidatorTest extends DefaultTestCase
+final class ProjectsRequestValidatorTest extends TestCase
 {
-  protected MockObject|ProjectsRequestValidator $object;
+  private ProjectsRequestValidator $validator;
 
   #[\Override]
   protected function setUp(): void
   {
-    $this->object = $this->getMockBuilder(ProjectsRequestValidator::class)
-      ->disableOriginalConstructor()
-      ->onlyMethods([])
-      ->getMock()
-    ;
+    $symfony_validator = $this->createStub(ValidatorInterface::class);
+    $translator = $this->createStub(TranslatorInterface::class);
+    $translator->method('trans')->willReturnArgument(0);
+    $user_manager = $this->createStub(UserManager::class);
+
+    $this->validator = new ProjectsRequestValidator($symfony_validator, $translator, $user_manager);
   }
 
   /**
    * @group unit
-   *
-   * @throws \ReflectionException
    */
-  public function testValidateName(): void
+  #[DataProvider('validNameProvider')]
+  public function testValidateUpdateRequestWithValidName(string $name): void
   {
-    $validation_wrapper = new ValidationWrapper();
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'validationWrapper', $validation_wrapper);
-
-    $names = ['a', 'ab', 'abc', str_pad('a', 253, 'a'), str_pad('a', 254, 'a'), str_pad('a', 255, 'a')];
-
-    foreach ($names as $name) {
-      $this->invokeMethod($this->object, 'validateName', [$name, 'en']);
-      $this->assertFalse($validation_wrapper->hasError());
-      $validation_wrapper->clear();
-    }
-  }
-
-  /**
-   * @group unit
-   *
-   * @throws \ReflectionException
-   * @throws Exception
-   */
-  public function testValidateNameEmpty(): void
-  {
-    $validation_wrapper = new ValidationWrapper();
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'validationWrapper', $validation_wrapper);
-    $translator = $this->createMock(TranslatorInterface::class);
-    $translator->method('trans')->with('api.project.nameEmpty', [], 'catroweb', 'en')->willReturn('EMPTY');
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'translator', $translator);
-
-    $this->invokeMethod($this->object, 'validateName', ['', 'en']);
-    $this->assertCount(1, $validation_wrapper->getErrors());
-    $this->assertSame('EMPTY', $validation_wrapper->getError('name'));
-  }
-
-  /**
-   * @group unit
-   *
-   * @throws \ReflectionException
-   * @throws Exception
-   */
-  public function testValidateNameTooLong(): void
-  {
-    $validation_wrapper = new ValidationWrapper();
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'validationWrapper', $validation_wrapper);
-    $translator = $this->createMock(TranslatorInterface::class);
-    $translator->method('trans')->with('api.project.nameTooLong', [], 'catroweb', 'en')->willReturn('TOO LONG');
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'translator', $translator);
-
-    $this->invokeMethod($this->object, 'validateName', [str_pad('a', 256, 'a'), 'en']);
-    $this->assertCount(1, $validation_wrapper->getErrors());
-    $this->assertSame('TOO LONG', $validation_wrapper->getError('name'));
-  }
-
-  /**
-   * @group unit
-   *
-   * @throws \ReflectionException
-   */
-  public function testValidateDescription(): void
-  {
-    $validation_wrapper = new ValidationWrapper();
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'validationWrapper', $validation_wrapper);
-
-    $names = ['', 'a', str_pad('a', 9_999, 'a'), str_pad('a', 10_000, 'a')];
-
-    foreach ($names as $name) {
-      $this->invokeMethod($this->object, 'validateDescription', [$name, 'en']);
-      $this->assertFalse($validation_wrapper->hasError());
-      $validation_wrapper->clear();
-    }
-  }
-
-  /**
-   * @group unit
-   *
-   * @throws \ReflectionException
-   * @throws Exception
-   */
-  public function testValidateDescriptionTooLong(): void
-  {
-    $validation_wrapper = new ValidationWrapper();
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'validationWrapper', $validation_wrapper);
-    $translator = $this->createMock(TranslatorInterface::class);
-    $translator->method('trans')->with('api.project.descriptionTooLong', [], 'catroweb', 'en')->willReturn('TOO LONG');
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'translator', $translator);
-
-    $this->invokeMethod($this->object, 'validateDescription', [str_pad('a', 10_001, 'a'), 'en']);
-    $this->assertCount(1, $validation_wrapper->getErrors());
-    $this->assertSame('TOO LONG', $validation_wrapper->getError('description'));
-  }
-
-  /**
-   * @group unit
-   *
-   * @throws \ReflectionException
-   */
-  public function testValidateCredits(): void
-  {
-    $validation_wrapper = new ValidationWrapper();
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'validationWrapper', $validation_wrapper);
-
-    $names = ['', 'a', str_pad('a', 2_999, 'a'), str_pad('a', 3_000, 'a')];
-
-    foreach ($names as $name) {
-      $this->invokeMethod($this->object, 'validateCredits', [$name, 'en']);
-      $this->assertFalse($validation_wrapper->hasError());
-      $validation_wrapper->clear();
-    }
-  }
-
-  /**
-   * @group unit
-   *
-   * @throws \ReflectionException
-   * @throws Exception
-   */
-  public function testValidateCreditsTooLong(): void
-  {
-    $validation_wrapper = new ValidationWrapper();
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'validationWrapper', $validation_wrapper);
-    $translator = $this->createMock(TranslatorInterface::class);
-    $translator->method('trans')->with('api.project.creditsTooLong', [], 'catroweb', 'en')->willReturn('TOO LONG');
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'translator', $translator);
-
-    $this->invokeMethod($this->object, 'validateCredits', [str_pad('a', 3_001, 'a'), 'en']);
-    $this->assertCount(1, $validation_wrapper->getErrors());
-    $this->assertSame('TOO LONG', $validation_wrapper->getError('credits'));
-  }
-
-  /**
-   * @group unit
-   *
-   * @throws \ReflectionException
-   */
-  public function testValidateScreenshot(): void
-  {
-    $validation_wrapper = new ValidationWrapper();
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'validationWrapper', $validation_wrapper);
-
-    $small_gif_base64 = 'R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
-    $screenshot = 'data:image/gif;base64,'.$small_gif_base64;
-
-    $this->invokeMethod($this->object, 'validateScreenshot', [$screenshot, 'en']);
-    $this->assertFalse($validation_wrapper->hasError());
-  }
-
-  /**
-   * @group unit
-   *
-   * @throws \ReflectionException
-   * @throws Exception
-   */
-  public function testValidateScreenshotInvalid(): void
-  {
-    $validation_wrapper = new ValidationWrapper();
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'validationWrapper', $validation_wrapper);
-    $translator = $this->createMock(TranslatorInterface::class);
-    $translator->method('trans')->with('api.project.screenshotInvalid', [], 'catroweb', 'en')->willReturn('INVALID');
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'translator', $translator);
-
-    $screenshots = [
-      '', // empty -> invalid regex
-      'data:image/jpeg;base64,Q2F0cm93ZWI=', // invalid image, valid base64
-      'data:image/png;base64,Catro/web', // invalid base64, valid regex
-      'data:video/webm;base32,invalid', // invalid regex
-    ];
-
-    foreach ($screenshots as $screenshot) {
-      $this->invokeMethod($this->object, 'validateScreenshot', [$screenshot, 'en']);
-      $this->assertCount(1, $validation_wrapper->getErrors());
-      $this->assertSame('INVALID', $validation_wrapper->getError('screenshot'));
-      $validation_wrapper->clear();
-    }
-  }
-
-  /**
-   * @throws \ReflectionException
-   */
-  #[Group('unit')]
-  public function testValidateUpdateRequest(): void
-  {
-    $validation_wrapper = new ValidationWrapper();
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'validationWrapper', $validation_wrapper);
-
     $small_gif_base64 = 'R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
     $valid_screenshot = 'data:image/gif;base64,'.$small_gif_base64;
 
-    $update_request = new UpdateProjectRequest([
+    $request = new UpdateProjectRequest([
+      'name' => $name,
+      'description' => 'Valid description',
+      'credits' => '',
+      'private' => false,
+      'screenshot' => $valid_screenshot,
+    ]);
+
+    $result = $this->validator->validateUpdateRequest($request, 'en');
+    $this->assertFalse($result->hasError(), "Name '{$name}' should be valid");
+  }
+
+  public static function validNameProvider(): array
+  {
+    return [
+      'single char' => ['a'],
+      'two chars' => ['ab'],
+      'three chars' => ['abc'],
+      'max minus 2' => [str_pad('a', 253, 'a')],
+      'max minus 1' => [str_pad('a', 254, 'a')],
+      'max length' => [str_pad('a', 255, 'a')],
+    ];
+  }
+
+  /**
+   * @group unit
+   */
+  public function testValidateUpdateRequestWithEmptyName(): void
+  {
+    $request = new UpdateProjectRequest([
+      'name' => '',
+      'description' => 'Valid description',
+      'credits' => '',
+      'private' => false,
+    ]);
+
+    $result = $this->validator->validateUpdateRequest($request, 'en');
+    $this->assertTrue($result->hasError());
+    $this->assertSame('api.project.nameEmpty', $result->getError('name'));
+  }
+
+  /**
+   * @group unit
+   */
+  public function testValidateUpdateRequestWithNameTooLong(): void
+  {
+    $request = new UpdateProjectRequest([
+      'name' => str_pad('a', 256, 'a'),
+      'description' => 'Valid description',
+      'credits' => '',
+      'private' => false,
+    ]);
+
+    $result = $this->validator->validateUpdateRequest($request, 'en');
+    $this->assertTrue($result->hasError());
+    $this->assertSame('api.project.nameTooLong', $result->getError('name'));
+  }
+
+  /**
+   * @group unit
+   */
+  #[DataProvider('validDescriptionProvider')]
+  public function testValidateUpdateRequestWithValidDescription(string $description): void
+  {
+    $small_gif_base64 = 'R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+    $valid_screenshot = 'data:image/gif;base64,'.$small_gif_base64;
+
+    $request = new UpdateProjectRequest([
+      'name' => 'Valid name',
+      'description' => $description,
+      'credits' => '',
+      'private' => false,
+      'screenshot' => $valid_screenshot,
+    ]);
+
+    $result = $this->validator->validateUpdateRequest($request, 'en');
+    $this->assertFalse($result->hasError());
+  }
+
+  public static function validDescriptionProvider(): array
+  {
+    return [
+      'empty' => [''],
+      'single char' => ['a'],
+      'max minus 1' => [str_pad('a', 9_999, 'a')],
+      'max length' => [str_pad('a', 10_000, 'a')],
+    ];
+  }
+
+  /**
+   * @group unit
+   */
+  public function testValidateUpdateRequestWithDescriptionTooLong(): void
+  {
+    $request = new UpdateProjectRequest([
+      'name' => 'Valid name',
+      'description' => str_pad('a', 10_001, 'a'),
+      'credits' => '',
+      'private' => false,
+    ]);
+
+    $result = $this->validator->validateUpdateRequest($request, 'en');
+    $this->assertTrue($result->hasError());
+    $this->assertSame('api.project.descriptionTooLong', $result->getError('description'));
+  }
+
+  /**
+   * @group unit
+   */
+  #[DataProvider('validCreditsProvider')]
+  public function testValidateUpdateRequestWithValidCredits(string $credits): void
+  {
+    $small_gif_base64 = 'R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+    $valid_screenshot = 'data:image/gif;base64,'.$small_gif_base64;
+
+    $request = new UpdateProjectRequest([
+      'name' => 'Valid name',
+      'description' => 'Valid description',
+      'credits' => $credits,
+      'private' => false,
+      'screenshot' => $valid_screenshot,
+    ]);
+
+    $result = $this->validator->validateUpdateRequest($request, 'en');
+    $this->assertFalse($result->hasError());
+  }
+
+  public static function validCreditsProvider(): array
+  {
+    return [
+      'empty' => [''],
+      'single char' => ['a'],
+      'max minus 1' => [str_pad('a', 2_999, 'a')],
+      'max length' => [str_pad('a', 3_000, 'a')],
+    ];
+  }
+
+  /**
+   * @group unit
+   */
+  public function testValidateUpdateRequestWithCreditsTooLong(): void
+  {
+    $request = new UpdateProjectRequest([
+      'name' => 'Valid name',
+      'description' => 'Valid description',
+      'credits' => str_pad('a', 3_001, 'a'),
+      'private' => false,
+    ]);
+
+    $result = $this->validator->validateUpdateRequest($request, 'en');
+    $this->assertTrue($result->hasError());
+    $this->assertSame('api.project.creditsTooLong', $result->getError('credits'));
+  }
+
+  /**
+   * @group unit
+   */
+  public function testValidateUpdateRequestWithValidScreenshot(): void
+  {
+    $small_gif_base64 = 'R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+    $screenshot = 'data:image/gif;base64,'.$small_gif_base64;
+
+    $request = new UpdateProjectRequest([
+      'name' => 'Valid name',
+      'description' => 'Valid description',
+      'credits' => '',
+      'private' => false,
+      'screenshot' => $screenshot,
+    ]);
+
+    $result = $this->validator->validateUpdateRequest($request, 'en');
+    $this->assertFalse($result->hasError());
+  }
+
+  /**
+   * @group unit
+   */
+  #[DataProvider('invalidScreenshotProvider')]
+  public function testValidateUpdateRequestWithInvalidScreenshot(string $screenshot, string $description): void
+  {
+    $request = new UpdateProjectRequest([
+      'name' => 'Valid name',
+      'description' => 'Valid description',
+      'credits' => '',
+      'private' => false,
+      'screenshot' => $screenshot,
+    ]);
+
+    $result = $this->validator->validateUpdateRequest($request, 'en');
+    $this->assertTrue($result->hasError(), "Screenshot should be invalid: {$description}");
+    $this->assertSame('api.project.screenshotInvalid', $result->getError('screenshot'));
+  }
+
+  public static function invalidScreenshotProvider(): array
+  {
+    return [
+      'empty string' => ['', 'empty -> invalid regex'],
+      'invalid image data' => ['data:image/jpeg;base64,Q2F0cm93ZWI=', 'invalid image, valid base64'],
+      'invalid base64' => ['data:image/png;base64,Catro/web', 'invalid base64, valid regex'],
+      'invalid format' => ['data:video/webm;base32,invalid', 'invalid regex'],
+    ];
+  }
+
+  /**
+   * @group unit
+   */
+  public function testValidateUpdateRequestWithAllValidFields(): void
+  {
+    $small_gif_base64 = 'R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+    $valid_screenshot = 'data:image/gif;base64,'.$small_gif_base64;
+
+    $request = new UpdateProjectRequest([
       'name' => 'My project',
       'description' => 'An amazing Catrobat project',
       'credits' => '',
       'private' => false,
       'screenshot' => $valid_screenshot,
     ]);
-    $this->object->validateUpdateRequest($update_request, 'en');
-    $this->assertFalse($validation_wrapper->hasError());
+
+    $result = $this->validator->validateUpdateRequest($request, 'en');
+    $this->assertFalse($result->hasError());
   }
 
   /**
-   * @throws \ReflectionException
-   * @throws Exception
+   * @group unit
    */
-  #[Group('unit')]
-  public function testValidateUpdateRequestInvalid(): void
+  public function testValidateUpdateRequestWithMultipleInvalidFields(): void
   {
-    $validation_wrapper = new ValidationWrapper();
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'validationWrapper', $validation_wrapper);
-
-    $translator = $this->createMock(TranslatorInterface::class);
-    $translator->method('trans')->willReturnArgument(0);
-    $this->mockProperty(AbstractRequestValidator::class, $this->object, 'translator', $translator);
-
-    $update_request = new UpdateProjectRequest([
+    $request = new UpdateProjectRequest([
       'name' => '',
       'description' => str_pad('a', 10_001, 'a'),
       'credits' => str_pad('b', 3_001, 'b'),
@@ -257,11 +278,11 @@ final class ProjectsRequestValidatorTest extends DefaultTestCase
       'screenshot' => 'invalid',
     ]);
 
-    $this->object->validateUpdateRequest($update_request, 'en');
-    $this->assertCount(4, $validation_wrapper->getErrors());
-    $this->assertSame('api.project.nameEmpty', $validation_wrapper->getError('name'));
-    $this->assertSame('api.project.descriptionTooLong', $validation_wrapper->getError('description'));
-    $this->assertSame('api.project.creditsTooLong', $validation_wrapper->getError('credits'));
-    $this->assertSame('api.project.screenshotInvalid', $validation_wrapper->getError('screenshot'));
+    $result = $this->validator->validateUpdateRequest($request, 'en');
+    $this->assertCount(4, $result->getErrors());
+    $this->assertSame('api.project.nameEmpty', $result->getError('name'));
+    $this->assertSame('api.project.descriptionTooLong', $result->getError('description'));
+    $this->assertSame('api.project.creditsTooLong', $result->getError('credits'));
+    $this->assertSame('api.project.screenshotInvalid', $result->getError('screenshot'));
   }
 }

--- a/tests/PhpUnit/Api/Services/ValidationWrapperTest.php
+++ b/tests/PhpUnit/Api/Services/ValidationWrapperTest.php
@@ -8,7 +8,6 @@ use App\Api\Services\ValidationWrapper;
 use App\System\Testing\PhpUnit\DefaultTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @internal
@@ -16,16 +15,12 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[CoversClass(ValidationWrapper::class)]
 final class ValidationWrapperTest extends DefaultTestCase
 {
-  protected MockObject|ValidationWrapper $object;
+  protected ValidationWrapper $object;
 
   #[\Override]
   protected function setUp(): void
   {
-    $this->object = $this->getMockBuilder(ValidationWrapper::class)
-      ->disableOriginalConstructor()
-      ->onlyMethods([])
-      ->getMock()
-    ;
+    $this->object = new ValidationWrapper();
   }
 
   #[Group('unit')]

--- a/tests/PhpUnit/Api/UtilityApiTest.php
+++ b/tests/PhpUnit/Api/UtilityApiTest.php
@@ -14,7 +14,7 @@ use OpenAPI\Server\Model\SurveyResponse;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\Exception;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -25,7 +25,7 @@ class UtilityApiTest extends DefaultTestCase
 {
   protected UtilityApi $utility_api;
 
-  protected MockObject|UtilityApiFacade $facade;
+  protected UtilityApiFacade|Stub $facade;
 
   /**
    * @throws Exception
@@ -33,7 +33,7 @@ class UtilityApiTest extends DefaultTestCase
   #[\Override]
   protected function setUp(): void
   {
-    $this->facade = $this->createMock(UtilityApiFacade::class);
+    $this->facade = $this->createStub(UtilityApiFacade::class);
     $this->utility_api = new UtilityApi($this->facade);
   }
 
@@ -57,7 +57,7 @@ class UtilityApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(UtilityApiLoader::class);
+    $loader = $this->createStub(UtilityApiLoader::class);
     $loader->method('getSurvey')->willReturn(null);
     $this->facade->method('getLoader')->willReturn($loader);
 
@@ -76,8 +76,8 @@ class UtilityApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(UtilityApiLoader::class);
-    $loader->method('getSurvey')->willReturn($this->createMock(Survey::class));
+    $loader = $this->createStub(UtilityApiLoader::class);
+    $loader->method('getSurvey')->willReturn($this->createStub(Survey::class));
     $this->facade->method('getLoader')->willReturn($loader);
 
     $response = $this->utility_api->surveyLangCodeGet('de', '', '', $response_code, $response_headers);
@@ -96,8 +96,8 @@ class UtilityApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(UtilityApiLoader::class);
-    $loader->method('getSurvey')->willReturn($this->createMock(Survey::class));
+    $loader = $this->createStub(UtilityApiLoader::class);
+    $loader->method('getSurvey')->willReturn($this->createStub(Survey::class));
     $flavor = new Flavor();
     $flavor->setName('embroidery');
     $loader->method('getSurveyFlavor')->willReturn($flavor);
@@ -119,8 +119,8 @@ class UtilityApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(UtilityApiLoader::class);
-    $loader->method('getSurvey')->willReturn($this->createMock(Survey::class));
+    $loader = $this->createStub(UtilityApiLoader::class);
+    $loader->method('getSurvey')->willReturn($this->createStub(Survey::class));
     $flavor = new Flavor();
     $flavor->setName(Flavor::POCKETCODE);
     $loader->method('getSurveyFlavor')->willReturn($flavor);
@@ -142,8 +142,8 @@ class UtilityApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(UtilityApiLoader::class);
-    $loader->method('getSurvey')->willReturn($this->createMock(Survey::class));
+    $loader = $this->createStub(UtilityApiLoader::class);
+    $loader->method('getSurvey')->willReturn($this->createStub(Survey::class));
     $loader->method('getSurveyFlavor')->willReturn(null);
     $this->facade->method('getLoader')->willReturn($loader);
 
@@ -163,8 +163,8 @@ class UtilityApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(UtilityApiLoader::class);
-    $loader->method('getSurvey')->willReturn($this->createMock(Survey::class));
+    $loader = $this->createStub(UtilityApiLoader::class);
+    $loader->method('getSurvey')->willReturn($this->createStub(Survey::class));
     $this->facade->method('getLoader')->willReturn($loader);
 
     $response = $this->utility_api->surveyLangCodeGet('de', '', 'ios', $response_code, $response_headers);
@@ -183,8 +183,8 @@ class UtilityApiTest extends DefaultTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $loader = $this->createMock(UtilityApiLoader::class);
-    $loader->method('getSurvey')->willReturn($this->createMock(Survey::class));
+    $loader = $this->createStub(UtilityApiLoader::class);
+    $loader->method('getSurvey')->willReturn($this->createStub(Survey::class));
     $this->facade->method('getLoader')->willReturn($loader);
 
     $response = $this->utility_api->surveyLangCodeGet('de', '', 'windows', $response_code, $response_headers);

--- a/tests/PhpUnit/Application/Twig/TwigExtensionTest.php
+++ b/tests/PhpUnit/Application/Twig/TwigExtensionTest.php
@@ -137,12 +137,12 @@ class TwigExtensionTest extends TestCase
    */
   private function createTwigExtension(string $locale): TwigExtension
   {
-    $repo = $this->createMock(MediaPackageFileRepository::class);
+    $repo = $this->createStub(MediaPackageFileRepository::class);
     $request_stack = $this->mockRequestStack($locale);
-    $parameter_bag = $this->createMock(ParameterBag::class);
-    $translator = $this->createMock(TranslatorInterface::class);
-    $feature_flag_manager = $this->createMock(FeatureFlagManager::class);
-    $statistics_repository = $this->createMock(StatisticRepository::class);
+    $parameter_bag = $this->createStub(ParameterBag::class);
+    $translator = $this->createStub(TranslatorInterface::class);
+    $feature_flag_manager = $this->createStub(FeatureFlagManager::class);
+    $statistics_repository = $this->createStub(StatisticRepository::class);
 
     return new TwigExtension(
       $request_stack,

--- a/tests/PhpUnit/Project/AddProjectRequestTest.php
+++ b/tests/PhpUnit/Project/AddProjectRequestTest.php
@@ -9,7 +9,7 @@ use App\DB\Entity\User\User;
 use App\Project\AddProjectRequest;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\Exception;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\File\File;
 
@@ -23,7 +23,7 @@ class AddProjectRequestTest extends TestCase
 
   private AddProjectRequest $add_program_request;
 
-  private MockObject|User $user;
+  private Stub|User $user;
 
   /**
    * @throws Exception
@@ -31,7 +31,7 @@ class AddProjectRequestTest extends TestCase
   #[\Override]
   protected function setUp(): void
   {
-    $this->user = $this->createMock(User::class);
+    $this->user = $this->createStub(User::class);
     fopen('/tmp/PhpUnitTest', 'w');
     $this->file = new File('/tmp/PhpUnitTest');
     $this->add_program_request = new AddProjectRequest($this->user, $this->file);
@@ -47,7 +47,7 @@ class AddProjectRequestTest extends TestCase
    */
   public function testHoldsAUser(): void
   {
-    $new_user = $this->createMock(User::class);
+    $new_user = $this->createStub(User::class);
     $this->assertSame($this->user, $this->add_program_request->getUser());
     $this->add_program_request->setUser($new_user);
     $this->assertSame($new_user, $this->add_program_request->getUser());

--- a/tests/PhpUnit/Project/CatrobatFile/ExtractedCatrobatFileTest.php
+++ b/tests/PhpUnit/Project/CatrobatFile/ExtractedCatrobatFileTest.php
@@ -11,7 +11,6 @@ use App\Project\Remix\RemixData;
 use App\System\Testing\PhpUnit\Extension\BootstrapExtension;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -27,11 +26,6 @@ class ExtractedCatrobatFileTest extends TestCase
   protected function setUp(): void
   {
     $this->extracted_catrobat_file = new ExtractedCatrobatFile(BootstrapExtension::$GENERATED_FIXTURES_DIR.'base/', '/webpath', 'hash');
-  }
-
-  public function testInitialization(): void
-  {
-    $this->assertInstanceOf(ExtractedCatrobatFile::class, $this->extracted_catrobat_file);
   }
 
   public function testGetsTheProgramNameFromXml(): void
@@ -131,12 +125,9 @@ class ExtractedCatrobatFileTest extends TestCase
       .'The Periodic Table [/app/project/3570]', $this->extracted_catrobat_file->getRemixUrlsString());
   }
 
-  /**
-   * @throws Exception
-   */
   public function testGetsRelativeAndAbsoluteRemixUrls(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'https://scratch.mit.edu/projects/117697631/';
     $second_expected_url = '/app/project/3570';
     $new_program_id = '3571';
@@ -165,12 +156,10 @@ class ExtractedCatrobatFileTest extends TestCase
 
   /**
    * @psalm-suppress UndefinedPropertyAssignment
-   *
-   * @throws Exception
    */
   public function testCanExtractSimpleCatrobatAbsoluteRemixUrl(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'https://pocketcode.org/details/1234/';
     $this->extracted_catrobat_file->getProjectXmlProperties()->header->url = $first_expected_url;
     $new_program_id = '1300';
@@ -181,12 +170,10 @@ class ExtractedCatrobatFileTest extends TestCase
 
   /**
    * @psalm-suppress UndefinedPropertyAssignment
-   *
-   * @throws Exception
    */
   public function testNotExtractNumberFromNormalText(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'SomeText 123';
     $this->extracted_catrobat_file->getProjectXmlProperties()->header->url = $first_expected_url;
     $new_program_id = '124';
@@ -196,12 +183,10 @@ class ExtractedCatrobatFileTest extends TestCase
 
   /**
    * @psalm-suppress UndefinedPropertyAssignment
-   *
-   * @throws Exception
    */
   public function testCanExtractSimpleScratchAbsoluteRemixUrl(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'https://scratch.mit.edu/projects/117697631/';
     $this->extracted_catrobat_file->getProjectXmlProperties()->header->url = $first_expected_url;
     $new_program_id = '1';
@@ -212,12 +197,10 @@ class ExtractedCatrobatFileTest extends TestCase
 
   /**
    * @psalm-suppress UndefinedPropertyAssignment
-   *
-   * @throws Exception
    */
   public function testCanExtractSimpleRelativeCatrobatRemixUrl(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = '/app/flavors/3570/';
     $this->extracted_catrobat_file->getProjectXmlProperties()->header->url = $first_expected_url;
     $new_program_id = '6310';
@@ -231,7 +214,7 @@ class ExtractedCatrobatFileTest extends TestCase
    */
   public function testCanExtractMergedProgramRemixUrls(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'https://share2.catrob.at/details/1234';
     $second_expected_url = 'http://pocketcode.org/details/3570/';
     $new_program_id = '3571';
@@ -245,12 +228,10 @@ class ExtractedCatrobatFileTest extends TestCase
 
   /**
    * @psalm-suppress UndefinedPropertyAssignment
-   *
-   * @throws Exception
    */
   public function testExtractUniqueProgramRemixUrls(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'https://share2.catrob.at/details/1234';
     $second_expected_url = 'http://pocketcode.org/details/1234/';
     $new_program_id = '3571';
@@ -263,12 +244,10 @@ class ExtractedCatrobatFileTest extends TestCase
 
   /**
    * @psalm-suppress UndefinedPropertyAssignment
-   *
-   * @throws Exception
    */
   public function testDontExtractProgramRemixUrlsReferencingToCurrentProgram(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'https://share2.catrob.at/details/1234';
     $second_expected_url = 'http://pocketcode.org/details/790/';
     $new_program_id = '1234';
@@ -281,12 +260,10 @@ class ExtractedCatrobatFileTest extends TestCase
 
   /**
    * @psalm-suppress UndefinedPropertyAssignment
-   *
-   * @throws Exception
    */
   public function testExtractOnlyOlderProgramRemixUrls(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'https://share2.catrob.at/details/1234';
     $second_expected_url = 'http://pocketcode.org/details/790/';
     $new_program_id = '791';
@@ -299,12 +276,10 @@ class ExtractedCatrobatFileTest extends TestCase
 
   /**
    * @psalm-suppress UndefinedPropertyAssignment
-   *
-   * @throws Exception
    */
   public function testCanExtractDoubleMergedProgramRemixUrls(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'https://share2.catrob.at/details/1234';
     $second_expected_url = 'http://pocketcode.org/details/3570/';
     $third_expected_url = 'https://scratch.mit.edu/projects/121648946/';
@@ -321,12 +296,10 @@ class ExtractedCatrobatFileTest extends TestCase
 
   /**
    * @psalm-suppress UndefinedPropertyAssignment
-   *
-   * @throws Exception
    */
   public function testExtractUniqueProgramRemixUrlsOfDoubleMergedProgram(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'https://share2.catrob.at/details/1234';
     $second_expected_url = 'https://scratch.mit.edu/projects/121648946/';
     $third_expected_url = 'http://pocketcode.org/details/1234/';
@@ -343,12 +316,10 @@ class ExtractedCatrobatFileTest extends TestCase
 
   /**
    * @psalm-suppress UndefinedPropertyAssignment
-   *
-   * @throws Exception
    */
   public function testDontExtractProgramRemixUrlsReferencingToCurrentDoubleMergedProgram(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'https://share2.catrob.at/details/1234';
     $second_expected_url = 'http://pocketcode.org/details/7901';
     $third_expected_url = 'http://pocketcode.org/details/1234/';
@@ -365,12 +336,10 @@ class ExtractedCatrobatFileTest extends TestCase
 
   /**
    * @psalm-suppress UndefinedPropertyAssignment
-   *
-   * @throws Exception
    */
   public function testCanExtractMultipleMergedRemixUrls(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'https://scratch.mit.edu/projects/117697631/';
     $second_expected_url = '/pocketalice/project/3570';
     $third_expected_url = 'https://scratch.mit.edu/projects/121648946/';
@@ -388,12 +357,10 @@ class ExtractedCatrobatFileTest extends TestCase
 
   /**
    * @psalm-suppress UndefinedPropertyAssignment
-   *
-   * @throws Exception
    */
   public function testExtractUniqueProgramRemixUrlsOfMultipleMergedProgram(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'https://scratch.mit.edu/projects/117697631/';
     $second_expected_url = '/pocketalice/project/16267';
     $third_expected_url = $first_expected_url;
@@ -411,12 +378,10 @@ class ExtractedCatrobatFileTest extends TestCase
 
   /**
    * @psalm-suppress UndefinedPropertyAssignment
-   *
-   * @throws Exception
    */
   public function testExtractOnlyOlderProgramRemixUrlsOfMultipleMergedProgramIfItIsAnInitialVersion(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'https://scratch.mit.edu/projects/117697631/';
     $second_expected_url = '/pocketalice/project/16268';
     $third_expected_url = $first_expected_url;
@@ -434,12 +399,10 @@ class ExtractedCatrobatFileTest extends TestCase
 
   /**
    * @psalm-suppress UndefinedPropertyAssignment
-   *
-   * @throws Exception
    */
   public function testExtractOlderProgramRemixUrlsOfMultipleMergedProgramIfItIsNotAnInitialVersion(): void
   {
-    $program_repository = $this->createMock(ProgramRepository::class);
+    $program_repository = $this->createStub(ProgramRepository::class);
     $first_expected_url = 'https://scratch.mit.edu/projects/117697631/';
     $second_expected_url = '/pocketalice/project/16267';
     $third_expected_url = $first_expected_url;

--- a/tests/PhpUnit/Project/CatrobatFile/ProjectFileRepositoryTest.php
+++ b/tests/PhpUnit/Project/CatrobatFile/ProjectFileRepositoryTest.php
@@ -11,7 +11,6 @@ use App\Storage\FileHelper;
 use App\System\Testing\PhpUnit\Extension\BootstrapExtension;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -56,23 +55,17 @@ class ProjectFileRepositoryTest extends TestCase
     $this->assertInstanceOf(ProjectFileRepository::class, $this->program_file_repository);
   }
 
-  /**
-   * @throws Exception
-   */
   public function testThrowsAnExceptionIfDirectoryIsNotFound(): void
   {
     $this->expectException(\Exception::class);
-    $file_compressor = $this->createMock(CatrobatFileCompressor::class);
+    $file_compressor = new CatrobatFileCompressor();
     $this->program_file_repository = new ProjectFileRepository(__DIR__.'/invalid_directory/', $this->extract_dir, $file_compressor);
   }
 
-  /**
-   * @throws Exception
-   */
   public function testThrowsAnExceptionIfDirectoryIsNotFound2(): void
   {
     $this->expectException(\Exception::class);
-    $file_compressor = $this->createMock(CatrobatFileCompressor::class);
+    $file_compressor = new CatrobatFileCompressor();
     $this->program_file_repository = new ProjectFileRepository($this->storage_dir, __DIR__.'/invalid_directory/', $file_compressor);
   }
 

--- a/tests/PhpUnit/Project/Extension/ProjectExtensionManagerTest.php
+++ b/tests/PhpUnit/Project/Extension/ProjectExtensionManagerTest.php
@@ -9,6 +9,7 @@ use App\Project\CatrobatFile\ExtractedCatrobatFile;
 use App\Project\Extension\ProjectExtensionManager;
 use App\System\Testing\PhpUnit\DefaultTestCase;
 use App\System\Testing\PhpUnit\Extension\BootstrapExtension;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -17,8 +18,13 @@ use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
+ *
+ * Note: Uses getMockBuilder with onlyMethods([]) as a workaround to enable
+ * testing of protected methods via reflection (isAnEmbroideryProject, isAMindstormsProject, isAPhiroProject).
+ * The mock has no expectations and doesn't override any methods - it's just needed for the invokeMethod helper.
  */
 #[CoversClass(ProjectExtensionManager::class)]
+#[AllowMockObjectsWithoutExpectations]
 class ProjectExtensionManagerTest extends DefaultTestCase
 {
   protected ExtractedCatrobatFile $extracted_catrobat_file_with_extensions;

--- a/tests/PhpUnit/Project/Remix/RemixManagerTest.php
+++ b/tests/PhpUnit/Project/Remix/RemixManagerTest.php
@@ -20,6 +20,7 @@ use App\Project\Remix\RemixManager;
 use App\User\Notification\NotificationManager;
 use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -29,6 +30,7 @@ use PHPUnit\Framework\TestCase;
  * @internal
  */
 #[CoversClass(RemixManager::class)]
+#[AllowMockObjectsWithoutExpectations]
 class RemixManagerTest extends TestCase
 {
   private RemixManager $remix_manager;

--- a/tests/PhpUnit/Security/OAuth/HwiOauthUserProviderTest.php
+++ b/tests/PhpUnit/Security/OAuth/HwiOauthUserProviderTest.php
@@ -86,13 +86,13 @@ json;
    */
   public function testLoadUserByOauthResponse(): void
   {
-    $httpClient = $this->createMock(HttpClientInterface::class);
+    $httpClient = $this->createStub(HttpClientInterface::class);
 
-    $storage = $this->createMock(RequestDataStorageInterface::class);
+    $storage = $this->createStub(RequestDataStorageInterface::class);
 
     $response_test = new PathUserResponse();
 
-    $httpUtils = $this->createMock(HttpUtils::class);
+    $httpUtils = $this->createStub(HttpUtils::class);
     $resourceOwner = new GoogleResourceOwner(
       $httpClient,
       $httpUtils,

--- a/tests/PhpUnit/Studio/StudioManagerTest.php
+++ b/tests/PhpUnit/Studio/StudioManagerTest.php
@@ -20,7 +20,6 @@ use App\User\UserManager;
 use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 /**
@@ -29,7 +28,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 #[CoversClass(StudioManager::class)]
 class StudioManagerTest extends DefaultTestCase
 {
-  protected MockObject|StudioManager $object;
+  protected StudioManager $object;
 
   protected ?UserDataFixtures $user_fixture;
 
@@ -57,22 +56,18 @@ class StudioManagerTest extends DefaultTestCase
     $user_comment_repository = $this->entity_manager->getRepository(UserComment::class);
     $studio_join_request_repository = $this->entity_manager->getRepository(StudioJoinRequest::class);
     $studio_program_repository = $this->entity_manager->getRepository(Program::class);
-    $parameter_bag = $this->getMockBuilder(ParameterBagInterface::class)->getMock();
-    $this->object = $this->getMockBuilder(StudioManager::class)->setConstructorArgs(
-      [
-        $this->entity_manager,
-        $studio_repository,
-        $studio_activity_repository,
-        $studio_project_repository,
-        $studio_user_repository,
-        $user_comment_repository,
-        $studio_join_request_repository,
-        $studio_program_repository,
-        $parameter_bag,
-      ])
-      ->onlyMethods([])
-      ->getMock()
-    ;
+    $parameter_bag = $this->createStub(ParameterBagInterface::class);
+    $this->object = new StudioManager(
+      $this->entity_manager,
+      $studio_repository,
+      $studio_activity_repository,
+      $studio_project_repository,
+      $studio_user_repository,
+      $user_comment_repository,
+      $studio_join_request_repository,
+      $studio_program_repository,
+      $parameter_bag,
+    );
     $this->user_manager = $container->get(UserManager::class);
     $this->user_fixture = $container->get(UserDataFixtures::class);
     $this->project_fixture = $container->get(ProjectDataFixtures::class);

--- a/tests/PhpUnit/Utils/ElapsedTimeStringFormatterTest.php
+++ b/tests/PhpUnit/Utils/ElapsedTimeStringFormatterTest.php
@@ -39,11 +39,6 @@ class ElapsedTimeStringFormatterTest extends TestCase
     ;
   }
 
-  public function testInitialization(): void
-  {
-    $this->assertInstanceOf(ElapsedTimeStringFormatter::class, $this->object);
-  }
-
   /**
    * @throws \Exception
    */


### PR DESCRIPTION
### Audit tests
Run the test suite and capture the list of files that trigger the notice.  
Each notice shows the file and line number, making it easy to locate offending test cases.

Create a list of test classes where `createMock()` is used without any `expects()` calls  
or only uses the deprecated `$this->any()`.

---

### Convert mocks without expectations to stubs
For each offending test:

Identify whether the test really needs a mock.  
If it only needs a dependency that returns values and doesn’t assert that a method was called,  
replace `createMock()` with `createStub()` or `createConfiguredStub()`.

```php
// Before: mock without expectations – triggers notice
$facade = $this->createMock(AuthenticationApiFacade::class);

// After: use a stub – no notice
$facade = $this->createStub(AuthenticationApiFacade::class);
```

If the test needs to control return values, use `createConfiguredStub()`:

```php
$loaderStub = $this->createConfiguredStub(MediaLibraryApiLoader::class, [
'loadMediaFiles' => ['dummyData'],
]);
```

Avoid `$this->any()`.  
If you need to allow unlimited calls, remove the expectation.  
If you need to verify call count, use `$this->once()` or `$this->never()`.

---

### Add real expectations where necessary
If the test actually verifies that a collaborator is called, keep using `createMock()`  
but configure explicit expectations:

```php
$processorMock = $this->createMock(AuthenticationApiProcessor::class);
$processorMock->expects($this->once())
->method('logout')
->with($this->equalTo($request))
->willReturn(...);
```

Replace `expects($this->any())` with `$this->once()` or `$this->exactly($n)`.

---

### Use `AllowMockObjectsWithoutExpectations` as a temporary measure
If many tests cannot be refactored immediately, apply  
`#[AllowMockObjectsWithoutExpectations]` at the class or method level.

```php
use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;

#[AllowMockObjectsWithoutExpectations]
final class AuthenticationApiTest extends TestCase
{
// …
}
```

This attribute can also be placed on a shared abstract base test class to suppress
the notices temporarily while refactoring.

---

### Remove deprecated matchers
Search the test suite for `expects($this->any())` and remove or replace these calls.  
`any()` is deprecated and should be eliminated.

---

### Update PHPUnit configuration if needed
Ensure PHPUnit 12.x is used.  
Later patch releases improve notice wording but still require the same fixes.

Optionally configure CI to treat PHPUnit notices as failures.

---

### Iterative refactoring
Refactor or annotate remaining tests incrementally  
until the suite runs without “mock without expectations” notices.

