### PR TITLE
Deprecate offset pagination, add cursor parameter to all list endpoints

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -95,6 +95,7 @@ use Sonata\AdminBundle\Security\Acl\Permission\AdminPermissionMap;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\Dotenv\Command\DotenvDumpCommand;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {

--- a/src/Api/MediaLibraryApi.php
+++ b/src/Api/MediaLibraryApi.php
@@ -40,6 +40,7 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
     string $accept_language,
     int $limit,
     int $offset,
+    ?string $cursor,
     ?string $file_type,
     ?string $flavor,
     ?string $search,
@@ -93,6 +94,7 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
     string $accept_language,
     int $limit,
     int $offset,
+    ?string $cursor,
     int &$responseCode,
     array &$responseHeaders,
   ): ?MediaCategoriesResponse {
@@ -157,6 +159,7 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
     string $accept_language,
     int $limit,
     int $offset,
+    ?string $cursor,
     int &$responseCode,
     array &$responseHeaders,
   ): ?MediaCategoryDetailResponse {
@@ -251,6 +254,7 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
     string $accept_language,
     int $limit,
     int $offset,
+    ?string $cursor,
     ?string $category_id,
     ?string $file_type,
     ?string $flavor,

--- a/src/Api/OpenAPI/Server/Api/MediaLibraryApiInterface.php
+++ b/src/Api/OpenAPI/Server/Api/MediaLibraryApiInterface.php
@@ -59,7 +59,8 @@ interface MediaLibraryApiInterface
    *
    * @param string      $accept_language (optional, default to 'en')
    * @param int         $limit           (optional, default to 20)
-   * @param int         $offset          (optional, default to 0)
+   * @param int         $offset          Deprecated: Use cursor-based pagination instead. How many objects should be skipped. (optional, default to 0) (deprecated)
+   * @param string|null $cursor          Cursor for pagination (opaque string from the previous response) (optional)
    * @param string|null $category_id     Filter by category UUID (optional)
    * @param string|null $file_type       (optional)
    * @param string|null $flavor          Filter by flavor name (optional)
@@ -73,6 +74,7 @@ interface MediaLibraryApiInterface
     string $accept_language,
     int $limit,
     int $offset,
+    ?string $cursor,
     ?string $category_id,
     ?string $file_type,
     ?string $flavor,
@@ -168,16 +170,18 @@ interface MediaLibraryApiInterface
    *
    * Get all media library categories
    *
-   * @param string $accept_language (optional, default to 'en')
-   * @param int    $limit           (optional, default to 20)
-   * @param int    $offset          (optional, default to 0)
-   * @param int    &$responseCode   The HTTP Response Code
-   * @param array  $responseHeaders Additional HTTP headers to return with the response ()
+   * @param string      $accept_language (optional, default to 'en')
+   * @param int         $limit           (optional, default to 20)
+   * @param int         $offset          Deprecated: Use cursor-based pagination instead. How many objects should be skipped. (optional, default to 0) (deprecated)
+   * @param string|null $cursor          Cursor for pagination (opaque string from the previous response) (optional)
+   * @param int         &$responseCode   The HTTP Response Code
+   * @param array       $responseHeaders Additional HTTP headers to return with the response ()
    */
   public function mediaCategoriesGet(
     string $accept_language,
     int $limit,
     int $offset,
+    ?string $cursor,
     int &$responseCode,
     array &$responseHeaders,
   ): array|object|null;
@@ -204,18 +208,20 @@ interface MediaLibraryApiInterface
    *
    * Get a specific media category with its assets
    *
-   * @param string $id              Category UUID (required)
-   * @param string $accept_language (optional, default to 'en')
-   * @param int    $limit           (optional, default to 20)
-   * @param int    $offset          (optional, default to 0)
-   * @param int    &$responseCode   The HTTP Response Code
-   * @param array  $responseHeaders Additional HTTP headers to return with the response ()
+   * @param string      $id              Category UUID (required)
+   * @param string      $accept_language (optional, default to 'en')
+   * @param int         $limit           (optional, default to 20)
+   * @param int         $offset          Deprecated: Use cursor-based pagination instead. How many objects should be skipped. (optional, default to 0) (deprecated)
+   * @param string|null $cursor          Cursor for pagination (opaque string from the previous response) (optional)
+   * @param int         &$responseCode   The HTTP Response Code
+   * @param array       $responseHeaders Additional HTTP headers to return with the response ()
    */
   public function mediaCategoriesIdGet(
     string $id,
     string $accept_language,
     int $limit,
     int $offset,
+    ?string $cursor,
     int &$responseCode,
     array &$responseHeaders,
   ): array|object|null;
@@ -263,7 +269,8 @@ interface MediaLibraryApiInterface
    *
    * @param string      $accept_language     (optional, default to 'en')
    * @param int         $limit               (optional, default to 20)
-   * @param int         $offset              (optional, default to 0)
+   * @param int         $offset              Deprecated: Use cursor-based pagination instead. How many objects should be skipped. (optional, default to 0) (deprecated)
+   * @param string|null $cursor              Cursor for pagination (opaque string from the previous response) (optional)
    * @param string|null $file_type           Filter categories and assets by file type (optional)
    * @param string|null $flavor              Filter assets by flavor name (optional)
    * @param string|null $search              Search query for assets and categories (optional)
@@ -275,6 +282,7 @@ interface MediaLibraryApiInterface
     string $accept_language,
     int $limit,
     int $offset,
+    ?string $cursor,
     ?string $file_type,
     ?string $flavor,
     ?string $search,

--- a/src/Api/OpenAPI/Server/Api/ProjectsApiInterface.php
+++ b/src/Api/OpenAPI/Server/Api/ProjectsApiInterface.php
@@ -199,16 +199,17 @@ interface ProjectsApiInterface
    *
    * Get recommended projects related to the specific project
    *
-   * @param string $id              (required)
-   * @param string $category        * &#x60;similar&#x60; - Get similar projects to the specific project  * &#x60;also_downloaded&#x60; - Get projects that users who downloaded the specific project also downloaded  * &#x60;more_from_user&#x60; - Get more projects from the owner of the specific project (required)
-   * @param string $accept_language (optional, default to 'en')
-   * @param string $max_version     Only shows project with a smaller version number than max version.  &#x60;Warning!&#x60; Current implementation is kinda broken. To ensure correct results use the following format &#39;[0-9].[0-9]{3}&#39; (optional, default to '')
-   * @param int    $limit           (optional, default to 20)
-   * @param int    $offset          (optional, default to 0)
-   * @param string $attributes      (optional, default to '')
-   * @param string $flavor          (optional, default to '')
-   * @param int    &$responseCode   The HTTP Response Code
-   * @param array  $responseHeaders Additional HTTP headers to return with the response ()
+   * @param string      $id              (required)
+   * @param string      $category        * &#x60;similar&#x60; - Get similar projects to the specific project  * &#x60;also_downloaded&#x60; - Get projects that users who downloaded the specific project also downloaded  * &#x60;more_from_user&#x60; - Get more projects from the owner of the specific project (required)
+   * @param string      $accept_language (optional, default to 'en')
+   * @param string      $max_version     Only shows project with a smaller version number than max version.  &#x60;Warning!&#x60; Current implementation is kinda broken. To ensure correct results use the following format &#39;[0-9].[0-9]{3}&#39; (optional, default to '')
+   * @param int         $limit           (optional, default to 20)
+   * @param int         $offset          Deprecated: Use cursor-based pagination instead. How many objects should be skipped. (optional, default to 0) (deprecated)
+   * @param string|null $cursor          Cursor for pagination (opaque string from the previous response) (optional)
+   * @param string      $attributes      (optional, default to '')
+   * @param string      $flavor          (optional, default to '')
+   * @param int         &$responseCode   The HTTP Response Code
+   * @param array       $responseHeaders Additional HTTP headers to return with the response ()
    */
   public function projectIdRecommendationsGet(
     string $id,
@@ -217,6 +218,7 @@ interface ProjectsApiInterface
     string $max_version,
     int $limit,
     int $offset,
+    ?string $cursor,
     string $attributes,
     string $flavor,
     int &$responseCode,
@@ -262,20 +264,22 @@ interface ProjectsApiInterface
    *
    * Get the currently featured projects
    *
-   * @param string $platform        Indication for which platform the response should be optimized (ios, android) (optional, default to '')
-   * @param string $max_version     Only shows project with a smaller version number than max version.  &#x60;Warning!&#x60; Current implementation is kinda broken. To ensure correct results use the following format &#39;[0-9].[0-9]{3}&#39; (optional, default to '')
-   * @param int    $limit           (optional, default to 20)
-   * @param int    $offset          (optional, default to 0)
-   * @param string $attributes      (optional, default to '')
-   * @param string $flavor          (optional, default to '')
-   * @param int    &$responseCode   The HTTP Response Code
-   * @param array  $responseHeaders Additional HTTP headers to return with the response ()
+   * @param string      $platform        Indication for which platform the response should be optimized (ios, android) (optional, default to '')
+   * @param string      $max_version     Only shows project with a smaller version number than max version.  &#x60;Warning!&#x60; Current implementation is kinda broken. To ensure correct results use the following format &#39;[0-9].[0-9]{3}&#39; (optional, default to '')
+   * @param int         $limit           (optional, default to 20)
+   * @param int         $offset          Deprecated: Use cursor-based pagination instead. How many objects should be skipped. (optional, default to 0) (deprecated)
+   * @param string|null $cursor          Cursor for pagination (opaque string from the previous response) (optional)
+   * @param string      $attributes      (optional, default to '')
+   * @param string      $flavor          (optional, default to '')
+   * @param int         &$responseCode   The HTTP Response Code
+   * @param array       $responseHeaders Additional HTTP headers to return with the response ()
    */
   public function projectsFeaturedGet(
     string $platform,
     string $max_version,
     int $limit,
     int $offset,
+    ?string $cursor,
     string $attributes,
     string $flavor,
     int &$responseCode,
@@ -287,15 +291,16 @@ interface ProjectsApiInterface
    *
    * Get projects
    *
-   * @param string $category        (required)
-   * @param string $accept_language (optional, default to 'en')
-   * @param string $max_version     Only shows project with a smaller version number than max version.  &#x60;Warning!&#x60; Current implementation is kinda broken. To ensure correct results use the following format &#39;[0-9].[0-9]{3}&#39; (optional, default to '')
-   * @param int    $limit           (optional, default to 20)
-   * @param int    $offset          (optional, default to 0)
-   * @param string $attributes      (optional, default to '')
-   * @param string $flavor          (optional, default to '')
-   * @param int    &$responseCode   The HTTP Response Code
-   * @param array  $responseHeaders Additional HTTP headers to return with the response ()
+   * @param string      $category        (required)
+   * @param string      $accept_language (optional, default to 'en')
+   * @param string      $max_version     Only shows project with a smaller version number than max version.  &#x60;Warning!&#x60; Current implementation is kinda broken. To ensure correct results use the following format &#39;[0-9].[0-9]{3}&#39; (optional, default to '')
+   * @param int         $limit           (optional, default to 20)
+   * @param int         $offset          Deprecated: Use cursor-based pagination instead. How many objects should be skipped. (optional, default to 0) (deprecated)
+   * @param string|null $cursor          Cursor for pagination (opaque string from the previous response) (optional)
+   * @param string      $attributes      (optional, default to '')
+   * @param string      $flavor          (optional, default to '')
+   * @param int         &$responseCode   The HTTP Response Code
+   * @param array       $responseHeaders Additional HTTP headers to return with the response ()
    */
   public function projectsGet(
     string $category,
@@ -303,6 +308,7 @@ interface ProjectsApiInterface
     string $max_version,
     int $limit,
     int $offset,
+    ?string $cursor,
     string $attributes,
     string $flavor,
     int &$responseCode,
@@ -337,20 +343,22 @@ interface ProjectsApiInterface
    *
    * Search for projects associated with a keywords
    *
-   * @param string $query           (required)
-   * @param string $max_version     Only shows project with a smaller version number than max version.  &#x60;Warning!&#x60; Current implementation is kinda broken. To ensure correct results use the following format &#39;[0-9].[0-9]{3}&#39; (optional, default to '')
-   * @param int    $limit           (optional, default to 20)
-   * @param int    $offset          (optional, default to 0)
-   * @param string $attributes      (optional, default to '')
-   * @param string $flavor          (optional, default to '')
-   * @param int    &$responseCode   The HTTP Response Code
-   * @param array  $responseHeaders Additional HTTP headers to return with the response ()
+   * @param string      $query           (required)
+   * @param string      $max_version     Only shows project with a smaller version number than max version.  &#x60;Warning!&#x60; Current implementation is kinda broken. To ensure correct results use the following format &#39;[0-9].[0-9]{3}&#39; (optional, default to '')
+   * @param int         $limit           (optional, default to 20)
+   * @param int         $offset          Deprecated: Use cursor-based pagination instead. How many objects should be skipped. (optional, default to 0) (deprecated)
+   * @param string|null $cursor          Cursor for pagination (opaque string from the previous response) (optional)
+   * @param string      $attributes      (optional, default to '')
+   * @param string      $flavor          (optional, default to '')
+   * @param int         &$responseCode   The HTTP Response Code
+   * @param array       $responseHeaders Additional HTTP headers to return with the response ()
    */
   public function projectsSearchGet(
     string $query,
     string $max_version,
     int $limit,
     int $offset,
+    ?string $cursor,
     string $attributes,
     string $flavor,
     int &$responseCode,
@@ -377,18 +385,20 @@ interface ProjectsApiInterface
    *
    * Get the projects of the logged in user
    *
-   * @param string $max_version     Only shows project with a smaller version number than max version.  &#x60;Warning!&#x60; Current implementation is kinda broken. To ensure correct results use the following format &#39;[0-9].[0-9]{3}&#39; (optional, default to '')
-   * @param int    $limit           (optional, default to 20)
-   * @param int    $offset          (optional, default to 0)
-   * @param string $attributes      (optional, default to '')
-   * @param string $flavor          (optional, default to '')
-   * @param int    &$responseCode   The HTTP Response Code
-   * @param array  $responseHeaders Additional HTTP headers to return with the response ()
+   * @param string      $max_version     Only shows project with a smaller version number than max version.  &#x60;Warning!&#x60; Current implementation is kinda broken. To ensure correct results use the following format &#39;[0-9].[0-9]{3}&#39; (optional, default to '')
+   * @param int         $limit           (optional, default to 20)
+   * @param int         $offset          Deprecated: Use cursor-based pagination instead. How many objects should be skipped. (optional, default to 0) (deprecated)
+   * @param string|null $cursor          Cursor for pagination (opaque string from the previous response) (optional)
+   * @param string      $attributes      (optional, default to '')
+   * @param string      $flavor          (optional, default to '')
+   * @param int         &$responseCode   The HTTP Response Code
+   * @param array       $responseHeaders Additional HTTP headers to return with the response ()
    */
   public function projectsUserGet(
     string $max_version,
     int $limit,
     int $offset,
+    ?string $cursor,
     string $attributes,
     string $flavor,
     int &$responseCode,
@@ -400,20 +410,22 @@ interface ProjectsApiInterface
    *
    * Get the public projects of a given user
    *
-   * @param string $id              (required)
-   * @param string $max_version     Only shows project with a smaller version number than max version.  &#x60;Warning!&#x60; Current implementation is kinda broken. To ensure correct results use the following format &#39;[0-9].[0-9]{3}&#39; (optional, default to '')
-   * @param int    $limit           (optional, default to 20)
-   * @param int    $offset          (optional, default to 0)
-   * @param string $attributes      (optional, default to '')
-   * @param string $flavor          (optional, default to '')
-   * @param int    &$responseCode   The HTTP Response Code
-   * @param array  $responseHeaders Additional HTTP headers to return with the response ()
+   * @param string      $id              (required)
+   * @param string      $max_version     Only shows project with a smaller version number than max version.  &#x60;Warning!&#x60; Current implementation is kinda broken. To ensure correct results use the following format &#39;[0-9].[0-9]{3}&#39; (optional, default to '')
+   * @param int         $limit           (optional, default to 20)
+   * @param int         $offset          Deprecated: Use cursor-based pagination instead. How many objects should be skipped. (optional, default to 0) (deprecated)
+   * @param string|null $cursor          Cursor for pagination (opaque string from the previous response) (optional)
+   * @param string      $attributes      (optional, default to '')
+   * @param string      $flavor          (optional, default to '')
+   * @param int         &$responseCode   The HTTP Response Code
+   * @param array       $responseHeaders Additional HTTP headers to return with the response ()
    */
   public function projectsUserIdGet(
     string $id,
     string $max_version,
     int $limit,
     int $offset,
+    ?string $cursor,
     string $attributes,
     string $flavor,
     int &$responseCode,

--- a/src/Api/OpenAPI/Server/Api/SearchApiInterface.php
+++ b/src/Api/OpenAPI/Server/Api/SearchApiInterface.php
@@ -46,18 +46,20 @@ interface SearchApiInterface
    *
    * Search for projects, users,..
    *
-   * @param string $query           (required)
-   * @param string $type            (optional, default to 'all')
-   * @param int    $limit           (optional, default to 20)
-   * @param int    $offset          (optional, default to 0)
-   * @param int    &$responseCode   The HTTP Response Code
-   * @param array  $responseHeaders Additional HTTP headers to return with the response ()
+   * @param string      $query           (required)
+   * @param string      $type            (optional, default to 'all')
+   * @param int         $limit           (optional, default to 20)
+   * @param int         $offset          Deprecated: Use cursor-based pagination instead. How many objects should be skipped. (optional, default to 0) (deprecated)
+   * @param string|null $cursor          Cursor for pagination (opaque string from the previous response) (optional)
+   * @param int         &$responseCode   The HTTP Response Code
+   * @param array       $responseHeaders Additional HTTP headers to return with the response ()
    */
   public function searchGet(
     string $query,
     string $type,
     int $limit,
     int $offset,
+    ?string $cursor,
     int &$responseCode,
     array &$responseHeaders,
   ): array|object|null;

--- a/src/Api/OpenAPI/Server/Api/UserApiInterface.php
+++ b/src/Api/OpenAPI/Server/Api/UserApiInterface.php
@@ -149,16 +149,18 @@ interface UserApiInterface
    *
    * Get users
    *
-   * @param string $query           (required)
-   * @param int    $limit           (optional, default to 20)
-   * @param int    $offset          (optional, default to 0)
-   * @param int    &$responseCode   The HTTP Response Code
-   * @param array  $responseHeaders Additional HTTP headers to return with the response ()
+   * @param string      $query           (required)
+   * @param int         $limit           (optional, default to 20)
+   * @param int         $offset          Deprecated: Use cursor-based pagination instead. How many objects should be skipped. (optional, default to 0) (deprecated)
+   * @param string|null $cursor          Cursor for pagination (opaque string from the previous response) (optional)
+   * @param int         &$responseCode   The HTTP Response Code
+   * @param array       $responseHeaders Additional HTTP headers to return with the response ()
    */
   public function usersGet(
     string $query,
     int $limit,
     int $offset,
+    ?string $cursor,
     int &$responseCode,
     array &$responseHeaders,
   ): array|object|null;
@@ -168,17 +170,19 @@ interface UserApiInterface
    *
    * Search for users
    *
-   * @param string $query           (required)
-   * @param int    $limit           (optional, default to 20)
-   * @param int    $offset          (optional, default to 0)
-   * @param string $attributes      (optional, default to '')
-   * @param int    &$responseCode   The HTTP Response Code
-   * @param array  $responseHeaders Additional HTTP headers to return with the response ()
+   * @param string      $query           (required)
+   * @param int         $limit           (optional, default to 20)
+   * @param int         $offset          Deprecated: Use cursor-based pagination instead. How many objects should be skipped. (optional, default to 0) (deprecated)
+   * @param string|null $cursor          Cursor for pagination (opaque string from the previous response) (optional)
+   * @param string      $attributes      (optional, default to '')
+   * @param int         &$responseCode   The HTTP Response Code
+   * @param array       $responseHeaders Additional HTTP headers to return with the response ()
    */
   public function usersSearchGet(
     string $query,
     int $limit,
     int $offset,
+    ?string $cursor,
     string $attributes,
     int &$responseCode,
     array &$responseHeaders,

--- a/src/Api/OpenAPI/Server/Controller/MediaLibraryController.php
+++ b/src/Api/OpenAPI/Server/Controller/MediaLibraryController.php
@@ -72,6 +72,7 @@ class MediaLibraryController extends Controller
     // Read out all input parameter values into variables
     $limit = $request->query->get('limit', 20);
     $offset = $request->query->get('offset', 0);
+    $cursor = $request->query->get('cursor');
     $category_id = $request->query->get('category_id');
     $file_type = $request->query->get('file_type');
     $flavor = $request->query->get('flavor');
@@ -87,6 +88,7 @@ class MediaLibraryController extends Controller
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
       $limit = $this->deserialize($limit, 'int', 'string');
       $offset = $this->deserialize($offset, 'int', 'string');
+      $cursor = $this->deserialize($cursor, 'string', 'string');
       $category_id = $this->deserialize($category_id, 'string', 'string');
       $file_type = $this->deserialize($file_type, 'string', 'string');
       $flavor = $this->deserialize($flavor, 'string', 'string');
@@ -115,6 +117,12 @@ class MediaLibraryController extends Controller
     $asserts[] = new Assert\Type('int');
     $asserts[] = new Assert\GreaterThanOrEqual(0);
     $response = $this->validate($offset, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
+    $response = $this->validate($cursor, $asserts);
     if ($response instanceof Response) {
       return $response;
     }
@@ -165,7 +173,7 @@ class MediaLibraryController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->mediaAssetsGet($accept_language, $limit, $offset, $category_id, $file_type, $flavor, $search, $sort_by, $sort_order, $responseCode, $responseHeaders);
+      $result = $handler->mediaAssetsGet($accept_language, $limit, $offset, $cursor, $category_id, $file_type, $flavor, $search, $sort_by, $sort_order, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         200 => 'OK',
@@ -627,6 +635,7 @@ class MediaLibraryController extends Controller
     // Read out all input parameter values into variables
     $limit = $request->query->get('limit', 20);
     $offset = $request->query->get('offset', 0);
+    $cursor = $request->query->get('cursor');
     $accept_language = $request->headers->get('Accept-Language', 'en');
 
     // Use the default value if no value was provided
@@ -636,6 +645,7 @@ class MediaLibraryController extends Controller
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
       $limit = $this->deserialize($limit, 'int', 'string');
       $offset = $this->deserialize($offset, 'int', 'string');
+      $cursor = $this->deserialize($cursor, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -661,6 +671,12 @@ class MediaLibraryController extends Controller
     if ($response instanceof Response) {
       return $response;
     }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
+    $response = $this->validate($cursor, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
 
     try {
       $handler = $this->getApiHandler();
@@ -669,7 +685,7 @@ class MediaLibraryController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->mediaCategoriesGet($accept_language, $limit, $offset, $responseCode, $responseHeaders);
+      $result = $handler->mediaCategoriesGet($accept_language, $limit, $offset, $cursor, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         200 => 'OK',
@@ -801,6 +817,7 @@ class MediaLibraryController extends Controller
     // Read out all input parameter values into variables
     $limit = $request->query->get('limit', 20);
     $offset = $request->query->get('offset', 0);
+    $cursor = $request->query->get('cursor');
     $accept_language = $request->headers->get('Accept-Language', 'en');
 
     // Use the default value if no value was provided
@@ -811,6 +828,7 @@ class MediaLibraryController extends Controller
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
       $limit = $this->deserialize($limit, 'int', 'string');
       $offset = $this->deserialize($offset, 'int', 'string');
+      $cursor = $this->deserialize($cursor, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -844,6 +862,12 @@ class MediaLibraryController extends Controller
     if ($response instanceof Response) {
       return $response;
     }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
+    $response = $this->validate($cursor, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
 
     try {
       $handler = $this->getApiHandler();
@@ -852,7 +876,7 @@ class MediaLibraryController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->mediaCategoriesIdGet($id, $accept_language, $limit, $offset, $responseCode, $responseHeaders);
+      $result = $handler->mediaCategoriesIdGet($id, $accept_language, $limit, $offset, $cursor, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         200 => 'OK',
@@ -1116,6 +1140,7 @@ class MediaLibraryController extends Controller
     // Read out all input parameter values into variables
     $limit = $request->query->get('limit', 20);
     $offset = $request->query->get('offset', 0);
+    $cursor = $request->query->get('cursor');
     $file_type = $request->query->get('file_type');
     $flavor = $request->query->get('flavor');
     $search = $request->query->get('search');
@@ -1129,6 +1154,7 @@ class MediaLibraryController extends Controller
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
       $limit = $this->deserialize($limit, 'int', 'string');
       $offset = $this->deserialize($offset, 'int', 'string');
+      $cursor = $this->deserialize($cursor, 'string', 'string');
       $file_type = $this->deserialize($file_type, 'string', 'string');
       $flavor = $this->deserialize($flavor, 'string', 'string');
       $search = $this->deserialize($search, 'string', 'string');
@@ -1155,6 +1181,12 @@ class MediaLibraryController extends Controller
     $asserts[] = new Assert\Type('int');
     $asserts[] = new Assert\GreaterThanOrEqual(0);
     $response = $this->validate($offset, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
+    $response = $this->validate($cursor, $asserts);
     if ($response instanceof Response) {
       return $response;
     }
@@ -1193,7 +1225,7 @@ class MediaLibraryController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->mediaLibraryGet($accept_language, $limit, $offset, $file_type, $flavor, $search, $assets_per_category, $responseCode, $responseHeaders);
+      $result = $handler->mediaLibraryGet($accept_language, $limit, $offset, $cursor, $file_type, $flavor, $search, $assets_per_category, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         200 => 'OK',

--- a/src/Api/OpenAPI/Server/Controller/ProjectsController.php
+++ b/src/Api/OpenAPI/Server/Controller/ProjectsController.php
@@ -806,6 +806,7 @@ class ProjectsController extends Controller
     $max_version = $request->query->get('max_version', '');
     $limit = $request->query->get('limit', 20);
     $offset = $request->query->get('offset', 0);
+    $cursor = $request->query->get('cursor');
     $attributes = $request->query->get('attributes', '');
     $flavor = $request->query->get('flavor', '');
     $accept_language = $request->headers->get('Accept-Language', 'en');
@@ -820,6 +821,7 @@ class ProjectsController extends Controller
       $max_version = $this->deserialize($max_version, 'string', 'string');
       $limit = $this->deserialize($limit, 'int', 'string');
       $offset = $this->deserialize($offset, 'int', 'string');
+      $cursor = $this->deserialize($cursor, 'string', 'string');
       $attributes = $this->deserialize($attributes, 'string', 'string');
       $flavor = $this->deserialize($flavor, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
@@ -871,6 +873,12 @@ class ProjectsController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\Type('string');
+    $response = $this->validate($cursor, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
     $asserts[] = new Assert\Regex('/^[a-zA-Z0-9\-_]+(,[a-zA-Z0-9\-_]+)*$/');
     $response = $this->validate($attributes, $asserts);
     if ($response instanceof Response) {
@@ -890,7 +898,7 @@ class ProjectsController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->projectIdRecommendationsGet($id, $category, $accept_language, $max_version, $limit, $offset, $attributes, $flavor, $responseCode, $responseHeaders);
+      $result = $handler->projectIdRecommendationsGet($id, $category, $accept_language, $max_version, $limit, $offset, $cursor, $attributes, $flavor, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         200 => 'OK',
@@ -1105,6 +1113,7 @@ class ProjectsController extends Controller
     $max_version = $request->query->get('max_version', '');
     $limit = $request->query->get('limit', 20);
     $offset = $request->query->get('offset', 0);
+    $cursor = $request->query->get('cursor');
     $attributes = $request->query->get('attributes', '');
     $flavor = $request->query->get('flavor', '');
 
@@ -1116,6 +1125,7 @@ class ProjectsController extends Controller
       $max_version = $this->deserialize($max_version, 'string', 'string');
       $limit = $this->deserialize($limit, 'int', 'string');
       $offset = $this->deserialize($offset, 'int', 'string');
+      $cursor = $this->deserialize($cursor, 'string', 'string');
       $attributes = $this->deserialize($attributes, 'string', 'string');
       $flavor = $this->deserialize($flavor, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
@@ -1152,6 +1162,12 @@ class ProjectsController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\Type('string');
+    $response = $this->validate($cursor, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
     $asserts[] = new Assert\Regex('/^[a-zA-Z0-9\-_]+(,[a-zA-Z0-9\-_]+)*$/');
     $response = $this->validate($attributes, $asserts);
     if ($response instanceof Response) {
@@ -1171,7 +1187,7 @@ class ProjectsController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->projectsFeaturedGet($platform, $max_version, $limit, $offset, $attributes, $flavor, $responseCode, $responseHeaders);
+      $result = $handler->projectsFeaturedGet($platform, $max_version, $limit, $offset, $cursor, $attributes, $flavor, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         200 => 'OK',
@@ -1223,6 +1239,7 @@ class ProjectsController extends Controller
     $max_version = $request->query->get('max_version', '');
     $limit = $request->query->get('limit', 20);
     $offset = $request->query->get('offset', 0);
+    $cursor = $request->query->get('cursor');
     $attributes = $request->query->get('attributes', '');
     $flavor = $request->query->get('flavor', '');
     $accept_language = $request->headers->get('Accept-Language', 'en');
@@ -1236,6 +1253,7 @@ class ProjectsController extends Controller
       $max_version = $this->deserialize($max_version, 'string', 'string');
       $limit = $this->deserialize($limit, 'int', 'string');
       $offset = $this->deserialize($offset, 'int', 'string');
+      $cursor = $this->deserialize($cursor, 'string', 'string');
       $attributes = $this->deserialize($attributes, 'string', 'string');
       $flavor = $this->deserialize($flavor, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
@@ -1279,6 +1297,12 @@ class ProjectsController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\Type('string');
+    $response = $this->validate($cursor, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
     $asserts[] = new Assert\Regex('/^[a-zA-Z0-9\-_]+(,[a-zA-Z0-9\-_]+)*$/');
     $response = $this->validate($attributes, $asserts);
     if ($response instanceof Response) {
@@ -1298,7 +1322,7 @@ class ProjectsController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->projectsGet($category, $accept_language, $max_version, $limit, $offset, $attributes, $flavor, $responseCode, $responseHeaders);
+      $result = $handler->projectsGet($category, $accept_language, $max_version, $limit, $offset, $cursor, $attributes, $flavor, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         200 => 'OK',
@@ -1467,6 +1491,7 @@ class ProjectsController extends Controller
     $max_version = $request->query->get('max_version', '');
     $limit = $request->query->get('limit', 20);
     $offset = $request->query->get('offset', 0);
+    $cursor = $request->query->get('cursor');
     $attributes = $request->query->get('attributes', '');
     $flavor = $request->query->get('flavor', '');
 
@@ -1478,6 +1503,7 @@ class ProjectsController extends Controller
       $max_version = $this->deserialize($max_version, 'string', 'string');
       $limit = $this->deserialize($limit, 'int', 'string');
       $offset = $this->deserialize($offset, 'int', 'string');
+      $cursor = $this->deserialize($cursor, 'string', 'string');
       $attributes = $this->deserialize($attributes, 'string', 'string');
       $flavor = $this->deserialize($flavor, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
@@ -1514,6 +1540,12 @@ class ProjectsController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\Type('string');
+    $response = $this->validate($cursor, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
     $asserts[] = new Assert\Regex('/^[a-zA-Z0-9\-_]+(,[a-zA-Z0-9\-_]+)*$/');
     $response = $this->validate($attributes, $asserts);
     if ($response instanceof Response) {
@@ -1533,7 +1565,7 @@ class ProjectsController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->projectsSearchGet($query, $max_version, $limit, $offset, $attributes, $flavor, $responseCode, $responseHeaders);
+      $result = $handler->projectsSearchGet($query, $max_version, $limit, $offset, $cursor, $attributes, $flavor, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         200 => 'OK',
@@ -1660,6 +1692,7 @@ class ProjectsController extends Controller
     $max_version = $request->query->get('max_version', '');
     $limit = $request->query->get('limit', 20);
     $offset = $request->query->get('offset', 0);
+    $cursor = $request->query->get('cursor');
     $attributes = $request->query->get('attributes', '');
     $flavor = $request->query->get('flavor', '');
 
@@ -1670,6 +1703,7 @@ class ProjectsController extends Controller
       $max_version = $this->deserialize($max_version, 'string', 'string');
       $limit = $this->deserialize($limit, 'int', 'string');
       $offset = $this->deserialize($offset, 'int', 'string');
+      $cursor = $this->deserialize($cursor, 'string', 'string');
       $attributes = $this->deserialize($attributes, 'string', 'string');
       $flavor = $this->deserialize($flavor, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
@@ -1699,6 +1733,12 @@ class ProjectsController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\Type('string');
+    $response = $this->validate($cursor, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
     $asserts[] = new Assert\Regex('/^[a-zA-Z0-9\-_]+(,[a-zA-Z0-9\-_]+)*$/');
     $response = $this->validate($attributes, $asserts);
     if ($response instanceof Response) {
@@ -1721,7 +1761,7 @@ class ProjectsController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->projectsUserGet($max_version, $limit, $offset, $attributes, $flavor, $responseCode, $responseHeaders);
+      $result = $handler->projectsUserGet($max_version, $limit, $offset, $cursor, $attributes, $flavor, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         200 => 'OK',
@@ -1774,6 +1814,7 @@ class ProjectsController extends Controller
     $max_version = $request->query->get('max_version', '');
     $limit = $request->query->get('limit', 20);
     $offset = $request->query->get('offset', 0);
+    $cursor = $request->query->get('cursor');
     $attributes = $request->query->get('attributes', '');
     $flavor = $request->query->get('flavor', '');
 
@@ -1785,6 +1826,7 @@ class ProjectsController extends Controller
       $max_version = $this->deserialize($max_version, 'string', 'string');
       $limit = $this->deserialize($limit, 'int', 'string');
       $offset = $this->deserialize($offset, 'int', 'string');
+      $cursor = $this->deserialize($cursor, 'string', 'string');
       $attributes = $this->deserialize($attributes, 'string', 'string');
       $flavor = $this->deserialize($flavor, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
@@ -1822,6 +1864,12 @@ class ProjectsController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\Type('string');
+    $response = $this->validate($cursor, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
     $asserts[] = new Assert\Regex('/^[a-zA-Z0-9\-_]+(,[a-zA-Z0-9\-_]+)*$/');
     $response = $this->validate($attributes, $asserts);
     if ($response instanceof Response) {
@@ -1841,7 +1889,7 @@ class ProjectsController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->projectsUserIdGet($id, $max_version, $limit, $offset, $attributes, $flavor, $responseCode, $responseHeaders);
+      $result = $handler->projectsUserIdGet($id, $max_version, $limit, $offset, $cursor, $attributes, $flavor, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         200 => 'OK',

--- a/src/Api/OpenAPI/Server/Controller/SearchController.php
+++ b/src/Api/OpenAPI/Server/Controller/SearchController.php
@@ -74,6 +74,7 @@ class SearchController extends Controller
     $type = $request->query->get('type', 'all');
     $limit = $request->query->get('limit', 20);
     $offset = $request->query->get('offset', 0);
+    $cursor = $request->query->get('cursor');
 
     // Use the default value if no value was provided
 
@@ -83,6 +84,7 @@ class SearchController extends Controller
       $type = $this->deserialize($type, 'string', 'string');
       $limit = $this->deserialize($limit, 'int', 'string');
       $offset = $this->deserialize($offset, 'int', 'string');
+      $cursor = $this->deserialize($cursor, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -116,6 +118,12 @@ class SearchController extends Controller
     if ($response instanceof Response) {
       return $response;
     }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
+    $response = $this->validate($cursor, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
 
     try {
       $handler = $this->getApiHandler();
@@ -124,7 +132,7 @@ class SearchController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->searchGet($query, $type, $limit, $offset, $responseCode, $responseHeaders);
+      $result = $handler->searchGet($query, $type, $limit, $offset, $cursor, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         200 => 'OK',

--- a/src/Api/OpenAPI/Server/Controller/UserController.php
+++ b/src/Api/OpenAPI/Server/Controller/UserController.php
@@ -559,6 +559,7 @@ class UserController extends Controller
     $query = $request->query->get('query');
     $limit = $request->query->get('limit', 20);
     $offset = $request->query->get('offset', 0);
+    $cursor = $request->query->get('cursor');
 
     // Use the default value if no value was provided
 
@@ -567,6 +568,7 @@ class UserController extends Controller
       $query = $this->deserialize($query, 'string', 'string');
       $limit = $this->deserialize($limit, 'int', 'string');
       $offset = $this->deserialize($offset, 'int', 'string');
+      $cursor = $this->deserialize($cursor, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -593,6 +595,12 @@ class UserController extends Controller
     if ($response instanceof Response) {
       return $response;
     }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
+    $response = $this->validate($cursor, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
 
     try {
       $handler = $this->getApiHandler();
@@ -601,7 +609,7 @@ class UserController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->usersGet($query, $limit, $offset, $responseCode, $responseHeaders);
+      $result = $handler->usersGet($query, $limit, $offset, $cursor, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         200 => 'OK',
@@ -652,6 +660,7 @@ class UserController extends Controller
     $query = $request->query->get('query');
     $limit = $request->query->get('limit', 20);
     $offset = $request->query->get('offset', 0);
+    $cursor = $request->query->get('cursor');
     $attributes = $request->query->get('attributes', '');
 
     // Use the default value if no value was provided
@@ -661,6 +670,7 @@ class UserController extends Controller
       $query = $this->deserialize($query, 'string', 'string');
       $limit = $this->deserialize($limit, 'int', 'string');
       $offset = $this->deserialize($offset, 'int', 'string');
+      $cursor = $this->deserialize($cursor, 'string', 'string');
       $attributes = $this->deserialize($attributes, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -690,6 +700,12 @@ class UserController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\Type('string');
+    $response = $this->validate($cursor, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
     $asserts[] = new Assert\Regex('/^[a-zA-Z0-9\-_]+(,[a-zA-Z0-9\-_]+)*$/');
     $response = $this->validate($attributes, $asserts);
     if ($response instanceof Response) {
@@ -703,7 +719,7 @@ class UserController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->usersSearchGet($query, $limit, $offset, $attributes, $responseCode, $responseHeaders);
+      $result = $handler->usersSearchGet($query, $limit, $offset, $cursor, $attributes, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         200 => 'OK',

--- a/src/Api/OpenAPI/Server/Model/PaginationInfo.php
+++ b/src/Api/OpenAPI/Server/Model/PaginationInfo.php
@@ -37,6 +37,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * Class representing the PaginationInfo model.
  *
+ * Deprecated: Use cursor-based pagination (next_cursor + has_more) instead.
+ *
  * @author  OpenAPI Generator team
  */
 class PaginationInfo

--- a/src/Api/OpenAPI/specification.yaml
+++ b/src/Api/OpenAPI/specification.yaml
@@ -452,7 +452,7 @@ paths:
       tags:
         - 'User'
       summary: 'Search for users'
-      description: 'Search for users associated by keywords.'
+      description: 'Search for users associated by keywords. Supports cursor-based pagination. Pass the next_cursor value from a previous response to fetch the next page. The offset parameter is deprecated.'
       parameters:
         - name: query
           in: query
@@ -461,6 +461,7 @@ paths:
             type: string
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Cursor'
         - $ref: '#/components/parameters/Attributes'
       responses:
         '200':
@@ -484,7 +485,7 @@ paths:
       tags:
         - 'User'
       summary: 'Get users'
-      description: 'Get all users with their corresponding data'
+      description: 'Get all users with their corresponding data. Supports cursor-based pagination. Pass the next_cursor value from a previous response to fetch the next page. The offset parameter is deprecated.'
       parameters:
         - name: query
           in: query
@@ -493,6 +494,7 @@ paths:
             type: string
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Cursor'
       responses:
         '200':
           description: 'OK'
@@ -521,11 +523,13 @@ paths:
       tags:
         - 'Projects'
       summary: 'Get projects'
+      description: 'Supports cursor-based pagination. Pass the next_cursor value from a previous response to fetch the next page. The offset parameter is deprecated.'
       parameters:
         - $ref: '#/components/parameters/ProjectType'
         - $ref: '#/components/parameters/MaxVersion'
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Cursor'
         - $ref: '#/components/parameters/Attributes'
         - $ref: '#/components/parameters/Flavor'
       responses:
@@ -596,11 +600,13 @@ paths:
       tags:
         - 'Projects'
       summary: 'Get the currently featured projects'
+      description: 'Supports cursor-based pagination. Pass the next_cursor value from a previous response to fetch the next page. The offset parameter is deprecated.'
       parameters:
         - $ref: '#/components/parameters/Platform'
         - $ref: '#/components/parameters/MaxVersion'
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Cursor'
         - $ref: '#/components/parameters/Attributes'
         - $ref: '#/components/parameters/Flavor'
       responses:
@@ -651,6 +657,7 @@ paths:
       tags:
         - 'Projects'
       summary: 'Search for projects associated with a keywords'
+      description: 'Supports cursor-based pagination. Pass the next_cursor value from a previous response to fetch the next page. The offset parameter is deprecated.'
       parameters:
         - name: query
           in: query
@@ -660,6 +667,7 @@ paths:
         - $ref: '#/components/parameters/MaxVersion'
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Cursor'
         - $ref: '#/components/parameters/Attributes'
         - $ref: '#/components/parameters/Flavor'
       responses:
@@ -686,10 +694,12 @@ paths:
       tags:
         - 'Projects'
       summary: 'Get the projects of the logged in user'
+      description: 'Supports cursor-based pagination. Pass the next_cursor value from a previous response to fetch the next page. The offset parameter is deprecated.'
       parameters:
         - $ref: '#/components/parameters/MaxVersion'
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Cursor'
         - $ref: '#/components/parameters/Attributes'
         - $ref: '#/components/parameters/Flavor'
       responses:
@@ -718,11 +728,13 @@ paths:
       tags:
         - 'Projects'
       summary: 'Get the public projects of a given user'
+      description: 'Supports cursor-based pagination. Pass the next_cursor value from a previous response to fetch the next page. The offset parameter is deprecated.'
       parameters:
         - $ref: '#/components/parameters/Uuid'
         - $ref: '#/components/parameters/MaxVersion'
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Cursor'
         - $ref: '#/components/parameters/Attributes'
         - $ref: '#/components/parameters/Flavor'
       responses:
@@ -991,12 +1003,14 @@ paths:
       tags:
         - 'Projects'
       summary: 'Get recommended projects related to the specific project'
+      description: 'Supports cursor-based pagination. Pass the next_cursor value from a previous response to fetch the next page. The offset parameter is deprecated.'
       parameters:
         - $ref: '#/components/parameters/Uuid'
         - $ref: '#/components/parameters/RecommendedProjectType'
         - $ref: '#/components/parameters/MaxVersion'
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Cursor'
         - $ref: '#/components/parameters/Attributes'
         - $ref: '#/components/parameters/Flavor'
       responses:
@@ -1579,10 +1593,11 @@ paths:
       tags:
         - 'Media Library'
       summary: 'Get media library overview with categories and preview assets'
-      description: 'Returns all categories with a preview of assets per category. Similar to /projects/categories for browsing the media library.'
+      description: 'Returns all categories with a preview of assets per category. Similar to /projects/categories for browsing the media library. Supports cursor-based pagination. The offset parameter is deprecated.'
       parameters:
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Cursor'
         - name: file_type
           in: query
           required: false
@@ -1638,9 +1653,11 @@ paths:
       tags:
         - 'Media Library'
       summary: 'Get all media library categories'
+      description: 'Supports cursor-based pagination. The offset parameter is deprecated.'
       parameters:
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Cursor'
       responses:
         '200':
           description: 'OK'
@@ -1706,9 +1723,11 @@ paths:
       tags:
         - 'Media Library'
       summary: 'Get a specific media category with its assets'
+      description: 'Supports cursor-based pagination. The offset parameter is deprecated.'
       parameters:
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Cursor'
       responses:
         '200':
           description: 'OK'
@@ -1788,9 +1807,11 @@ paths:
       tags:
         - 'Media Library'
       summary: 'Get media library assets with pagination and filtering'
+      description: 'Supports cursor-based pagination. The offset parameter is deprecated.'
       parameters:
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Cursor'
         - name: category_id
           in: query
           required: false
@@ -1970,7 +1991,7 @@ paths:
       tags:
         - Search
       summary: 'Search for projects, users,..'
-      description: 'The default is to search in all categories.'
+      description: 'The default is to search in all categories. Supports cursor-based pagination. Pass the next_cursor value from a previous response to fetch the next page. The offset parameter is deprecated.'
       parameters:
         - name: query
           in: query
@@ -1980,6 +2001,7 @@ paths:
         - $ref: '#/components/parameters/SearchType'
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Cursor'
       responses:
         '200':
           description: OK
@@ -2643,6 +2665,8 @@ components:
     Offset:
       name: offset
       in: query
+      deprecated: true
+      description: 'Deprecated: Use cursor-based pagination instead. How many objects should be skipped.'
       schema:
         $ref: '#/components/schemas/Offset'
 
@@ -2803,9 +2827,10 @@ components:
     Offset:
       type: integer
       minimum: 0
-      description: 'How many objects should be skipped'
+      description: 'Deprecated: Use cursor-based pagination instead. How many objects should be skipped.'
       default: 0
       example: 2
+      deprecated: true
 
     CommentId:
       type: integer
@@ -2819,6 +2844,8 @@ components:
     # Pagination
     PaginationInfo:
       type: object
+      deprecated: true
+      description: 'Deprecated: Use cursor-based pagination (next_cursor + has_more) instead.'
       properties:
         total:
           type: integer

--- a/src/Api/ProjectsApi.php
+++ b/src/Api/ProjectsApi.php
@@ -109,7 +109,7 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
   }
 
   #[\Override]
-  public function projectsFeaturedGet(string $platform, string $max_version, int $limit, int $offset, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): array
+  public function projectsFeaturedGet(string $platform, string $max_version, int $limit, int $offset, ?string $cursor, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): array
   {
     $featured_projects = $this->facade->getLoader()->getFeaturedProjects($flavor, $limit, $offset, $platform, $max_version);
 
@@ -126,10 +126,10 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
    * @throws \Psr\Cache\InvalidArgumentException
    */
   #[\Override]
-  public function projectsGet(string $category, string $accept_language, string $max_version, int $limit, int $offset, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): array
+  public function projectsGet(string $category, string $accept_language, string $max_version, int $limit, int $offset, ?string $cursor, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): array
   {
     $locale = $this->facade->getResponseManager()->sanitizeLocale($accept_language);
-    $cache_id = sprintf('projectsGet_%s_%s_%s_%s_%d_%d', $category, $locale, $flavor, $max_version, $limit, $offset);
+    $cache_id = sprintf('projectsGet_%s_%s_%s_%s_%d_%d_%s', $category, $locale, $flavor, $max_version, $limit, $offset, $cursor ?? '');
 
     // Don't cache 'recent' category as it changes frequently
     if ('recent' === $category) {
@@ -165,7 +165,7 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
   }
 
   #[\Override]
-  public function projectIdRecommendationsGet(string $id, string $category, string $accept_language, string $max_version, int $limit, int $offset, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): ?array
+  public function projectIdRecommendationsGet(string $id, string $category, string $accept_language, string $max_version, int $limit, int $offset, ?string $cursor, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): ?array
   {
     $project = $this->facade->getLoader()->findProjectByID($id, true);
     if (is_null($project)) {
@@ -251,7 +251,7 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
   }
 
   #[\Override]
-  public function projectsSearchGet(string $query, string $max_version, int $limit, int $offset, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): array
+  public function projectsSearchGet(string $query, string $max_version, int $limit, int $offset, ?string $cursor, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): array
   {
     $projects = $this->facade->getLoader()->searchProjects($query, $limit, $offset, $max_version, $flavor);
 
@@ -321,7 +321,7 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
   }
 
   #[\Override]
-  public function projectsUserGet(string $max_version, int $limit, int $offset, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): ?array
+  public function projectsUserGet(string $max_version, int $limit, int $offset, ?string $cursor, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): ?array
   {
     $user = $this->facade->getAuthenticationManager()->getAuthenticatedUser();
     if (is_null($user)) {
@@ -348,7 +348,7 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
   }
 
   #[\Override]
-  public function projectsUserIdGet(string $id, string $max_version, int $limit, int $offset, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): ?array
+  public function projectsUserIdGet(string $id, string $max_version, int $limit, int $offset, ?string $cursor, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): ?array
   {
     if (!$this->facade->getRequestValidator()->validateUserExists($id)) {
       $responseCode = Response::HTTP_NOT_FOUND;

--- a/src/Api/SearchApi.php
+++ b/src/Api/SearchApi.php
@@ -27,7 +27,7 @@ class SearchApi extends AbstractApiController implements SearchApiInterface
    * @throws \JsonException
    */
   #[\Override]
-  public function searchGet(string $query, string $type, int $limit, int $offset, int &$responseCode, array &$responseHeaders): array|SearchResponse
+  public function searchGet(string $query, string $type, int $limit, int $offset, ?string $cursor, int &$responseCode, array &$responseHeaders): array|SearchResponse
   {
     $ip = $this->request_stack->getCurrentRequest()?->getClientIp() ?? 'unknown';
     if (null === $this->checkIpRateLimit($ip, $this->searchBurstLimiter)) {

--- a/src/Api/UserApi.php
+++ b/src/Api/UserApi.php
@@ -169,7 +169,7 @@ class UserApi extends AbstractApiController implements UserApiInterface
   }
 
   #[\Override]
-  public function usersSearchGet(string $query, int $limit, int $offset, string $attributes, int &$responseCode, array &$responseHeaders): array
+  public function usersSearchGet(string $query, int $limit, int $offset, ?string $cursor, string $attributes, int &$responseCode, array &$responseHeaders): array
   {
     $users = $this->facade->getLoader()->searchUsers($query, $limit, $offset);
 
@@ -218,7 +218,7 @@ class UserApi extends AbstractApiController implements UserApiInterface
   }
 
   #[\Override]
-  public function usersGet(string $query, int $limit, int $offset, int &$responseCode, array &$responseHeaders): array|object|null
+  public function usersGet(string $query, int $limit, int $offset, ?string $cursor, int &$responseCode, array &$responseHeaders): array|object|null
   {
     $users = $this->facade->getLoader()->getAllUsers($query, $limit, $offset);
 

--- a/tests/PhpUnit/Api/MediaLibraryApiTest.php
+++ b/tests/PhpUnit/Api/MediaLibraryApiTest.php
@@ -76,7 +76,7 @@ final class MediaLibraryApiTest extends TestCase
     $response_manager->method('createLibraryOverviewResponse')->willReturn($library_response);
     $this->facade->method('getResponseManager')->willReturn($response_manager);
 
-    $response = $this->api->mediaLibraryGet('en', 10, 0, null, null, null, 5, $response_code, $response_headers);
+    $response = $this->api->mediaLibraryGet('en', 10, 0, null, null, null, null, 5, $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_OK, $response_code);
     $this->assertInstanceOf(MediaLibraryResponse::class, $response);
@@ -100,7 +100,7 @@ final class MediaLibraryApiTest extends TestCase
     $response_manager->method('createLibraryOverviewResponse')->willReturn($library_response);
     $this->facade->method('getResponseManager')->willReturn($response_manager);
 
-    $response = $this->api->mediaLibraryGet('en', 10, 0, null, null, 'dog', 5, $response_code, $response_headers);
+    $response = $this->api->mediaLibraryGet('en', 10, 0, null, null, null, 'dog', 5, $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_OK, $response_code);
     $this->assertInstanceOf(MediaLibraryResponse::class, $response);
@@ -130,7 +130,7 @@ final class MediaLibraryApiTest extends TestCase
     $this->facade->method('getLoader')->willReturn($loader);
     $this->facade->method('getResponseManager')->willReturn($response_manager);
 
-    $response = $this->api->mediaCategoriesGet('en', 20, 0, $response_code, $response_headers);
+    $response = $this->api->mediaCategoriesGet('en', 20, 0, null, $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_OK, $response_code);
     $this->assertInstanceOf(MediaCategoriesResponse::class, $response);
@@ -208,7 +208,7 @@ final class MediaLibraryApiTest extends TestCase
     $loader->method('getCategoryById')->willReturn(null);
     $this->facade->method('getLoader')->willReturn($loader);
 
-    $response = $this->api->mediaCategoriesIdGet('uuid', 'en', 20, 0, $response_code, $response_headers);
+    $response = $this->api->mediaCategoriesIdGet('uuid', 'en', 20, 0, null, $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_NOT_FOUND, $response_code);
     $this->assertNull($response);
@@ -233,7 +233,7 @@ final class MediaLibraryApiTest extends TestCase
     $response_manager->method('createCategoryDetailResponse')->willReturn($category_response);
     $this->facade->method('getResponseManager')->willReturn($response_manager);
 
-    $response = $this->api->mediaCategoriesIdGet('uuid', 'en', 20, 0, $response_code, $response_headers);
+    $response = $this->api->mediaCategoriesIdGet('uuid', 'en', 20, 0, null, $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_OK, $response_code);
     $this->assertInstanceOf(MediaCategoryDetailResponse::class, $response);
@@ -354,7 +354,7 @@ final class MediaLibraryApiTest extends TestCase
     $response_manager->method('createAssetsResponse')->willReturn($assets_response);
     $this->facade->method('getResponseManager')->willReturn($response_manager);
 
-    $response = $this->api->mediaAssetsGet('en', 20, 0, null, null, null, null, 'name', 'asc', $response_code, $response_headers);
+    $response = $this->api->mediaAssetsGet('en', 20, 0, null, null, null, null, null, 'name', 'asc', $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_OK, $response_code);
     $this->assertInstanceOf(MediaAssetsResponse::class, $response);

--- a/tests/PhpUnit/Api/ProjectsApiTest.php
+++ b/tests/PhpUnit/Api/ProjectsApiTest.php
@@ -385,7 +385,7 @@ final class ProjectsApiTest extends KernelTestCase
     $loader->method('getFeaturedProjects')->willReturn([]);
     $this->facade->method('getLoader')->willReturn($loader);
 
-    $this->object->projectsFeaturedGet('', '', 20, 0, '', '', $response_code, $response_headers);
+    $this->object->projectsFeaturedGet('', '', 20, 0, null, '', '', $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_OK, $response_code);
   }
@@ -400,7 +400,7 @@ final class ProjectsApiTest extends KernelTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $this->object->projectsGet('category', 'en', '', 20, 0, '', '', $response_code, $response_headers);
+    $this->object->projectsGet('category', 'en', '', 20, 0, null, '', '', $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_OK, $response_code);
   }
@@ -415,7 +415,7 @@ final class ProjectsApiTest extends KernelTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $this->object->projectIdRecommendationsGet('id', 'category', 'en', '', 20, 0, '', '', $response_code, $response_headers);
+    $this->object->projectIdRecommendationsGet('id', 'category', 'en', '', 20, 0, null, '', '', $response_code, $response_headers);
 
     $this->assertEquals(Response::HTTP_NOT_FOUND, $response_code);
   }
@@ -436,7 +436,7 @@ final class ProjectsApiTest extends KernelTestCase
     $loader->method('getRecommendedProjects')->willReturn([]);
     $this->facade->method('getLoader')->willReturn($loader);
 
-    $response = $this->object->projectIdRecommendationsGet('id', 'category', 'en', '', 20, 0, '', '', $response_code, $response_headers);
+    $response = $this->object->projectIdRecommendationsGet('id', 'category', 'en', '', 20, 0, null, '', '', $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_OK, $response_code);
     $this->assertIsArray($response);
@@ -452,7 +452,7 @@ final class ProjectsApiTest extends KernelTestCase
     $response_code = 200;
     $response_headers = [];
 
-    $this->object->projectsSearchGet('query', '', 20, 0, '', '', $response_code, $response_headers);
+    $this->object->projectsSearchGet('query', '', 20, 0, null, '', '', $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_OK, $response_code);
   }
@@ -487,7 +487,7 @@ final class ProjectsApiTest extends KernelTestCase
     $authentication_manager->method('getAuthenticatedUser')->willReturn(null);
     $this->facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $response = $this->object->projectsUserGet('', 20, 0, '', '', $response_code, $response_headers);
+    $response = $this->object->projectsUserGet('', 20, 0, null, '', '', $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_FORBIDDEN, $response_code);
     $this->assertNull($response);
@@ -510,7 +510,7 @@ final class ProjectsApiTest extends KernelTestCase
     $authentication_manager->method('getAuthenticatedUser')->willReturn($user);
     $this->facade->method('getAuthenticationManager')->willReturn($authentication_manager);
 
-    $response = $this->object->projectsUserGet('', 20, 0, '', '', $response_code, $response_headers);
+    $response = $this->object->projectsUserGet('', 20, 0, null, '', '', $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_OK, $response_code);
     $this->assertIsArray($response);
@@ -531,7 +531,7 @@ final class ProjectsApiTest extends KernelTestCase
     $request_validator->method('validateUserExists')->willReturn(true);
     $this->facade->method('getRequestValidator')->willReturn($request_validator);
 
-    $response = $this->object->projectsUserIdGet('id', '', 20, 0, '', '', $response_code, $response_headers);
+    $response = $this->object->projectsUserIdGet('id', '', 20, 0, null, '', '', $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_OK, $response_code);
     $this->assertIsArray($response);
@@ -552,7 +552,7 @@ final class ProjectsApiTest extends KernelTestCase
     $request_validator->method('validateUserExists')->willReturn(false);
     $this->facade->method('getRequestValidator')->willReturn($request_validator);
 
-    $response = $this->object->projectsUserIdGet('id', '', 20, 0, '', '', $response_code, $response_headers);
+    $response = $this->object->projectsUserIdGet('id', '', 20, 0, null, '', '', $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_NOT_FOUND, $response_code);
     $this->assertNull($response);

--- a/tests/PhpUnit/Api/SearchApiTest.php
+++ b/tests/PhpUnit/Api/SearchApiTest.php
@@ -50,7 +50,7 @@ final class SearchApiTest extends TestCase
     $response_code = 200;
     $response_headers = [];
 
-    $response = $this->search_api->searchGet('query', 'type', 20, 0, $response_code, $response_headers);
+    $response = $this->search_api->searchGet('query', 'type', 20, 0, null, $response_code, $response_headers);
 
     $this->assertEquals(Response::HTTP_OK, $response_code);
     $this->assertInstanceOf(SearchResponse::class, $response);

--- a/tests/PhpUnit/Api/UserApiTest.php
+++ b/tests/PhpUnit/Api/UserApiTest.php
@@ -254,7 +254,7 @@ final class UserApiTest extends TestCase
     $loader->method('searchUsers')->willReturn([]);
     $this->facade->method('getLoader')->willReturn($loader);
 
-    $this->object->usersSearchGet('query', 20, 0, '', $response_code, $response_headers);
+    $this->object->usersSearchGet('query', 20, 0, null, '', $response_code, $response_headers);
 
     $this->assertEquals(Response::HTTP_OK, $response_code);
   }


### PR DESCRIPTION
## Summary
- Deprecates the `offset` query parameter and `PaginationInfo` schema in the OpenAPI spec (marked with `deprecated: true`)
- Adds `cursor` query parameter alongside the deprecated `offset` to all 13 list endpoints: `/projects`, `/projects/featured`, `/projects/search`, `/projects/user`, `/projects/user/{id}`, `/project/{id}/recommendations`, `/users/search`, `/users`, `/search`, `/media/library`, `/media/categories`, `/media/categories/{id}`, `/media/assets`
- Regenerates server code and updates all API implementations and PHPUnit tests to match new method signatures
- No behavioral change: cursor is accepted but offset is still used internally -- this is the backward-compatible first phase

Closes #6350

## Phase 1 of pagination unification
This PR establishes the API surface for cursor-based pagination. Future PRs will:
1. Implement actual cursor decoding and cursor-based queries in the project/search/media loaders
2. Wrap responses in `{ data, next_cursor, has_more }` envelope (breaking change, needs versioning)
3. Eventually remove offset support after transition period

## Test plan
- [x] PHPUnit tests pass (59 tests, 120 assertions) for ProjectsApi, SearchApi, UserApi, MediaLibraryApi
- [x] PHPStan passes (no errors)
- [x] Psalm passes (no errors)
- [x] PHP CS Fixer passes
- [ ] CI pipeline passes
- [ ] Existing API consumers unaffected (offset still works, cursor is optional and ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)