### PR TITLE
Potential fix for code scanning alert no. 23: Overly permissive regular expression range

### DIFF
--- a/assets/Project/Project.js
+++ b/assets/Project/Project.js
@@ -35,7 +35,7 @@ export const Project = function (
   function createLinks() {
     document.querySelectorAll('#description').forEach((element) => {
       element.innerHTML = element.innerHTML.replace(
-        /((http|https|ftp):\/\/[\w?=&./+-;#~%-]+(?![\w\s?&./;#~%"=-]*>))/g,
+        /((http|https|ftp):\/\/[\w?=&./+\-;#~%-]+(?![\w\s?&./;#~%"=-]*>))/g,
         '<a href="$1" target="_blank">$1</a> ',
       )
     })

--- a/assets/Project/Project.js
+++ b/assets/Project/Project.js
@@ -35,7 +35,7 @@ export const Project = function (
   function createLinks() {
     document.querySelectorAll('#description').forEach((element) => {
       element.innerHTML = element.innerHTML.replace(
-        /((http|https|ftp):\/\/[\w?=&./+\-;#~%-]+(?![\w\s?&./;#~%"=-]*>))/g,
+        /((http|https|ftp):\/\/[\w?=&./+\-;#~%]+(?![\w\s?&./;#~%"=-]*>))/g,
         '<a href="$1" target="_blank">$1</a> ',
       )
     })


### PR DESCRIPTION
Potential fix for [https://github.com/Catrobat/Catroweb/security/code-scanning/23](https://github.com/Catrobat/Catroweb/security/code-scanning/23)

In general, to fix overly permissive character ranges, ensure that any `-` inside a character class either denotes a deliberate range (like `A-Z`) or is escaped or moved to an edge position so it’s treated as a literal hyphen. Also avoid mixed upper/lowercase ranges like `A-f` which unintentionally span more characters than expected.

Here, the suspicious part is `[\w?=&./+-;#~%-]+`. The `+-;` segment forms an unintended range from `+` to `;`. The simplest fix that preserves existing functionality is to treat `-` as a literal by escaping it. Changing `+-;` to `+\-;` (i.e., `.../+\-;#...`) makes `-` a literal hyphen while keeping `+` and `;` as separate allowed characters. No other changes to the pattern are necessary for this specific CodeQL issue. Concretely, in `assets/Project/Project.js`, within `createLinks()` on line 38, update the regex from `/((http|https|ftp):\/\/[\w?=&./+-;#~%-]+(?![\w\s?&./;#~%"=-]*>))/g` to `/((http|https|ftp):\/\/[\w?=&./+\-;#~%-]+(?![\w\s?&./;#~%"=-]*>))/g`. This does not change surrounding code or imports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
