### PR TITLE
Fix pagination visibility handling on media library overview page

### DIFF
--- a/assets/MediaLibrary/OverviewPage.js
+++ b/assets/MediaLibrary/OverviewPage.js
@@ -27,7 +27,9 @@ if (overviewContainer) {
 
   const categoryStates = new Map()
 
-  paginationContainer.style.display = 'none'
+  if (paginationContainer) {
+    paginationContainer.style.display = 'none'
+  }
 
   setupDownloadActions()
   setupInfiniteScroll()


### PR DESCRIPTION
### Description
Fixes an issue where the pagination container visibility was accessed
without checking if the element exists on the media library overview page.

### Changes
- Added a null-check before modifying pagination container visibility
- Prevents potential JavaScript runtime errors and UI inconsistencies

Fixes #6154
