### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_api_spec.yaml
+++ b/.github/workflows/deploy_api_spec.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   deploy-swagger-ui:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Potential fix for [https://github.com/Catrobat/Catroweb/security/code-scanning/7](https://github.com/Catrobat/Catroweb/security/code-scanning/7)

In general, the fix is to add an explicit `permissions` block to the workflow (at the top level or within the specific job) and restrict the `GITHUB_TOKEN` to the minimal scopes required. This prevents the workflow from inheriting overly broad default repository/organization permissions.

For this workflow, the `deploy-swagger-ui` job needs to push generated static files to GitHub Pages via `peaceiris/actions-gh-pages@v4`, which requires write access to repository contents. The simplest, least-disruptive fix is to add a job-level `permissions` block under `deploy-swagger-ui` specifying `contents: write`. This both satisfies the CodeQL requirement and documents clearly what the token can do. No other permissions (issues, pull requests, etc.) are required based on the shown steps, so they should not be granted.

Concretely, in `.github/workflows/deploy_api_spec.yaml`, under `jobs: > deploy-swagger-ui:`, insert:

```yaml
    permissions:
      contents: write
```

indented to match `runs-on`. No additional imports, methods, or external definitions are needed because this is a pure YAML configuration change within the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
