### PR TITLE
Potential fix for code scanning alert no. 24: DOM text reinterpreted as HTML

### DIFF
--- a/assets/Admin/SystemManagement/Logs.js
+++ b/assets/Admin/SystemManagement/Logs.js
@@ -90,7 +90,7 @@ function applyFilters() {
 function loadFileContent(file) {
   document.getElementById('loading-spinner').style.display = 'block'
   document.getElementById('innerLogContainer').innerHTML = ''
-  document.getElementById('currentFileName').innerHTML = file
+  document.getElementById('currentFileName').textContent = file
 
   fetch(`${window.location.href}?file=${file}&count=1000`)
     .then((response) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Catrobat/Catroweb/security/code-scanning/24](https://github.com/Catrobat/Catroweb/security/code-scanning/24)

In general, to fix DOM text reinterpreted as HTML issues, ensure that data coming from the DOM (or any untrusted source) is not written back to the DOM via HTML sinks (`innerHTML`, jQuery `.html()`, etc.) without proper escaping. For content that should be displayed as plain text (like a filename), use text-only properties (`textContent`, `innerText`) or safe APIs that treat it as text, not HTML.

For this concrete case, the best fix is to stop using `innerHTML` when setting the current file name and instead use `textContent`. The `file` parameter is just a file identifier/name that should be displayed as text. Replacing:

```js
document.getElementById('currentFileName').innerHTML = file
```

with:

```js
document.getElementById('currentFileName').textContent = file
```

preserves the existing behavior (showing the filename) but prevents any HTML markup or scripts in `file` from being parsed or executed. No other code changes are necessary in this file: the logic around loading the file content and inserting the fetched HTML into `innerLogContainer` remains as-is, since that content is presumably server-generated HTML rather than DOM text being “unescaped.”

This change is confined to `assets/Admin/SystemManagement/Logs.js` at line 93; no new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
