### PR TITLE
Fix notification controller naming and optimize count query

### DIFF
--- a/src/Api/Services/Notifications/NotificationsResponseManager.php
+++ b/src/Api/Services/Notifications/NotificationsResponseManager.php
@@ -32,38 +32,9 @@ class NotificationsResponseManager extends AbstractResponseManager
 
   public function createNotificationsCountResponse(User $user): NotificationsCountResponse
   {
-    $notifications_all = $this->notification_repository->findBy(['user' => $user]);
-    $likes = 0;
-    $followers = 0;
-    $comments = 0;
-    $remixes = 0;
-    $all = 0;
-    foreach ($notifications_all as $notification) {
-      /** @var CatroNotification $notification */
-      if ($notification->getSeen()) {
-        continue;
-      }
+    $counts = $this->notification_repository->getUnseenCounts($user);
 
-      if ($notification instanceof LikeNotification) {
-        ++$likes;
-      } elseif ($notification instanceof FollowNotification || $notification instanceof NewProgramNotification) {
-        ++$followers;
-      } elseif ($notification instanceof CommentNotification) {
-        ++$comments;
-      } elseif ($notification instanceof RemixNotification) {
-        ++$remixes;
-      }
-
-      ++$all;
-    }
-
-    return new NotificationsCountResponse([
-      'total' => $all,
-      'like' => $likes,
-      'follower' => $followers,
-      'comment' => $comments,
-      'remix' => $remixes,
-    ]);
+    return new NotificationsCountResponse($counts);
   }
 
   /**

--- a/src/Application/Controller/User/NotificationController.php
+++ b/src/Application/Controller/User/NotificationController.php
@@ -11,7 +11,7 @@ use Symfony\Component\Routing\Attribute\Route;
 class NotificationController extends AbstractController
 {
   #[Route(path: '/user_notifications', name: 'notifications', methods: ['GET'])]
-  public function Notifications(): Response
+  public function notifications(): Response
   {
     if (!$this->getUser()) {
       return $this->redirectToRoute('login');

--- a/src/DB/EntityRepository/User/Notification/NotificationRepository.php
+++ b/src/DB/EntityRepository/User/Notification/NotificationRepository.php
@@ -139,6 +139,48 @@ class NotificationRepository extends ServiceEntityRepository
     return ['notifications' => $results, 'has_more' => $has_more];
   }
 
+  /**
+   * @return array{total: int, like: int, follower: int, comment: int, remix: int}
+   */
+  public function getUnseenCounts(User $user): array
+  {
+    $em = $this->getEntityManager();
+    $baseWhere = ['n.user = :user', 'n.seen = false'];
+
+    $total = (int) $em->createQueryBuilder()
+      ->select('COUNT(n.id)')
+      ->from(CatroNotification::class, 'n')
+      ->where($baseWhere[0])
+      ->andWhere($baseWhere[1])
+      ->setParameter('user', $user)
+      ->getQuery()
+      ->getSingleScalarResult()
+    ;
+
+    $typeFilters = [
+      'like' => 'n INSTANCE OF '.LikeNotification::class,
+      'follower' => '(n INSTANCE OF '.FollowNotification::class.' OR n INSTANCE OF '.NewProgramNotification::class.')',
+      'comment' => 'n INSTANCE OF '.CommentNotification::class,
+      'remix' => 'n INSTANCE OF '.RemixNotification::class,
+    ];
+
+    $result = ['total' => $total];
+    foreach ($typeFilters as $key => $filter) {
+      $result[$key] = (int) $em->createQueryBuilder()
+        ->select('COUNT(n.id)')
+        ->from(CatroNotification::class, 'n')
+        ->where($baseWhere[0])
+        ->andWhere($baseWhere[1])
+        ->andWhere($filter)
+        ->setParameter('user', $user)
+        ->getQuery()
+        ->getSingleScalarResult()
+      ;
+    }
+
+    return $result;
+  }
+
   private function applyTypeFilter(QueryBuilder $qb, string $type): void
   {
     match ($type) {


### PR DESCRIPTION
## Summary
- Rename `NotificationController::Notifications()` to `notifications()` (PascalCase method names are non-standard)
- Replace memory-intensive notification count query that loaded ALL user notifications into PHP memory (`findBy` + loop) with DQL `COUNT` queries that run on the database and return only the counts

## Test plan
- [x] All sidebar badge Behat tests pass (`web-notifications`)
- [x] All API notification tests pass (`api-notifications`)
- [x] PHPUnit tests pass
- [x] PHPStan, Psalm, PHP-CS-Fixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)