### PR TITLE
Fix JS error when share button is missing on project list (#6154)

### DIFF
--- a/assets/Project/OwnProjectList.js
+++ b/assets/Project/OwnProjectList.js
@@ -319,7 +319,7 @@ export class OwnProjectList {
 
     const shareButton = document.querySelector('#project-share-action')
 
-    if (navigator.share) {
+    if (navigator.share && shareButton) {
       shareButton.addEventListener('click', function () {
         navigator
           .share({


### PR DESCRIPTION
### Description
This PR adds a null-check before attaching the click handler to the project share button.

In some cases, the share button element is not present in the DOM, which caused a JavaScript error when `navigator.share` was available.

### Changes
- Added a safe null-check before calling `addEventListener` on the share button
- Prevents runtime JS errors on the project list page

### Related Issue
Fixes #6154
