### PR TITLE
Performance: Enable framework caching (was disabled)

### DIFF
--- a/config/packages/cache.php
+++ b/config/packages/cache.php
@@ -8,7 +8,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
   $containerConfigurator->extension(
     'framework',
     [
-      'cache' => null,
+      'cache' => [
+        'app' => 'cache.adapter.filesystem',
+        'system' => 'cache.adapter.system',
+      ],
     ]
   );
 };


### PR DESCRIPTION
## Summary
- Replace `'cache' => null` with filesystem and system cache adapters
- Enables Doctrine query/result caching (already configured in prod Doctrine config but was no-op due to null cache)
- Enables Symfony internal caches (routing, serializer, validator)
- Filesystem adapter is the safest default — no extension required, works everywhere

## Expected Impact
- Significant reduction in database queries (Doctrine result caching)
- Faster routing and serialization (system cache)
- Minimal memory overhead

## Test plan
- [ ] Verify application starts and serves pages correctly
- [ ] Verify `var/cache/` directory is being populated
- [ ] Check Symfony profiler for cache hit/miss ratios
- [ ] Run full test suite to ensure no cache-related regressions

Closes #6329

🤖 Generated with [Claude Code](https://claude.com/claude-code)