### PR TITLE
Performance: Enable gzip compression and browser caching headers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Overwrite default apache config
-RUN a2enmod rewrite
+RUN a2enmod rewrite deflate headers
 COPY /docker/apache/catroweb.conf /etc/apache2/sites-available/catroweb.conf
 RUN a2dissite 000-default.conf && \
     a2ensite catroweb.conf

--- a/docker/apache/catroweb.conf
+++ b/docker/apache/catroweb.conf
@@ -19,6 +19,21 @@
 
         SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 
+        # Compression
+        <IfModule mod_deflate.c>
+            AddOutputFilterByType DEFLATE text/html text/plain text/css text/javascript application/javascript application/json image/svg+xml application/xml
+        </IfModule>
+
+        # Browser caching for static assets
+        <IfModule mod_headers.c>
+            <FilesMatch "\.(jpg|jpeg|png|gif|ico|svg|webp|woff|woff2|ttf|eot)$">
+                Header set Cache-Control "max-age=2592000, public"
+            </FilesMatch>
+            <FilesMatch "\.(css|js)$">
+                Header set Cache-Control "max-age=31536000, public, immutable"
+            </FilesMatch>
+        </IfModule>
+
         ErrorLog ${APACHE_LOG_DIR}/error.log
         CustomLog ${APACHE_LOG_DIR}/access.log combined
 </VirtualHost>


### PR DESCRIPTION
## Summary
- Enable `mod_deflate` and `mod_headers` Apache modules in Dockerfile
- Add gzip compression for HTML, CSS, JS, JSON, SVG, XML
- Add 30-day cache for images/fonts, 1-year immutable cache for CSS/JS
- Webpack content hashes make immutable caching safe for CSS/JS

## Expected Impact
- ~60% reduction in CSS/JS transfer size
- Near-zero asset loading for repeat visitors
- Significant bandwidth savings on limited hardware

## Test plan
- [ ] Rebuild Docker image: \`docker compose -f docker/docker-compose.dev.yaml build --no-cache app.catroweb\`
- [ ] Verify \`Content-Encoding: gzip\` in response headers for CSS/JS
- [ ] Verify \`Cache-Control\` headers on static assets
- [ ] Verify site loads correctly after changes

Closes #6340

🤖 Generated with [Claude Code](https://claude.com/claude-code)