### PR TITLE
Accessibility: Fix viewport zoom, add semantic landmarks and noscript

### DIFF
--- a/templates/Layout/Base.html.twig
+++ b/templates/Layout/Base.html.twig
@@ -5,7 +5,6 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta charset="UTF-8">
-  <meta name='viewport' content='width=device-width, user-scalable=no'/>
 
   {% if gtm_container_id %}
     <!-- Google Tag Manager (noscript) -->
@@ -46,6 +45,12 @@
 
 <body class="body-with-sidebar">
 
+<noscript>
+  <div class="noscript-warning" style="background-color: #fff3cd; color: #856404; text-align: center; padding: 1rem; font-size: 1rem;">
+    This site requires JavaScript to function. Please enable JavaScript in your browser.
+  </div>
+</noscript>
+
 {{ include('Layout/Header.html.twig',
   {
     top_bar_page_title: block('top_bar_page_title') ?? '',
@@ -62,11 +67,11 @@
 
 {{ include(('Layout/LanguageMenu.html.twig')) }}
 
-<div id="main_container_content" class="body-content">
+<main id="main_container_content" class="body-content">
   <div class="page-content{% if app.request.attributes.get('_route') != 'studio_details' %} container{% endif %}">
     {% block body %}{% endblock %}
   </div>
-</div>
+</main>
 
 {{ include('Layout/Footer.html.twig') }}
 


### PR DESCRIPTION
## Summary
- Remove duplicate viewport meta with `user-scalable=no` (violates WCAG 1.4.4 — blocks pinch-to-zoom)
- Change `<div id="main_container_content">` to `<main>` element for screen reader landmarks
- Add `<noscript>` warning banner for users without JavaScript

## Test plan
- [ ] Verify pinch-to-zoom works on mobile devices
- [ ] Verify screen readers announce the `<main>` landmark
- [ ] Verify noscript banner appears when JS is disabled
- [ ] Verify no CSS/JS breakage (id and class preserved on main element)
- [ ] Run Behat web tests to check for regressions

Closes #6339

🤖 Generated with [Claude Code](https://claude.com/claude-code)