### PR TITLE
Potential fix for code scanning alert no. 26: DOM text reinterpreted as HTML

### DIFF
--- a/assets/Security/LoginTokenHandler.js
+++ b/assets/Security/LoginTokenHandler.js
@@ -11,9 +11,23 @@ export class LoginTokenHandler {
   getRedirectUri() {
     const self = this
     const targetPath = document.getElementById('target-path')
-    return targetPath && targetPath.value && targetPath.value !== ''
-      ? targetPath.value
-      : self.indexPath
+    const rawValue =
+      targetPath && typeof targetPath.value === 'string' ? targetPath.value.trim() : ''
+
+    // Only use a provided target path if it results in a same-origin URL.
+    if (rawValue !== '') {
+      try {
+        // The URL constructor will resolve relative paths against the current origin.
+        const url = new URL(rawValue, window.location.origin)
+        if (url.origin === window.location.origin) {
+          return url.pathname + url.search + url.hash
+        }
+      } catch {
+        // If URL construction fails, fall through to the safe default.
+      }
+    }
+
+    return self.indexPath
   }
 
   initListeners() {


### PR DESCRIPTION
Potential fix for [https://github.com/Catrobat/Catroweb/security/code-scanning/26](https://github.com/Catrobat/Catroweb/security/code-scanning/26)

In general, to fix this kind of problem you must not treat arbitrary DOM text as a trusted URL/HTML. Instead, validate and constrain the value read from the DOM before using it in a sensitive sink like `window.location.href`. Common mitigations include: only allowing same-origin relative paths, rejecting `javascript:` or other dangerous schemes, and falling back to a safe default when validation fails.

For this specific case, the best fix without changing intended functionality is to make `getRedirectUri` validate `targetPath.value` before returning it. We can treat `indexPath` as the safe default redirect. When a `target-path` value exists, we should only use it if it is a non-empty string that represents a safe, same-origin URL. A simple and robust approach is:

- Read `targetPath.value` into a local variable.
- Trim whitespace.
- Reject values that start with a dangerous scheme like `javascript:`.
- Normalize them to a full URL using the `URL` constructor with `window.location.origin` as the base.
- Only accept the value if the resulting URL has the same origin as `window.location.origin`.
- Otherwise, return `this.indexPath`.

This keeps behavior (redirecting to a supplied target path) but prevents attackers from forcing navigation to arbitrary or `javascript:` URLs. All changes are confined to the `getRedirectUri` method in `assets/Security/LoginTokenHandler.js`. No new imports are needed; `URL` and `window.location` are standard browser APIs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
