### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -7,6 +7,8 @@
 #  - Secrets required!
 #
 name: Deployment
+permissions:
+  contents: read
 
 # Run-on every merge of a pull request into the main branch
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Catrobat/Catroweb/security/code-scanning/12](https://github.com/Catrobat/Catroweb/security/code-scanning/12)

In general, this issue is fixed by explicitly declaring a `permissions` block in the workflow (either at the top level or per job) and restricting the `GITHUB_TOKEN` to the minimal scopes required. For this deployment workflow, the steps only need to read repository contents to perform a checkout; the deployment itself is done via SSH using secrets, so no write scopes on the `GITHUB_TOKEN` are necessary.

The best minimal fix without changing existing functionality is to add a workflow-level `permissions` block directly under the `name: Deployment` line, setting `contents: read`. This will apply to all jobs (including `deploy`) that do not override permissions. No other scopes appear necessary based on the shown code. Concretely, in `.github/workflows/deployment.yaml`, insert:

```yaml
permissions:
  contents: read
```

after line 9 (`name: Deployment`). No imports or other definitions are needed since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
