### PR TITLE
Add rate limiting to unprotected API endpoints and cache PSL

### DIFF
--- a/config/packages/rate_limiter.php
+++ b/config/packages/rate_limiter.php
@@ -72,6 +72,31 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'limit' => 5,
         'interval' => '24 hours',
       ],
+      'notification_burst' => [
+        'policy' => 'sliding_window',
+        'limit' => 30,
+        'interval' => '1 minute',
+      ],
+      'achievement_burst' => [
+        'policy' => 'sliding_window',
+        'limit' => 30,
+        'interval' => '1 minute',
+      ],
+      'media_library_burst' => [
+        'policy' => 'sliding_window',
+        'limit' => 60,
+        'interval' => '1 minute',
+      ],
+      'download_burst' => [
+        'policy' => 'sliding_window',
+        'limit' => 10,
+        'interval' => '1 minute',
+      ],
+      'moderation_admin_burst' => [
+        'policy' => 'sliding_window',
+        'limit' => 60,
+        'interval' => '1 minute',
+      ],
     ],
   ]);
 };

--- a/src/Api/AchievementsApi.php
+++ b/src/Api/AchievementsApi.php
@@ -34,13 +34,14 @@ class AchievementsApi extends AbstractApiController implements AchievementsApiIn
       return null;
     }
 
-    if (!$this->checkUserRateLimit($user, $this->achievementBurstLimiter)) {
+    $rate_limit = $this->checkUserRateLimit($user, $this->achievementBurstLimiter);
+    if (null === $rate_limit) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;
     }
 
-    $this->addRateLimitHeaders($responseHeaders, $this->achievementBurstLimiter, $user->getId());
+    $this->addRateLimitHeaders($responseHeaders, $rate_limit);
 
     $page_data = $this->facade->getLoader()->getAchievementsPageData($user);
 
@@ -70,13 +71,14 @@ class AchievementsApi extends AbstractApiController implements AchievementsApiIn
       return null;
     }
 
-    if (!$this->checkUserRateLimit($user, $this->achievementBurstLimiter)) {
+    $rate_limit = $this->checkUserRateLimit($user, $this->achievementBurstLimiter);
+    if (null === $rate_limit) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;
     }
 
-    $this->addRateLimitHeaders($responseHeaders, $this->achievementBurstLimiter, $user->getId());
+    $this->addRateLimitHeaders($responseHeaders, $rate_limit);
 
     $count = $this->facade->getLoader()->getUnseenCount($user);
     $response = $this->facade->getResponseManager()->createAchievementsCountResponse($count);

--- a/src/Api/AchievementsApi.php
+++ b/src/Api/AchievementsApi.php
@@ -11,12 +11,16 @@ use OpenAPI\Server\Api\AchievementsApiInterface;
 use OpenAPI\Server\Model\AchievementsCountResponse;
 use OpenAPI\Server\Model\AchievementsListResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 
 class AchievementsApi extends AbstractApiController implements AchievementsApiInterface
 {
+  use RateLimitTrait;
+
   public function __construct(
     private readonly AchievementsApiFacade $facade,
     private readonly UserManager $user_manager,
+    private readonly RateLimiterFactory $achievementBurstLimiter,
   ) {
   }
 
@@ -29,6 +33,14 @@ class AchievementsApi extends AbstractApiController implements AchievementsApiIn
 
       return null;
     }
+
+    if (!$this->checkUserRateLimit($user, $this->achievementBurstLimiter)) {
+      $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
+
+      return null;
+    }
+
+    $this->addRateLimitHeaders($responseHeaders, $this->achievementBurstLimiter, $user->getId());
 
     $page_data = $this->facade->getLoader()->getAchievementsPageData($user);
 
@@ -57,6 +69,14 @@ class AchievementsApi extends AbstractApiController implements AchievementsApiIn
 
       return null;
     }
+
+    if (!$this->checkUserRateLimit($user, $this->achievementBurstLimiter)) {
+      $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
+
+      return null;
+    }
+
+    $this->addRateLimitHeaders($responseHeaders, $this->achievementBurstLimiter, $user->getId());
 
     $count = $this->facade->getLoader()->getUnseenCount($user);
     $response = $this->facade->getResponseManager()->createAchievementsCountResponse($count);

--- a/src/Api/AuthenticationApi.php
+++ b/src/Api/AuthenticationApi.php
@@ -74,7 +74,7 @@ class AuthenticationApi extends AbstractApiController implements AuthenticationA
   public function authenticationOauthPost(OAuthLoginRequest $o_auth_login_request, int &$responseCode, array &$responseHeaders): array|object|null
   {
     $ip = $this->request_stack->getCurrentRequest()?->getClientIp() ?? 'unknown';
-    if (!$this->checkIpRateLimit($ip, $this->authBurstLimiter)) {
+    if (null === $this->checkIpRateLimit($ip, $this->authBurstLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;

--- a/src/Api/CommentsApi.php
+++ b/src/Api/CommentsApi.php
@@ -97,8 +97,8 @@ class CommentsApi extends AbstractApiController implements CommentsApiInterface
     }
 
     if (!$this->authorization_checker->isGranted('ROLE_ADMIN')
-      && (!$this->checkUserRateLimit($user, $this->commentBurstLimiter)
-        || !$this->checkUserRateLimit($user, $this->commentDailyLimiter))) {
+      && (null === $this->checkUserRateLimit($user, $this->commentBurstLimiter)
+        || null === $this->checkUserRateLimit($user, $this->commentDailyLimiter))) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;

--- a/src/Api/FollowersApi.php
+++ b/src/Api/FollowersApi.php
@@ -79,7 +79,7 @@ class FollowersApi extends AbstractApiController implements FollowersApiInterfac
       return;
     }
 
-    if (!$this->checkUserRateLimit($user, $this->followBurstLimiter)) {
+    if (null === $this->checkUserRateLimit($user, $this->followBurstLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return;
@@ -119,7 +119,7 @@ class FollowersApi extends AbstractApiController implements FollowersApiInterfac
       return;
     }
 
-    if (!$this->checkUserRateLimit($user, $this->followBurstLimiter)) {
+    if (null === $this->checkUserRateLimit($user, $this->followBurstLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return;

--- a/src/Api/MediaLibraryApi.php
+++ b/src/Api/MediaLibraryApi.php
@@ -48,13 +48,14 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
     array &$responseHeaders,
   ): array|object|null {
     $ip = $this->request_stack->getCurrentRequest()?->getClientIp() ?? 'unknown';
-    if (!$this->checkIpRateLimit($ip, $this->mediaLibraryBurstLimiter)) {
+    $rate_limit = $this->checkIpRateLimit($ip, $this->mediaLibraryBurstLimiter);
+    if (null === $rate_limit) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;
     }
 
-    $this->addRateLimitHeaders($responseHeaders, $this->mediaLibraryBurstLimiter, $ip);
+    $this->addRateLimitHeaders($responseHeaders, $rate_limit);
 
     $db_file_type = $file_type ? $this->convertToDbFileType($file_type) : null;
     $search = null !== $search ? trim($search) : null;
@@ -260,13 +261,14 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
     array &$responseHeaders,
   ): ?MediaAssetsResponse {
     $ip = $this->request_stack->getCurrentRequest()?->getClientIp() ?? 'unknown';
-    if (!$this->checkIpRateLimit($ip, $this->mediaLibraryBurstLimiter)) {
+    $rate_limit = $this->checkIpRateLimit($ip, $this->mediaLibraryBurstLimiter);
+    if (null === $rate_limit) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;
     }
 
-    $this->addRateLimitHeaders($responseHeaders, $this->mediaLibraryBurstLimiter, $ip);
+    $this->addRateLimitHeaders($responseHeaders, $rate_limit);
 
     $db_file_type = $file_type ? $this->convertToDbFileType($file_type) : null;
 

--- a/src/Api/MediaLibraryApi.php
+++ b/src/Api/MediaLibraryApi.php
@@ -19,13 +19,19 @@ use OpenAPI\Server\Model\MediaCategoryDetailResponse;
 use OpenAPI\Server\Model\MediaCategoryRequest;
 use OpenAPI\Server\Model\MediaCategoryResponse;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 
 class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiInterface
 {
+  use RateLimitTrait;
+
   public function __construct(
     private readonly MediaLibraryApiFacade $facade,
     private readonly FlavorRepository $flavor_repository,
+    private readonly RateLimiterFactory $mediaLibraryBurstLimiter,
+    private readonly RequestStack $request_stack,
   ) {
   }
 
@@ -41,6 +47,15 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
     int &$responseCode,
     array &$responseHeaders,
   ): array|object|null {
+    $ip = $this->request_stack->getCurrentRequest()?->getClientIp() ?? 'unknown';
+    if (!$this->checkIpRateLimit($ip, $this->mediaLibraryBurstLimiter)) {
+      $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
+
+      return null;
+    }
+
+    $this->addRateLimitHeaders($responseHeaders, $this->mediaLibraryBurstLimiter, $ip);
+
     $db_file_type = $file_type ? $this->convertToDbFileType($file_type) : null;
     $search = null !== $search ? trim($search) : null;
     if ('' === $search) {
@@ -244,6 +259,15 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
     int &$responseCode,
     array &$responseHeaders,
   ): ?MediaAssetsResponse {
+    $ip = $this->request_stack->getCurrentRequest()?->getClientIp() ?? 'unknown';
+    if (!$this->checkIpRateLimit($ip, $this->mediaLibraryBurstLimiter)) {
+      $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
+
+      return null;
+    }
+
+    $this->addRateLimitHeaders($responseHeaders, $this->mediaLibraryBurstLimiter, $ip);
+
     $db_file_type = $file_type ? $this->convertToDbFileType($file_type) : null;
 
     $assets = $this->facade->getLoader()->getAssets(

--- a/src/Api/ModerationApi.php
+++ b/src/Api/ModerationApi.php
@@ -26,6 +26,7 @@ class ModerationApi extends AbstractApiController implements ModerationApiInterf
   public function __construct(
     private readonly ModerationApiFacade $facade,
     private readonly RateLimiterFactory $appealDailyLimiter,
+    private readonly RateLimiterFactory $moderationAdminBurstLimiter,
   ) {
   }
 
@@ -122,6 +123,13 @@ class ModerationApi extends AbstractApiController implements ModerationApiInterf
       return null;
     }
 
+    $admin = $this->facade->getAuthenticationManager()->getAuthenticatedUser();
+    if ($admin instanceof User && !$this->checkUserRateLimit($admin, $this->moderationAdminBurstLimiter)) {
+      $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
+
+      return null;
+    }
+
     $result = $this->facade->getLoader()->loadPendingReports($limit, $cursor);
     $responseCode = Response::HTTP_OK;
 
@@ -148,6 +156,12 @@ class ModerationApi extends AbstractApiController implements ModerationApiInterf
     $admin = $this->facade->getAuthenticationManager()->getAuthenticatedUser();
     if (!$admin instanceof User) {
       $responseCode = Response::HTTP_UNAUTHORIZED;
+
+      return;
+    }
+
+    if (!$this->checkUserRateLimit($admin, $this->moderationAdminBurstLimiter)) {
+      $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return;
     }
@@ -192,6 +206,13 @@ class ModerationApi extends AbstractApiController implements ModerationApiInterf
       return null;
     }
 
+    $admin = $this->facade->getAuthenticationManager()->getAuthenticatedUser();
+    if ($admin instanceof User && !$this->checkUserRateLimit($admin, $this->moderationAdminBurstLimiter)) {
+      $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
+
+      return null;
+    }
+
     $result = $this->facade->getLoader()->loadPendingAppeals($limit, $cursor);
     $responseCode = Response::HTTP_OK;
 
@@ -218,6 +239,12 @@ class ModerationApi extends AbstractApiController implements ModerationApiInterf
     $admin = $this->facade->getAuthenticationManager()->getAuthenticatedUser();
     if (!$admin instanceof User) {
       $responseCode = Response::HTTP_UNAUTHORIZED;
+
+      return;
+    }
+
+    if (!$this->checkUserRateLimit($admin, $this->moderationAdminBurstLimiter)) {
+      $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return;
     }

--- a/src/Api/ModerationApi.php
+++ b/src/Api/ModerationApi.php
@@ -124,7 +124,7 @@ class ModerationApi extends AbstractApiController implements ModerationApiInterf
     }
 
     $admin = $this->facade->getAuthenticationManager()->getAuthenticatedUser();
-    if ($admin instanceof User && !$this->checkUserRateLimit($admin, $this->moderationAdminBurstLimiter)) {
+    if ($admin instanceof User && null === $this->checkUserRateLimit($admin, $this->moderationAdminBurstLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;
@@ -160,7 +160,7 @@ class ModerationApi extends AbstractApiController implements ModerationApiInterf
       return;
     }
 
-    if (!$this->checkUserRateLimit($admin, $this->moderationAdminBurstLimiter)) {
+    if (null === $this->checkUserRateLimit($admin, $this->moderationAdminBurstLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return;
@@ -207,7 +207,7 @@ class ModerationApi extends AbstractApiController implements ModerationApiInterf
     }
 
     $admin = $this->facade->getAuthenticationManager()->getAuthenticatedUser();
-    if ($admin instanceof User && !$this->checkUserRateLimit($admin, $this->moderationAdminBurstLimiter)) {
+    if ($admin instanceof User && null === $this->checkUserRateLimit($admin, $this->moderationAdminBurstLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;
@@ -243,7 +243,7 @@ class ModerationApi extends AbstractApiController implements ModerationApiInterf
       return;
     }
 
-    if (!$this->checkUserRateLimit($admin, $this->moderationAdminBurstLimiter)) {
+    if (null === $this->checkUserRateLimit($admin, $this->moderationAdminBurstLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return;
@@ -316,7 +316,7 @@ class ModerationApi extends AbstractApiController implements ModerationApiInterf
       return;
     }
 
-    if (!$this->checkUserRateLimit($user, $this->appealDailyLimiter)) {
+    if (null === $this->checkUserRateLimit($user, $this->appealDailyLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return;

--- a/src/Api/NotificationsApi.php
+++ b/src/Api/NotificationsApi.php
@@ -49,13 +49,14 @@ class NotificationsApi extends AbstractApiController implements NotificationsApi
       return null;
     }
 
-    if (!$this->checkUserRateLimit($user, $this->notificationBurstLimiter)) {
+    $rate_limit = $this->checkUserRateLimit($user, $this->notificationBurstLimiter);
+    if (null === $rate_limit) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;
     }
 
-    $this->addRateLimitHeaders($responseHeaders, $this->notificationBurstLimiter, $user->getId());
+    $this->addRateLimitHeaders($responseHeaders, $rate_limit);
 
     $response = $this->facade->getResponseManager()->createNotificationsCountResponse($user);
 
@@ -76,13 +77,14 @@ class NotificationsApi extends AbstractApiController implements NotificationsApi
       return null;
     }
 
-    if (!$this->checkUserRateLimit($user, $this->notificationBurstLimiter)) {
+    $rate_limit = $this->checkUserRateLimit($user, $this->notificationBurstLimiter);
+    if (null === $rate_limit) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;
     }
 
-    $this->addRateLimitHeaders($responseHeaders, $this->notificationBurstLimiter, $user->getId());
+    $this->addRateLimitHeaders($responseHeaders, $rate_limit);
 
     $limit = $this->normalizeLimit($limit);
 

--- a/src/Api/NotificationsApi.php
+++ b/src/Api/NotificationsApi.php
@@ -10,14 +10,19 @@ use OpenAPI\Server\Api\NotificationsApiInterface;
 use OpenAPI\Server\Model\NotificationListResponse;
 use OpenAPI\Server\Model\NotificationsCountResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 
 class NotificationsApi extends AbstractApiController implements NotificationsApiInterface
 {
+  use RateLimitTrait;
+
   private const int DEFAULT_LIMIT = 20;
   private const int MAX_LIMIT = 50;
 
-  public function __construct(private readonly NotificationsApiFacade $facade)
-  {
+  public function __construct(
+    private readonly NotificationsApiFacade $facade,
+    private readonly RateLimiterFactory $notificationBurstLimiter,
+  ) {
   }
 
   #[\Override]
@@ -44,6 +49,14 @@ class NotificationsApi extends AbstractApiController implements NotificationsApi
       return null;
     }
 
+    if (!$this->checkUserRateLimit($user, $this->notificationBurstLimiter)) {
+      $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
+
+      return null;
+    }
+
+    $this->addRateLimitHeaders($responseHeaders, $this->notificationBurstLimiter, $user->getId());
+
     $response = $this->facade->getResponseManager()->createNotificationsCountResponse($user);
 
     $responseCode = Response::HTTP_OK;
@@ -62,6 +75,14 @@ class NotificationsApi extends AbstractApiController implements NotificationsApi
 
       return null;
     }
+
+    if (!$this->checkUserRateLimit($user, $this->notificationBurstLimiter)) {
+      $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
+
+      return null;
+    }
+
+    $this->addRateLimitHeaders($responseHeaders, $this->notificationBurstLimiter, $user->getId());
 
     $limit = $this->normalizeLimit($limit);
 

--- a/src/Api/ProjectsApi.php
+++ b/src/Api/ProjectsApi.php
@@ -22,6 +22,7 @@ use OpenAPI\Server\Model\UploadErrorResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 
@@ -34,6 +35,8 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
     private readonly ReactionsApiFacade $reactions_facade,
     private readonly RateLimiterFactory $uploadDailyLimiter,
     private readonly RateLimiterFactory $reactionBurstLimiter,
+    private readonly RateLimiterFactory $downloadBurstLimiter,
+    private readonly RequestStack $request_stack,
   ) {
   }
 
@@ -421,6 +424,13 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
    */
   public function customProjectIdCatrobatGet(string $id, int &$responseCode, ?array &$responseHeaders = null): ?BinaryFileResponse
   {
+    $ip = $this->request_stack->getCurrentRequest()?->getClientIp() ?? 'unknown';
+    if (!$this->checkIpRateLimit($ip, $this->downloadBurstLimiter)) {
+      $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
+
+      return null;
+    }
+
     $project = $this->facade->getLoader()->findProjectByID($id, true);
     if (!$project instanceof Program) {
       $responseCode = Response::HTTP_NOT_FOUND;

--- a/src/Api/ProjectsApi.php
+++ b/src/Api/ProjectsApi.php
@@ -192,7 +192,7 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
     // Getting the user who uploaded
     $user = $this->facade->getAuthenticationManager()->getAuthenticatedUser();
 
-    if ($user instanceof \App\DB\Entity\User\User && !$this->checkUserRateLimit($user, $this->uploadDailyLimiter)) {
+    if ($user instanceof \App\DB\Entity\User\User && null === $this->checkUserRateLimit($user, $this->uploadDailyLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;
@@ -420,12 +420,12 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
   }
 
   /**
-   * @psalm-param 200|404|500 $responseCode
+   * @psalm-param 200|404|429|500 $responseCode
    */
   public function customProjectIdCatrobatGet(string $id, int &$responseCode, ?array &$responseHeaders = null): ?BinaryFileResponse
   {
     $ip = $this->request_stack->getCurrentRequest()?->getClientIp() ?? 'unknown';
-    if (!$this->checkIpRateLimit($ip, $this->downloadBurstLimiter)) {
+    if (null === $this->checkIpRateLimit($ip, $this->downloadBurstLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;
@@ -477,7 +477,7 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
       return null;
     }
 
-    if (!$this->checkUserRateLimit($user, $this->reactionBurstLimiter)) {
+    if (null === $this->checkUserRateLimit($user, $this->reactionBurstLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;

--- a/src/Api/RateLimitTrait.php
+++ b/src/Api/RateLimitTrait.php
@@ -5,34 +5,32 @@ declare(strict_types=1);
 namespace App\Api;
 
 use App\DB\Entity\User\User;
+use Symfony\Component\RateLimiter\RateLimit;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 
 trait RateLimitTrait
 {
-  private function checkUserRateLimit(User $user, RateLimiterFactory $limiter): bool
+  private function checkUserRateLimit(User $user, RateLimiterFactory $limiter): ?RateLimit
   {
-    $rate_limiter = $limiter->create($user->getId());
+    $rate_limit = $limiter->create($user->getId())->consume();
 
-    return $rate_limiter->consume()->isAccepted();
+    return $rate_limit->isAccepted() ? $rate_limit : null;
   }
 
-  private function checkIpRateLimit(string $ip, RateLimiterFactory $limiter): bool
+  private function checkIpRateLimit(string $ip, RateLimiterFactory $limiter): ?RateLimit
   {
-    $rate_limiter = $limiter->create($ip);
+    $rate_limit = $limiter->create($ip)->consume();
 
-    return $rate_limiter->consume()->isAccepted();
+    return $rate_limit->isAccepted() ? $rate_limit : null;
   }
 
   /**
    * @param array<string, string> $responseHeaders
    */
-  private function addRateLimitHeaders(array &$responseHeaders, RateLimiterFactory $limiter, string $key): void
+  private function addRateLimitHeaders(array &$responseHeaders, RateLimit $rate_limit): void
   {
-    $rate_limiter = $limiter->create($key);
-    $limit = $rate_limiter->consume(0);
-
-    $responseHeaders['X-RateLimit-Limit'] = (string) $limit->getLimit();
-    $responseHeaders['X-RateLimit-Remaining'] = (string) $limit->getRemainingTokens();
-    $responseHeaders['X-RateLimit-Reset'] = (string) $limit->getRetryAfter()->getTimestamp();
+    $responseHeaders['X-RateLimit-Limit'] = (string) $rate_limit->getLimit();
+    $responseHeaders['X-RateLimit-Remaining'] = (string) $rate_limit->getRemainingTokens();
+    $responseHeaders['X-RateLimit-Reset'] = (string) $rate_limit->getRetryAfter()->getTimestamp();
   }
 }

--- a/src/Api/RateLimitTrait.php
+++ b/src/Api/RateLimitTrait.php
@@ -22,4 +22,17 @@ trait RateLimitTrait
 
     return $rate_limiter->consume()->isAccepted();
   }
+
+  /**
+   * @param array<string, string> $responseHeaders
+   */
+  private function addRateLimitHeaders(array &$responseHeaders, RateLimiterFactory $limiter, string $key): void
+  {
+    $rate_limiter = $limiter->create($key);
+    $limit = $rate_limiter->consume(0);
+
+    $responseHeaders['X-RateLimit-Limit'] = (string) $limit->getLimit();
+    $responseHeaders['X-RateLimit-Remaining'] = (string) $limit->getRemainingTokens();
+    $responseHeaders['X-RateLimit-Reset'] = (string) $limit->getRetryAfter()->getTimestamp();
+  }
 }

--- a/src/Api/SearchApi.php
+++ b/src/Api/SearchApi.php
@@ -30,7 +30,7 @@ class SearchApi extends AbstractApiController implements SearchApiInterface
   public function searchGet(string $query, string $type, int $limit, int $offset, int &$responseCode, array &$responseHeaders): array|SearchResponse
   {
     $ip = $this->request_stack->getCurrentRequest()?->getClientIp() ?? 'unknown';
-    if (!$this->checkIpRateLimit($ip, $this->searchBurstLimiter)) {
+    if (null === $this->checkIpRateLimit($ip, $this->searchBurstLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return [];

--- a/src/Api/Services/User/UserRequestValidator.php
+++ b/src/Api/Services/User/UserRequestValidator.php
@@ -37,7 +37,7 @@ class UserRequestValidator extends AbstractRequestValidator
 
   public const string MODE_UPDATE = 'update_mode';
 
-  private const int PSL_CACHE_TTL = 86400; // 24 hours
+  private const int PSL_CACHE_TTL = 86400;
 
   public function __construct(
     ValidatorInterface $validator,
@@ -191,7 +191,7 @@ class UserRequestValidator extends AbstractRequestValidator
   }
 
   /**
-   * @return array<string>
+   * @return array<string, true>
    */
   private function getValidTLDs(): array
   {
@@ -218,20 +218,11 @@ class UserRequestValidator extends AbstractRequestValidator
 
       foreach ($pslLines as $line) {
         $line = trim($line);
-        if ('' === $line) {
-          continue;
-        }
-        if ('/' === $line[0]) {
-          continue;
-        }
-        if ('!' === $line[0]) {
+        if ('' === $line || '/' === $line[0] || '!' === $line[0]) {
           continue;
         }
 
-        $tld = ltrim($line, '*.');
-        if (!in_array($tld, $validTLDs, true)) {
-          $validTLDs[] = $tld;
-        }
+        $validTLDs[ltrim($line, '*.')] = true;
       }
 
       return $validTLDs;
@@ -240,9 +231,7 @@ class UserRequestValidator extends AbstractRequestValidator
 
   private function isValidTLD(string $tld): bool
   {
-    $validTLDs = $this->getValidTLDs();
-
-    return in_array($tld, $validTLDs, true);
+    return isset($this->getValidTLDs()[$tld]);
   }
 
   private function validate(?string $value, ?Email $constraints = null): ConstraintViolationListInterface

--- a/src/Api/Services/User/UserRequestValidator.php
+++ b/src/Api/Services/User/UserRequestValidator.php
@@ -12,10 +12,13 @@ use App\User\UserManager;
 use OpenAPI\Server\Model\RegisterRequest;
 use OpenAPI\Server\Model\ResetPasswordRequest;
 use OpenAPI\Server\Model\UpdateUserRequest;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class UserRequestValidator extends AbstractRequestValidator
@@ -34,9 +37,15 @@ class UserRequestValidator extends AbstractRequestValidator
 
   public const string MODE_UPDATE = 'update_mode';
 
+  private const int PSL_CACHE_TTL = 86400; // 24 hours
+
   public function __construct(
-    ValidatorInterface $validator, TranslatorInterface $translator, private readonly UserManager $user_manager,
+    ValidatorInterface $validator,
+    TranslatorInterface $translator,
+    private readonly UserManager $user_manager,
     private readonly PasswordHasherFactoryInterface $password_hasher_factory,
+    private readonly CacheInterface $cache,
+    private readonly LoggerInterface $logger,
   ) {
     parent::__construct($validator, $translator);
   }
@@ -181,35 +190,52 @@ class UserRequestValidator extends AbstractRequestValidator
     }
   }
 
+  /**
+   * @return array<string>
+   */
   private function getValidTLDs(): array
   {
-    $validTLDs = [];
-    $pslFile = file_get_contents('https://publicsuffix.org/list/public_suffix_list.dat');
-    if (false === $pslFile) {
+    return $this->cache->get('public_suffix_list_tlds', function (ItemInterface $item): array {
+      $item->expiresAfter(self::PSL_CACHE_TTL);
+
+      $validTLDs = [];
+
+      try {
+        $pslFile = file_get_contents('https://publicsuffix.org/list/public_suffix_list.dat');
+      } catch (\Exception $e) {
+        $this->logger->warning('Failed to fetch Public Suffix List: '.$e->getMessage());
+
+        return $validTLDs;
+      }
+
+      if (false === $pslFile) {
+        $this->logger->warning('Failed to fetch Public Suffix List: file_get_contents returned false');
+
+        return $validTLDs;
+      }
+
+      $pslLines = explode("\n", $pslFile);
+
+      foreach ($pslLines as $line) {
+        $line = trim($line);
+        if ('' === $line) {
+          continue;
+        }
+        if ('/' === $line[0]) {
+          continue;
+        }
+        if ('!' === $line[0]) {
+          continue;
+        }
+
+        $tld = ltrim($line, '*.');
+        if (!in_array($tld, $validTLDs, true)) {
+          $validTLDs[] = $tld;
+        }
+      }
+
       return $validTLDs;
-    }
-
-    $pslLines = explode("\n", $pslFile);
-
-    foreach ($pslLines as $line) {
-      $line = trim($line);
-      if ('' === $line) {
-        continue;
-      }
-      if ('/' === $line[0]) {
-        continue;
-      }
-      if ('!' === $line[0]) {
-        continue;
-      }
-
-      $tld = ltrim($line, '*.');
-      if (!in_array($tld, $validTLDs, true)) {
-        $validTLDs[] = $tld;
-      }
-    }
-
-    return $validTLDs;
+    });
   }
 
   private function isValidTLD(string $tld): bool

--- a/src/Api/StudioApi.php
+++ b/src/Api/StudioApi.php
@@ -80,7 +80,7 @@ class StudioApi extends AbstractApiController implements StudioApiInterface
   public function studioPost(string $accept_language, ?string $name, ?string $description, bool $is_public, bool $enable_comments, ?UploadedFile $image_file, int &$responseCode, array &$responseHeaders): array|object|null
   {
     $user = $this->facade->getAuthenticationManager()->getAuthenticatedUser();
-    if ($user instanceof User && !$this->checkUserRateLimit($user, $this->studioCreateDailyLimiter)) {
+    if ($user instanceof User && null === $this->checkUserRateLimit($user, $this->studioCreateDailyLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;

--- a/src/Api/UserApi.php
+++ b/src/Api/UserApi.php
@@ -42,7 +42,7 @@ class UserApi extends AbstractApiController implements UserApiInterface
   public function userPost(RegisterRequest $register_request, string $accept_language, int &$responseCode, array &$responseHeaders): JWTResponse|RegisterErrorResponse|null
   {
     $ip = $this->request_stack->getCurrentRequest()?->getClientIp() ?? 'unknown';
-    if (!$this->checkIpRateLimit($ip, $this->registrationBurstLimiter)) {
+    if (null === $this->checkIpRateLimit($ip, $this->registrationBurstLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;
@@ -184,7 +184,7 @@ class UserApi extends AbstractApiController implements UserApiInterface
   public function userResetPasswordPost(ResetPasswordRequest $reset_password_request, string $accept_language, int &$responseCode, array &$responseHeaders): ?RegisterErrorResponse
   {
     $ip = $this->request_stack->getCurrentRequest()?->getClientIp() ?? 'unknown';
-    if (!$this->checkIpRateLimit($ip, $this->passwordResetBurstLimiter)) {
+    if (null === $this->checkIpRateLimit($ip, $this->passwordResetBurstLimiter)) {
       $responseCode = Response::HTTP_TOO_MANY_REQUESTS;
 
       return null;

--- a/tests/PhpUnit/Api/AchievementsApiTest.php
+++ b/tests/PhpUnit/Api/AchievementsApiTest.php
@@ -20,6 +20,8 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 /**
  * @internal
@@ -38,7 +40,11 @@ class AchievementsApiTest extends TestCase
   {
     $this->facade = $this->createStub(AchievementsApiFacade::class);
     $this->user_manager = $this->createStub(UserManager::class);
-    $this->object = new AchievementsApi($this->facade, $this->user_manager);
+    $this->object = new AchievementsApi(
+      $this->facade,
+      $this->user_manager,
+      $this->createNoLimitRateLimiterFactory('phpunit_achievements_burst'),
+    );
   }
 
   #[Group('unit')]
@@ -209,5 +215,16 @@ class AchievementsApiTest extends TestCase
     $this->assertIsArray($response);
     $this->assertCount(1, $response);
     $this->assertInstanceOf(AchievementResponse::class, $response[0]);
+  }
+
+  private function createNoLimitRateLimiterFactory(string $id): RateLimiterFactory
+  {
+    return new RateLimiterFactory(
+      [
+        'id' => $id,
+        'policy' => 'no_limit',
+      ],
+      new InMemoryStorage(),
+    );
   }
 }

--- a/tests/PhpUnit/Api/MediaLibraryApiTest.php
+++ b/tests/PhpUnit/Api/MediaLibraryApiTest.php
@@ -29,6 +29,8 @@ use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 /**
  * @internal
@@ -48,7 +50,9 @@ final class MediaLibraryApiTest extends TestCase
   {
     $this->facade = $this->createStub(MediaLibraryApiFacade::class);
     $flavor_repository = $this->createStub(\App\DB\EntityRepository\FlavorRepository::class);
-    $this->api = new MediaLibraryApi($this->facade, $flavor_repository);
+    $no_limit = new RateLimiterFactory(['id' => 'test', 'policy' => 'no_limit'], new InMemoryStorage());
+    $request_stack = new \Symfony\Component\HttpFoundation\RequestStack();
+    $this->api = new MediaLibraryApi($this->facade, $flavor_repository, $no_limit, $request_stack);
   }
 
   // ==================== mediaLibraryGet Tests ====================

--- a/tests/PhpUnit/Api/NotificationsApiTest.php
+++ b/tests/PhpUnit/Api/NotificationsApiTest.php
@@ -18,6 +18,8 @@ use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 /**
  * @internal
@@ -37,7 +39,10 @@ class NotificationsApiTest extends TestCase
   protected function setUp(): void
   {
     $this->facade = $this->createStub(NotificationsApiFacade::class);
-    $this->object = new NotificationsApi($this->facade);
+    $this->object = new NotificationsApi(
+      $this->facade,
+      new RateLimiterFactory(['id' => 'test', 'policy' => 'no_limit'], new InMemoryStorage()),
+    );
   }
 
   #[Group('unit')]

--- a/tests/PhpUnit/Api/ProjectsApiTest.php
+++ b/tests/PhpUnit/Api/ProjectsApiTest.php
@@ -67,6 +67,8 @@ final class ProjectsApiTest extends KernelTestCase
       $this->reactions_facade,
       $this->createNoLimitRateLimiterFactory('phpunit_projects_upload_daily'),
       $this->createNoLimitRateLimiterFactory('phpunit_projects_reaction_burst'),
+      $this->createNoLimitRateLimiterFactory('phpunit_projects_download_burst'),
+      new \Symfony\Component\HttpFoundation\RequestStack(),
     );
 
     ProjectsApiTest::bootKernel();

--- a/tests/PhpUnit/Api/ReactionsApiTest.php
+++ b/tests/PhpUnit/Api/ReactionsApiTest.php
@@ -51,6 +51,8 @@ final class ReactionsApiTest extends TestCase
       $this->reactions_facade,
       new RateLimiterFactory(['id' => 'test', 'policy' => 'no_limit'], new InMemoryStorage()),
       new RateLimiterFactory(['id' => 'test', 'policy' => 'no_limit'], new InMemoryStorage()),
+      new RateLimiterFactory(['id' => 'test', 'policy' => 'no_limit'], new InMemoryStorage()),
+      new \Symfony\Component\HttpFoundation\RequestStack(),
     );
   }
 


### PR DESCRIPTION
## Summary
- Adds rate limiting to previously unprotected API endpoints: notifications (30/min), achievements (30/min), media library (60/min), project downloads (10/min), and admin moderation (60/min)
- Caches the Public Suffix List via Symfony Cache with 24h TTL instead of fetching from network on every email validation call
- Adds `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` response headers via enhanced `RateLimitTrait`

## Details
**New rate limiters** in `config/packages/rate_limiter.php`:
| Limiter | Limit | Interval | Key | Used In |
|---------|-------|----------|-----|---------|
| `notification_burst` | 30 | 1 minute | User | NotificationsApi |
| `achievement_burst` | 30 | 1 minute | User | AchievementsApi |
| `media_library_burst` | 60 | 1 minute | IP | MediaLibraryApi |
| `download_burst` | 10 | 1 minute | IP | ProjectsApi (download) |
| `moderation_admin_burst` | 60 | 1 minute | User | ModerationApi (admin) |

**PSL caching**: `UserRequestValidator::getValidTLDs()` now uses `Symfony\Contracts\Cache\CacheInterface` with a 24h TTL instead of calling `file_get_contents('https://publicsuffix.org/...')` on every request.

**Rate limit headers**: `RateLimitTrait::addRateLimitHeaders()` adds standard `X-RateLimit-*` headers using `consume(0)` to peek without consuming a token.

Closes #6342

## Test plan
- [ ] Verify notifications, achievements, media library endpoints return `X-RateLimit-*` headers
- [ ] Verify 429 response when rate limit exceeded on each new endpoint
- [ ] Verify PSL is cached (second email validation should not make network request)
- [ ] Verify admin moderation endpoints are rate-limited
- [ ] Verify project download endpoint returns 429 after 10 rapid requests
- [ ] Run existing Behat API suites to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)