### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create_release_pull_request.yaml
+++ b/.github/workflows/create_release_pull_request.yaml
@@ -13,6 +13,10 @@
 #
 name: Create Release PR
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Catrobat/Catroweb/security/code-scanning/17](https://github.com/Catrobat/Catroweb/security/code-scanning/17)

In general, the fix is to add an explicit `permissions:` block to the workflow (either at the top level or per job) that grants only the repository scopes required for the jobs: primarily `contents: write` for pushing commits and creating tags/releases, and `pull-requests: write` for creating PRs. This replaces the implicit, potentially broad default permissions with an explicit least‑privilege set.

The best minimal change here is to define a workflow‑level `permissions:` block after `name:` and before `on:`, so it applies to all jobs. All three jobs need to write to repository contents: `create_release_01` and `create_release_02` commit changes and rely on `peter-evans/create-pull-request`, which pushes branches; `create_release_tag` uses `gh release create`, which creates a release (and may create tags). The PR‑creating jobs also need `pull-requests: write`. We do not see any use of issues, packages, or other resources, so we can leave those at their implicit default of `none`. Concretely, in `.github/workflows/create_release_pull_request.yaml`, add:

```yaml
permissions:
  contents: write
  pull-requests: write
```

on new lines after line 14 (`name: Create Release PR`) and before line 16 (`on:`). No extra imports or tooling changes are needed; this is purely a YAML configuration change for the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
