### PR TITLE
Potential fix for code scanning alert no. 26: DOM text reinterpreted as HTML

### DIFF
--- a/assets/Security/LoginTokenHandler.js
+++ b/assets/Security/LoginTokenHandler.js
@@ -14,16 +14,22 @@ export class LoginTokenHandler {
     const rawValue =
       targetPath && typeof targetPath.value === 'string' ? targetPath.value.trim() : ''
 
-    // Only use a provided target path if it results in a same-origin URL.
+    // Only use a provided target path if it results in a safe same-origin HTTP(S) URL.
     if (rawValue !== '') {
-      try {
-        // The URL constructor will resolve relative paths against the current origin.
-        const url = new URL(rawValue, window.location.origin)
-        if (url.origin === window.location.origin) {
-          return url.pathname + url.search + url.hash
+      // Reject values that look like they contain a URL scheme (for example, "javascript:" or "http:").
+      if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(rawValue)) {
+        try {
+          // The URL constructor will resolve relative paths against the current origin.
+          const url = new URL(rawValue, window.location.origin)
+          // Enforce same origin and restrict to HTTP(S) protocols.
+          const isSameOrigin = url.origin === window.location.origin
+          const isHttpProtocol = url.protocol === 'http:' || url.protocol === 'https:'
+          if (isSameOrigin && isHttpProtocol) {
+            return url.pathname + url.search + url.hash
+          }
+        } catch {
+          // If URL construction fails, fall through to the safe default.
         }
-      } catch {
-        // If URL construction fails, fall through to the safe default.
       }
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Catrobat/Catroweb/security/code-scanning/26](https://github.com/Catrobat/Catroweb/security/code-scanning/26)

General approach: ensure that the value taken from `#target-path` is not treated as a full URL but only as an application-internal path, and reject any value that attempts to specify a scheme/host or an unsafe path (like absolute external URLs). This keeps redirects strictly within the intended area and removes the possibility of the DOM text being interpreted as a full URL.

Best concrete fix here:

- Parse the trimmed `rawValue` using `new URL(rawValue, window.location.origin)` as before.
- Explicitly reject any value that:
  - Specifies a non-empty `url.protocol` that is not `http:`/`https:` (i.e., drop things like `javascript:` even if they somehow pass the origin check).
  - Specifies a different `origin` than `window.location.origin`.
  - Contains unexpected components (e.g., keep only `pathname`, `search`, and `hash` as already done).
- Additionally, avoid treating `rawValue` as a full URL by requiring that it either:
  - Starts with `/` (absolute same-origin path), or
  - Is a plain relative path without any scheme component (`://`).

We can implement this fully inside `getRedirectUri()` within the existing file. No new imports are needed. The main change is to add stricter checks on `rawValue` before constructing the redirect string, preserving the existing functionality (valid same-origin paths still work) while appeasing CodeQL by clearly preventing arbitrary URL interpretation.

Concretely, modify lines 17–28 of `getRedirectUri` to:

- Early-return the default `indexPath` if `rawValue` looks like it contains a scheme (`/^\w+:/`).
- After constructing `url`, ensure `url.origin === window.location.origin` and that `url.protocol` is `http:` or `https:`.
- Only then return `url.pathname + url.search + url.hash`; otherwise fall back to `indexPath`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
