### PR TITLE
Refactor: Fix outdated @var annotation style and remove redundant setApkStatus call in ApkController

### DIFF
--- a/src/Admin/ApkGeneration/ApkController.php
+++ b/src/Admin/ApkGeneration/ApkController.php
@@ -1,9 +1,6 @@
 <?php
-
 declare(strict_types=1);
-
 namespace App\Admin\ApkGeneration;
-
 use App\DB\Entity\Project\Program;
 use App\Project\Apk\JenkinsDispatcher;
 use App\Project\ProjectManager;
@@ -13,7 +10,6 @@ use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Exception\LockException;
 use Sonata\AdminBundle\Exception\ModelManagerThrowable;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-
 /**
  * @phpstan-extends CRUDController<Program>
  */
@@ -25,7 +21,6 @@ class ApkController extends CRUDController
     protected EntityManagerInterface $entity_manager,
   ) {
   }
-
   /**
    * @throws LockException
    * @throws ModelManagerThrowable
@@ -38,10 +33,8 @@ class ApkController extends CRUDController
     $project->setApkRequestTime(null);
     $this->admin->update($project);
     $this->addFlash('sonata_flash_success', 'Reset APK status of '.$project->getName().' successful');
-
     return new RedirectResponse($this->admin->generateUrl('list'));
   }
-
   /**
    * @throws \Exception
    */
@@ -54,10 +47,8 @@ class ApkController extends CRUDController
     $project->setApkStatus(Program::APK_PENDING);
     $this->admin->update($project);
     $this->addFlash('sonata_flash_success', 'Requested a rebuild of '.$project->getName());
-
     return new RedirectResponse($this->admin->generateUrl('list'));
   }
-
   public function resetPendingProjectsAction(): RedirectResponse
   {
     $this->entity_manager->createQueryBuilder()
@@ -71,29 +62,22 @@ class ApkController extends CRUDController
       ->getQuery()
       ->execute()
     ;
-
     $this->addFlash('sonata_flash_success', 'All pending APKs have been reset');
-
     return new RedirectResponse($this->admin->generateUrl('list'));
   }
-
   /**
    * @throws \Exception
    */
   public function rebuildAllApkAction(): RedirectResponse
   {
     $projects = $this->project_manager->findBy(['apk_status' => Program::APK_PENDING]);
-
-    /* @var $project Program */
+    /** @var Program $project */
     foreach ($projects as $project) {
       $this->jenkins_dispatcher->sendBuildRequest($project->getId());
       $project->setApkRequestTime(TimeUtils::getDateTime());
-      $project->setApkStatus(Program::APK_PENDING);
       $this->admin->update($project);
     }
-
     $this->addFlash('sonata_flash_success', 'A new build request for all pending APKs has been sent');
-
     return new RedirectResponse($this->admin->generateUrl('list'));
   }
 }


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [contributing guidelines](./contributing.md) and [wiki pages](../docs/README.md) of this repository.
- [x] Include the name and id of the Jira ticket in the PR's title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (_develop_)
- [x] Confirm that the changes follow the project's coding guidelines
- [x] Verify that the changes generate no warnings and errors
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing (CI), if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project's git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [x] Ask for a code reviewer
- [x] Check that your pull request has been successfully deployed to https://web-test-1.catrob.at/

### Additional Description
Fixes two code quality issues in `src/Admin/ApkGeneration/ApkController.php`:

1. Replaced outdated `/* @var $project Program */` annotation with the
   modern PHPDoc style `/** @var Program $project */` in `rebuildAllApkAction()`.

2. Removed a redundant `$project->setApkStatus(Program::APK_PENDING)` call
   inside `rebuildAllApkAction()` — projects are already fetched with
   `apk_status = APK_PENDING`, so re-setting the same value is unnecessary.

No behaviour is changed — this is a pure code quality refactor.

Closes #6306 