### PR TITLE
Potential fix for code scanning alert no. 27: DOM text reinterpreted as HTML

### DIFF
--- a/assets/User/NotificationsPage.js
+++ b/assets/User/NotificationsPage.js
@@ -368,7 +368,11 @@ class UserNotifications {
       window.location.assign('follower')
     }
     if (['comment', 'reaction', 'remix', 'program'].includes(type)) {
-      window.location.assign(`project/${id}`)
+      const safeId =
+        typeof id === 'string'
+          ? encodeURIComponent(id.replace(/[^A-Za-z0-9_-]/g, ''))
+          : ''
+      window.location.assign(`project/${safeId}`)
     }
   }
 

--- a/assets/User/NotificationsPage.js
+++ b/assets/User/NotificationsPage.js
@@ -369,9 +369,7 @@ class UserNotifications {
     }
     if (['comment', 'reaction', 'remix', 'program'].includes(type)) {
       const safeId =
-        typeof id === 'string'
-          ? encodeURIComponent(id.replace(/[^A-Za-z0-9_-]/g, ''))
-          : ''
+        typeof id === 'string' ? encodeURIComponent(id.replace(/[^A-Za-z0-9_-]/g, '')) : ''
       window.location.assign(`project/${safeId}`)
     }
   }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "glob-all": "^3.3.1",
     "globals": "^17.3.0",
     "noop-webpack-plugin": "^1.0.1",
+    "postcss": "^8.4.38",
     "postcss-loader": "^8.2.1",
     "prettier": "^3.8.1",
     "purgecss-webpack-plugin": "^8.0.0",
@@ -71,6 +72,7 @@
     "stimulus": "^3.2.2",
     "stylelint": "^17.3.0",
     "stylelint-config-standard-scss": "^17.0.0",
+    "webpack": "^5.95.0",
     "webpack-bugsnag-plugins": "^2.2.3",
     "webpack-cli": "^6.0.1",
     "webpack-notifier": "^1.15.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3918,6 +3918,7 @@ __metadata:
     lazysizes: "npm:^5.3.2"
     material-icons: "npm:^1.13.14"
     noop-webpack-plugin: "npm:^1.0.1"
+    postcss: "npm:^8.4.38"
     postcss-loader: "npm:^8.2.1"
     prettier: "npm:^3.8.1"
     purgecss-webpack-plugin: "npm:^8.0.0"
@@ -3931,6 +3932,7 @@ __metadata:
     textfilljs: "npm:^1.0.3-a"
     typeface-roboto: "npm:^1.1.13"
     vis: "npm:^4.21.0-EOL"
+    webpack: "npm:^5.95.0"
     webpack-bugsnag-plugins: "npm:^2.2.3"
     webpack-cli: "npm:^6.0.1"
     webpack-notifier: "npm:^1.15.0"
@@ -8480,7 +8482,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.2.14, postcss@npm:^8.4.40, postcss@npm:^8.4.47, postcss@npm:^8.5.6":
+"postcss@npm:^8.2.14, postcss@npm:^8.4.38, postcss@npm:^8.4.40, postcss@npm:^8.4.47, postcss@npm:^8.5.6":
   version: 8.5.6
   resolution: "postcss@npm:8.5.6"
   dependencies:
@@ -10365,7 +10367,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:>=5.95.0":
+"webpack@npm:>=5.95.0, webpack@npm:^5.95.0":
   version: 5.105.2
   resolution: "webpack@npm:5.105.2"
   dependencies:


### PR DESCRIPTION
Potential fix for [https://github.com/Catrobat/Catroweb/security/code-scanning/27](https://github.com/Catrobat/Catroweb/security/code-scanning/27)

In general, the fix is to avoid passing unvalidated DOM text directly into a navigation API. Instead, treat the value as an opaque identifier, validate it strictly (e.g., allow only IDs or a limited pattern), and then safely construct the URL. This both prevents any possibility of HTML/JS interpretation through odd URL schemes and ensures that `window.location.assign` only ever receives an expected, well-formed path.

For this code, the best minimal fix without changing functionality is to sanitize the `id` argument inside `redirectUser` before it is interpolated into `` `project/${id}` ``. Because `id` is used as a path segment, we can (a) restrict its character set to a safe subset (alphanumerics, dash, underscore, etc.) and (b) URL-encode it when building the final URL. This preserves the behavior for well-formed IDs while neutralizing potentially malicious values from `data-notification-redirect`.

Concretely:
- In `redirectUser(type, id)`, introduce a small helper that:
  - Returns an empty string if `id` is not a string.
  - Strips all characters except a safe whitelist (for example: `A-Za-z0-9_-`).
  - Applies `encodeURIComponent` before concatenating into the path.
- Use the sanitized value in `window.location.assign` instead of the raw `id`.

All changes are confined to `assets/User/NotificationsPage.js` in the `redirectUser` method. No new imports or external libraries are needed; we can rely on built‑in JavaScript functions like `encodeURIComponent` and `String.prototype.replace`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
