### PR TITLE
Harden web auth cookies without breaking API clients

### DIFF
--- a/assets/Api/ApiHelper.js
+++ b/assets/Api/ApiHelper.js
@@ -1,6 +1,5 @@
 /* global globalConfiguration */
 
-import { getCookie } from '../Security/CookieHelper'
 import MessageDialogs from '../Components/MessageDialogs'
 
 export class ApiFetch {
@@ -14,9 +13,8 @@ export class ApiFetch {
   generateAuthenticatedFetch() {
     const config = {
       method: this.method,
-      headers: {
-        Authorization: 'Bearer ' + getCookie('BEARER'),
-      },
+      credentials: 'same-origin',
+      headers: {},
     }
 
     if (this.data !== undefined) {

--- a/assets/Layout/Base.js
+++ b/assets/Layout/Base.js
@@ -13,7 +13,6 @@ import 'material-icons/iconfont/material-icons.css'
 import textFillDefault from '../Components/TextFillDefault'
 import './TopBar'
 import './Sidebar'
-import { TokenExpirationHandler } from '../Security/TokenExpirationHandler'
 import { LogoutTokenHandler } from '../Security/LogoutTokenHandler'
 import { showSnackbar } from './Snackbar'
 
@@ -39,7 +38,6 @@ initAnalyticsIfConsented()
 require('./Base.scss')
 require('./Footer.scss')
 
-new TokenExpirationHandler()
 new LogoutTokenHandler()
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/assets/Moderation/AppealDialog.js
+++ b/assets/Moderation/AppealDialog.js
@@ -1,5 +1,4 @@
 import Swal from 'sweetalert2'
-import { getCookie } from '../Security/CookieHelper'
 import { handleAccountState403 } from '../Security/AccountStateErrorHandler'
 import { escapeAttr } from '../Components/HtmlEscape'
 
@@ -43,13 +42,11 @@ export function showAppealDialog({ apiUrl, translations }) {
 }
 
 function submitAppeal(apiUrl, reason, translations) {
-  const token = getCookie('BEARER')
-
   return fetch(apiUrl, {
     method: 'POST',
+    credentials: 'same-origin',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: 'Bearer ' + token,
     },
     body: JSON.stringify({ reason }),
   })

--- a/assets/Moderation/ReportDialog.js
+++ b/assets/Moderation/ReportDialog.js
@@ -1,5 +1,4 @@
 import Swal from 'sweetalert2'
-import { getCookie } from '../Security/CookieHelper'
 import { handleAccountState403 } from '../Security/AccountStateErrorHandler'
 import { escapeHtml, escapeAttr } from '../Components/HtmlEscape'
 import { REPORT_CATEGORIES } from './ReportCategories'
@@ -74,13 +73,11 @@ export function showReportDialog({
 }
 
 function submitReport(apiUrl, { category, note }, translations, sessionKey) {
-  const token = getCookie('BEARER')
-
   return fetch(apiUrl, {
     method: 'POST',
+    credentials: 'same-origin',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: 'Bearer ' + token,
     },
     body: JSON.stringify({ category, note: note || null }),
   })

--- a/assets/Project/ProjectComments.js
+++ b/assets/Project/ProjectComments.js
@@ -1,5 +1,4 @@
 import Swal from 'sweetalert2'
-import { getCookie } from '../Security/CookieHelper'
 
 export function ProjectComments(
   programId,
@@ -31,6 +30,7 @@ export function ProjectComments(
   const parentCommentContainer = document.querySelector('.js-project-parentComment')
   const repliesParentId = parentCommentContainer?.dataset.parentCommentId
   const isRepliesPage = Boolean(parentCommentContainer && repliesParentId)
+  const isLoggedIn = projectComments?.dataset.isLoggedIn === 'true'
 
   const commentUploadDates = document.getElementsByClassName('comment-upload-date')
   for (const element of commentUploadDates) {
@@ -113,7 +113,7 @@ export function ProjectComments(
           contentId: reportButton.dataset.contentId,
           apiUrl: reportButton.dataset.reportUrl,
           loginUrl: projectComments?.dataset.pathLoginUrl,
-          isLoggedIn: Boolean(getCookie('BEARER')),
+          isLoggedIn,
           translations: {
             title: projectComments?.dataset.transReportTitle,
             submit: projectComments?.dataset.transReportSubmit,
@@ -262,9 +262,9 @@ export function ProjectComments(
 
     fetch(postCommentUrl, {
       method: 'POST',
+      credentials: 'same-origin',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: 'Bearer ' + getCookie('BEARER'),
       },
       body: JSON.stringify(payload),
     })
@@ -365,12 +365,7 @@ export function ProjectComments(
     if (!listUrl) return
 
     fetchActive = true
-    const loadHeaders = {}
-    const bearerToken = getCookie('BEARER')
-    if (bearerToken) {
-      loadHeaders['Authorization'] = 'Bearer ' + bearerToken
-    }
-    fetch(listUrl, { headers: loadHeaders })
+    fetch(listUrl, { credentials: 'same-origin' })
       .then((response) => {
         if (response.ok) {
           return response.json()
@@ -453,9 +448,7 @@ export function ProjectComments(
 
     fetch(`${commentsBaseUrl}/${commentId}`, {
       method: 'DELETE',
-      headers: {
-        Authorization: 'Bearer ' + getCookie('BEARER'),
-      },
+      credentials: 'same-origin',
     })
       .then((response) => {
         if (response.ok) {

--- a/assets/Project/ProjectEditorModel.js
+++ b/assets/Project/ProjectEditorModel.js
@@ -1,5 +1,4 @@
 import { CustomTranslationApi } from '../Api/CustomTranslationApi'
-import { getCookie } from '../Security/CookieHelper'
 import AcceptLanguage from '../Api/AcceptLanguage'
 
 export const DIALOG = {
@@ -115,10 +114,10 @@ export function ProjectEditorModel(programId, textFieldModels) {
 
       fetch(`${this.baseUrl}/api/project/${this.programId}`, {
         method: 'PUT',
+        credentials: 'same-origin',
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',
-          Authorization: 'Bearer ' + getCookie('BEARER'),
           'Accept-Language': new AcceptLanguage().get(),
         },
         body: JSON.stringify(requestData),

--- a/assets/Security/LoginTokenHandler.js
+++ b/assets/Security/LoginTokenHandler.js
@@ -1,9 +1,6 @@
-import { setCookie } from './CookieHelper'
-
 export class LoginTokenHandler {
   constructor() {
     const routingDataset = document.getElementById('js-api-routing').dataset
-    this.baseUrl = routingDataset.baseUrl
     this.indexPath = routingDataset.index
     this.authenticationPath = routingDataset.authentication
   }
@@ -48,25 +45,19 @@ export class LoginTokenHandler {
   login(data) {
     fetch(this.authenticationPath, {
       method: 'POST',
+      credentials: 'same-origin',
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
+        'X-Auth-Mode': 'cookie',
       },
       body: JSON.stringify(data),
     })
       .then((response) => {
-        if (response.status === 200) {
-          return response.json()
+        if (!response.ok) {
+          throw new Error('Login failed')
         }
-      })
-      .then((data) => {
-        setCookie('BEARER', data.token, 'Tue, 19 Jan 2038 00:00:01 GMT', this.baseUrl + '/')
-        setCookie(
-          'REFRESH_TOKEN',
-          data.refresh_token,
-          'Tue, 19 Jan 2038 00:00:01 GMT',
-          this.baseUrl + '/',
-        )
+
         window.location.href = this.getRedirectUri()
       })
       .catch(() => {

--- a/assets/Security/LogoutTokenHandler.js
+++ b/assets/Security/LogoutTokenHandler.js
@@ -1,9 +1,6 @@
-import { deleteCookie } from './CookieHelper'
-
 export class LogoutTokenHandler {
   constructor() {
     const routingDataset = document.getElementById('js-api-routing').dataset
-    this.baseUrl = routingDataset.baseUrl
     this.authenticationPath = routingDataset.authentication
     this.initListeners()
   }
@@ -15,20 +12,17 @@ export class LogoutTokenHandler {
       return
     }
     logoutButton.onclick = function () {
-      const xhr = new XMLHttpRequest()
-      xhr.addEventListener('readystatechange', function () {
-        if (this.readyState === this.DONE) {
-          deleteCookie('BEARER', self.baseUrl + '/')
-          deleteCookie('REFRESH_TOKEN', self.baseUrl + '/')
-          if (logoutButton.dataset && logoutButton.dataset.logoutPath) {
-            window.location.href = logoutButton.dataset.logoutPath
-          }
+      fetch(self.authenticationPath, {
+        method: 'DELETE',
+        credentials: 'same-origin',
+        headers: {
+          'X-Refresh': 'cookie',
+        },
+      }).finally(() => {
+        if (logoutButton.dataset && logoutButton.dataset.logoutPath) {
+          window.location.href = logoutButton.dataset.logoutPath
         }
       })
-
-      xhr.open('DELETE', self.authenticationPath)
-      xhr.setRequestHeader('X-Refresh', 'token')
-      xhr.send()
     }
   }
 }

--- a/assets/Studio/CreatePage.js
+++ b/assets/Studio/CreatePage.js
@@ -1,5 +1,4 @@
 import '../Components/Switch'
-import { getCookie } from '../Security/CookieHelper'
 import { showValidationMessage } from '../Components/TextField'
 import AcceptLanguage from '../Api/AcceptLanguage'
 
@@ -36,10 +35,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const response = await fetch(config.url, {
       method: 'POST',
+      credentials: 'same-origin',
       body: formData,
       headers: {
         Accept: 'application/json',
-        Authorization: 'Bearer ' + getCookie('BEARER'),
         'Accept-Language': new AcceptLanguage().get(),
       },
     })

--- a/assets/Studio/StudioDetailPage.js
+++ b/assets/Studio/StudioDetailPage.js
@@ -6,7 +6,6 @@ import '../Components/TextField'
 import { showSnackbar } from '../Layout/Snackbar'
 import Swal from 'sweetalert2'
 import StudioCommentHandler from './StudioCommentHandler'
-import { getCookie } from '../Security/CookieHelper'
 import AcceptLanguage from '../Api/AcceptLanguage'
 require('../Project/ProjectList.scss')
 require('./AdminSettings.scss')
@@ -47,10 +46,10 @@ async function uploadCoverImage(url, file) {
 
   const response = await fetch(url, {
     method: 'POST',
+    credentials: 'same-origin',
     body: formData,
     headers: {
       Accept: 'application/json',
-      Authorization: 'Bearer ' + getCookie('BEARER'),
       'Accept-Language': new AcceptLanguage().get(),
     },
   })

--- a/assets/User/FollowerOverview.js
+++ b/assets/User/FollowerOverview.js
@@ -2,8 +2,7 @@ import Swal from 'sweetalert2'
 import '../Components/TabBar'
 import './Profile.scss'
 import { showSnackbar } from '../Layout/Snackbar'
-import { escapeHtml, escapeAttr } from '../Components/HtmlEscape'
-import { getCookie } from '../Security/CookieHelper'
+import { escapeAttr, escapeHtml } from '../Components/HtmlEscape'
 
 document.addEventListener('DOMContentLoaded', () => {
   const container = document.querySelector('.js-follower-overview')
@@ -29,15 +28,6 @@ document.addEventListener('DOMContentLoaded', () => {
     follows: container.dataset.transFollows,
     follow: container.dataset.transFollow,
     followsMe: container.dataset.transFollowsMe,
-  }
-
-  function getAuthHeaders() {
-    const token = getCookie('BEARER')
-    const headers = { Accept: 'application/json' }
-    if (token) {
-      headers['Authorization'] = 'Bearer ' + token
-    }
-    return headers
   }
 
   function showVerificationAlert(message) {
@@ -141,8 +131,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const followingUrl = baseUrl + '/api/user/' + userId + '/following'
 
     Promise.all([
-      fetch(followersUrl, { headers: getAuthHeaders() }).then((r) => r.json()),
-      fetch(followingUrl, { headers: getAuthHeaders() }).then((r) => r.json()),
+      fetch(followersUrl, { credentials: 'same-origin' }).then((r) => r.json()),
+      fetch(followingUrl, { credentials: 'same-origin' }).then((r) => r.json()),
     ])
       .then(([followersData, followingData]) => {
         updateTabCounts(followersData.total_followers, followersData.total_following)
@@ -171,7 +161,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const url = baseUrl + '/api/user/' + targetUserId + '/follow'
     fetch(url, {
       method: 'POST',
-      headers: getAuthHeaders(),
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
     })
       .then((response) => {
         if (response.ok) {
@@ -227,7 +218,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const url = baseUrl + '/api/user/' + targetUserId + '/unfollow'
         fetch(url, {
           method: 'DELETE',
-          headers: getAuthHeaders(),
+          credentials: 'same-origin',
+          headers: { Accept: 'application/json' },
         })
           .then((response) => {
             if (response.ok || response.status === 204) {

--- a/assets/User/MyProfilePage.js
+++ b/assets/User/MyProfilePage.js
@@ -8,7 +8,6 @@ import { Modal } from 'bootstrap'
 import { PasswordVisibilityToggle } from '../Components/PasswordVisibilityToggle'
 import { OwnProjectList } from '../Project/OwnProjectList'
 import Swal from 'sweetalert2'
-import { deleteCookie } from '../Security/CookieHelper'
 import MessageDialogs from '../Components/MessageDialogs'
 import { ApiDeleteFetch, ApiPutFetch } from '../Api/ApiHelper'
 import VerifyAccountHandler from './VerifyAccountHandler'
@@ -232,7 +231,6 @@ class OwnProfile {
             'Delete User',
             myProfileConfiguration.messages.unspecifiedErrorText,
             function () {
-              deleteCookie('BEARER', routingDataset.baseUrl + '/')
               window.location.href = routingDataset.index
             },
           ).run()

--- a/assets/User/VerifyAccountHandler.js
+++ b/assets/User/VerifyAccountHandler.js
@@ -1,4 +1,3 @@
-import { getCookie } from '../Security/CookieHelper'
 import AcceptLanguage from '../Api/AcceptLanguage'
 import { showSnackbar } from '../Layout/Snackbar'
 
@@ -11,9 +10,9 @@ export default class {
       btn.setAttribute('disabled', 'disabled')
       fetch(baseUrl + 'verify', {
         method: 'POST',
+        credentials: 'same-origin',
         headers: {
           Accept: 'application/json',
-          Authorization: 'Bearer ' + getCookie('BEARER'),
           'Accept-Language': new AcceptLanguage().get(),
         },
       }).then((response) => {

--- a/config/packages/security.php
+++ b/config/packages/security.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use App\DB\Entity\User\User;
+use App\Security\Authentication\ApiAuthenticationSuccessHandler;
 use App\Security\Authentication\FormLoginSuccessHandler;
+use App\Security\Authentication\JwtRefresh\ApiRefreshTokenSuccessHandler;
 use App\Security\Authentication\WebView\WebviewJWTAuthenticator;
 use App\Security\OAuth\HwiOauthUserProvider;
 use App\Security\OAuth\OAuthSuccessHandler;
@@ -33,11 +35,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
           'stateless' => true,
           'json_login' => [
             'check_path' => '/api/authentication',
-            'success_handler' => 'lexik_jwt_authentication.handler.authentication_success',
+            'success_handler' => ApiAuthenticationSuccessHandler::class,
             'failure_handler' => 'lexik_jwt_authentication.handler.authentication_failure',
           ],
           'refresh_jwt' => [
             'check_path' => '/api/authentication/refresh',
+            'success_handler' => ApiRefreshTokenSuccessHandler::class,
           ],
         ],
         'api' => [

--- a/config/services.php
+++ b/config/services.php
@@ -84,6 +84,8 @@ use App\DB\Entity\User\Achievements\Achievement;
 use App\DB\Entity\User\Comment\UserComment;
 use App\DB\Entity\User\Notifications\BroadcastNotification;
 use App\DB\Entity\User\User;
+use App\Security\Authentication\ApiAuthenticationSuccessHandler;
+use App\Security\Authentication\JwtRefresh\ApiRefreshTokenSuccessHandler;
 use App\Security\Captcha\CaptchaVerifier;
 use App\User\UserProvider;
 use Monolog\Formatter\LineFormatter;
@@ -93,6 +95,7 @@ use Sonata\AdminBundle\Security\Acl\Permission\AdminPermissionMap;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\Dotenv\Command\DotenvDumpCommand;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
   $parameters = $containerConfigurator->parameters();
@@ -162,6 +165,20 @@ return static function (ContainerConfigurator $containerConfigurator): void {
   $services->alias(Sonata\AdminBundle\SonataConfiguration::class, 'sonata.admin.configuration');
   $services->alias(UserProviderInterface::class, UserProvider::class);
   $services->set('security.acl.permission.map', AdminPermissionMap::class);
+  $services->set(ApiAuthenticationSuccessHandler::class)
+    ->args([
+      service('lexik_jwt_authentication.handler.authentication_success'),
+      service(App\Security\Authentication\AuthenticationModeResolver::class),
+      service(App\Security\Authentication\MainFirewallSessionLogin::class),
+      service(App\Security\Authentication\AuthenticationSuccessResponseProcessor::class),
+    ])
+  ;
+  $services->set(ApiRefreshTokenSuccessHandler::class)
+    ->args([
+      service('gesdinet_jwt_refresh_token.security.authentication.success_handler'),
+      service(App\Security\Authentication\AuthenticationSuccessResponseProcessor::class),
+    ])
+  ;
 
   // Custom formatting for our logs
   $logFormat = "[%%datetime%%] %%level_name%% %%channel%%: %%message%% | ip=%%extra.client_ip%% user=%%extra.session_user%% %%context%% %%extra%%\n";
@@ -205,7 +222,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
   //   - each services defines a page in the admin interface - go to /admin
   //
   $services->set('admin.block.projects.overview', ProjectsAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Projects Overview',
@@ -215,20 +233,24 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'model_class' => Program::class,
         'controller' => null,
         'pager_type' => 'simple',
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.projects.approve', ApproveProjectsAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Approve Projects',
         'code' => null,
         'model_class' => Program::class,
         'controller' => ApproveProjectsController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.comments.overview', CommentsAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Comments Overview',
@@ -236,30 +258,36 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'code' => null,
         'model_class' => UserComment::class,
         'controller' => null,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.moderation.reports', ModerationQueueAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Moderation Queue',
         'code' => null,
         'model_class' => ContentReport::class,
         'controller' => ModerationQueueController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.moderation.appeals', AppealQueueAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Appeal Queue',
         'code' => null,
         'model_class' => ContentAppeal::class,
         'controller' => AppealQueueController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.media_library.category', MediaCategoryAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Media Library Categories',
@@ -267,10 +295,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'code' => null,
         'model_class' => MediaCategory::class,
         'controller' => null,
-      ])
+      ]
+    )
   ;
   $services->set('admin.media_library.asset', MediaAssetAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Media Library Assets',
@@ -278,50 +308,60 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'code' => null,
         'model_class' => MediaAsset::class,
         'controller' => null,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.featured.projects', FeaturedProjectAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Featured Projects',
         'code' => null,
         'model_class' => FeaturedProgram::class,
         'controller' => null,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.example.projects', ExampleProjectAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Example Projects',
         'code' => null,
         'model_class' => ExampleProgram::class,
         'controller' => null,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.apk.pending', ApkPendingAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Pending',
         'code' => null,
         'model_class' => Program::class,
         'controller' => ApkController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.apk.list', ApkReadyAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Ready',
         'code' => null,
         'model_class' => Program::class,
         'controller' => ApkController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.users.overview', UserAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'model_class' => User::class,
@@ -331,20 +371,24 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'code' => null,
         'controller' => null,
         'pager_type' => 'simple',
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.users.data_report', UserDataReportAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'User Data Report',
         'code' => null,
         'model_class' => User::class,
         'controller' => UserDataReportController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.survey', AllSurveysAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Surveys',
@@ -353,10 +397,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'code' => null,
         'model_class' => Survey::class,
         'controller' => null,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.special_updater', SpecialUpdaterAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'DB Special Updater',
@@ -364,10 +410,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'code' => null,
         'model_class' => CronJob::class,
         'controller' => SpecialUpdaterAdminController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.cron_jobs', CronJobsAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Cron Jobs',
@@ -375,50 +423,60 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'code' => null,
         'model_class' => CronJob::class,
         'controller' => CronJobsAdminController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.achievements', AchievementsAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'DB-Updater Achievements',
         'code' => null,
         'model_class' => Achievement::class,
         'controller' => AchievementsAdminController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.flavors', FlavorsAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'DB-Updater Flavors',
         'code' => null,
         'model_class' => Flavor::class,
         'controller' => FlavorsAdminController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.extensions', ExtensionsAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'DB-Updater Extensions',
         'code' => null,
         'model_class' => Extension::class,
         'controller' => ExtensionsAdminController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.tags', TagsAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'DB-Updater Tags',
         'code' => null,
         'model_class' => Tag::class,
         'controller' => TagsAdminController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.tools.maintain', MaintenanceAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'System Dashboard',
@@ -426,10 +484,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'code' => null,
         'model_class' => CronJob::class,
         'controller' => MaintenanceController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.tools.logs', LogsAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Logs',
@@ -437,77 +497,92 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'code' => null,
         'model_class' => CronJob::class,
         'controller' => LogsController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.tools.broadcast', BroadcastNotificationAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Send Notification',
         'code' => null,
         'model_class' => BroadcastNotification::class,
         'controller' => BroadcastNotificationController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.tools.mail', SendMailToUserAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Send Mail',
         'code' => null,
         'model_class' => CronJob::class,
         'controller' => SendMailToUserController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.tools.feature_flag', FeatureFlagAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Feature Flag',
         'code' => null,
         'model_class' => FeatureFlag::class,
         'controller' => FeatureFlagController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.tools.maintenance_information', MaintenanceInformationAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Maintenance Information',
         'code' => null,
         'model_class' => MaintenanceInformation::class,
         'controller' => MaintenanceInformationController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.statistics.project_machine_translation', ProjectMachineTranslationAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Project Machine Translation',
         'code' => null,
         'model_class' => ProjectMachineTranslation::class,
         'controller' => ProjectMachineTranslationAdminController::class,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.statistics.project_custom_translation', ProjectCustomTranslationAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Project Custom Translation',
         'code' => null,
         'model_class' => ProjectCustomTranslation::class,
         'controller' => null,
-      ])
+      ]
+    )
   ;
   $services->set('admin.block.statistics.comment_machine_translation', CommentMachineTranslationAdmin::class)
-    ->tag('sonata.admin',
+    ->tag(
+      'sonata.admin',
       [
         'manager_type' => 'orm',
         'label' => 'Comment Machine Translation',
         'code' => null,
         'model_class' => CommentMachineTranslation::class,
         'controller' => CommentMachineTranslationAdminController::class,
-      ])
+      ]
+    )
   ;
 
   // enable prod env dumping without composer

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -424,12 +424,6 @@
       <code><![CDATA[$user]]></code>
     </PossiblyNullArgument>
   </file>
-  <file src="src/Security/Authentication/CookieService.php">
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$_ENV['APP_ENV']]]></code>
-      <code><![CDATA[$_ENV['APP_ENV']]]></code>
-    </PossiblyUndefinedArrayOffset>
-  </file>
   <file src="src/Security/Authentication/FormLoginSuccessHandler.php">
     <PossiblyNullArgument>
       <code><![CDATA[$refresh_token->getRefreshToken()]]></code>

--- a/src/Admin/System/FeatureFlag/FeatureFlagController.php
+++ b/src/Admin/System/FeatureFlag/FeatureFlagController.php
@@ -7,6 +7,8 @@ namespace App\Admin\System\FeatureFlag;
 use App\DB\Entity\System\FeatureFlag;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @phpstan-extends CRUDController<FeatureFlag>
@@ -15,6 +17,14 @@ class FeatureFlagController extends CRUDController
 {
   public function __construct(protected FeatureFlagManager $manager)
   {
+  }
+
+  #[\Override]
+  public function listAction(Request $request): Response
+  {
+    $this->manager->synchronizeDefaults();
+
+    return parent::listAction($request);
   }
 
   public function setFlagAction(): RedirectResponse

--- a/src/Admin/System/FeatureFlag/FeatureFlagManager.php
+++ b/src/Admin/System/FeatureFlag/FeatureFlagManager.php
@@ -12,6 +12,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class FeatureFlagManager
 {
   private array $defaultFlags;
+  private bool $defaultsSynchronized = false;
 
   public function __construct(
     protected RequestStack $requestStack,
@@ -19,30 +20,7 @@ class FeatureFlagManager
     #[Autowire('%feature_flags%')]
     protected array $feature_flags,
   ) {
-    if ($this->entityManager->getConnection()->isConnected()) {
-      $this->defaultFlags = $this->feature_flags;
-
-      $flagMap = [];
-      foreach ($this->defaultFlags as $name => $value) {
-        $flagMap[$name] = new FeatureFlag($name, $value);
-        $flag = $this->entityManager->getRepository(FeatureFlag::class)->findOneBy(['name' => $name]);
-
-        if (null === $flag) {
-          $flag = $flagMap[$name];
-          $this->entityManager->persist($flag);
-        }
-      }
-
-      $entityManagerFlags = $this->entityManager->getRepository(FeatureFlag::class)->findAll();
-      foreach ($entityManagerFlags as $flag) {
-        $flagName = $flag->getName();
-        if (!array_key_exists((string) $flagName, $flagMap)) {
-          $this->entityManager->remove($flag);
-        }
-      }
-
-      $this->entityManager->flush();
-    }
+    $this->defaultFlags = $this->feature_flags;
   }
 
   public function isEnabled(string $flagName): bool
@@ -50,8 +28,39 @@ class FeatureFlagManager
     return $this->getFlagValue($flagName) ?? false;
   }
 
+  public function synchronizeDefaults(): void
+  {
+    if ($this->defaultsSynchronized) {
+      return;
+    }
+
+    $flagRepository = $this->entityManager->getRepository(FeatureFlag::class);
+
+    $existingFlags = [];
+    foreach ($flagRepository->findAll() as $flag) {
+      $existingFlags[(string) $flag->getName()] = $flag;
+    }
+
+    foreach ($this->defaultFlags as $name => $value) {
+      if (!isset($existingFlags[$name])) {
+        $this->entityManager->persist(new FeatureFlag($name, $value));
+      }
+    }
+
+    foreach ($existingFlags as $name => $flag) {
+      if (!array_key_exists($name, $this->defaultFlags)) {
+        $this->entityManager->remove($flag);
+      }
+    }
+
+    $this->entityManager->flush();
+    $this->defaultsSynchronized = true;
+  }
+
   public function setFlagValue(string $flagName, bool $value): void
   {
+    $this->synchronizeDefaults();
+
     $flag = $this->entityManager->getRepository(FeatureFlag::class)->findOneBy(['name' => $flagName]);
 
     if (null === $flag) {
@@ -66,6 +75,8 @@ class FeatureFlagManager
 
   public function getFlagValue(string $flagName): ?bool
   {
+    $this->synchronizeDefaults();
+
     $request = $this->requestStack->getCurrentRequest();
 
     if ($request && $request->headers->has('X-Feature-Flag-'.$flagName)) {

--- a/src/Api/AuthenticationApi.php
+++ b/src/Api/AuthenticationApi.php
@@ -48,6 +48,8 @@ class AuthenticationApi extends AbstractApiController implements AuthenticationA
   #[\Override]
   public function authenticationDelete(string $x_refresh, int &$responseCode, array &$responseHeaders): void
   {
+    $this->facade->getResponseManager()->addClearedAuthenticationCookiesToHeader($responseHeaders);
+
     if ($this->facade->getProcessor()->deleteRefreshToken($x_refresh)) {
       $responseCode = Response::HTTP_OK;
 

--- a/src/Api/Services/Authentication/AuthenticationResponseManager.php
+++ b/src/Api/Services/Authentication/AuthenticationResponseManager.php
@@ -5,10 +5,22 @@ declare(strict_types=1);
 namespace App\Api\Services\Authentication;
 
 use App\Api\Services\Base\AbstractResponseManager;
+use App\Security\Authentication\CookieService;
 use OpenAPI\Server\Model\JWTResponse;
+use OpenAPI\Server\Service\SerializerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AuthenticationResponseManager extends AbstractResponseManager
 {
+  public function __construct(
+    TranslatorInterface $translator,
+    SerializerInterface $serializer,
+    \Psr\Cache\CacheItemPoolInterface $cache,
+    private readonly CookieService $cookie_service,
+  ) {
+    parent::__construct($translator, $serializer, $cache);
+  }
+
   public function createOAuthPostResponse(string $token, string $refresh_token): JWTResponse
   {
     return new JWTResponse(
@@ -17,5 +29,10 @@ class AuthenticationResponseManager extends AbstractResponseManager
         'refresh_token' => $refresh_token,
       ]
     );
+  }
+
+  public function addClearedAuthenticationCookiesToHeader(array &$responseHeaders): void
+  {
+    $this->cookie_service->addClearedAuthenticationCookiesToHeader($responseHeaders);
   }
 }

--- a/src/Api/Services/AuthenticationManager.php
+++ b/src/Api/Services/AuthenticationManager.php
@@ -82,6 +82,15 @@ class AuthenticationManager
   {
     $refreshToken = $this->refresh_manager->get($x_refresh);
     if (null === $refreshToken) {
+      // The web logout flow sends the sentinel value "cookie" in X-Refresh and lets the
+      // server resolve the actual refresh token from the HttpOnly cookie.
+      $refresh_token_cookie = $this->request_helper->getCurrentRequest()?->cookies->get('REFRESH_TOKEN');
+      if (\is_string($refresh_token_cookie) && '' !== $refresh_token_cookie) {
+        $refreshToken = $this->refresh_manager->get($refresh_token_cookie);
+      }
+    }
+
+    if (null === $refreshToken) {
       return false;
     }
 

--- a/src/Api/Services/Base/AbstractApiController.php
+++ b/src/Api/Services/Base/AbstractApiController.php
@@ -5,8 +5,24 @@ declare(strict_types=1);
 namespace App\Api\Services\Base;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Service\Attribute\Required;
 
 abstract class AbstractApiController extends AbstractController implements BearerAuthenticationInterface
 {
   use BearerAuthenticationTrait;
+
+  private ?RequestStack $request_stack = null;
+
+  #[Required]
+  public function setRequestStack(RequestStack $request_stack): void
+  {
+    $this->request_stack = $request_stack;
+  }
+
+  protected function getCurrentRequest(): ?Request
+  {
+    return $this->request_stack?->getCurrentRequest();
+  }
 }

--- a/src/Api/Services/Base/BearerAuthenticationTrait.php
+++ b/src/Api/Services/Base/BearerAuthenticationTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Api\Services\Base;
 
 use App\Api\Exceptions\ApiException;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -19,7 +20,18 @@ trait BearerAuthenticationTrait
    */
   public function setBearerAuth(?string $value): void
   {
-    $this->token = $this->extractAuthenticationToken($value ?? '');
+    if (null !== $value && '' !== trim($value)) {
+      $this->token = $this->extractAuthenticationToken($value);
+
+      return;
+    }
+
+    $cookie_token = $this->getBearerCookieToken();
+    if ('' === $cookie_token) {
+      throw new ApiException('The route must be registered under the jwt_token_authenticator! (security.yaml)', Response::HTTP_UNAUTHORIZED);
+    }
+
+    $this->token = $cookie_token;
   }
 
   public function getAuthenticationToken(): string
@@ -32,11 +44,26 @@ trait BearerAuthenticationTrait
    */
   private function extractAuthenticationToken(string $value): string
   {
-    $split = preg_split('#\s+#', $value);
-    if (!\is_array($split) || count($split) < 2 || empty($split[1])) {
+    $split = preg_split('#\s+#', trim($value), 2);
+    if (!\is_array($split)) {
       throw new ApiException('The route must be registered under the jwt_token_authenticator! (security.yaml)', Response::HTTP_UNAUTHORIZED);
     }
 
-    return strval($split[1]);
+    $token = $split[1] ?? '';
+    if ('' === $token) {
+      throw new ApiException('The route must be registered under the jwt_token_authenticator! (security.yaml)', Response::HTTP_UNAUTHORIZED);
+    }
+
+    return $token;
+  }
+
+  protected function getBearerCookieToken(): string
+  {
+    return strval($this->getCurrentRequest()?->cookies->get('BEARER'));
+  }
+
+  protected function getCurrentRequest(): ?Request
+  {
+    return null;
   }
 }

--- a/src/Api/Services/User/UserResponseManager.php
+++ b/src/Api/Services/User/UserResponseManager.php
@@ -121,4 +121,9 @@ class UserResponseManager extends AbstractResponseManager
       $this->cookie_service->createRefreshTokenCookie($refresh_token),
     ];
   }
+
+  public function addClearedAuthenticationCookiesToHeader(array &$responseHeaders): void
+  {
+    $this->cookie_service->addClearedAuthenticationCookiesToHeader($responseHeaders);
+  }
 }

--- a/src/Api/UserApi.php
+++ b/src/Api/UserApi.php
@@ -91,6 +91,7 @@ class UserApi extends AbstractApiController implements UserApiInterface
     $responseCode = Response::HTTP_NO_CONTENT;
 
     $this->facade->getProcessor()->deleteUser($this->facade->getAuthenticationManager()->getAuthenticatedUser());
+    $this->facade->getResponseManager()->addClearedAuthenticationCookiesToHeader($responseHeaders);
   }
 
   /**

--- a/src/Security/Authentication/ApiAuthenticationSuccessHandler.php
+++ b/src/Security/Authentication/ApiAuthenticationSuccessHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security\Authentication;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+
+final readonly class ApiAuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterface
+{
+  public function __construct(
+    private AuthenticationSuccessHandlerInterface $inner_handler,
+    private AuthenticationModeResolver $mode_resolver,
+    private MainFirewallSessionLogin $main_firewall_session_login,
+    private AuthenticationSuccessResponseProcessor $response_processor,
+  ) {
+  }
+
+  #[\Override]
+  public function onAuthenticationSuccess(Request $request, TokenInterface $token): Response
+  {
+    $response = $this->inner_handler->onAuthenticationSuccess($request, $token);
+    if (!$response instanceof Response) {
+      return new Response();
+    }
+
+    if ($this->mode_resolver->isCookieMode($request)) {
+      $this->main_firewall_session_login->login($request, $token);
+    }
+
+    return $this->response_processor->process($request, $response);
+  }
+}

--- a/src/Security/Authentication/AuthenticationModeResolver.php
+++ b/src/Security/Authentication/AuthenticationModeResolver.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security\Authentication;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class AuthenticationModeResolver
+{
+  public const string HEADER_NAME = 'X-Auth-Mode';
+  public const string API_MODE = 'api';
+  public const string COOKIE_MODE = 'cookie';
+
+  /**
+   * @return self::API_MODE|self::COOKIE_MODE
+   */
+  public function resolve(?Request $request): string
+  {
+    $mode = strtolower(trim((string) $request?->headers->get(self::HEADER_NAME, self::API_MODE)));
+
+    return self::COOKIE_MODE === $mode ? self::COOKIE_MODE : self::API_MODE;
+  }
+
+  public function isCookieMode(?Request $request): bool
+  {
+    return self::COOKIE_MODE === $this->resolve($request);
+  }
+}

--- a/src/Security/Authentication/AuthenticationSuccessResponseProcessor.php
+++ b/src/Security/Authentication/AuthenticationSuccessResponseProcessor.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security\Authentication;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final readonly class AuthenticationSuccessResponseProcessor
+{
+  public function __construct(
+    private AuthenticationModeResolver $mode_resolver,
+    private CookieService $cookie_service,
+  ) {
+  }
+
+  public function process(Request $request, Response $response): Response
+  {
+    if (!$this->mode_resolver->isCookieMode($request)) {
+      return $response;
+    }
+
+    $response_data = json_decode((string) $response->getContent(), true);
+    if (!\is_array($response_data)) {
+      return $response;
+    }
+
+    $bearer_token = $response_data['token'] ?? null;
+    if (\is_string($bearer_token) && '' !== $bearer_token) {
+      $response->headers->setCookie($this->cookie_service->createBearerTokenCookie($bearer_token));
+      unset($response_data['token']);
+    }
+
+    $refresh_token = $response_data['refresh_token'] ?? null;
+    if (\is_string($refresh_token) && '' !== $refresh_token) {
+      $response->headers->setCookie($this->cookie_service->createRefreshTokenCookie($refresh_token));
+      unset($response_data['refresh_token']);
+    }
+
+    $response->setContent([] === $response_data ? '{}' : json_encode($response_data, \JSON_THROW_ON_ERROR));
+
+    return $response;
+  }
+}

--- a/src/Security/Authentication/CookieService.php
+++ b/src/Security/Authentication/CookieService.php
@@ -28,18 +28,12 @@ readonly class CookieService
       'BEARER',
       $bearer_token,
       time() + $this->jwtTokenLifetime,
-      // expiration
-      $this->router->getContext()->getBaseUrl().'/',
-      // path
+      $this->getCookiePath(),
       null,
-      // domain, null means that Symfony will generate it on its own.
-      'prod' === $_ENV['APP_ENV'],
-      // secure (HTTPS only)
+      $this->isSecureCookie(),
+      true,
       false,
-      // httpOnly
-      false,
-      // raw
-      'lax'
+      Cookie::SAMESITE_LAX
     );
   }
 
@@ -52,27 +46,72 @@ readonly class CookieService
       'REFRESH_TOKEN',
       $refresh_token,
       time() + $this->refreshTokenLifetime,
-      // expiration
-      $this->router->getContext()->getBaseUrl().'/',
-      // path - optional /api/authentication
+      $this->getCookiePath(),
       null,
-      // domain, null means that Symfony will generate it on its own.
-      'prod' === $_ENV['APP_ENV'],
-      // secure (HTTPS only)
+      $this->isSecureCookie(),
       true,
-      // httpOnly
       false,
-      // raw
-      'strict'
+      Cookie::SAMESITE_STRICT
     );
+  }
+
+  public function createClearedCookie(string $cookie): Cookie
+  {
+    return Cookie::create(
+      $cookie,
+      '',
+      time() - 3600,
+      $this->getCookiePath(),
+      null,
+      $this->isSecureCookie(),
+      true,
+      false,
+      $this->getSameSite($cookie)
+    );
+  }
+
+  /**
+   * @return array{0: Cookie, 1: Cookie}
+   */
+  public function createClearedAuthenticationCookies(): array
+  {
+    return [
+      $this->createClearedCookie('BEARER'),
+      $this->createClearedCookie('REFRESH_TOKEN'),
+    ];
+  }
+
+  public function addClearedAuthenticationCookiesToHeader(array &$responseHeaders): void
+  {
+    $responseHeaders['Set-Cookie'] = $this->createClearedAuthenticationCookies();
   }
 
   public function clearCookie(string $cookie): void
   {
     if (isset($_COOKIE[$cookie])) {
-      setcookie($cookie, '', ['expires' => time() - 3600, 'path' => $this->router->getContext()->getBaseUrl().'/']);
-      setcookie($cookie, '', ['expires' => time() - 3600, 'path' => '/']);
+      $same_site = $this->getSameSite($cookie);
+
+      setcookie($cookie, '', ['expires' => time() - 3600, 'path' => $this->getCookiePath(), 'secure' => $this->isSecureCookie(), 'httponly' => true, 'samesite' => $same_site]);
+      setcookie($cookie, '', ['expires' => time() - 3600, 'path' => '/', 'secure' => $this->isSecureCookie(), 'httponly' => true, 'samesite' => $same_site]);
       unset($_COOKIE[$cookie]);
     }
+  }
+
+  private function getCookiePath(): string
+  {
+    return $this->router->getContext()->getBaseUrl().'/';
+  }
+
+  private function isSecureCookie(): bool
+  {
+    return 'prod' === ($_ENV['APP_ENV'] ?? 'dev');
+  }
+
+  /**
+   * @return 'lax'|'strict'
+   */
+  private function getSameSite(string $cookie): string
+  {
+    return 'REFRESH_TOKEN' === $cookie ? Cookie::SAMESITE_STRICT : Cookie::SAMESITE_LAX;
   }
 }

--- a/src/Security/Authentication/JwtRefresh/ApiRefreshTokenSuccessHandler.php
+++ b/src/Security/Authentication/JwtRefresh/ApiRefreshTokenSuccessHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security\Authentication\JwtRefresh;
+
+use App\Security\Authentication\AuthenticationSuccessResponseProcessor;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+
+final readonly class ApiRefreshTokenSuccessHandler implements AuthenticationSuccessHandlerInterface
+{
+  public function __construct(
+    private AuthenticationSuccessHandlerInterface $inner_handler,
+    private AuthenticationSuccessResponseProcessor $response_processor,
+  ) {
+  }
+
+  #[\Override]
+  public function onAuthenticationSuccess(Request $request, TokenInterface $token): Response
+  {
+    $response = $this->inner_handler->onAuthenticationSuccess($request, $token);
+    if (!$response instanceof Response) {
+      return new Response();
+    }
+
+    return $this->response_processor->process($request, $response);
+  }
+}

--- a/src/Security/Authentication/JwtRefresh/RefreshBearerCookieOnKernelRequestEventListener.php
+++ b/src/Security/Authentication/JwtRefresh/RefreshBearerCookieOnKernelRequestEventListener.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security\Authentication\JwtRefresh;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+#[AsEventListener(event: KernelEvents::REQUEST, method: 'refreshBearerCookie', priority: 200)]
+class RefreshBearerCookieOnKernelRequestEventListener
+{
+  public function __construct(private readonly RefreshTokenService $refresh_token_service)
+  {
+  }
+
+  public function refreshBearerCookie(RequestEvent $event): void
+  {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+
+    $this->refresh_token_service->refreshRequestAuthentication($event->getRequest());
+  }
+}

--- a/src/Security/Authentication/JwtRefresh/RefreshBearerCookieOnKernelResponseEventListener.php
+++ b/src/Security/Authentication/JwtRefresh/RefreshBearerCookieOnKernelResponseEventListener.php
@@ -17,13 +17,10 @@ class RefreshBearerCookieOnKernelResponseEventListener
 
   public function refreshBearerCookie(ResponseEvent $event): void
   {
-    if ($this->refresh_token_service->isBearerCookieSet()) {
+    if (!$event->isMainRequest()) {
       return;
     }
-    if (!$this->refresh_token_service->isRefreshTokenCookieSet($event)) {
-      return;
-    }
-    // Bearer is missing, however we can try to create a new cookie one from the refresh token
-    $this->refresh_token_service->refreshBearerCookie($event);
+
+    $this->refresh_token_service->syncAuthenticationCookies($event);
   }
 }

--- a/src/Security/Authentication/JwtRefresh/RefreshTokenService.php
+++ b/src/Security/Authentication/JwtRefresh/RefreshTokenService.php
@@ -10,13 +10,17 @@ use App\User\UserManager;
 use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTDecodeFailureException;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 class RefreshTokenService
 {
+  public const string REFRESHED_BEARER_COOKIE_ATTRIBUTE = '_refreshed_bearer_cookie';
+  public const string CLEAR_AUTHENTICATION_COOKIES_ATTRIBUTE = '_clear_authentication_cookies';
+
   public function __construct(
     #[Autowire('%env(REFRESH_TOKEN_TTL)%')]
     protected int $refreshTokenLifetime,
@@ -49,15 +53,28 @@ class RefreshTokenService
     }
   }
 
-  public function refreshBearerCookie(ResponseEvent $event): void
+  public function refreshRequestAuthentication(Request $request): void
   {
-    $refresh_token = $this->getRefreshTokenFromEvent($event);
+    if ($request->headers->has('Authorization') || !$request->cookies->has('REFRESH_TOKEN')) {
+      return;
+    }
+
+    if ($this->hasValidBearerCookie($request)) {
+      return;
+    }
+
+    $refresh_token = $this->getRefreshTokenFromRequest($request);
     if ($this->isValidRefreshToken($refresh_token)) {
       /** @var User|null $user */
       $user = $this->user_manager->findUserByUsername($refresh_token->getUsername());
       if (null !== $user) {
         $new_bearer = $this->jwt_manager->create($user);
-        $event->getResponse()->headers->setCookie($this->cookie_service->createBearerTokenCookie($new_bearer));
+        $request->attributes->set(self::REFRESHED_BEARER_COOKIE_ATTRIBUTE, $new_bearer);
+        // Update both Symfony's ParameterBag and the PHP superglobal so that
+        // downstream code works regardless of which source it reads from.
+        $request->cookies->set('BEARER', $new_bearer);
+        $_COOKIE['BEARER'] = $new_bearer;
+        $this->setAuthorizationHeader($request, $new_bearer);
 
         return;
       }
@@ -65,12 +82,21 @@ class RefreshTokenService
       $this->refresh_manager->delete($refresh_token);
     }
 
-    $this->cookie_service->clearCookie('REFRESH_TOKEN');
+    $this->markAuthenticationCookiesForClearing($request);
   }
 
-  protected function getRefreshTokenFromEvent(KernelEvent $event): ?RefreshTokenInterface
+  public function syncAuthenticationCookies(ResponseEvent $event): void
   {
-    return $this->refresh_manager->get($this->getRefreshCookieValue($event));
+    $request = $event->getRequest();
+    $refreshed_bearer = $request->attributes->get(self::REFRESHED_BEARER_COOKIE_ATTRIBUTE);
+    if (\is_string($refreshed_bearer) && '' !== $refreshed_bearer) {
+      $event->getResponse()->headers->setCookie($this->cookie_service->createBearerTokenCookie($refreshed_bearer));
+    }
+
+    if (true === $request->attributes->get(self::CLEAR_AUTHENTICATION_COOKIES_ATTRIBUTE)) {
+      $event->getResponse()->headers->setCookie($this->cookie_service->createClearedCookie('BEARER'));
+      $event->getResponse()->headers->setCookie($this->cookie_service->createClearedCookie('REFRESH_TOKEN'));
+    }
   }
 
   protected function isValidRefreshToken(?RefreshTokenInterface $refresh_token): bool
@@ -78,28 +104,47 @@ class RefreshTokenService
     return $refresh_token instanceof RefreshTokenInterface && $refresh_token->isValid() && !empty($refresh_token->getUsername());
   }
 
-  public function isBearerCookieSet(): bool
+  protected function getRefreshTokenFromRequest(Request $request): ?RefreshTokenInterface
   {
-    return isset($_COOKIE['BEARER']);
+    return $this->refresh_manager->get($this->getRefreshCookieValue($request));
   }
 
-  public function isRefreshTokenCookieSet(KernelEvent $event): bool
+  protected function getBearerCookieValue(Request $request): string
   {
-    return $event->getRequest()->cookies->has('REFRESH_TOKEN');
+    return strval($request->cookies->get('BEARER'));
   }
 
-  protected function getBearerCookieValue(KernelEvent $event): string
+  protected function getRefreshCookieValue(Request $request): string
   {
-    return strval($event->getRequest()->cookies->get('BEARER'));
+    return strval($request->cookies->get('REFRESH_TOKEN'));
   }
 
-  protected function getRefreshCookieValue(KernelEvent $event): string
+  protected function hasValidBearerCookie(Request $request): bool
   {
-    return strval($event->getRequest()->cookies->get('REFRESH_TOKEN'));
+    $bearer_token = $this->getBearerCookieValue($request);
+    if ('' === $bearer_token) {
+      return false;
+    }
+
+    try {
+      $this->jwt_manager->parse($bearer_token);
+
+      return true;
+    } catch (JWTDecodeFailureException) {
+      return false;
+    }
   }
 
-  protected function setAuthorizationHeader(KernelEvent $event, string $bearer_token): void
+  protected function setAuthorizationHeader(Request $request, string $bearer_token): void
   {
-    $event->getRequest()->headers->set('Authorization', 'Bearer '.$bearer_token);
+    $request->headers->set('Authorization', 'Bearer '.$bearer_token);
+  }
+
+  protected function markAuthenticationCookiesForClearing(Request $request): void
+  {
+    $request->attributes->set(self::CLEAR_AUTHENTICATION_COOKIES_ATTRIBUTE, true);
+    $request->cookies->remove('BEARER');
+    $request->cookies->remove('REFRESH_TOKEN');
+    unset($_COOKIE['BEARER'], $_COOKIE['REFRESH_TOKEN']);
   }
 }

--- a/src/Security/Authentication/MainFirewallSessionLogin.php
+++ b/src/Security/Authentication/MainFirewallSessionLogin.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security\Authentication;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
+
+final readonly class MainFirewallSessionLogin
+{
+  private const string FIREWALL_NAME = 'main';
+  private const string SESSION_KEY = '_security_'.self::FIREWALL_NAME;
+
+  public function __construct(
+    private SessionAuthenticationStrategyInterface $session_authentication_strategy,
+  ) {
+  }
+
+  public function login(Request $request, TokenInterface $token): void
+  {
+    if (!$request->hasSession()) {
+      return;
+    }
+
+    $user = $token->getUser();
+    if (!$user instanceof UserInterface) {
+      return;
+    }
+
+    // JWT cookies stay scoped to the themed web base path, so admin routes
+    // still need the regular main-firewall session to see the logged-in user.
+    $session_token = new UsernamePasswordToken($user, self::FIREWALL_NAME, $token->getRoleNames());
+    if ($request->hasPreviousSession()) {
+      $this->session_authentication_strategy->onAuthentication($request, $session_token);
+    }
+
+    $request->getSession()->set(self::SESSION_KEY, serialize($session_token));
+  }
+}

--- a/templates/Project/Comment/JsData.html.twig
+++ b/templates/Project/Comment/JsData.html.twig
@@ -32,5 +32,6 @@
      data-trans-report-duplicate="{{ 'moderation.report.duplicate'|trans({}, 'catroweb') }}"
      data-trans-report-trust-too-low="{{ 'moderation.report.trust_too_low'|trans({}, 'catroweb') }}"
      data-trans-report-rate-limited="{{ 'moderation.report.rate_limited'|trans({}, 'catroweb') }}"
-     data-trans-report-placeholder="{{ 'moderation.report.reason_placeholder'|trans({}, 'catroweb') }}">
+     data-trans-report-placeholder="{{ 'moderation.report.reason_placeholder'|trans({}, 'catroweb') }}"
+     data-is-logged-in="{{ app.user ? 'true' : 'false' }}">
 </div>

--- a/tests/PhpUnit/Admin/System/FeatureFlag/FeatureFlagManagerTest.php
+++ b/tests/PhpUnit/Admin/System/FeatureFlag/FeatureFlagManagerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Admin\System\FeatureFlag;
+
+use App\Admin\System\FeatureFlag\FeatureFlagManager;
+use App\DB\Entity\System\FeatureFlag;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @internal
+ */
+#[CoversClass(FeatureFlagManager::class)]
+final class FeatureFlagManagerTest extends TestCase
+{
+  public function testSynchronizeDefaultsPersistsMissingFlagsAndRemovesStaleFlags(): void
+  {
+    $repository = $this->createMock(EntityRepository::class);
+    $entityManager = $this->createMock(EntityManagerInterface::class);
+
+    $existingFlag = new FeatureFlag('Sidebar-Studio-Link-Feature', false);
+    $staleFlag = new FeatureFlag('Deprecated-Flag', true);
+
+    $entityManager
+      ->expects($this->once())
+      ->method('getRepository')
+      ->with(FeatureFlag::class)
+      ->willReturn($repository)
+    ;
+
+    $repository
+      ->expects($this->once())
+      ->method('findAll')
+      ->willReturn([$existingFlag, $staleFlag])
+    ;
+
+    $entityManager
+      ->expects($this->once())
+      ->method('persist')
+      ->with($this->callback(static fn ($flag): bool => $flag instanceof FeatureFlag && 'Test-Flag' === $flag->getName()))
+    ;
+
+    $entityManager
+      ->expects($this->once())
+      ->method('remove')
+      ->with($staleFlag)
+    ;
+
+    $entityManager
+      ->expects($this->once())
+      ->method('flush')
+    ;
+
+    $manager = new FeatureFlagManager(
+      $this->createStub(RequestStack::class),
+      $entityManager,
+      [
+        'Test-Flag' => false,
+        'Sidebar-Studio-Link-Feature' => false,
+      ],
+    );
+
+    $manager->synchronizeDefaults();
+  }
+}

--- a/tests/PhpUnit/Api/Services/AuthenticationManagerTest.php
+++ b/tests/PhpUnit/Api/Services/AuthenticationManagerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Api\Services;
+
+use App\Api\Services\AuthenticationManager;
+use App\User\UserManager;
+use App\Utils\RequestHelper;
+use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(AuthenticationManager::class)]
+final class AuthenticationManagerTest extends TestCase
+{
+  #[Group('unit')]
+  public function testDeleteRefreshTokenFallsBackToRefreshCookie(): void
+  {
+    $refresh_manager = $this->createMock(RefreshTokenManagerInterface::class);
+    $refresh_token = $this->createStub(RefreshTokenInterface::class);
+
+    $request = Request::create('/api/authentication', 'DELETE');
+    $request->cookies->set('REFRESH_TOKEN', 'refresh-cookie');
+
+    $request_helper = $this->createMock(RequestHelper::class);
+    $request_helper
+      ->expects($this->once())
+      ->method('getCurrentRequest')
+      ->willReturn($request)
+    ;
+
+    $refresh_manager
+      ->expects($this->exactly(2))
+      ->method('get')
+      ->willReturnMap([
+        ['placeholder-header', null],
+        ['refresh-cookie', $refresh_token],
+      ])
+    ;
+    $refresh_manager
+      ->expects($this->once())
+      ->method('delete')
+      ->with($refresh_token)
+    ;
+
+    $manager = new AuthenticationManager(
+      $this->createStub(TokenStorageInterface::class),
+      $this->createStub(JWTTokenManagerInterface::class),
+      $this->createStub(UserManager::class),
+      $this->createStub(RefreshTokenGeneratorInterface::class),
+      $refresh_manager,
+      $request_helper,
+      3600,
+    );
+
+    $this->assertTrue($manager->deleteRefreshToken('placeholder-header'));
+  }
+}

--- a/tests/PhpUnit/Api/Services/Base/BearerAuthenticationTraitTest.php
+++ b/tests/PhpUnit/Api/Services/Base/BearerAuthenticationTraitTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @internal
@@ -23,6 +24,12 @@ final class BearerAuthenticationTraitTest extends TestCase
   protected function setUp(): void
   {
     $this->object = new BearerAuthenticationTraitTestClass();
+  }
+
+  #[\Override]
+  protected function tearDown(): void
+  {
+    $this->object->setCurrentRequest(null);
   }
 
   #[Group('integration')]
@@ -73,5 +80,20 @@ final class BearerAuthenticationTraitTest extends TestCase
         'expected' => 'Abcdefghijklmnopqrstuvwxyz1234567890',
       ],
     ];
+  }
+
+  /**
+   * @throws \Exception
+   */
+  #[Group('unit')]
+  public function testSetBearerAuthFallsBackToBearerCookie(): void
+  {
+    $request = Request::create('/api/projects', 'GET');
+    $request->cookies->set('BEARER', 'cookie-token');
+    $this->object->setCurrentRequest($request);
+
+    $this->object->setBearerAuth(null);
+
+    $this->assertSame('cookie-token', $this->object->getAuthenticationToken());
   }
 }

--- a/tests/PhpUnit/Api/Services/Base/BearerAuthenticationTraitTestClass.php
+++ b/tests/PhpUnit/Api/Services/Base/BearerAuthenticationTraitTestClass.php
@@ -6,8 +6,21 @@ namespace Tests\PhpUnit\Api\Services\Base;
 
 use App\Api\Services\Base\BearerAuthenticationInterface;
 use App\Api\Services\Base\BearerAuthenticationTrait;
+use Symfony\Component\HttpFoundation\Request;
 
 class BearerAuthenticationTraitTestClass implements BearerAuthenticationInterface
 {
   use BearerAuthenticationTrait;
+
+  private ?Request $request = null;
+
+  public function setCurrentRequest(?Request $request): void
+  {
+    $this->request = $request;
+  }
+
+  protected function getCurrentRequest(): ?Request
+  {
+    return $this->request;
+  }
 }

--- a/tests/PhpUnit/Security/Authentication/ApiAuthenticationSuccessHandlerTest.php
+++ b/tests/PhpUnit/Security/Authentication/ApiAuthenticationSuccessHandlerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Security\Authentication;
+
+use App\Security\Authentication\ApiAuthenticationSuccessHandler;
+use App\Security\Authentication\AuthenticationModeResolver;
+use App\Security\Authentication\MainFirewallSessionLogin;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(ApiAuthenticationSuccessHandler::class)]
+final class ApiAuthenticationSuccessHandlerTest extends TestCase
+{
+  use AuthenticationTestFactory;
+
+  #[Group('unit')]
+  public function testDelegatesToInnerHandlerAndProcessesResponse(): void
+  {
+    $request = Request::create('/api/authentication', 'POST');
+    $token = $this->createStub(TokenInterface::class);
+    $response = new Response('{}');
+
+    $inner_handler = $this->createMock(AuthenticationSuccessHandlerInterface::class);
+    $inner_handler
+      ->expects($this->once())
+      ->method('onAuthenticationSuccess')
+      ->with($request, $token)
+      ->willReturn($response)
+    ;
+
+    $handler = new ApiAuthenticationSuccessHandler(
+      $inner_handler,
+      new AuthenticationModeResolver(),
+      $this->createMainFirewallSessionLogin(),
+      $this->createResponseProcessor(),
+    );
+
+    $this->assertSame($response, $handler->onAuthenticationSuccess($request, $token));
+  }
+
+  #[Group('unit')]
+  public function testCookieModeAlsoPersistsMainFirewallSession(): void
+  {
+    $request = Request::create('/api/authentication', 'POST');
+    $request->headers->set(AuthenticationModeResolver::HEADER_NAME, AuthenticationModeResolver::COOKIE_MODE);
+    $session = new Session(new MockArraySessionStorage());
+    $request->setSession($session);
+    $session->start();
+    $request->cookies->set($session->getName(), $session->getId());
+
+    $token = new UsernamePasswordToken(
+      new TestUser('cookie-user', ['ROLE_USER']),
+      'api_authentication_login',
+      ['ROLE_USER'],
+    );
+    $response = new Response('{"token":"jwt-token","refresh_token":"refresh-token"}', Response::HTTP_OK, ['Content-Type' => 'application/json']);
+
+    $inner_handler = $this->createMock(AuthenticationSuccessHandlerInterface::class);
+    $inner_handler
+      ->expects($this->once())
+      ->method('onAuthenticationSuccess')
+      ->with($request, $token)
+      ->willReturn($response)
+    ;
+
+    $handler = new ApiAuthenticationSuccessHandler(
+      $inner_handler,
+      new AuthenticationModeResolver(),
+      $this->createMainFirewallSessionLogin(),
+      $this->createResponseProcessor(),
+    );
+
+    $processed_response = $handler->onAuthenticationSuccess($request, $token);
+
+    $this->assertSame('{}', $processed_response->getContent());
+    $stored_token = unserialize((string) $session->get('_security_main'), ['allowed_classes' => true]);
+    self::assertInstanceOf(UsernamePasswordToken::class, $stored_token);
+    self::assertSame('cookie-user', $stored_token->getUserIdentifier());
+    self::assertSame('main', $stored_token->getFirewallName());
+  }
+
+  private function createMainFirewallSessionLogin(): MainFirewallSessionLogin
+  {
+    return new MainFirewallSessionLogin($this->createStub(SessionAuthenticationStrategyInterface::class));
+  }
+}

--- a/tests/PhpUnit/Security/Authentication/AuthenticationModeResolverTest.php
+++ b/tests/PhpUnit/Security/Authentication/AuthenticationModeResolverTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Security\Authentication;
+
+use App\Security\Authentication\AuthenticationModeResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(AuthenticationModeResolver::class)]
+final class AuthenticationModeResolverTest extends TestCase
+{
+  #[Group('unit')]
+  public function testMissingHeaderDefaultsToApiMode(): void
+  {
+    $resolver = new AuthenticationModeResolver();
+
+    $this->assertSame(AuthenticationModeResolver::API_MODE, $resolver->resolve(Request::create('/api/authentication', 'POST')));
+  }
+
+  #[Group('unit')]
+  public function testCookieHeaderEnablesCookieMode(): void
+  {
+    $resolver = new AuthenticationModeResolver();
+    $request = Request::create('/api/authentication', 'POST');
+    $request->headers->set(AuthenticationModeResolver::HEADER_NAME, 'cookie');
+
+    $this->assertTrue($resolver->isCookieMode($request));
+  }
+}

--- a/tests/PhpUnit/Security/Authentication/AuthenticationSuccessResponseProcessorTest.php
+++ b/tests/PhpUnit/Security/Authentication/AuthenticationSuccessResponseProcessorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Security\Authentication;
+
+use App\Security\Authentication\AuthenticationModeResolver;
+use App\Security\Authentication\AuthenticationSuccessResponseProcessor;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[CoversClass(AuthenticationSuccessResponseProcessor::class)]
+final class AuthenticationSuccessResponseProcessorTest extends TestCase
+{
+  use AuthenticationTestFactory;
+
+  #[Group('unit')]
+  public function testApiModeKeepsTokensInJsonBody(): void
+  {
+    $processor = $this->createResponseProcessor();
+    $request = Request::create('/api/authentication', 'POST');
+    $response = new Response('{"token":"jwt-token","refresh_token":"refresh-token"}', Response::HTTP_OK, ['Content-Type' => 'application/json']);
+
+    $processed_response = $processor->process($request, $response);
+
+    $this->assertSame('{"token":"jwt-token","refresh_token":"refresh-token"}', $processed_response->getContent());
+    $this->assertCount(0, $processed_response->headers->getCookies());
+  }
+
+  #[Group('unit')]
+  public function testCookieModeMovesTokensToCookies(): void
+  {
+    $processor = $this->createResponseProcessor();
+    $request = Request::create('/api/authentication', 'POST');
+    $request->headers->set(AuthenticationModeResolver::HEADER_NAME, AuthenticationModeResolver::COOKIE_MODE);
+    $response = new Response('{"token":"jwt-token","refresh_token":"refresh-token"}', Response::HTTP_OK, ['Content-Type' => 'application/json']);
+
+    $processed_response = $processor->process($request, $response);
+
+    $this->assertSame('{}', $processed_response->getContent());
+    $cookies = $processed_response->headers->getCookies();
+    $this->assertCount(2, $cookies);
+    $this->assertSame('BEARER', $cookies[0]->getName());
+    $this->assertSame('REFRESH_TOKEN', $cookies[1]->getName());
+  }
+}

--- a/tests/PhpUnit/Security/Authentication/AuthenticationTestFactory.php
+++ b/tests/PhpUnit/Security/Authentication/AuthenticationTestFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Security\Authentication;
+
+use App\Security\Authentication\AuthenticationModeResolver;
+use App\Security\Authentication\AuthenticationSuccessResponseProcessor;
+use App\Security\Authentication\CookieService;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouterInterface;
+
+trait AuthenticationTestFactory
+{
+  private function createResponseProcessor(): AuthenticationSuccessResponseProcessor
+  {
+    return new AuthenticationSuccessResponseProcessor(
+      new AuthenticationModeResolver(),
+      $this->createCookieService(),
+    );
+  }
+
+  private function createCookieService(): CookieService
+  {
+    $router = $this->createStub(RouterInterface::class);
+    $router->method('getContext')->willReturn(new RequestContext('/base'));
+
+    return new CookieService(3600, 7200, $router);
+  }
+}

--- a/tests/PhpUnit/Security/Authentication/CookieServiceTest.php
+++ b/tests/PhpUnit/Security/Authentication/CookieServiceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Security\Authentication;
+
+use App\Security\Authentication\CookieService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(CookieService::class)]
+final class CookieServiceTest extends TestCase
+{
+  use AuthenticationTestFactory;
+
+  #[Group('unit')]
+  public function testBearerCookieIsHttpOnly(): void
+  {
+    $cookie = $this->createCookieService()->createBearerTokenCookie('jwt-token');
+
+    $this->assertSame('BEARER', $cookie->getName());
+    $this->assertTrue($cookie->isHttpOnly());
+    $this->assertSame('/base/', $cookie->getPath());
+  }
+
+  #[Group('unit')]
+  public function testRefreshCookieIsHttpOnly(): void
+  {
+    $cookie = $this->createCookieService()->createRefreshTokenCookie('refresh-token');
+
+    $this->assertSame('REFRESH_TOKEN', $cookie->getName());
+    $this->assertTrue($cookie->isHttpOnly());
+    $this->assertSame('/base/', $cookie->getPath());
+    $this->assertSame('strict', $cookie->getSameSite());
+  }
+
+  #[Group('unit')]
+  public function testClearedRefreshCookieKeepsStrictSameSite(): void
+  {
+    $cookie = $this->createCookieService()->createClearedCookie('REFRESH_TOKEN');
+
+    $this->assertSame('REFRESH_TOKEN', $cookie->getName());
+    $this->assertTrue($cookie->isHttpOnly());
+    $this->assertSame('/base/', $cookie->getPath());
+    $this->assertSame('strict', $cookie->getSameSite());
+  }
+}

--- a/tests/PhpUnit/Security/Authentication/JwtRefresh/ApiRefreshTokenSuccessHandlerTest.php
+++ b/tests/PhpUnit/Security/Authentication/JwtRefresh/ApiRefreshTokenSuccessHandlerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Security\Authentication\JwtRefresh;
+
+use App\Security\Authentication\JwtRefresh\ApiRefreshTokenSuccessHandler;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Tests\PhpUnit\Security\Authentication\AuthenticationTestFactory;
+
+/**
+ * @internal
+ */
+#[CoversClass(ApiRefreshTokenSuccessHandler::class)]
+final class ApiRefreshTokenSuccessHandlerTest extends TestCase
+{
+  use AuthenticationTestFactory;
+
+  #[Group('unit')]
+  public function testDelegatesToInnerHandlerAndProcessesResponse(): void
+  {
+    $request = Request::create('/api/authentication/refresh', 'POST');
+    $token = $this->createStub(TokenInterface::class);
+    $response = new Response('{}');
+
+    $inner_handler = $this->createMock(AuthenticationSuccessHandlerInterface::class);
+    $inner_handler
+      ->expects($this->once())
+      ->method('onAuthenticationSuccess')
+      ->with($request, $token)
+      ->willReturn($response)
+    ;
+
+    $handler = new ApiRefreshTokenSuccessHandler($inner_handler, $this->createResponseProcessor());
+
+    $this->assertSame($response, $handler->onAuthenticationSuccess($request, $token));
+  }
+}

--- a/tests/PhpUnit/Security/Authentication/JwtRefresh/RefreshTokenServiceTest.php
+++ b/tests/PhpUnit/Security/Authentication/JwtRefresh/RefreshTokenServiceTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Security\Authentication\JwtRefresh;
+
+use App\DB\Entity\User\User;
+use App\Security\Authentication\CookieService;
+use App\Security\Authentication\JwtRefresh\RefreshTokenService;
+use App\User\UserManager;
+use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTDecodeFailureException;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(RefreshTokenService::class)]
+final class RefreshTokenServiceTest extends TestCase
+{
+  private RefreshTokenManagerInterface&MockObject $refresh_manager;
+  private RefreshTokenGeneratorInterface $refresh_token_generator;
+  private UserManager&MockObject $user_manager;
+  private JWTTokenManagerInterface&MockObject $jwt_manager;
+  private CookieService $cookie_service;
+  private RefreshTokenService $service;
+
+  #[\Override]
+  protected function setUp(): void
+  {
+    unset($_COOKIE['BEARER'], $_COOKIE['REFRESH_TOKEN']);
+
+    $this->refresh_manager = $this->createMock(RefreshTokenManagerInterface::class);
+    $this->refresh_token_generator = $this->createStub(RefreshTokenGeneratorInterface::class);
+    $this->user_manager = $this->createMock(UserManager::class);
+    $this->jwt_manager = $this->createMock(JWTTokenManagerInterface::class);
+    $this->cookie_service = $this->createStub(CookieService::class);
+
+    $this->service = new RefreshTokenService(
+      2592000,
+      $this->refresh_manager,
+      $this->refresh_token_generator,
+      $this->user_manager,
+      $this->jwt_manager,
+      $this->cookie_service,
+    );
+  }
+
+  #[\Override]
+  protected function tearDown(): void
+  {
+    unset($_COOKIE['BEARER'], $_COOKIE['REFRESH_TOKEN']);
+  }
+
+  #[Group('unit')]
+  public function testRefreshRequestAuthenticationCreatesNewBearerFromRefreshCookie(): void
+  {
+    $request = Request::create('/api/projects', 'GET');
+    $request->cookies->set('REFRESH_TOKEN', 'refresh-cookie');
+
+    $refresh_token = $this->createStub(RefreshTokenInterface::class);
+    $refresh_token->method('isValid')->willReturn(true);
+    $refresh_token->method('getUsername')->willReturn('cookie-user');
+    $user = $this->createStub(User::class);
+
+    $this->refresh_manager
+      ->expects($this->once())
+      ->method('get')
+      ->with('refresh-cookie')
+      ->willReturn($refresh_token)
+    ;
+    $this->user_manager
+      ->expects($this->once())
+      ->method('findUserByUsername')
+      ->with('cookie-user')
+      ->willReturn($user)
+    ;
+    $this->jwt_manager
+      ->expects($this->once())
+      ->method('create')
+      ->with($user)
+      ->willReturn('new-bearer-token')
+    ;
+
+    $this->service->refreshRequestAuthentication($request);
+
+    $this->assertSame('new-bearer-token', $request->cookies->get('BEARER'));
+    $this->assertSame('new-bearer-token', $_COOKIE['BEARER']);
+    $this->assertSame('Bearer new-bearer-token', $request->headers->get('Authorization'));
+    $this->assertSame(
+      'new-bearer-token',
+      $request->attributes->get(RefreshTokenService::REFRESHED_BEARER_COOKIE_ATTRIBUTE),
+    );
+  }
+
+  #[Group('unit')]
+  public function testRefreshRequestAuthenticationSkipsBearerParsingWithoutRefreshCookie(): void
+  {
+    $request = Request::create('/api/projects', 'GET');
+    $request->cookies->set('BEARER', 'existing-token');
+
+    $this->user_manager
+      ->expects($this->never())
+      ->method('findUserByUsername')
+    ;
+    $this->jwt_manager
+      ->expects($this->never())
+      ->method('parse')
+    ;
+    $this->refresh_manager
+      ->expects($this->never())
+      ->method('get')
+    ;
+
+    $this->service->refreshRequestAuthentication($request);
+  }
+
+  #[Group('unit')]
+  public function testRefreshRequestAuthenticationSkipsCookieRefreshWhenAuthorizationHeaderExists(): void
+  {
+    $request = Request::create('/api/projects', 'GET');
+    $request->headers->set('Authorization', 'Bearer existing-header-token');
+    $request->cookies->set('BEARER', 'existing-cookie-token');
+    $request->cookies->set('REFRESH_TOKEN', 'refresh-cookie');
+
+    $this->user_manager
+      ->expects($this->never())
+      ->method('findUserByUsername')
+    ;
+    $this->jwt_manager
+      ->expects($this->never())
+      ->method('parse')
+    ;
+    $this->refresh_manager
+      ->expects($this->never())
+      ->method('get')
+    ;
+
+    $this->service->refreshRequestAuthentication($request);
+  }
+
+  #[Group('unit')]
+  public function testRefreshRequestAuthenticationClearsInvalidAuthCookies(): void
+  {
+    $request = Request::create('/api/projects', 'GET');
+    $request->cookies->set('BEARER', 'expired-token');
+    $request->cookies->set('REFRESH_TOKEN', 'invalid-refresh-cookie');
+    $_COOKIE['BEARER'] = 'expired-token';
+    $_COOKIE['REFRESH_TOKEN'] = 'invalid-refresh-cookie';
+
+    $this->jwt_manager
+      ->expects($this->once())
+      ->method('parse')
+      ->with('expired-token')
+      ->willThrowException(
+        new JWTDecodeFailureException(
+          JWTDecodeFailureException::EXPIRED_TOKEN,
+          'Expired JWT Token',
+        )
+      )
+    ;
+    $this->user_manager
+      ->expects($this->never())
+      ->method('findUserByUsername')
+    ;
+    $this->refresh_manager
+      ->expects($this->once())
+      ->method('get')
+      ->with('invalid-refresh-cookie')
+      ->willReturn(null)
+    ;
+
+    $this->service->refreshRequestAuthentication($request);
+
+    $this->assertTrue(
+      $request->attributes->get(RefreshTokenService::CLEAR_AUTHENTICATION_COOKIES_ATTRIBUTE)
+    );
+    $this->assertFalse($request->cookies->has('BEARER'));
+    $this->assertFalse($request->cookies->has('REFRESH_TOKEN'));
+    $this->assertArrayNotHasKey('BEARER', $_COOKIE);
+    $this->assertArrayNotHasKey('REFRESH_TOKEN', $_COOKIE);
+  }
+}

--- a/tests/PhpUnit/Security/Authentication/MainFirewallSessionLoginTest.php
+++ b/tests/PhpUnit/Security/Authentication/MainFirewallSessionLoginTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Security\Authentication;
+
+use App\Security\Authentication\MainFirewallSessionLogin;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(MainFirewallSessionLogin::class)]
+final class MainFirewallSessionLoginTest extends TestCase
+{
+  #[Group('unit')]
+  public function testStoresMainFirewallTokenInSessionAndMigratesExistingSession(): void
+  {
+    $request = Request::create('/api/authentication', 'POST');
+    $session = new Session(new MockArraySessionStorage());
+    $request->setSession($session);
+    $session->start();
+    $request->cookies->set($session->getName(), $session->getId());
+
+    $strategy = $this->createMock(SessionAuthenticationStrategyInterface::class);
+    $strategy
+      ->expects($this->once())
+      ->method('onAuthentication')
+      ->with(
+        $request,
+        $this->callback(static function (TokenInterface $token): bool {
+          return $token instanceof UsernamePasswordToken
+            && 'main' === $token->getFirewallName()
+            && 'admin' === $token->getUserIdentifier();
+        })
+      )
+    ;
+
+    $service = new MainFirewallSessionLogin($strategy);
+    $service->login($request, new UsernamePasswordToken(new TestUser('admin', ['ROLE_ADMIN']), 'api_authentication_login', ['ROLE_ADMIN']));
+
+    $stored_token = unserialize((string) $session->get('_security_main'), ['allowed_classes' => true]);
+    self::assertInstanceOf(UsernamePasswordToken::class, $stored_token);
+    self::assertSame('admin', $stored_token->getUserIdentifier());
+    self::assertSame('main', $stored_token->getFirewallName());
+  }
+
+  #[Group('unit')]
+  public function testStartsSessionWithoutMigrationWhenNoPreviousSessionExists(): void
+  {
+    $request = Request::create('/api/authentication', 'POST');
+    $request->setSession(new Session(new MockArraySessionStorage()));
+
+    $strategy = $this->createMock(SessionAuthenticationStrategyInterface::class);
+    $strategy->expects($this->never())->method('onAuthentication');
+
+    $service = new MainFirewallSessionLogin($strategy);
+    $service->login($request, new UsernamePasswordToken(new TestUser('user', ['ROLE_USER']), 'api_authentication_login', ['ROLE_USER']));
+
+    $stored_token = unserialize((string) $request->getSession()->get('_security_main'), ['allowed_classes' => true]);
+    self::assertInstanceOf(UsernamePasswordToken::class, $stored_token);
+    self::assertSame('user', $stored_token->getUserIdentifier());
+  }
+}

--- a/tests/PhpUnit/Security/Authentication/TestUser.php
+++ b/tests/PhpUnit/Security/Authentication/TestUser.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Security\Authentication;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final readonly class TestUser implements UserInterface
+{
+  /**
+   * @param non-empty-string $identifier
+   * @param list<string>     $roles
+   */
+  public function __construct(
+    /** @var non-empty-string */
+    private string $identifier,
+    /** @var list<string> */
+    private array $roles,
+  ) {
+  }
+
+  #[\Override]
+  public function getRoles(): array
+  {
+    return $this->roles;
+  }
+
+  #[\Override]
+  public function eraseCredentials(): void
+  {
+  }
+
+  /**
+   * @return non-empty-string
+   */
+  #[\Override]
+  public function getUserIdentifier(): string
+  {
+    return $this->identifier;
+  }
+}


### PR DESCRIPTION
## Summary
- move browser auth from JavaScript-managed JWT cookies to HttpOnly cookies and refresh bearer cookies server-side from the refresh cookie
- keep `/api/authentication` and `/api/authentication/refresh` in JSON-token mode by default for the app and other API clients, with opt-in `X-Auth-Mode: cookie` for web flows
- restore `/app/login` to Symfony `form_login` so browser and admin pages keep a normal web session, and clean up the cookie-auth internals around request access and cookie clearing

## Testing
- `php bin/phpunit tests/PhpUnit/Security/Authentication/CookieServiceTest.php tests/PhpUnit/Security/Authentication/JwtRefresh/RefreshTokenServiceTest.php tests/PhpUnit/Api/Services/AuthenticationManagerTest.php tests/PhpUnit/Api/Services/Base/BearerAuthenticationTraitTest.php tests/PhpUnit/Security/Authentication/AuthenticationModeResolverTest.php tests/PhpUnit/Security/Authentication/AuthenticationSuccessResponseProcessorTest.php tests/PhpUnit/Security/Authentication/ApiAuthenticationSuccessHandlerTest.php tests/PhpUnit/Security/Authentication/JwtRefresh/ApiRefreshTokenSuccessHandlerTest.php`
- `bin/phpstan analyze`
- `vendor/vimeo/psalm/psalm`
- `php bin/console lint:container`
- `php bin/console lint:twig templates/Security/LoginPage.html.twig`
- `./node_modules/.bin/eslint assets/Api/ApiHelper.js assets/Security/LoginPage.js assets/Security/LoginTokenHandler.js assets/Security/LogoutTokenHandler.js`
- `php bin/php-cs-fixer fix --dry-run --allow-risky=yes --verbose --format=txt --config=.php-cs-fixer.dist.php --path-mode=intersection src/Security/Authentication/CookieService.php src/Api/Services/Base/BearerAuthenticationTrait.php src/Api/Services/Authentication/AuthenticationResponseManager.php src/Api/Services/User/UserResponseManager.php src/Api/Services/AuthenticationManager.php src/Security/Authentication/JwtRefresh/RefreshTokenService.php src/Security/Authentication/ApiAuthenticationSuccessHandler.php src/Security/Authentication/AuthenticationModeResolver.php src/Security/Authentication/AuthenticationSuccessResponseProcessor.php src/Security/Authentication/JwtRefresh/ApiRefreshTokenSuccessHandler.php src/Application/Controller/Security/LoginController.php config/packages/security.php tests/PhpUnit/Api/Services/Base/BearerAuthenticationTraitTest.php tests/PhpUnit/Security/Authentication/JwtRefresh/RefreshTokenServiceTest.php`
- `php bin/twig-cs-fixer lint templates/Project/Comment/JsData.html.twig`

Closes #6325
