### PR TITLE
Security: Fix path traversal in LogsController

### DIFF
--- a/src/Admin/System/Logs/LogsController.php
+++ b/src/Admin/System/Logs/LogsController.php
@@ -28,7 +28,7 @@ class LogsController extends CRUDController
     }
 
     if ($request->query->get('file')) {
-      $file = (string) $request->query->get('file');
+      $file = basename((string) $request->query->get('file'));
     }
 
     $searchParam = [];
@@ -37,6 +37,15 @@ class LogsController extends CRUDController
     if (empty($file) && [] !== $allFiles) {
       $file = $allFiles[0];
     }
+
+    if (!empty($file)) {
+      $realLogDir = realpath(self::LOG_DIR);
+      $realFilePath = realpath(self::LOG_DIR.$file);
+      if (false === $realLogDir || false === $realFilePath || !str_starts_with($realFilePath, $realLogDir.DIRECTORY_SEPARATOR)) {
+        $file = null;
+      }
+    }
+
     $content = empty($file) ? null : $this->getLogFileContent($file, self::LOG_DIR, $searchParam);
 
     return $this->render('Admin/SystemManagement/Logs.html.twig', [


### PR DESCRIPTION
## Summary
- Add `basename()` sanitization to strip directory traversal from the `file` query parameter
- Add `realpath()` containment check to verify resolved path stays within the log directory
- Both layers work together: basename prevents `../../etc/passwd`, realpath catches any edge cases

## Test plan
- [ ] Verify admin logs page still works normally
- [ ] Verify `?file=../../../../etc/passwd` returns empty/no content
- [ ] Verify `?file=../../../etc/shadow` returns empty/no content
- [ ] Verify legitimate log files still display correctly

Closes #6326

🤖 Generated with [Claude Code](https://claude.com/claude-code)