### PR TITLE
Fix follower tab counts, achievement styling, and link URLs

### DIFF
--- a/assets/User/AchievementBadge.js
+++ b/assets/User/AchievementBadge.js
@@ -5,12 +5,14 @@ export function achievementBadgeHtml(achievement, variant) {
     '<svg class="achievement__badge__coin achievement__badge__coin--' +
     variant +
     '"' +
+    ' width="100%" height="100%"' +
     ' data-src="' +
     escapeAttr(achievement.badge_svg_path) +
     '" data-unique-ids="disabled"></svg>' +
     '<svg class="achievement__badge__banner achievement__badge__banner--' +
     variant +
     '"' +
+    ' width="100%" height="100%"' +
     ' style="color: ' +
     escapeAttr(achievement.banner_color) +
     '"' +

--- a/assets/User/Achievements.scss
+++ b/assets/User/Achievements.scss
@@ -24,7 +24,8 @@
 }
 
 .achievement {
-  position: relative;
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   width: 50%;
@@ -34,6 +35,7 @@
 
 .achievement__badge {
   position: relative;
+  overflow: hidden;
 
   &.achievement__badge--tab {
     width: 10rem;
@@ -61,30 +63,13 @@
 }
 
 .achievement__badge__coin {
+  position: relative;
   z-index: 1;
-  max-width: 100%;
-
-  &.achievement__badge__coin--tab {
-    width: 10rem;
-    height: 10rem;
-    margin: auto;
-  }
-
-  &.achievement__badge__coin--top {
-    width: 7rem;
-    height: 7rem;
-    margin: 0;
-  }
-
-  &.achievement__badge__coin--profile {
-    width: 6rem;
-    height: 6rem;
-  }
+  display: block;
+  width: 100%;
+  height: 100%;
 
   &.achievement__badge__coin--popup {
-    width: 12rem;
-    height: 12rem;
-    margin: auto;
     transform-origin: center;
     animation: rotate-animation 1.5s ease-in-out infinite;
     animation-delay: 4s;
@@ -94,30 +79,16 @@
 .achievement__badge__banner {
   position: absolute;
   bottom: 0;
-  left: 50%;
+  left: 0;
   z-index: 2;
-  max-width: 100%;
-  transform: translate(-50%, 0);
+  width: 100%;
+  height: 20%;
 
   &.achievement__badge__banner--tab {
     bottom: 5%;
-    width: 10rem;
-    height: 2rem;
-  }
-
-  &.achievement__badge__banner--top {
-    width: 7rem;
-    height: 1.5rem;
-  }
-
-  &.achievement__badge__banner--profile {
-    width: 6rem;
-    height: 1.35rem;
   }
 
   &.achievement__badge__banner--popup {
-    width: 12rem;
-    height: 2.2rem;
     animation-name: fade-in-animation;
     animation-duration: 3s;
     animation-delay: 4s;
@@ -128,13 +99,15 @@
 .achievement__badge__banner__text {
   position: absolute;
   bottom: 0;
-  left: 50%;
+  left: 0;
   z-index: 3;
-  max-width: 100%;
+  width: 100%;
   overflow: hidden;
+  text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
-  transform: translate(-50%, -25%);
+  line-height: 1;
+  padding-bottom: 2%;
 
   &.achievement__badge__banner__text--tab {
     bottom: 5%;

--- a/assets/User/AchievementsPage.js
+++ b/assets/User/AchievementsPage.js
@@ -81,7 +81,7 @@ function createUnlockedAchievementElement(achievement) {
   const div = document.createElement('div')
   div.className = 'achievement'
   div.innerHTML =
-    '<div class="achievement__badge">' +
+    '<div class="achievement__badge achievement__badge--tab">' +
     achievementBadgeHtml(achievement, 'tab') +
     '</div>' +
     '<p class="achievement__badge__text">' +
@@ -94,8 +94,9 @@ function createLockedAchievementElement(achievement) {
   const div = document.createElement('div')
   div.className = 'achievement'
   div.innerHTML =
-    '<div class="achievement__badge">' +
+    '<div class="achievement__badge achievement__badge--tab">' +
     '<svg class="achievement__badge__coin achievement__badge__coin--tab"' +
+    ' width="100%" height="100%"' +
     ' data-src="' +
     escapeAttr(achievement.badge_locked_svg_path) +
     '" data-unique-ids="disabled"></svg>' +
@@ -112,13 +113,14 @@ function renderMostRecentSection(data) {
   }
 
   const achievement = data.most_recent
-  const tabContent = document.querySelector('.tab-content')
-  if (!tabContent) {
+  const tabBar = document.querySelector('.mdc-tab-bar')
+  if (!tabBar) {
     return
   }
 
   const section = document.createElement('div')
   section.id = 'most-recent-achievement'
+  section.className = 'mb-4'
 
   const xOutOfYText = trans.xOutOfY
     .replace('__UNLOCKED__', data.unlocked_count)
@@ -129,7 +131,7 @@ function renderMostRecentSection(data) {
     escapeHtml(trans.mostRecentTitle) +
     '</h2>' +
     '<div class="mt-4 mb-4 achievement-top__wrapper">' +
-    '<div class="achievement__badge">' +
+    '<div class="achievement__badge achievement__badge--top">' +
     achievementBadgeHtml(achievement, 'top') +
     '</div>' +
     '<div class="achievement-top__text-wrapper">' +
@@ -145,7 +147,7 @@ function renderMostRecentSection(data) {
     '</div>' +
     '</div>'
 
-  tabContent.parentNode.insertBefore(section, tabContent)
+  tabBar.parentNode.insertBefore(section, tabBar)
 }
 
 function updateEmptyStates(data) {

--- a/assets/User/FollowerOverview.js
+++ b/assets/User/FollowerOverview.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const userId = container.dataset.userId
   const baseUrl = container.dataset.baseUrl || ''
+  const theme = container.dataset.theme || 'pocketcode'
   const loginUrl = container.dataset.loginUrl
   const userRole = container.dataset.userRole || 'guest'
 
@@ -38,7 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function renderFollowerCard(user, showFollowsMe, itemClassPrefix) {
     const avatarSrc = user.avatar || baseUrl + '/images/default/avatar_default.png'
-    const profileUrl = baseUrl + '/user/' + escapeAttr(user.id)
+    const profileUrl = baseUrl + '/' + escapeAttr(theme) + '/user/' + escapeAttr(user.id)
     const itemClass = itemClassPrefix + '-' + escapeAttr(user.id)
 
     let followsMeHtml = ''

--- a/assets/User/Profile.scss
+++ b/assets/User/Profile.scss
@@ -47,6 +47,13 @@
     }
   }
 
+  img.round {
+    max-width: 4rem;
+    max-height: 4rem;
+    aspect-ratio: 1;
+    object-fit: cover;
+  }
+
   &__info {
     font-size: 0.7em;
     white-space: normal;

--- a/assets/User/ProfilePage.js
+++ b/assets/User/ProfilePage.js
@@ -4,7 +4,6 @@ import './FollowerOverview'
 
 import { shareLink } from '../Components/ShareLink'
 import { ProjectList } from '../Project/ProjectList'
-import { ApiFetch } from '../Api/ApiHelper'
 import { escapeHtml } from '../Components/HtmlEscape'
 import { achievementBadgeHtml } from './AchievementBadge'
 
@@ -56,8 +55,10 @@ function initProfileAchievements() {
   const userId = container.dataset.userId
   const title = container.dataset.transTitle
 
-  new ApiFetch(baseUrl + '/api/user/' + userId + '/achievements', 'GET', undefined, 'json')
-    .run()
+  fetch(baseUrl + '/api/user/' + userId + '/achievements', {
+    headers: { Accept: 'application/json' },
+  })
+    .then((r) => r.json())
     .then((achievements) => {
       if (!achievements || achievements.length === 0) {
         return
@@ -66,7 +67,7 @@ function initProfileAchievements() {
       const badgesHtml = achievements
         .map(
           (achievement) =>
-            '<div class="achievement__badge">' +
+            '<div class="achievement__badge achievement__badge--profile">' +
             achievementBadgeHtml(achievement, 'profile') +
             '</div>',
         )

--- a/templates/Components/TabBar.html.twig
+++ b/templates/Components/TabBar.html.twig
@@ -34,6 +34,9 @@
                   role="tab" aria-controls="{{ tab.controls }}" aria-selected="{{ loop.first }}">
 
             <span class="mdc-tab__content">
+              {% if tab.count_id is defined %}
+                <span class="mdc-tab__icon" id="{{ tab.count_id }}">-</span>
+              {% endif %}
               <span class="mdc-tab__icon-text">{{ tab.title }}</span>
             </span>
               <span class="mdc-tab-indicator {% if loop.first %} mdc-tab-indicator--active {% endif %}">

--- a/templates/User/Followers/FollowerOverviewData.html.twig
+++ b/templates/User/Followers/FollowerOverviewData.html.twig
@@ -2,6 +2,7 @@
 <div class="js-follower-overview"
      data-user-id="{{ follower_user_id }}"
      data-base-url="{{ app.request.getBaseURL() }}"
+     data-theme="{{ theme() }}"
      data-login-url="{{ url('login') }}"
      data-something-went-wrong-error="{{ 'somethingWentWrong'|trans({}, 'catroweb') }}"
      data-follow-error="{{ 'follower.followError'|trans({}, 'catroweb') }}"

--- a/templates/User/Followers/FollowersPage.html.twig
+++ b/templates/User/Followers/FollowersPage.html.twig
@@ -11,12 +11,14 @@
       tabs: [
         {
           id: 'follower-tab',
-          title: '- ' ~ 'follower.followers'|trans({}, 'catroweb'),
+          title: 'follower.followers'|trans({}, 'catroweb'),
+          count_id: 'followers-count',
           controls: 'follower-section',
         },
         {
           id: 'follows-tab',
-          title: '- ' ~ 'follower.follows'|trans({}, 'catroweb'),
+          title: 'follower.follows'|trans({}, 'catroweb'),
+          count_id: 'following-count',
           controls: 'following-section',
         },
       ],

--- a/tests/BehatFeatures/web/profile/follow.feature
+++ b/tests/BehatFeatures/web/profile/follow.feature
@@ -65,6 +65,31 @@ Feature: Follow feature on profiles
     And I wait for the element "#followers-count" to contain "0"
     And the "#followers-count" element should contain "0"
 
+  Scenario: Follower page tabs should show correct counts
+    Given there are followers:
+      | name     | following |
+      | Catrobat2 | Catrobat |
+      | Catrobat3 | Catrobat |
+      | Catrobat  | Catrobat4 |
+    And I log in as "Catrobat"
+    And I am on "/app/follower"
+    And I wait for the page to be loaded
+    And I wait for AJAX to finish
+    Then I wait for the element "#followers-count" to contain "2"
+    And the "#followers-count" element should contain "2"
+    And I wait for the element "#following-count" to contain "1"
+    And the "#following-count" element should contain "1"
+
+  Scenario: Follower page tabs should show 0 when user has no followers
+    Given I log in as "Catrobat"
+    And I am on "/app/follower"
+    And I wait for the page to be loaded
+    And I wait for AJAX to finish
+    Then I wait for the element "#followers-count" to contain "0"
+    And the "#followers-count" element should contain "0"
+    And I wait for the element "#following-count" to contain "0"
+    And the "#following-count" element should contain "0"
+
   Scenario: Following section should show appropriate information:
     Given I log in as "Catrobat2"
     And I am on "/app/user/1"


### PR DESCRIPTION
## Summary
- Fix follower page tab counts showing "-" instead of numbers (added `count_id` support to `TabBar` component)
- Fix achievement badge SVGs rendering at massive sizes (pre-set `width/height` on SVG placeholders to block `external-svg-loader` from copying pt-based dimensions)
- Fix follower page profile links missing theme prefix (e.g. `/user/123` instead of `/app/user/123`) causing 404s
- Fix profile page achievements not loading for guest users (`ApiFetch` always sends auth header, replaced with plain `fetch` for public endpoint)
- Move most-recent-achievement section above tabs to match original layout
- Constrain follower card avatar images to 4rem

## Test plan
- [ ] Verify follower page (`/app/follower`) shows correct numeric counts in tabs
- [ ] Verify follower page links to user profiles work (include theme prefix)
- [ ] Verify achievement badges render at correct size on `/app/achievements`
- [ ] Verify achievement badges render at correct size on `/app/user/{id}` profile pages
- [ ] Verify achievements show on profile pages when not logged in
- [ ] Verify most-recent-achievement section appears above the tab bar
- [ ] Run `bin/behat -s web-profile tests/BehatFeatures/web/profile/follow.feature` — all 10 scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)