### PR TITLE
Security: Add missing HTTP security headers

### DIFF
--- a/src/Security/SecurityHeadersSubscriber.php
+++ b/src/Security/SecurityHeadersSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+#[AsEventListener(event: KernelEvents::RESPONSE, method: 'onKernelResponse')]
+class SecurityHeadersSubscriber
+{
+  public function __construct(
+    #[Autowire('%kernel.environment%')]
+    private readonly string $kernelEnvironment,
+  ) {
+  }
+
+  public function onKernelResponse(ResponseEvent $event): void
+  {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+
+    $response = $event->getResponse();
+    $headers = $response->headers;
+
+    $headers->set('X-Content-Type-Options', 'nosniff');
+    $headers->set('X-Frame-Options', 'SAMEORIGIN');
+    $headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+    $headers->set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+
+    if ('prod' === $this->kernelEnvironment) {
+      $headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+    }
+  }
+}

--- a/tests/PhpUnit/Security/SecurityHeadersSubscriberTest.php
+++ b/tests/PhpUnit/Security/SecurityHeadersSubscriberTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Security;
+
+use App\Security\SecurityHeadersSubscriber;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(SecurityHeadersSubscriber::class)]
+class SecurityHeadersSubscriberTest extends TestCase
+{
+  public function testAddsSecurityHeadersOnMainRequest(): void
+  {
+    $subscriber = new SecurityHeadersSubscriber('dev');
+    $event = $this->createResponseEvent(HttpKernelInterface::MAIN_REQUEST);
+
+    $subscriber->onKernelResponse($event);
+
+    $response = $event->getResponse();
+    $this->assertSame('nosniff', $response->headers->get('X-Content-Type-Options'));
+    $this->assertSame('SAMEORIGIN', $response->headers->get('X-Frame-Options'));
+    $this->assertSame('strict-origin-when-cross-origin', $response->headers->get('Referrer-Policy'));
+    $this->assertSame('camera=(), microphone=(), geolocation=()', $response->headers->get('Permissions-Policy'));
+  }
+
+  public function testSkipsSubRequests(): void
+  {
+    $subscriber = new SecurityHeadersSubscriber('prod');
+    $event = $this->createResponseEvent(HttpKernelInterface::SUB_REQUEST);
+
+    $subscriber->onKernelResponse($event);
+
+    $response = $event->getResponse();
+    $this->assertNull($response->headers->get('X-Content-Type-Options'));
+  }
+
+  public function testAddsHstsInProdOnly(): void
+  {
+    $devSubscriber = new SecurityHeadersSubscriber('dev');
+    $devEvent = $this->createResponseEvent(HttpKernelInterface::MAIN_REQUEST);
+    $devSubscriber->onKernelResponse($devEvent);
+    $this->assertNull($devEvent->getResponse()->headers->get('Strict-Transport-Security'));
+
+    $prodSubscriber = new SecurityHeadersSubscriber('prod');
+    $prodEvent = $this->createResponseEvent(HttpKernelInterface::MAIN_REQUEST);
+    $prodSubscriber->onKernelResponse($prodEvent);
+    $this->assertSame(
+      'max-age=31536000; includeSubDomains',
+      $prodEvent->getResponse()->headers->get('Strict-Transport-Security')
+    );
+  }
+
+  public function testNoHstsInTestEnv(): void
+  {
+    $subscriber = new SecurityHeadersSubscriber('test');
+    $event = $this->createResponseEvent(HttpKernelInterface::MAIN_REQUEST);
+
+    $subscriber->onKernelResponse($event);
+
+    $this->assertNull($event->getResponse()->headers->get('Strict-Transport-Security'));
+  }
+
+  private function createResponseEvent(int $requestType): ResponseEvent
+  {
+    $kernel = $this->createStub(HttpKernelInterface::class);
+    $request = new Request();
+    $response = new Response();
+
+    return new ResponseEvent($kernel, $request, $requestType, $response);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `SecurityHeadersSubscriber` responding to `kernel.response`
- Sets `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy: camera=(), microphone=(), geolocation=()`
- HSTS (`max-age=31536000; includeSubDomains`) added only in prod (avoids dev issues)
- Only processes main requests (skips sub-requests)
- Includes unit tests for all headers and environment-conditional behavior

**Note:** CSP intentionally omitted — needs careful tuning to avoid breaking inline scripts/styles.

## Test plan
- [ ] Verify all 4 standard headers present in response (curl -I)
- [ ] Verify HSTS only appears in prod
- [ ] Run PHPUnit: `bin/phpunit tests/PhpUnit/Security/SecurityHeadersSubscriberTest.php`
- [ ] Verify no regression in existing functionality

Closes #6327

🤖 Generated with [Claude Code](https://claude.com/claude-code)