### PR TITLE
Fix: Swap inverted follower/following logic in API and trust score

### DIFF
--- a/src/Api/Services/Followers/FollowersApiLoader.php
+++ b/src/Api/Services/Followers/FollowersApiLoader.php
@@ -20,8 +20,8 @@ class FollowersApiLoader extends AbstractApiLoader
    */
   public function getFollowers(User $user): array
   {
-    $followers = $this->queryRelatedUsers($user, 'f.following');
-    $total_following = $this->countRelatedUsers($user, 'f.followers');
+    $followers = $this->queryRelatedUsers($user, 'f.followers');
+    $total_following = $this->countRelatedUsers($user, 'f.following');
 
     return [
       'users' => $followers,
@@ -35,8 +35,8 @@ class FollowersApiLoader extends AbstractApiLoader
    */
   public function getFollowing(User $user): array
   {
-    $following = $this->queryRelatedUsers($user, 'f.followers');
-    $total_followers = $this->countRelatedUsers($user, 'f.following');
+    $following = $this->queryRelatedUsers($user, 'f.following');
+    $total_followers = $this->countRelatedUsers($user, 'f.followers');
 
     return [
       'users' => $following,

--- a/src/Moderation/TrustScoreCalculator.php
+++ b/src/Moderation/TrustScoreCalculator.php
@@ -92,7 +92,7 @@ class TrustScoreCalculator
     $follower_count = (int) $this->entity_manager->createQueryBuilder()
       ->select('COUNT(f)')
       ->from(User::class, 'f')
-      ->join('f.following', 'u')
+      ->join('f.followers', 'u')
       ->where('u.id = :user_id')
       ->setParameter('user_id', $user_id)
       ->getQuery()


### PR DESCRIPTION
Fixes #6299

The `f.following` and `f.followers` Doctrine join relations were swapped in two places:

1. `FollowersApiLoader.php` — `getFollowers()` was joining on `f.following` instead of `f.followers`, and `getFollowing()` had the reverse. Both endpoints returned wrong user lists.
2. `TrustScoreCalculator.php` — `$follower_count` in `computeActivityScore()` was joining on `f.following`, so it counted outgoing follows instead of incoming followers, giving wrong trust scores.

---

### Your checklist for this pull request

Please review the [[contributing guidelines](https://github.com/Catrobat/Catroweb/compare/develop...abhinavsudhik:fix/contributing.md)](./contributing.md) and [[wiki pages](https://github.com/Catrobat/Catroweb/compare/docs/README.md)](../docs/README.md) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR's title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (_develop_)
- [x] Confirm that the changes follow the project's coding guidelines
- [x] Verify that the changes generate no warnings and errors
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing (CI), if not please state the test cases in the [[section](https://github.com/Catrobat/Catroweb/compare/develop...abhinavsudhik:fix/follower-following-logic-swap-6299?expand=1#Tests)](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project's git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [[Jira](https://jira.catrob.at/)](https://jira.catrob.at/)
- [ ] Ask for a code reviewer
- [ ] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description

`f.followers` joins from the `User` entity through its `followers` collection, returning users who follow that user. The old code used `f.following` here, which traverses the opposite direction. Fixed by swapping the join relation in all three query locations. No schema or API contract changes — existing `TrustScoreCalculatorTest` and `FollowersApiLoader` tests should pass as-is.