### PR TITLE
Fix corepack permission error during deployment

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -93,14 +93,13 @@ task('restart:php-fpm', function () {
 
 task('install:yarn', function () {
   cd('{{release_path}}');
-  run('corepack enable');
-  run('corepack prepare yarn@4.12.0 --activate');
-  run('yarn install --immutable');
+  run('corepack enable --install-directory=.corepack-bin');
+  run('export PATH={{release_path}}/.corepack-bin:$PATH && corepack prepare yarn@4.12.0 --activate && yarn install --immutable');
 });
 
 task('deploy:encore', function () {
   cd('{{release_path}}');
-  run('yarn run prod');
+  run('export PATH={{release_path}}/.corepack-bin:$PATH && yarn run prod');
 });
 
 task('deploy:jwt', function () {


### PR DESCRIPTION
## Summary
- `corepack enable` fails during deployment with `EACCES: permission denied, symlink` because it tries to write to `/usr/local/bin/`
- Use `--install-directory=.corepack-bin` to create yarn/pnpm shims locally within the release path instead
- Prepend the local shim directory to `PATH` for both `install:yarn` and `deploy:encore` tasks

## Test plan
- [ ] Deploy to staging and verify `yarn install --immutable` and `yarn run prod` succeed
- [ ] Verify the built assets are served correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)