### PR TITLE
Add cookie consent banner for GDPR compliance

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -535,7 +535,21 @@ Then the ".result" element should contain "expected"
 - Infinite scroll / lazy loading
 - Any operation that shows a loading spinner
 
-#### 7. Debugging Flaky Tests
+#### 7. Use `should not exist` When JS Removes Elements from DOM
+
+When JS calls `element.remove()`, the element is gone from the DOM entirely. Use `should not exist`, NOT `should not be visible`:
+
+```gherkin
+# WRONG — element is removed, not just hidden; isVisible() can't find it
+Then the element ".my-banner" should not be visible
+
+# CORRECT — element.remove() means it no longer exists in the DOM
+Then the element ".my-banner" should not exist
+```
+
+Rule: if the JS code calls `.remove()` on an element, assert with `should not exist`. Only use `should not be visible` when the element stays in the DOM but is hidden via CSS (`display: none`, `visibility: hidden`, etc.).
+
+#### 8. Debugging Flaky Tests
 
 If a test passes locally but fails in CI:
 

--- a/assets/Layout/Base.js
+++ b/assets/Layout/Base.js
@@ -20,8 +20,7 @@ import { showSnackbar } from './Snackbar'
 import Bugsnag from '@bugsnag/js'
 import BugsnagPerformance from '@bugsnag/browser-performance'
 
-import { Analytics } from 'analytics'
-import googleTagManager from '@analytics/google-tag-manager'
+import { initAnalyticsIfConsented, showCookieSettings } from './CookieConsent'
 
 // Start the stimulus app
 import '../bootstrap'
@@ -35,18 +34,7 @@ if (bugsnagApiKey) {
   BugsnagPerformance.start({ apiKey: bugsnagApiKey, appVersion })
 }
 
-const gtmContainerId = document.getElementById('gtm-container-id').dataset.gtmContainerId
-if (gtmContainerId) {
-  const analytics = Analytics({
-    app: 'share.catrob.at',
-    plugins: [
-      googleTagManager({
-        containerId: gtmContainerId,
-      }),
-    ],
-  })
-  analytics.page() /* Track a page view */
-}
+initAnalyticsIfConsented()
 
 require('./Base.scss')
 require('./Footer.scss')
@@ -58,7 +46,18 @@ document.addEventListener('DOMContentLoaded', () => {
   showFlashSnackbar()
   fitHeadingFontSizeToAvailableWidth()
   initScrollToHash()
+  initCookieSettingsLink()
 })
+
+function initCookieSettingsLink() {
+  const link = document.querySelector('.js-cookie-settings')
+  if (link) {
+    link.addEventListener('click', (e) => {
+      e.preventDefault()
+      showCookieSettings()
+    })
+  }
+}
 
 function showFlashSnackbar() {
   const snackbarFlashMessages = document.getElementsByClassName('js-flash-snackbar')

--- a/assets/Layout/Base.scss
+++ b/assets/Layout/Base.scss
@@ -17,3 +17,4 @@
 @import './Swal';
 @import './ProgressBar';
 @import './LegacyBase';
+@import './CookieConsent';

--- a/assets/Layout/CookieConsent.js
+++ b/assets/Layout/CookieConsent.js
@@ -1,0 +1,123 @@
+import { getCookie, setCookie } from '../Security/CookieHelper'
+
+const COOKIE_NAME = 'cookie_consent'
+const COOKIE_EXPIRY_DAYS = 365
+
+function getExpiry(days) {
+  const date = new Date()
+  date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000)
+  return date.toUTCString()
+}
+
+function getConsentStatus() {
+  return getCookie(COOKIE_NAME)
+}
+
+function initGTM() {
+  const gtmEl = document.getElementById('gtm-container-id')
+  if (!gtmEl) return
+  const gtmContainerId = gtmEl.dataset.gtmContainerId
+  if (!gtmContainerId) return
+
+  import('analytics').then(({ Analytics }) => {
+    import('@analytics/google-tag-manager').then(({ default: googleTagManager }) => {
+      const analytics = Analytics({
+        app: 'share.catrob.at',
+        plugins: [googleTagManager({ containerId: gtmContainerId })],
+      })
+      analytics.page()
+    })
+  })
+}
+
+function createBanner() {
+  const config = document.getElementById('cookie-consent-config')
+  if (!config) return null
+
+  const message = config.dataset.transMessage || 'We use cookies to help improve our services.'
+  const acceptText = config.dataset.transAccept || 'Accept'
+  const declineText = config.dataset.transDecline || 'Decline'
+  const privacyText = config.dataset.transPrivacyLinkText || 'Privacy Policy'
+  const privacyUrl = config.dataset.privacyUrl || '/pocketcode/privacy-policy'
+
+  const banner = document.createElement('div')
+  banner.className = 'cookie-consent-banner'
+  banner.setAttribute('role', 'dialog')
+  banner.setAttribute('aria-label', 'Cookie consent')
+  banner.innerHTML = `
+    <div class="cookie-consent-content">
+      <p class="cookie-consent-message">
+        ${escapeHtml(message)}
+        <a href="${escapeAttr(privacyUrl)}" class="cookie-consent-link">${escapeHtml(privacyText)}</a>
+      </p>
+      <div class="cookie-consent-actions">
+        <button class="cookie-consent-btn cookie-consent-decline" type="button">${escapeHtml(declineText)}</button>
+        <button class="cookie-consent-btn cookie-consent-accept" type="button">${escapeHtml(acceptText)}</button>
+      </div>
+    </div>
+  `
+
+  banner.querySelector('.cookie-consent-accept').addEventListener('click', () => {
+    setCookie(COOKIE_NAME, 'accepted', getExpiry(COOKIE_EXPIRY_DAYS), '/')
+    hideBanner(banner)
+    initGTM()
+  })
+
+  banner.querySelector('.cookie-consent-decline').addEventListener('click', () => {
+    setCookie(COOKIE_NAME, 'declined', getExpiry(COOKIE_EXPIRY_DAYS), '/')
+    hideBanner(banner)
+  })
+
+  return banner
+}
+
+function showBanner() {
+  const existing = document.querySelector('.cookie-consent-banner')
+  if (existing) {
+    existing.classList.add('cookie-consent-visible')
+    return
+  }
+
+  const banner = createBanner()
+  if (!banner) return
+  document.body.appendChild(banner)
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      banner.classList.add('cookie-consent-visible')
+    })
+  })
+}
+
+function hideBanner(banner) {
+  banner.classList.remove('cookie-consent-visible')
+  banner.addEventListener('transitionend', () => banner.remove(), { once: true })
+}
+
+function escapeHtml(str) {
+  const div = document.createElement('div')
+  div.appendChild(document.createTextNode(str))
+  return div.innerHTML
+}
+
+function escapeAttr(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+export function initAnalyticsIfConsented() {
+  const status = getConsentStatus()
+  if (status === 'accepted') {
+    initGTM()
+  } else if (!status) {
+    showBanner()
+  }
+}
+
+export function showCookieSettings() {
+  setCookie(COOKIE_NAME, '', 'Thu, 01 Jan 1970 00:00:01 GMT', '/')
+  showBanner()
+}

--- a/assets/Layout/CookieConsent.js
+++ b/assets/Layout/CookieConsent.js
@@ -1,4 +1,5 @@
-import { getCookie, setCookie } from '../Security/CookieHelper'
+import { deleteCookie, getCookie, setCookie } from '../Security/CookieHelper'
+import { escapeAttr, escapeHtml } from '../Components/HtmlEscape'
 
 const COOKIE_NAME = 'cookie_consent'
 const COOKIE_EXPIRY_DAYS = 365
@@ -19,15 +20,15 @@ function initGTM() {
   const gtmContainerId = gtmEl.dataset.gtmContainerId
   if (!gtmContainerId) return
 
-  import('analytics').then(({ Analytics }) => {
-    import('@analytics/google-tag-manager').then(({ default: googleTagManager }) => {
+  Promise.all([import('analytics'), import('@analytics/google-tag-manager')]).then(
+    ([{ Analytics }, { default: googleTagManager }]) => {
       const analytics = Analytics({
         app: 'share.catrob.at',
         plugins: [googleTagManager({ containerId: gtmContainerId })],
       })
       analytics.page()
-    })
-  })
+    },
+  )
 }
 
 function createBanner() {
@@ -90,22 +91,9 @@ function showBanner() {
 
 function hideBanner(banner) {
   banner.classList.remove('cookie-consent-visible')
-  banner.addEventListener('transitionend', () => banner.remove(), { once: true })
-}
-
-function escapeHtml(str) {
-  const div = document.createElement('div')
-  div.appendChild(document.createTextNode(str))
-  return div.innerHTML
-}
-
-function escapeAttr(str) {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  const remove = () => banner.remove()
+  banner.addEventListener('transitionend', remove, { once: true })
+  setTimeout(remove, 400)
 }
 
 export function initAnalyticsIfConsented() {
@@ -118,6 +106,6 @@ export function initAnalyticsIfConsented() {
 }
 
 export function showCookieSettings() {
-  setCookie(COOKIE_NAME, '', 'Thu, 01 Jan 1970 00:00:01 GMT', '/')
+  deleteCookie(COOKIE_NAME, '/')
   showBanner()
 }

--- a/assets/Layout/CookieConsent.scss
+++ b/assets/Layout/CookieConsent.scss
@@ -70,15 +70,7 @@
     background-color 0.2s ease,
     border-color 0.2s ease;
 
-  &.cookie-consent-decline {
-    background-color: transparent;
-    color: light-dark(#555, #ccc);
-
-    &:hover {
-      background-color: light-dark(#e9ecef, #3a3a3a);
-    }
-  }
-
+  &.cookie-consent-decline,
   &.cookie-consent-accept {
     background-color: transparent;
     color: light-dark(#555, #ccc);

--- a/assets/Layout/CookieConsent.scss
+++ b/assets/Layout/CookieConsent.scss
@@ -1,0 +1,90 @@
+@import './Variables';
+
+.cookie-consent-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background-color: light-dark(#f8f9fa, #2d2d2d);
+  border-top: 1px solid light-dark(#dee2e6, #444);
+  padding: 1rem;
+  transform: translateY(100%);
+  opacity: 0;
+  transition:
+    transform 0.3s ease,
+    opacity 0.3s ease;
+
+  &.cookie-consent-visible {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.cookie-consent-content {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+
+  @media (width < 768px) {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
+.cookie-consent-message {
+  margin: 0;
+  font-size: 0.875rem;
+  color: light-dark(#333, #e0e0e0);
+  flex: 1;
+  line-height: 1.4;
+}
+
+.cookie-consent-link {
+  color: var(--primary);
+  text-decoration: underline;
+  margin-left: 0.25rem;
+
+  &:hover {
+    color: var(--primary);
+    opacity: 0.8;
+  }
+}
+
+.cookie-consent-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.cookie-consent-btn {
+  padding: 0.4rem 1.25rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid light-dark(#adb5bd, #666);
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+
+  &.cookie-consent-decline {
+    background-color: transparent;
+    color: light-dark(#555, #ccc);
+
+    &:hover {
+      background-color: light-dark(#e9ecef, #3a3a3a);
+    }
+  }
+
+  &.cookie-consent-accept {
+    background-color: transparent;
+    color: light-dark(#555, #ccc);
+
+    &:hover {
+      background-color: light-dark(#e9ecef, #3a3a3a);
+    }
+  }
+}

--- a/templates/Layout/Base.html.twig
+++ b/templates/Layout/Base.html.twig
@@ -6,13 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta charset="UTF-8">
 
-  {% if gtm_container_id %}
-    <!-- Google Tag Manager (noscript) -->
-    <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_container_id }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    </noscript>
-    <!-- End Google Tag Manager (noscript) -->
-  {% endif %}
+  {# GTM noscript fallback only loads if user has accepted cookies (checked client-side) #}
 
   <title>
     {% block title %}{{ 'title'|trans({}, 'catroweb') }}{% endblock %}
@@ -81,6 +75,13 @@
 <div id="app-language" data-app-language="{{ app.request.locale }}"></div>
 <div class="js-app-env" data-app-env="'{{ app_env }}"></div>
 <div class="js-user-state" data-is-user-logged-in="{% if app.user != null %}true{% else %}false{% endif %}"></div>
+<div id="cookie-consent-config" style="display: none;"
+     data-trans-message="{{ 'cookie-consent.message'|trans({}, 'catroweb')|escape('html_attr') }}"
+     data-trans-accept="{{ 'cookie-consent.accept'|trans({}, 'catroweb')|escape('html_attr') }}"
+     data-trans-decline="{{ 'cookie-consent.decline'|trans({}, 'catroweb')|escape('html_attr') }}"
+     data-trans-privacy-link-text="{{ 'cookie-consent.privacy-link'|trans({}, 'catroweb')|escape('html_attr') }}"
+     data-privacy-url="{{ url('privacypolicy') }}"
+></div>
 {% for snackbarMsg in app.flashes('snackbar') %}
   <div class="js-flash-snackbar" data-msg="{{ snackbarMsg }}"></div>
 {% endfor %}

--- a/templates/Layout/Base.html.twig
+++ b/templates/Layout/Base.html.twig
@@ -6,8 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta charset="UTF-8">
 
-  {# GTM noscript fallback only loads if user has accepted cookies (checked client-side) #}
-
   <title>
     {% block title %}{{ 'title'|trans({}, 'catroweb') }}{% endblock %}
   </title>

--- a/templates/Layout/Footer.html.twig
+++ b/templates/Layout/Footer.html.twig
@@ -25,7 +25,8 @@
           <a href="https://catrob.at/ShareAbout" target="_blank">{{ 'about'|trans({}, 'catroweb') }}</a> |
           <a href="{{ url('licenseToPlay') }}">{{ 'licenseToPlay.link'|trans({}, 'catroweb') }}</a> |
           <a href="{{ url('privacypolicy') }}">{{ 'privacy-policy.header'|trans({}, 'catroweb') }}</a> |
-          <a href="{{ url('termsOfUse') }}">{{ 'termsOfUse.title'|trans({}, 'catroweb') }}</a>
+          <a href="{{ url('termsOfUse') }}">{{ 'termsOfUse.title'|trans({}, 'catroweb') }}</a> |
+          <a href="#" class="js-cookie-settings">{{ 'cookie-consent.settings-link'|trans({}, 'catroweb') }}</a>
         </div>
 
         <div class="footer-copyright mt-2">

--- a/tests/BehatFeatures/web/general/cookie_consent.feature
+++ b/tests/BehatFeatures/web/general/cookie_consent.feature
@@ -1,0 +1,59 @@
+@web @cookie-consent
+Feature: Cookie consent banner for GDPR compliance
+
+  Background:
+    Given there are users:
+      | id | name     |
+      | 1  | Catrobat |
+    And there are projects:
+      | id | name    | owned by |
+      | 1  | Minions | Catrobat |
+
+  Scenario: Cookie consent banner is shown on first visit
+    Given I am on homepage
+    And I wait for the page to be loaded
+    Then I wait for the element ".cookie-consent-banner" to be visible
+    And the element ".cookie-consent-accept" should be visible
+    And the element ".cookie-consent-decline" should be visible
+
+  Scenario: Accepting cookies hides the banner and sets consent cookie
+    Given I am on homepage
+    And I wait for the page to be loaded
+    And I wait for the element ".cookie-consent-banner" to be visible
+    When I click ".cookie-consent-accept"
+    And I wait 500 milliseconds
+    Then the element ".cookie-consent-banner" should not be visible
+    And cookie "cookie_consent" with value "accepted" should exist"
+
+  Scenario: Declining cookies hides the banner and sets consent cookie
+    Given I am on homepage
+    And I wait for the page to be loaded
+    And I wait for the element ".cookie-consent-banner" to be visible
+    When I click ".cookie-consent-decline"
+    And I wait 500 milliseconds
+    Then the element ".cookie-consent-banner" should not be visible
+    And cookie "cookie_consent" with value "declined" should exist"
+
+  Scenario: Banner does not reappear after accepting cookies
+    Given I set the cookie "cookie_consent" to "accepted"
+    And I am on homepage
+    And I wait for the page to be loaded
+    And I wait 500 milliseconds
+    Then the element ".cookie-consent-banner" should not exist
+
+  Scenario: Banner does not reappear after declining cookies
+    Given I set the cookie "cookie_consent" to "declined"
+    And I am on homepage
+    And I wait for the page to be loaded
+    And I wait 500 milliseconds
+    Then the element ".cookie-consent-banner" should not exist
+
+  Scenario: Cookie settings link in footer resets consent and shows banner
+    Given I set the cookie "cookie_consent" to "accepted"
+    And I am on homepage
+    And I wait for the page to be loaded
+    And I wait 500 milliseconds
+    Then the element ".cookie-consent-banner" should not exist
+    When I click ".js-cookie-settings"
+    And I wait 500 milliseconds
+    Then I wait for the element ".cookie-consent-banner" to be visible

--- a/tests/BehatFeatures/web/general/cookie_consent.feature
+++ b/tests/BehatFeatures/web/general/cookie_consent.feature
@@ -22,7 +22,7 @@ Feature: Cookie consent banner for GDPR compliance
     And I wait for the element ".cookie-consent-banner" to be visible
     When I click ".cookie-consent-accept"
     And I wait 500 milliseconds
-    Then the element ".cookie-consent-banner" should not be visible
+    Then the element ".cookie-consent-banner" should not exist
     And cookie "cookie_consent" with value "accepted" should exist"
 
   Scenario: Declining cookies hides the banner and sets consent cookie
@@ -31,7 +31,7 @@ Feature: Cookie consent banner for GDPR compliance
     And I wait for the element ".cookie-consent-banner" to be visible
     When I click ".cookie-consent-decline"
     And I wait 500 milliseconds
-    Then the element ".cookie-consent-banner" should not be visible
+    Then the element ".cookie-consent-banner" should not exist
     And cookie "cookie_consent" with value "declined" should exist"
 
   Scenario: Banner does not reappear after accepting cookies

--- a/translations/catroweb.en.yaml
+++ b/translations/catroweb.en.yaml
@@ -852,6 +852,13 @@ flavor:
 
 copyright: 'Copyright &copy; %year% <a href="http://www.catrobat.org">Catrobat</a>. All rights reserved.'
 
+cookie-consent:
+  message: "We use cookies to help improve our services. No data is sold or shared."
+  accept: "Accept"
+  decline: "Decline"
+  privacy-link: "Privacy Policy"
+  settings-link: "Cookie Settings"
+
 agree: Agree
 disagree: Disagree
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -186,7 +186,7 @@ Encore
       ]),
       content: ['**/*.twig', '**/*.js'],
       safelist: {
-        standard: [/^swal2/, /^modal/, /^mdc/, /^data-bs-theme/],
+        standard: [/^swal2/, /^modal/, /^mdc/, /^data-bs-theme/, /^cookie-consent/],
       },
       defaultExtractor: (content) => {
         return content.match(/[\w-/:]+(?<!:)/g) || []


### PR DESCRIPTION
## Summary
- Adds a lightweight cookie consent banner that gates GTM/analytics behind user consent (fixes #6354)
- Non-intrusive bottom bar with equal-weight Accept/Decline buttons — no dark patterns
- Persists consent choice in a `cookie_consent` cookie (1 year expiry)
- "Cookie Settings" link in footer allows consent withdrawal at any time
- Supports light/dark mode, mobile responsive, smooth slide-up animation
- Removes unconditional GTM noscript fallback from `<head>`

## Changes
| File | What |
|------|------|
| `assets/Layout/CookieConsent.js` | New module: consent checking, banner creation, lazy GTM init |
| `assets/Layout/CookieConsent.scss` | Banner styles with light-dark mode support |
| `assets/Layout/Base.js` | Replace direct GTM init with consent-gated call |
| `assets/Layout/Base.scss` | Import CookieConsent styles |
| `templates/Layout/Base.html.twig` | Remove unconditional GTM noscript, add consent config data element |
| `templates/Layout/Footer.html.twig` | Add "Cookie Settings" link |
| `translations/catroweb.en.yaml` | Add cookie consent translation strings |
| `webpack.config.js` | Add `cookie-consent` to PurgeCSS safelist |
| `tests/BehatFeatures/web/general/cookie_consent.feature` | 6 Behat scenarios covering banner display, accept, decline, persistence, and withdrawal |

## Test plan
- [ ] Verify banner appears on first visit (no `cookie_consent` cookie)
- [ ] Click "Accept" — banner hides, cookie set to `accepted`, GTM loads
- [ ] Click "Decline" — banner hides, cookie set to `declined`, GTM does not load
- [ ] Revisit after accepting — no banner, GTM loads automatically
- [ ] Revisit after declining — no banner, GTM does not load
- [ ] Click "Cookie Settings" in footer — cookie cleared, banner reappears
- [ ] Verify dark mode styling
- [ ] Verify mobile responsive layout
- [ ] Run `web-general` Behat suite: `bin/behat -f pretty -s web-general tests/BehatFeatures/web/general/cookie_consent.feature`

🤖 Generated with [Claude Code](https://claude.com/claude-code)