### PR TITLE
Fix XSS vulnerabilities in Twig templates

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -95,6 +95,7 @@ use Sonata\AdminBundle\Security\Acl\Permission\AdminPermissionMap;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\Dotenv\Command\DotenvDumpCommand;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {

--- a/src/Admin/UserCommunication/SendMailToUser/SendMailToUserController.php
+++ b/src/Admin/UserCommunication/SendMailToUser/SendMailToUserController.php
@@ -62,7 +62,6 @@ class SendMailToUserController extends CRUDController
       return new Response('Empty title!', Response::HTTP_BAD_REQUEST);
     }
 
-    $htmlText = str_replace(PHP_EOL, '<br>', $messageText);
     $mailTo = $user->getEmail();
     $this->mailer->send(
       $mailTo,
@@ -71,7 +70,7 @@ class SendMailToUserController extends CRUDController
       [
         'subject' => $subject,
         'title' => $title,
-        'message' => $htmlText,
+        'message' => $messageText,
       ]
     );
 

--- a/templates/Admin/SystemManagement/Maintain.html.twig
+++ b/templates/Admin/SystemManagement/Maintain.html.twig
@@ -66,7 +66,7 @@
                                   </span>
 
                   </div>
-                  <div id="Removable_{{ i }}" style="display: none">{{ RemovableObject.description|raw }}</div>
+                  <div id="Removable_{{ i }}" style="display: none">{{ RemovableObject.description }}</div>
                 </div>
                 {% set i = i + 1 %}
               {% else %}

--- a/templates/Admin/UserCommunication/SendMail/SimpleMessage.html.twig
+++ b/templates/Admin/UserCommunication/SendMail/SimpleMessage.html.twig
@@ -1,25 +1,19 @@
 {% extends 'Email/email.html.twig' %}
 
 {% block head_title %}
-  {% autoescape false %}
-    {{ subject }}
-  {% endautoescape %}
+  {{ subject }}
 {% endblock %}
 
 {% block body_title %}
-  {% autoescape false %}
-    <div align="center">
-      {{ title }}
-    </div>
-  {% endautoescape %}
+  <div align="center">
+    {{ title }}
+  </div>
 {% endblock %}
 
 {% block body_content %}
 
-  {% autoescape false %}
-    <div align="center">
-      {{ message }}
-    </div>
-  {% endautoescape %}
+  <div align="center">
+    {{ message|nl2br }}
+  </div>
 
 {% endblock %}

--- a/templates/Index/MaintenanceInformation.html.twig
+++ b/templates/Index/MaintenanceInformation.html.twig
@@ -19,7 +19,7 @@
             {% endif %}
             {% if featureName is defined %}
                 {% set translationParams = translationParams|merge({
-                    featureName: '<span class="maintenance-feature-name bold-text">' ~ featureName ~ '</span>',
+                    featureName: '<span class="maintenance-feature-name bold-text">' ~ featureName|e('html') ~ '</span>',
                 }) %}
             {% endif %}
             <span>
@@ -35,7 +35,7 @@
             <div class="additional-info-section" id="additional-info-{{ code }}">
              <span>
                       {% set translationParams = translationParams|merge({
-                          additionalInfo: '<span class="maintenance-additionalinfo-text  bold-text">' ~ additionalInfo ~ '</span>',
+                          additionalInfo: '<span class="maintenance-additionalinfo-text  bold-text">' ~ additionalInfo|e('html') ~ '</span>',
                       }) %}
                 {{ 'maintenanceinformations.maintenance_information.additional_info'|trans(translationParams, 'catroweb')|raw }}
              </span>

--- a/templates/Security/Registration/VerifyAccountEmail.html.twig
+++ b/templates/Security/Registration/VerifyAccountEmail.html.twig
@@ -1,21 +1,16 @@
 {% extends 'Email/email.html.twig' %}
 
 {% block head_title %}
-  {% autoescape false %}
-    {{ 'newAccountConfirmation.subject'|trans({}, 'catroweb') }}
-  {% endautoescape %}
+  {{ 'newAccountConfirmation.subject'|trans({}, 'catroweb') }}
 {% endblock %}
 
 {% block body_title %}
-  {% autoescape false %}
   <div align="center">
     {{ 'newAccountConfirmation.welcome'|trans({}, 'catroweb') }}
   </div>
-  {% endautoescape %}
 {% endblock %}
 
 {% block body_content %}
-  {% autoescape false %}
   <style>
 
   .btn-confirm {
@@ -32,7 +27,7 @@
     {{ 'newAccountConfirmation.messageHtml'|trans({'%time%': expire}, 'catroweb') }}
     <div align="center" class="container">
       <a href="{{ signedUrl }}">
-        <button id="confirm-account-button" class="btn btn-primary btn-confirm" >
+        <button id="confirm-account-button" class="btn btn-primary btn-confirm">
           <p><strong><big>{{ 'newAccountConfirmation.button'|trans({}, 'catroweb') }}</big></strong></p>
         </button>
       </a>
@@ -41,6 +36,5 @@
       {{ 'newAccountConfirmation.deleteHtml'|trans({'%deleteUrl%': deleteUrl}, 'catroweb') }}
     </small>
   </div>
-  {% endautoescape %}
 
 {% endblock %}

--- a/templates/Security/ResetPassword/ResetPasswordEmail.html.twig
+++ b/templates/Security/ResetPassword/ResetPasswordEmail.html.twig
@@ -1,48 +1,42 @@
 {% extends 'Email/email.html.twig' %}
 
 {% block head_title %}
-  {% autoescape false %}
-    {{ 'resetPassword.newemail.title'|trans({}, 'catroweb') }}
-  {% endautoescape %}
+  {{ 'resetPassword.newemail.title'|trans({}, 'catroweb') }}
 {% endblock %}
 
 {% block body_title %}
-  {% autoescape false %}
-  {% endautoescape %}
 {% endblock %}
 
 {% block body_content %}
-  {% autoescape false %}
 
-    <style>
+  <style>
 
-        .content {
-            text-align:center;
-            font-family: Arial, sans-serif;
-        }
+      .content {
+          text-align:center;
+          font-family: Arial, sans-serif;
+      }
 
-        .container {
-            padding: 25px;
-        }
+      .container {
+          padding: 25px;
+      }
 
-        .btn-reset {
-            padding: 20px 60px 0 60px;
-        }
+      .btn-reset {
+          padding: 20px 60px 0 60px;
+      }
 
-    </style>
+  </style>
 
-    <div class="content">
-      {{ 'resetPassword.newemail.content'|trans({}, 'catroweb') }}
-    </div>
-    <div align="center" class="container">
-      <a href="{{ url('app_reset_password', {theme: 'app', token: resetToken.token}) }}">
-        <button id="reset-password-button" class="btn btn-primary btn-reset">
-          <p><strong><big>{{ 'resetPassword.newemail.visitLink'|trans({}, 'catroweb') }}</big></strong></p>
-        </button>
-      </a>
-    </div>
-    <small>
-      <p align="center">{{ 'resetPassword.newemail.expire'|trans({'%time%': resetToken.expirationMessageKey|trans(resetToken.expirationMessageData, 'ResetPasswordBundle')}, 'catroweb') }}</p>
-    </small>
-  {% endautoescape %}
+  <div class="content">
+    {{ 'resetPassword.newemail.content'|trans({}, 'catroweb') }}
+  </div>
+  <div align="center" class="container">
+    <a href="{{ url('app_reset_password', {theme: 'app', token: resetToken.token}) }}">
+      <button id="reset-password-button" class="btn btn-primary btn-reset">
+        <p><strong><big>{{ 'resetPassword.newemail.visitLink'|trans({}, 'catroweb') }}</big></strong></p>
+      </button>
+    </a>
+  </div>
+  <small>
+    <p align="center">{{ 'resetPassword.newemail.expire'|trans({'%time%': resetToken.expirationMessageKey|trans(resetToken.expirationMessageData, 'ResetPasswordBundle')}, 'catroweb') }}</p>
+  </small>
 {% endblock %}

--- a/templates/Studio/ActivityListPage.html.twig
+++ b/templates/Studio/ActivityListPage.html.twig
@@ -4,17 +4,17 @@
     <span>
       {% if activity.getType() == 'user' %}
         {{ 'studio.details.activity_list.join_studio'|trans({
-          '%user%': '<a href="/">' ~ activity.getUser().getUserName() ~ '</a>',
+          '%user%': '<a href="/">' ~ activity.getUser().getUserName()|e('html') ~ '</a>',
         }, 'catroweb')|raw }}
       {% endif %}
       {% if activity.getType() == 'project' %}
         {{ 'studio.details.activity_list.add_project'|trans({
-          '%user%': '<a href="/">' ~ activity.getUser().getUserName() ~ '</a>',
+          '%user%': '<a href="/">' ~ activity.getUser().getUserName()|e('html') ~ '</a>',
         }, 'catroweb')|raw }}
       {% endif %}
       {% if activity.getType() == 'comment' %}
         {{ 'studio.details.activity_list.add_comment'|trans({
-          '%user%': '<a href="/">' ~ activity.getUser().getUserName() ~ '</a>',
+          '%user%': '<a href="/">' ~ activity.getUser().getUserName()|e('html') ~ '</a>',
         }, 'catroweb')|raw }}
       {% endif %}
     </span>


### PR DESCRIPTION
## Summary
- **Studio activity list**: escape `getUserName()` with `|e('html')` before concatenation into HTML `<a>` tags that are rendered with `|raw` -- prevents username-based XSS
- **Admin send-mail template**: remove `{% autoescape false %}` blocks; use `|nl2br` (which auto-escapes) instead of server-side `str_replace(PHP_EOL, '<br>')` -- prevents HTML injection in admin emails
- **Maintenance info**: escape `featureName` and `additionalInfo` with `|e('html')` inside their HTML span wrappers -- prevents stored XSS from admin-set database values
- **Admin maintain page**: remove `|raw` from `RemovableObject.description` -- use default auto-escaping
- **Email templates**: remove unnecessary `{% autoescape false %}` from password reset and account verification emails (hardening -- no user data was at risk)

Closes #6336

## Test plan
- [ ] Verify studio activity list still renders usernames correctly (with special chars like `<`, `&`, `"`)
- [ ] Verify admin send-mail still delivers emails with line breaks preserved
- [ ] Verify maintenance information page still renders feature names and additional info with bold styling
- [ ] Verify admin maintain page still shows removable object descriptions
- [ ] Verify password reset and account verification emails still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)