### PR TITLE
Create .corepack-bin directory before corepack enable

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -93,7 +93,7 @@ task('restart:php-fpm', function () {
 
 task('install:yarn', function () {
   cd('{{release_path}}');
-  run('corepack enable --install-directory=.corepack-bin');
+  run('mkdir -p .corepack-bin && corepack enable --install-directory=.corepack-bin');
   run('export PATH={{release_path}}/.corepack-bin:$PATH && corepack prepare yarn@4.12.0 --activate && yarn install --immutable');
 });
 


### PR DESCRIPTION
## Summary
- Follow-up to #6243 — `corepack enable --install-directory` requires the target directory to already exist
- Add `mkdir -p .corepack-bin` before running `corepack enable`

## Test plan
- [ ] Deploy and verify `install:yarn` task succeeds without ENOENT error

🤖 Generated with [Claude Code](https://claude.com/claude-code)