### PR TITLE
Remove obsolete sonata:admin:setup-acl command

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -132,11 +132,6 @@ task('update:special', function () {
   run('bin/console catrobat:update:special');
 });
 
-task('sonata:admin:setup:acl', function () {
-  cd('{{release_path}}');
-  run('bin/console sonata:admin:setup-acl');
-});
-
 // dump the .env file as .env.local.php to speed up the loading of the env vars
 task('dump:env', function () {
   cd('{{release_path}}');
@@ -162,7 +157,6 @@ task('deploy', [
   'deploy:jwt',
   'restart:nginx',
   'restart:php-fpm',
-  'sonata:admin:setup:acl',
   'update:flavors',
   'update:achievements',
   'update:tags',

--- a/src/System/Commands/Reset/ResetCommand.php
+++ b/src/System/Commands/Reset/ResetCommand.php
@@ -89,11 +89,6 @@ class ResetCommand extends Command
       ['bin/console', 'catrobat:update:extensions'], [], 'Creating constant tags', $output
     );
 
-    // SetUp Acl
-    CommandHelper::executeShellCommand(
-      ['bin/console', 'sonata:admin:setup-acl'], [], 'Set up Sonata admin ACL', $output
-    );
-
     $this->clearCache($output);
 
     $user_array = [

--- a/src/System/Testing/Behat/Context/CatrowebBrowserContext.php
+++ b/src/System/Testing/Behat/Context/CatrowebBrowserContext.php
@@ -19,9 +19,6 @@ use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\ResponseTextException;
 use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTEncodeFailureException;
 use PHPUnit\Framework\Assert;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\File\File;
@@ -58,20 +55,6 @@ class CatrowebBrowserContext extends BrowserContext
   // -------------------------------------------------------------------------------------------------------------------
   //  Hook
   // -------------------------------------------------------------------------------------------------------------------
-
-  /**
-   * @BeforeScenario
-   *
-   * @throws \Exception
-   */
-  public function initACL(): void
-  {
-    $application = new Application($this->getKernel());
-    $application->setAutoExit(false);
-
-    $input = new ArrayInput(['command' => 'sonata:admin:setup-acl']);
-    $application->run($input, new NullOutput());
-  }
 
   // --------------------------------------------------------------------------------------------------------------------
   //  Authentication


### PR DESCRIPTION
## Summary
- `sonata:admin:setup-acl` was removed in a newer Sonata Admin version, causing deploy failures
- Remove the deploy task and its reference in the deploy chain
- Remove the same call from `ResetCommand`
- Remove the unused `initACL()` method and its imports from `CatrowebBrowserContext`

## Test plan
- [ ] Deploy succeeds without the ACL setup step
- [ ] `bin/console catro:reset` works without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)