### PR TITLE
Potential fix for code scanning alert no. 28: Incomplete string escaping or encoding

### DIFF
--- a/assets/MediaLibrary/MediaLib.js
+++ b/assets/MediaLibrary/MediaLib.js
@@ -171,7 +171,7 @@ export function MediaLib(
                 .prepend(mediafileContainer)
             } // else ignore
           } else {
-            const catEscaped = file.category.replace(/"/g, '\\"')
+            const catEscaped = file.category.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
             document
               .querySelector('#content .category[data-name="' + catEscaped + '"] .files')
               .prepend(mediafileContainer)


### PR DESCRIPTION
Potential fix for [https://github.com/Catrobat/Catroweb/security/code-scanning/28](https://github.com/Catrobat/Catroweb/security/code-scanning/28)

In general, to fix this issue you should avoid hand-rolled partial escaping when embedding arbitrary strings into query selectors, and instead either (a) avoid string concatenation by using attribute-aware DOM APIs, or (b) correctly escape all special characters, including backslashes, using a robust method.

The best fix here, without changing functionality, is to stop building the selector string with an interpolated attribute value and instead select the category element using `querySelector` with an attribute-only selector (assuming `data-name` values are known beforehand), or more robustly, use `querySelectorAll` and compare `dataset.name` in code. However, that would be a functional change. A minimal, targeted fix that preserves current behavior is to escape both backslashes and double quotes in `file.category` in the correct order: first escape backslashes (`\` → `\\`), then escape double quotes (`"` → `\"`). This prevents existing backslashes from interfering with the escaping of quotes and ensures the resulting selector string is well-formed.

Concretely, in `assets/MediaLibrary/MediaLib.js`, around line 174, change:

```js
const catEscaped = file.category.replace(/"/g, '\\"')
```

to something that first escapes backslashes globally, then escapes quotes globally, for example:

```js
const catEscaped = file.category.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
```

No new imports or external libraries are needed, and this keeps the logic and usage of `catEscaped` identical while fixing the incomplete escaping.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
