### PR TITLE
Potential fix for code scanning alert no. 25: DOM text reinterpreted as HTML

### DIFF
--- a/assets/Project/Project.js
+++ b/assets/Project/Project.js
@@ -673,6 +673,26 @@ document.addEventListener('DOMContentLoaded', function () {
 // --------------------------------
 // Not 4 kids!
 
+// Allow only relative, same-origin URLs without dangerous characters.
+function isSafeRelativeUrl(url) {
+  if (!url || typeof url !== 'string') {
+    return false
+  }
+  // Disallow explicit schemes like "http:", "javascript:", etc.
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(url)) {
+    return false
+  }
+  // Disallow protocol-relative URLs like "//example.com"
+  if (url.startsWith('//')) {
+    return false
+  }
+  // Basic guard against HTML-like injection
+  if (/[<>]/.test(url)) {
+    return false
+  }
+  return true
+}
+
 document.addEventListener('DOMContentLoaded', function () {
   const button = document.getElementById('projectNotForKidsButton')
   if (button != null) {
@@ -681,6 +701,10 @@ document.addEventListener('DOMContentLoaded', function () {
       const markSafeForKidsText = document.getElementById('markSafeForKidsText')
       const markNotForKidsText = document.getElementById('markNotForKidsText')
       const url = document.getElementById('projectNotForKidsButton').getAttribute('data-url')
+      if (!isSafeRelativeUrl(url)) {
+        showSnackbar('Invalid target URL for this action.', 'error')
+        return
+      }
       let text = ''
       if (markSafeForKidsText != null) {
         text = 'Are you sure you want to remove the not for kids flag from this project?'
@@ -711,13 +735,17 @@ function askForConfirmation(continueWithAction, url, text) {
     confirmButtonText: okayText,
     cancelButtonText: cancel,
   }).then((result) => {
-    if (result.value) {
+    if (result.value && isSafeRelativeUrl(url)) {
       continueWithAction(url)
     }
   })
 }
 
 function submitNotForKidsForm(url) {
+  if (!isSafeRelativeUrl(url)) {
+    showSnackbar('Invalid target URL for this action.', 'error')
+    return
+  }
   const form = document.createElement('form')
   form.setAttribute('method', 'post')
   form.setAttribute('action', url)


### PR DESCRIPTION
Potential fix for [https://github.com/Catrobat/Catroweb/security/code-scanning/25](https://github.com/Catrobat/Catroweb/security/code-scanning/25)

In general: never trust values pulled from the DOM when they are used as URLs or HTML. Before using such a value in security-sensitive contexts (like a form `action`), validate it strictly (for example, allow only same-origin relative paths or a small whitelist of safe patterns), or otherwise reject/ignore it.

Best concrete fix here: ensure that the `url` extracted from `data-url` is a safe, same-origin relative path before using it. We can add a small helper to validate `url` and then use that helper both when deciding to proceed and when building the form. If the URL is invalid, we either abort the operation or show an error via `showSnackbar` (already imported), keeping existing behavior for valid URLs.

Specific changes in `assets/Project/Project.js`:

1. Define a local helper function, e.g. `isSafeRelativeUrl`, near the `askForConfirmation`/`submitNotForKidsForm` functions. This function:
   - Treats empty/undefined as unsafe.
   - Rejects any URL starting with a scheme (`^[a-zA-Z][a-zA-Z0-9+.-]*:`), `//` (protocol-relative), or containing HTML metacharacters like `<` or `>` that could indicate future HTML injection.
   - Optionally enforces starting with `/` or being a relative path without protocol.
2. In `button.addEventListener('click', ...)`, after obtaining `url`, verify it with `isSafeRelativeUrl`. If invalid, prevent proceeding and optionally show a snackbar message.
3. In `askForConfirmation`, before calling `continueWithAction(url)`, check that the `url` is still considered safe; if not, don’t call the continuation.
4. In `submitNotForKidsForm`, we assume it is only called with a validated `url`. If we want extra defense in depth, we can early-return if `!isSafeRelativeUrl(url)`.

This keeps the visible behavior the same for legitimate, safe URLs in `data-url`, while preventing unsafe values from being used as the form action.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
