### PR TITLE
fix follower/following inversion bug #6299

### DIFF
--- a/src/Api/Services/Followers/FollowersApiLoader.php
+++ b/src/Api/Services/Followers/FollowersApiLoader.php
@@ -20,8 +20,8 @@ class FollowersApiLoader extends AbstractApiLoader
    */
   public function getFollowers(User $user): array
   {
-    $followers = $this->queryRelatedUsers($user, 'f.following');
-    $total_following = $this->countRelatedUsers($user, 'f.followers');
+    $followers = $this->queryRelatedUsers($user, 'f.followers');
+    $total_following = $this->countRelatedUsers($user, 'f.following');
 
     return [
       'users' => $followers,
@@ -35,8 +35,8 @@ class FollowersApiLoader extends AbstractApiLoader
    */
   public function getFollowing(User $user): array
   {
-    $following = $this->queryRelatedUsers($user, 'f.followers');
-    $total_followers = $this->countRelatedUsers($user, 'f.following');
+    $following = $this->queryRelatedUsers($user, 'f.following');
+    $total_followers = $this->countRelatedUsers($user, 'f.followers');
 
     return [
       'users' => $following,

--- a/src/Moderation/TrustScoreCalculator.php
+++ b/src/Moderation/TrustScoreCalculator.php
@@ -92,7 +92,7 @@ class TrustScoreCalculator
     $follower_count = (int) $this->entity_manager->createQueryBuilder()
       ->select('COUNT(f)')
       ->from(User::class, 'f')
-      ->join('f.following', 'u')
+      ->join('f.followers', 'u')
       ->where('u.id = :user_id')
       ->setParameter('user_id', $user_id)
       ->getQuery()


### PR DESCRIPTION
This PR fixes incorrect follower/following logic in the codebase.

Changes:

* Corrected usage of `f.followers` and `f.following` in FollowersApiLoader.php
* Fixed trust score calculation in TrustScoreCalculator.php

Result:

* Followers API now returns correct data
* Trust scores are calculated using the correct follower count
