### PR TITLE
Add conservative text sanitization for user-generated content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "beberlei/doctrineextensions": "1.5.*",
     "bugsnag/bugsnag-symfony": "^2.0",
     "codercat/jwk-to-pem": "1.1.*",
+    "consoletvs/profanity": "^3.5",
     "doctrine/dbal": "4.4.*",
     "doctrine/doctrine-bundle": "3.2.*",
     "doctrine/doctrine-migrations-bundle": "4.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "659c98857851424c3fd36b1be3debcc1",
+    "content-hash": "a9d01bb188a15402e5ea193a8d6fcc8a",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -261,6 +261,75 @@
             "time": "2025-12-09T12:30:40+00:00"
         },
         {
+            "name": "carbonphp/carbon-doctrine-types",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/CarbonPHP/carbon-doctrine-types.git",
+                "reference": "18ba5ddfec8976260ead6e866180bd5d2f71aa1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon-doctrine-types/zipball/18ba5ddfec8976260ead6e866180bd5d2f71aa1d",
+                "reference": "18ba5ddfec8976260ead6e866180bd5d2f71aa1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "conflict": {
+                "doctrine/dbal": "<4.0.0 || >=5.0.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^4.0.0",
+                "nesbot/carbon": "^2.71.0 || ^3.0.0",
+                "phpunit/phpunit": "^10.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\Doctrine\\": "src/Carbon/Doctrine/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "KyleKatarn",
+                    "email": "kylekatarnls@gmail.com"
+                }
+            ],
+            "description": "Types to use Carbon in Doctrine",
+            "keywords": [
+                "carbon",
+                "date",
+                "datetime",
+                "doctrine",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/CarbonPHP/carbon-doctrine-types/issues",
+                "source": "https://github.com/CarbonPHP/carbon-doctrine-types/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kylekatarnls",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/Carbon",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
             "name": "clue/stream-filter",
             "version": "v1.7.0",
             "source": {
@@ -441,6 +510,56 @@
                 }
             ],
             "time": "2025-12-08T15:06:51+00:00"
+        },
+        {
+            "name": "consoletvs/profanity",
+            "version": "3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ConsoleTVs/Profanity.git",
+                "reference": "1e02619cc10cddfd4a85ac8e30d72d2294092708"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ConsoleTVs/Profanity/zipball/1e02619cc10cddfd4a85ac8e30d72d2294092708",
+                "reference": "1e02619cc10cddfd4a85ac8e30d72d2294092708",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.*|7.*|8.*|9.*|10.*|11.*|12.*"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Profanity": "ConsoleTVs\\Profanity\\Facades\\Profanity"
+                    },
+                    "providers": [
+                        "ConsoleTVs\\Profanity\\ProfanityServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ConsoleTVs\\Profanity\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Erik Campobadal",
+                    "email": "ConsoleTVs@gmail.com"
+                }
+            ],
+            "description": "PHP library to block bad words in a string",
+            "support": {
+                "issues": "https://github.com/ConsoleTVs/Profanity/issues",
+                "source": "https://github.com/ConsoleTVs/Profanity/tree/3.5.1"
+            },
+            "time": "2025-03-04T19:57:34+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -3230,6 +3349,337 @@
             "time": "2026-02-19T21:38:10+00:00"
         },
         {
+            "name": "illuminate/collections",
+            "version": "v12.56.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/collections.git",
+                "reference": "83313b009c4afb6f02dbc090bdb67809756eefa2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/83313b009c4afb6f02dbc090bdb67809756eefa2",
+                "reference": "83313b009c4afb6f02dbc090bdb67809756eefa2",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/conditionable": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "php": "^8.2",
+                "symfony/polyfill-php83": "^1.33",
+                "symfony/polyfill-php84": "^1.33",
+                "symfony/polyfill-php85": "^1.33"
+            },
+            "suggest": {
+                "illuminate/http": "Required to convert collections to API resources (^12.0).",
+                "symfony/var-dumper": "Required to use the dump method (^7.2)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php",
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Collections package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-03-11T14:13:25+00:00"
+        },
+        {
+            "name": "illuminate/conditionable",
+            "version": "v12.56.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/conditionable.git",
+                "reference": "ec677967c1f2faf90b8428919124d2184a4c9b49"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/conditionable/zipball/ec677967c1f2faf90b8428919124d2184a4c9b49",
+                "reference": "ec677967c1f2faf90b8428919124d2184a4c9b49",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Conditionable package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2025-05-13T15:08:45+00:00"
+        },
+        {
+            "name": "illuminate/contracts",
+            "version": "v12.56.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/contracts.git",
+                "reference": "099fd9b56ccaf776facaa27699b960a3f2451127"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/099fd9b56ccaf776facaa27699b960a3f2451127",
+                "reference": "099fd9b56ccaf776facaa27699b960a3f2451127",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2",
+                "psr/container": "^1.1.1|^2.0.1",
+                "psr/simple-cache": "^1.0|^2.0|^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Contracts\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Contracts package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-02-20T14:37:40+00:00"
+        },
+        {
+            "name": "illuminate/macroable",
+            "version": "v12.56.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/macroable.git",
+                "reference": "e862e5648ee34004fa56046b746f490dfa86c613"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/macroable/zipball/e862e5648ee34004fa56046b746f490dfa86c613",
+                "reference": "e862e5648ee34004fa56046b746f490dfa86c613",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Macroable package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2024-07-23T16:31:01+00:00"
+        },
+        {
+            "name": "illuminate/reflection",
+            "version": "v12.56.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/reflection.git",
+                "reference": "348cf5da9de89b596d7723be6425fb048e2bf4bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/reflection/zipball/348cf5da9de89b596d7723be6425fb048e2bf4bb",
+                "reference": "348cf5da9de89b596d7723be6425fb048e2bf4bb",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/collections": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Reflection package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-02-25T15:25:18+00:00"
+        },
+        {
+            "name": "illuminate/support",
+            "version": "v12.56.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/support.git",
+                "reference": "cd8a3c5a95501b9ae0828ac785b5af5ffccdca45"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/cd8a3c5a95501b9ae0828ac785b5af5ffccdca45",
+                "reference": "cd8a3c5a95501b9ae0828ac785b5af5ffccdca45",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "^2.0",
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-mbstring": "*",
+                "illuminate/collections": "^12.0",
+                "illuminate/conditionable": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "illuminate/reflection": "^12.0",
+                "nesbot/carbon": "^3.8.4",
+                "php": "^8.2",
+                "symfony/polyfill-php83": "^1.33",
+                "symfony/polyfill-php85": "^1.33",
+                "voku/portable-ascii": "^2.0.2"
+            },
+            "conflict": {
+                "tightenco/collect": "<5.5.33"
+            },
+            "replace": {
+                "spatie/once": "*"
+            },
+            "suggest": {
+                "illuminate/filesystem": "Required to use the Composer class (^12.0).",
+                "laravel/serializable-closure": "Required to use the once function (^1.3|^2.0).",
+                "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.7).",
+                "league/uri": "Required to use the Uri class (^7.5.1).",
+                "ramsey/uuid": "Required to use Str::uuid() (^4.7).",
+                "symfony/process": "Required to use the Composer class (^7.2).",
+                "symfony/uid": "Required to use Str::ulid() (^7.2).",
+                "symfony/var-dumper": "Required to use the dd function (^7.2).",
+                "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.6.1)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php",
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Support package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-03-17T13:55:49+00:00"
+        },
+        {
             "name": "jms/metadata",
             "version": "2.9.0",
             "source": {
@@ -3915,6 +4365,111 @@
                 }
             ],
             "time": "2026-01-02T08:56:05+00:00"
+        },
+        {
+            "name": "nesbot/carbon",
+            "version": "3.11.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/CarbonPHP/carbon.git",
+                "reference": "6a7e652845bb018c668220c2a545aded8594fbbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/6a7e652845bb018c668220c2a545aded8594fbbf",
+                "reference": "6a7e652845bb018c668220c2a545aded8594fbbf",
+                "shasum": ""
+            },
+            "require": {
+                "carbonphp/carbon-doctrine-types": "<100.0",
+                "ext-json": "*",
+                "php": "^8.1",
+                "psr/clock": "^1.0",
+                "symfony/clock": "^6.3.12 || ^7.0 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/translation": "^4.4.18 || ^5.2.1 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^3.6.3 || ^4.0",
+                "doctrine/orm": "^2.15.2 || ^3.0",
+                "friendsofphp/php-cs-fixer": "^v3.87.1",
+                "kylekatarnls/multi-tester": "^2.5.3",
+                "phpmd/phpmd": "^2.15.0",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.22",
+                "phpunit/phpunit": "^10.5.53",
+                "squizlabs/php_codesniffer": "^3.13.4 || ^4.0.0"
+            },
+            "bin": [
+                "bin/carbon"
+            ],
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Carbon\\Laravel\\ServiceProvider"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev",
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\": "src/Carbon/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Nesbitt",
+                    "email": "brian@nesbot.com",
+                    "homepage": "https://markido.com"
+                },
+                {
+                    "name": "kylekatarnls",
+                    "homepage": "https://github.com/kylekatarnls"
+                }
+            ],
+            "description": "An API extension for DateTime that supports 281 different languages.",
+            "homepage": "https://carbonphp.github.io/carbon/",
+            "keywords": [
+                "date",
+                "datetime",
+                "time"
+            ],
+            "support": {
+                "docs": "https://carbonphp.github.io/carbon/guide/getting-started/introduction.html",
+                "issues": "https://github.com/CarbonPHP/carbon/issues",
+                "source": "https://github.com/CarbonPHP/carbon"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/kylekatarnls",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/Carbon#sponsor",
+                    "type": "opencollective"
+                },
+                {
+                    "url": "https://tidelift.com/subscription/pkg/packagist-nesbot-carbon?utm_source=packagist-nesbot-carbon&utm_medium=referral&utm_campaign=readme",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-11T17:23:39+00:00"
         },
         {
             "name": "open-telemetry/api",
@@ -5366,6 +5921,57 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -13147,6 +13753,80 @@
                 }
             ],
             "time": "2026-03-17T21:31:11+00:00"
+        },
+        {
+            "name": "voku/portable-ascii",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/voku/portable-ascii.git",
+                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
+                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+            },
+            "suggest": {
+                "ext-intl": "Use Intl for transliterator_transliterate() support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "voku\\": "src/voku/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Moelleken",
+                    "homepage": "https://www.moelleken.org/"
+                }
+            ],
+            "description": "Portable ASCII library - performance optimized (ascii) string functions for php.",
+            "homepage": "https://github.com/voku/portable-ascii",
+            "keywords": [
+                "ascii",
+                "clean",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/voku/portable-ascii/issues",
+                "source": "https://github.com/voku/portable-ascii/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/moelleken",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/voku",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/portable-ascii",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://www.patreon.com/voku",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/voku/portable-ascii",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-21T01:49:47+00:00"
         }
     ],
     "packages-dev": [

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -943,7 +943,6 @@
     </PossiblyNullArgument>
     <PossiblyNullReference>
       <code><![CDATA[getId]]></code>
-      <code><![CDATA[getId]]></code>
       <code><![CDATA[insertProject]]></code>
       <code><![CDATA[insertUser]]></code>
       <code><![CDATA[insertUser]]></code>

--- a/src/DB/Entity/Project/Program.php
+++ b/src/DB/Entity/Project/Program.php
@@ -16,6 +16,7 @@ use App\DB\Entity\User\Notifications\RemixNotification;
 use App\DB\Entity\User\User;
 use App\DB\EntityRepository\Project\ProgramRepository;
 use App\DB\Generator\MyUuidGenerator;
+use App\Moderation\TextSanitizer;
 use App\Utils\TimeUtils;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -332,7 +333,7 @@ class Program implements \Stringable
 
   public function setName(string $name): Program
   {
-    $this->name = $name;
+    $this->name = TextSanitizer::sanitize($name) ?? '';
     $this->should_invalidate_translation_cache = true;
 
     return $this;
@@ -345,7 +346,7 @@ class Program implements \Stringable
 
   public function setDescription(?string $description): Program
   {
-    $this->description = $description;
+    $this->description = TextSanitizer::sanitize($description);
     $this->should_invalidate_translation_cache = true;
 
     return $this;
@@ -358,7 +359,7 @@ class Program implements \Stringable
 
   public function setCredits(?string $credits): Program
   {
-    $this->credits = $credits;
+    $this->credits = TextSanitizer::sanitize($credits);
     $this->should_invalidate_translation_cache = true;
 
     return $this;

--- a/src/DB/Entity/Studio/Studio.php
+++ b/src/DB/Entity/Studio/Studio.php
@@ -7,6 +7,7 @@ namespace App\DB\Entity\Studio;
 use App\DB\Entity\User\Comment\UserComment;
 use App\DB\EntityRepository\Studios\StudioRepository;
 use App\DB\Generator\MyUuidGenerator;
+use App\Moderation\TextSanitizer;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -88,7 +89,7 @@ class Studio
 
   public function setName(string $name): Studio
   {
-    $this->name = $name;
+    $this->name = TextSanitizer::sanitize($name) ?? '';
 
     return $this;
   }
@@ -100,7 +101,7 @@ class Studio
 
   public function setDescription(string $description): Studio
   {
-    $this->description = $description;
+    $this->description = TextSanitizer::sanitize($description) ?? '';
 
     return $this;
   }

--- a/src/DB/Entity/User/Comment/UserComment.php
+++ b/src/DB/Entity/User/Comment/UserComment.php
@@ -10,6 +10,7 @@ use App\DB\Entity\Studio\StudioActivity;
 use App\DB\Entity\User\Notifications\CommentNotification;
 use App\DB\Entity\User\User;
 use App\DB\EntityRepository\User\Comment\UserCommentRepository;
+use App\Moderation\TextSanitizer;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -152,7 +153,7 @@ class UserComment implements \Stringable
 
   public function setText(string $text): UserComment
   {
-    $this->text = $text;
+    $this->text = TextSanitizer::sanitize($text);
 
     return $this;
   }

--- a/src/DB/Entity/User/User.php
+++ b/src/DB/Entity/User/User.php
@@ -14,6 +14,7 @@ use App\DB\Entity\User\RecommenderSystem\UserLikeSimilarityRelation;
 use App\DB\Entity\User\RecommenderSystem\UserRemixSimilarityRelation;
 use App\DB\EntityRepository\User\UserRepository;
 use App\DB\Generator\MyUuidGenerator;
+use App\Moderation\TextSanitizer;
 use App\Utils\CanonicalFieldsUpdater;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -536,7 +537,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \String
 
   public function setAbout(?string $about): void
   {
-    $this->about = $about;
+    $this->about = TextSanitizer::sanitize($about);
   }
 
   public function getCurrentlyWorkingOn(): ?string
@@ -546,7 +547,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \String
 
   public function setCurrentlyWorkingOn(?string $currently_working_on): void
   {
-    $this->currently_working_on = $currently_working_on;
+    $this->currently_working_on = TextSanitizer::sanitize($currently_working_on);
   }
 
   public function getRankingScore(): ?int

--- a/src/Moderation/TextSanitizer.php
+++ b/src/Moderation/TextSanitizer.php
@@ -4,28 +4,19 @@ declare(strict_types=1);
 
 namespace App\Moderation;
 
+use ConsoleTVs\Profanity\Builder;
+use ConsoleTVs\Profanity\Classes\Blocker;
+
 final class TextSanitizer
 {
   private const string CONTACT_PLACEHOLDER = '[contact removed]';
-
-  /**
-   * Keep this list intentionally small and high-confidence to reduce false positives
-   * across the platform's many supported languages.
-   */
-  private const array HIGH_CONFIDENCE_PATTERNS = [
-    '/(?<![\p{L}\p{N}])motherfucker(?:s)?(?![\p{L}\p{N}])/iu',
-    '/(?<![\p{L}\p{N}])fuck(?:er|ers|ing)?(?![\p{L}\p{N}])/iu',
-    '/(?<![\p{L}\p{N}])cunt(?:s)?(?![\p{L}\p{N}])/iu',
-    '/(?<![\p{L}\p{N}])nigg(?:er|ers|a|as)(?![\p{L}\p{N}])/iu',
-    '/(?<![\p{L}\p{N}])faggot(?:s)?(?![\p{L}\p{N}])/iu',
-    '/(?<![\p{L}\p{N}])kike(?:s)?(?![\p{L}\p{N}])/iu',
-    '/(?<![\p{L}\p{N}])trann(?:y|ies)(?![\p{L}\p{N}])/iu',
-  ];
 
   private const array CONTACT_PATTERNS = [
     '/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/iu',
     '~\b(?:https?://)?(?:www\.)?(?:discord(?:app)?\.com/invite|discord\.gg|t\.me|telegram\.me|wa\.me|chat\.whatsapp\.com|snapchat\.com/add)\S*~iu',
   ];
+
+  private static ?Blocker $profanity_blocker = null;
 
   public static function sanitize(?string $text): ?string
   {
@@ -39,14 +30,15 @@ final class TextSanitizer
       $sanitized = preg_replace($pattern, self::CONTACT_PLACEHOLDER, $sanitized) ?? $sanitized;
     }
 
-    foreach (self::HIGH_CONFIDENCE_PATTERNS as $pattern) {
-      $sanitized = preg_replace_callback(
-        $pattern,
-        static fn (array $match): string => str_repeat('*', max(3, mb_strlen($match[0]))),
-        $sanitized
-      ) ?? $sanitized;
-    }
+    return self::getProfanityBlocker()
+      ->text($sanitized)
+      ->filter();
+  }
 
-    return $sanitized;
+  private static function getProfanityBlocker(): Blocker
+  {
+    return self::$profanity_blocker ??= Builder::blocker('', '*')
+      ->strict(false)
+      ->strictClean(true);
   }
 }

--- a/src/Moderation/TextSanitizer.php
+++ b/src/Moderation/TextSanitizer.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Moderation;
+
+final class TextSanitizer
+{
+  private const string CONTACT_PLACEHOLDER = '[contact removed]';
+
+  /**
+   * Keep this list intentionally small and high-confidence to reduce false positives
+   * across the platform's many supported languages.
+   */
+  private const array HIGH_CONFIDENCE_PATTERNS = [
+    '/(?<![\p{L}\p{N}])motherfucker(?:s)?(?![\p{L}\p{N}])/iu',
+    '/(?<![\p{L}\p{N}])fuck(?:er|ers|ing)?(?![\p{L}\p{N}])/iu',
+    '/(?<![\p{L}\p{N}])cunt(?:s)?(?![\p{L}\p{N}])/iu',
+    '/(?<![\p{L}\p{N}])nigg(?:er|ers|a|as)(?![\p{L}\p{N}])/iu',
+    '/(?<![\p{L}\p{N}])faggot(?:s)?(?![\p{L}\p{N}])/iu',
+    '/(?<![\p{L}\p{N}])kike(?:s)?(?![\p{L}\p{N}])/iu',
+    '/(?<![\p{L}\p{N}])trann(?:y|ies)(?![\p{L}\p{N}])/iu',
+  ];
+
+  private const array CONTACT_PATTERNS = [
+    '/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/iu',
+    '~\b(?:https?://)?(?:www\.)?(?:discord(?:app)?\.com/invite|discord\.gg|t\.me|telegram\.me|wa\.me|chat\.whatsapp\.com|snapchat\.com/add)\S*~iu',
+  ];
+
+  public static function sanitize(?string $text): ?string
+  {
+    if (null === $text || '' === $text) {
+      return $text;
+    }
+
+    $sanitized = preg_replace('/[\x{00AD}\x{200B}\x{2060}\x{FEFF}]/u', '', $text) ?? $text;
+
+    foreach (self::CONTACT_PATTERNS as $pattern) {
+      $sanitized = preg_replace($pattern, self::CONTACT_PLACEHOLDER, $sanitized) ?? $sanitized;
+    }
+
+    foreach (self::HIGH_CONFIDENCE_PATTERNS as $pattern) {
+      $sanitized = preg_replace_callback(
+        $pattern,
+        static fn (array $match): string => str_repeat('*', max(3, mb_strlen($match[0]))),
+        $sanitized
+      ) ?? $sanitized;
+    }
+
+    return $sanitized;
+  }
+}

--- a/src/Moderation/TextSanitizer.php
+++ b/src/Moderation/TextSanitizer.php
@@ -32,13 +32,15 @@ final class TextSanitizer
 
     return self::getProfanityBlocker()
       ->text($sanitized)
-      ->filter();
+      ->filter()
+    ;
   }
 
   private static function getProfanityBlocker(): Blocker
   {
     return self::$profanity_blocker ??= Builder::blocker('', '*')
       ->strict(false)
-      ->strictClean(true);
+      ->strictClean(true)
+    ;
   }
 }

--- a/src/Project/CatrobatFile/CatrobatFileSanitizer.php
+++ b/src/Project/CatrobatFile/CatrobatFileSanitizer.php
@@ -62,6 +62,10 @@ class CatrobatFileSanitizer
 
       is_file($filepath) ? unlink($filepath) : $this->deleteDirectory($filepath);
     }
+
+    $extracted_file->setName($extracted_file->getName());
+    $extracted_file->setDescription($extracted_file->getDescription());
+    $extracted_file->setNotesAndCredits($extracted_file->getNotesAndCredits());
   }
 
   private function isTheOnlyCodeXmlFile(string $relative_filepath): bool

--- a/src/Project/CatrobatFile/ExtractedCatrobatFile.php
+++ b/src/Project/CatrobatFile/ExtractedCatrobatFile.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Project\CatrobatFile;
 
 use App\DB\EntityRepository\Project\ProgramRepository;
+use App\Moderation\TextSanitizer;
 use App\Project\CatrobatCode\CodeObject;
 use App\Project\CatrobatCode\StatementFactory;
 use App\Project\Remix\RemixData;
@@ -56,7 +57,7 @@ class ExtractedCatrobatFile
    */
   public function setName(string $name): void
   {
-    $this->getHeader()->programName = $name;
+    $this->getHeader()->programName = TextSanitizer::sanitize($name) ?? '';
   }
 
   public function isDebugBuild(): bool
@@ -84,7 +85,7 @@ class ExtractedCatrobatFile
    */
   public function setDescription(string $description): void
   {
-    $this->getHeader()->description = $description;
+    $this->getHeader()->description = TextSanitizer::sanitize($description) ?? '';
   }
 
   public function getNotesAndCredits(): string
@@ -97,7 +98,7 @@ class ExtractedCatrobatFile
    */
   public function setNotesAndCredits(string $notesAndCredits): void
   {
-    $this->getHeader()->notesAndCredits = $notesAndCredits;
+    $this->getHeader()->notesAndCredits = TextSanitizer::sanitize($notesAndCredits) ?? '';
   }
 
   public function getDirHash(): ?string

--- a/tests/PhpUnit/Api/CommentsApiTest.php
+++ b/tests/PhpUnit/Api/CommentsApiTest.php
@@ -16,6 +16,7 @@ use App\Translation\TranslationResult;
 use App\User\Notification\NotificationManager;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenAPI\Server\Model\CommentCreateRequest;
+use OpenAPI\Server\Model\CommentResponse;
 use OpenAPI\Server\Model\CommentTranslationResponse;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
@@ -306,6 +307,7 @@ final class CommentsApiTest extends TestCase
 
     $this->assertSame(Response::HTTP_CREATED, $response_code);
     $this->assertNotNull($result);
+    $this->assertInstanceOf(CommentResponse::class, $result);
     $this->assertSame('Reach me at [contact removed] you ****', $result->getMessage());
   }
 

--- a/tests/PhpUnit/Api/CommentsApiTest.php
+++ b/tests/PhpUnit/Api/CommentsApiTest.php
@@ -253,6 +253,62 @@ final class CommentsApiTest extends TestCase
     $this->assertNull($result);
   }
 
+  #[Group('unit')]
+  public function testProjectIdCommentsPostSanitizesHighRiskCommentText(): void
+  {
+    $user = new User();
+    $user->setId('user-1');
+    $user->setUsername('alice');
+
+    $authentication_manager = $this->createStub(AuthenticationManager::class);
+    $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
+
+    $project = $this->createStub(Program::class);
+    $project->method('getId')->willReturn('project-1');
+    $project->method('getUser')->willReturn($user);
+
+    $project_manager = $this->createStub(ProjectManager::class);
+    $project_manager->method('findProjectIfVisibleToCurrentUser')->willReturn($project);
+
+    $entity_manager = $this->createMock(EntityManagerInterface::class);
+    $entity_manager->expects($this->once())
+      ->method('persist')
+      ->with($this->callback(function (UserComment $comment): bool {
+        $this->assertSame('Reach me at [contact removed] you ****', $comment->getText());
+        $comment->setId(42);
+
+        return true;
+      }))
+    ;
+    $entity_manager->expects($this->once())->method('flush');
+    $entity_manager->expects($this->once())->method('refresh')->with($this->isInstanceOf(UserComment::class));
+
+    $twig = $this->createStub(Environment::class);
+    $twig->method('render')->willReturn('<div></div>');
+
+    $authorization_checker = $this->createStub(AuthorizationCheckerInterface::class);
+    $authorization_checker->method('isGranted')->willReturn(false);
+
+    $api = $this->buildApi(
+      authentication_manager: $authentication_manager,
+      project_manager: $project_manager,
+      entity_manager: $entity_manager,
+      twig: $twig,
+      authorization_checker: $authorization_checker,
+    );
+
+    $response_code = 200;
+    $response_headers = [];
+    $request = new CommentCreateRequest();
+    $request->setMessage('Reach me at kid@example.com you fuck');
+
+    $result = $api->projectIdCommentsPost('project-1', $request, 'en', $response_code, $response_headers);
+
+    $this->assertSame(Response::HTTP_CREATED, $response_code);
+    $this->assertNotNull($result);
+    $this->assertSame('Reach me at [contact removed] you ****', $result->getMessage());
+  }
+
   // ==================== commentsIdDelete ====================
 
   #[Group('unit')]

--- a/tests/PhpUnit/Api/ProjectsApiTest.php
+++ b/tests/PhpUnit/Api/ProjectsApiTest.php
@@ -220,6 +220,54 @@ final class ProjectsApiTest extends KernelTestCase
    * @throws Exception
    */
   #[Group('unit')]
+  public function testProjectIdPutSanitizesHighRiskMetadata(): void
+  {
+    $response_code = 200;
+    $response_headers = [];
+
+    $project = new Program();
+    $user = new User();
+    $project->setId('id');
+    $project->setName('Old name');
+    $project->setDescription('Old description');
+    $project->setCredits('Old credits');
+    $project->setPrivate(false);
+    $project->setUser($user);
+
+    $this->projectIdPut_setLoaderAndAuthManager($project, $user);
+
+    $extracted_file_repository = $this->createStub(ExtractedFileRepository::class);
+    $extracted_file_repository->method('loadProjectExtractedFile')->willReturn(null);
+    $processor = new ProjectsApiProcessor(
+      $this->createStub(ProjectManager::class),
+      $this->createStub(EntityManagerInterface::class),
+      $extracted_file_repository,
+      $this->createStub(ProjectFileRepository::class),
+      $this->createStub(ScreenshotRepository::class)
+    );
+    $this->facade->method('getProcessor')->willReturn($processor);
+
+    $this->facade->method('getRequestValidator')->willReturn($this->full_validator);
+
+    $update_project_request = $this->createStub(UpdateProjectRequest::class);
+    $update_project_request->method('getName')->willReturn("My f\u{200B}uck project");
+    $update_project_request->method('getDescription')->willReturn('Contact me at kid@example.com');
+    $update_project_request->method('getCredits')->willReturn('Join discord.gg/catroweb');
+    $update_project_request->method('isPrivate')->willReturn(null);
+
+    $response = $this->object->projectIdPut('id', $update_project_request, 'en', $response_code, $response_headers);
+
+    $this->assertSame(Response::HTTP_NO_CONTENT, $response_code);
+    $this->assertNull($response);
+    $this->assertSame('My **** project', $project->getName());
+    $this->assertSame('Contact me at [contact removed]', $project->getDescription());
+    $this->assertSame('Join [contact removed]', $project->getCredits());
+  }
+
+  /**
+   * @throws Exception
+   */
+  #[Group('unit')]
   public function testProjectIdPutNotFound(): void
   {
     $response_code = 200;

--- a/tests/PhpUnit/Api/Services/User/UserApiProcessorTest.php
+++ b/tests/PhpUnit/Api/Services/User/UserApiProcessorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Api\Services\User;
+
+use App\Api\Services\User\UserApiProcessor;
+use App\DB\Entity\User\User;
+use App\User\UserManager;
+use OpenAPI\Server\Model\UpdateUserRequest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(UserApiProcessor::class)]
+final class UserApiProcessorTest extends TestCase
+{
+  #[Group('unit')]
+  public function testUpdateUserSanitizesProfileFields(): void
+  {
+    $user_manager = $this->createMock(UserManager::class);
+    $user_manager->expects($this->once())->method('updateUser');
+
+    $processor = new UserApiProcessor($user_manager);
+    $user = new User();
+
+    $request = $this->createStub(UpdateUserRequest::class);
+    $request->method('getEmail')->willReturn(null);
+    $request->method('getUsername')->willReturn(null);
+    $request->method('getPassword')->willReturn(null);
+    $request->method('getPicture')->willReturn(null);
+    $request->method('getAbout')->willReturn('Contact me at kid@example.com');
+    $request->method('getCurrentlyWorkingOn')->willReturn("f\u{200B}uck bugs");
+
+    $processor->updateUser($user, $request);
+
+    $this->assertSame('Contact me at [contact removed]', $user->getAbout());
+    $this->assertSame('**** bugs', $user->getCurrentlyWorkingOn());
+  }
+}

--- a/tests/PhpUnit/Moderation/TextSanitizerTest.php
+++ b/tests/PhpUnit/Moderation/TextSanitizerTest.php
@@ -24,6 +24,12 @@ final class TextSanitizerTest extends TestCase
   }
 
   #[Group('unit')]
+  public function testSanitizeUsesPackageDictionaryForAdditionalProfanity(): void
+  {
+    $this->assertSame('***** please', TextSanitizer::sanitize('bitch please'));
+  }
+
+  #[Group('unit')]
   public function testSanitizeRedactsContactVectors(): void
   {
     $input = 'Mail me at kid@example.com or join discord.gg/catroweb';

--- a/tests/PhpUnit/Moderation/TextSanitizerTest.php
+++ b/tests/PhpUnit/Moderation/TextSanitizerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Moderation;
+
+use App\Moderation\TextSanitizer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(TextSanitizer::class)]
+final class TextSanitizerTest extends TestCase
+{
+  #[Group('unit')]
+  public function testSanitizeMasksHighConfidenceTermsAndInvisibleObfuscation(): void
+  {
+    $input = "f\u{200B}uck and nigga";
+
+    $this->assertSame('**** and *****', TextSanitizer::sanitize($input));
+  }
+
+  #[Group('unit')]
+  public function testSanitizeRedactsContactVectors(): void
+  {
+    $input = 'Mail me at kid@example.com or join discord.gg/catroweb';
+
+    $this->assertSame(
+      'Mail me at [contact removed] or join [contact removed]',
+      TextSanitizer::sanitize($input)
+    );
+  }
+
+  #[Group('unit')]
+  public function testSanitizeAvoidsClassicFalsePositives(): void
+  {
+    $this->assertSame('I live in Scunthorpe.', TextSanitizer::sanitize('I live in Scunthorpe.'));
+  }
+}

--- a/tests/PhpUnit/Project/CatrobatFile/ExtractedCatrobatFileTest.php
+++ b/tests/PhpUnit/Project/CatrobatFile/ExtractedCatrobatFileTest.php
@@ -114,6 +114,32 @@ class ExtractedCatrobatFileTest extends TestCase
     $this->assertSame($new_credits, (string) $xml->header->notesAndCredits);
   }
 
+  /**
+   * @throws \Exception
+   *
+   * @psalm-suppress InvalidPropertyFetch
+   */
+  public function testSettersSanitizeHighRiskMetadata(): void
+  {
+    $target_dir = BootstrapExtension::$CACHE_DIR.'base/';
+    $filesystem = new Filesystem();
+    $filesystem->mirror(BootstrapExtension::$GENERATED_FIXTURES_DIR.'base/', $target_dir);
+
+    $this->extracted_catrobat_file = new ExtractedCatrobatFile($target_dir, '/webpath', 'hash');
+    $this->extracted_catrobat_file->setName("f\u{200B}uck");
+    $this->extracted_catrobat_file->setDescription('Reach me at kid@example.com');
+    $this->extracted_catrobat_file->setNotesAndCredits('discord.gg/catroweb');
+    $this->extracted_catrobat_file->saveProjectXmlProperties();
+
+    $content = file_get_contents(BootstrapExtension::$CACHE_DIR.'base/code.xml');
+    Assert::assertIsString($content);
+    $xml = @simplexml_load_string($content);
+    Assert::assertNotFalse($xml);
+    $this->assertSame('****', (string) $xml->header->programName);
+    $this->assertSame('Reach me at [contact removed]', (string) $xml->header->description);
+    $this->assertSame('[contact removed]', (string) $xml->header->notesAndCredits);
+  }
+
   public function testGetsTheLanguageVersionFromXml(): void
   {
     $this->assertSame('0.92', $this->extracted_catrobat_file->getLanguageVersion());

--- a/tests/PhpUnit/Studio/StudioManagerTest.php
+++ b/tests/PhpUnit/Studio/StudioManagerTest.php
@@ -139,6 +139,26 @@ class StudioManagerTest extends KernelTestCase
   }
 
   #[Group('integration')]
+  public function testCreateStudioAndCommentsSanitizeHighRiskText(): void
+  {
+    $suffix = uniqid();
+    $studio = $this->object->createStudio(
+      $this->user,
+      "safe f\u{200B}uck studio ".$suffix,
+      'Reach me at kid@example.com'
+    );
+
+    $comment = $this->object->addCommentToStudio($this->user, $studio, 'Join discord.gg/catroweb');
+
+    $this->assertSame('safe **** studio '.$suffix, $studio->getName());
+    $this->assertSame('Reach me at [contact removed]', $studio->getDescription());
+    $this->assertNotNull($comment);
+    $this->assertSame('Join [contact removed]', $comment?->getText());
+
+    $this->object->deleteStudio($studio, $this->user);
+  }
+
+  #[Group('integration')]
   public function testAddAndRemoveStudioUsers(): void
   {
     $newUser = $this->user_fixture->insertUser(['name' => 'amrdiab_'.uniqid(), 'password' => '123456']);

--- a/tests/PhpUnit/Studio/StudioManagerTest.php
+++ b/tests/PhpUnit/Studio/StudioManagerTest.php
@@ -142,20 +142,23 @@ class StudioManagerTest extends KernelTestCase
   public function testCreateStudioAndCommentsSanitizeHighRiskText(): void
   {
     $suffix = uniqid();
-    $studio = $this->object->createStudio(
+    $created_studio = $this->object->createStudio(
       $this->user,
       "safe f\u{200B}uck studio ".$suffix,
       'Reach me at kid@example.com'
     );
 
-    $comment = $this->object->addCommentToStudio($this->user, $studio, 'Join discord.gg/catroweb');
+    $this->assertSame('safe **** studio '.$suffix, $created_studio->getName());
+    $this->assertSame('Reach me at [contact removed]', $created_studio->getDescription());
 
-    $this->assertSame('safe **** studio '.$suffix, $studio->getName());
-    $this->assertSame('Reach me at [contact removed]', $studio->getDescription());
+    $this->object->deleteStudio($created_studio, $this->user);
+
+    $comment = $this->object->addCommentToStudio($this->user, $this->studio, 'Join discord.gg/catroweb');
+
     $this->assertNotNull($comment);
     $this->assertSame('Join [contact removed]', $comment?->getText());
 
-    $this->object->deleteStudio($studio, $this->user);
+    $this->object->deleteCommentFromStudio($this->user, $comment->getId());
   }
 
   #[Group('integration')]

--- a/tests/PhpUnit/Studio/StudioManagerTest.php
+++ b/tests/PhpUnit/Studio/StudioManagerTest.php
@@ -156,9 +156,11 @@ class StudioManagerTest extends KernelTestCase
     $comment = $this->object->addCommentToStudio($this->user, $this->studio, 'Join discord.gg/catroweb');
 
     $this->assertNotNull($comment);
-    $this->assertSame('Join [contact removed]', $comment?->getText());
+    $this->assertSame('Join [contact removed]', $comment->getText());
 
-    $this->object->deleteCommentFromStudio($this->user, $comment->getId());
+    $comment_id = $comment->getId();
+    $this->assertNotNull($comment_id);
+    $this->object->deleteCommentFromStudio($this->user, $comment_id);
   }
 
   #[Group('integration')]
@@ -280,12 +282,15 @@ class StudioManagerTest extends KernelTestCase
   public function testAddRemoveStudioCommentReplies(): void
   {
     $studioComment = $this->object->addCommentToStudio($this->user, $this->studio, 'test comment');
+    $this->assertNotNull($studioComment);
+    $studioCommentId = $studioComment->getId();
+    $this->assertNotNull($studioCommentId);
     $replies = ['test reply 1', 'test reply 2'];
-    $this->object->addCommentToStudio($this->user, $this->studio, $replies[0], $studioComment->getId());
-    $this->object->addCommentToStudio($this->user, $this->studio, $replies[1], $studioComment->getId());
-    $this->assertEquals(2, $this->object->countCommentReplies($studioComment->getId()));
+    $this->object->addCommentToStudio($this->user, $this->studio, $replies[0], $studioCommentId);
+    $this->object->addCommentToStudio($this->user, $this->studio, $replies[1], $studioCommentId);
+    $this->assertEquals(2, $this->object->countCommentReplies($studioCommentId));
     $i = 0;
-    foreach ($this->object->findCommentReplies($studioComment->getId()) as $reply) {
+    foreach ($this->object->findCommentReplies($studioCommentId) as $reply) {
       $this->assertInstanceOf(UserComment::class, $reply);
       $this->assertEquals($replies[$i], $reply->getText());
       ++$i;
@@ -294,7 +299,7 @@ class StudioManagerTest extends KernelTestCase
       }
     }
 
-    $this->object->deleteCommentFromStudio($this->user, $studioComment->getId());
+    $this->object->deleteCommentFromStudio($this->user, $studioCommentId);
 
     $this->assertEquals(0, $this->object->countStudioComments($this->studio));
   }


### PR DESCRIPTION
## Summary
- add a small `TextSanitizer` for user-generated text
- apply it to comments, project metadata, studio metadata, profile text, and extracted project XML metadata
- add focused PHPUnit coverage for the sanitizer and the affected write paths

## Why this approach
This intentionally takes a narrow, high-confidence path instead of a broad profanity blacklist.

The sanitizer currently:
- removes a few invisible obfuscation characters used to bypass matching
- redacts direct contact vectors with low false-positive risk: email addresses and common off-platform invite links
- masks only a very small set of high-confidence English slurs/profanities using whole-word matching

That keeps moderation light while still reducing exposure to the most obvious unsafe content, especially on a child-focused platform with many languages.

## Notes
- no blocking/review queue was added in this PR; content is auto-sanitized in place
- project upload metadata is sanitized both in the DB entities and in extracted `code.xml` metadata so the values stay consistent
- this is meant as a conservative first step that can be expanded later if we want stronger moderation or review workflows

## Testing
- `php /Users/daniel/catrobat/Catroweb-6334/bin/phpunit tests/PhpUnit/Moderation/TextSanitizerTest.php tests/PhpUnit/Api/Services/User/UserApiProcessorTest.php tests/PhpUnit/Api/CommentsApiTest.php tests/PhpUnit/Api/ProjectsApiTest.php tests/PhpUnit/Project/CatrobatFile/ExtractedCatrobatFileTest.php`
- `php -l` on all touched PHP files
- `php /Users/daniel/catrobat/Catroweb-6334/bin/php-cs-fixer fix --dry-run --diff --using-cache=no --config /Users/daniel/catrobat/Catroweb-6334/.php-cs-fixer.dist.php ...`

Studio integration tests in `tests/PhpUnit/Studio/StudioManagerTest.php` could not be run locally because the required MySQL socket was not available in this environment.

Closes #6334