### PR TITLE
Fix inverted follower/following logic in API and trust score calculation

### DIFF
--- a/src/Api/Services/Followers/FollowersApiLoader.php
+++ b/src/Api/Services/Followers/FollowersApiLoader.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Api\Services\Followers;
+
+use App\DB\Entity\User\User;
+use App\DB\EntityRepository\User\UserRepository;
+use Symfony\Component\Security\Core\Security;
+
+class FollowersApiLoader
+{
+    public function __construct(
+        private readonly UserRepository $user_repository,
+        private readonly Security $security,
+    ) {
+    }
+
+    /**
+     * Returns the list of users who follow the given user.
+     *
+     * Joins on f.following so that we find rows where the given user
+     * is the one being followed (i.e. f.following = user), then returns
+     * f.follower — the accounts that performed the follow action.
+     *
+     * Previously this accidentally queried f.followers (the inverse side),
+     * which returned who the user follows rather than who follows them.
+     * See: https://github.com/Catrobat/Catroweb/issues/6299
+     */
+    public function getFollowers(string $username, int $limit, int $offset): array
+    {
+        /** @var User|null $user */
+        $user = $this->user_repository->findUserByUsername($username);
+        if (null === $user) {
+            return [];
+        }
+
+        return $this->user_repository->createQueryBuilder('u')
+            ->innerJoin('u.followers', 'f')         // f = UserFollowing row
+            ->innerJoin('f.following', 'followed')  // followed = the user being followed
+            ->where('followed = :user')
+            ->setParameter('user', $user)
+            ->setMaxResults($limit)
+            ->setFirstResult($offset)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+
+    /**
+     * Returns the list of users that the given user follows.
+     *
+     * Joins on f.follower so that we find rows where the given user
+     * is the one doing the following (i.e. f.follower = user), then
+     * returns f.following — the accounts the user has subscribed to.
+     *
+     * Previously this accidentally queried f.following (the inverse side),
+     * which returned who follows the user rather than who the user follows.
+     * See: https://github.com/Catrobat/Catroweb/issues/6299
+     */
+    public function getFollowing(string $username, int $limit, int $offset): array
+    {
+        /** @var User|null $user */
+        $user = $this->user_repository->findUserByUsername($username);
+        if (null === $user) {
+            return [];
+        }
+
+        return $this->user_repository->createQueryBuilder('u')
+            ->innerJoin('u.following', 'f')          // f = UserFollowing row
+            ->innerJoin('f.follower', 'follower')    // follower = the user who initiated the follow
+            ->where('follower = :user')
+            ->setParameter('user', $user)
+            ->setMaxResults($limit)
+            ->setFirstResult($offset)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+}

--- a/src/Moderation/TrustScoreCalculator.php
+++ b/src/Moderation/TrustScoreCalculator.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Moderation;
+
+use App\DB\Entity\User\User;
+use App\DB\EntityRepository\User\UserRepository;
+use App\DB\EntityRepository\Project\ProgramRepository;
+
+/**
+ * Calculates a trust score for a given user.
+ *
+ * The score is a weighted sum of several signals. Higher scores indicate
+ * higher trustworthiness and are used by moderation tooling to prioritise
+ * manual reviews.
+ *
+ * Fix applied (issue #6299): the $follower_count calculation previously
+ * joined on `f.follower` (i.e. counted outbound follows) instead of
+ * `f.following` (i.e. counted inbound followers). This caused the trust
+ * score to reflect how many accounts a user follows rather than how popular
+ * the user is — a signal with opposite meaning. The DQL join is now corrected.
+ */
+class TrustScoreCalculator
+{
+    // Scoring weights — adjust to tune moderation sensitivity.
+    private const WEIGHT_UPLOAD_COUNT    = 2;
+    private const WEIGHT_FOLLOWER_COUNT  = 3;
+    private const WEIGHT_DOWNLOAD_COUNT  = 1;
+    private const WEIGHT_ACCOUNT_AGE     = 5;   // points per year
+
+    public function __construct(
+        private readonly UserRepository    $user_repository,
+        private readonly ProgramRepository $program_repository,
+    ) {
+    }
+
+    public function calculate(User $user): float
+    {
+        $upload_count   = $this->getUploadCount($user);
+        $follower_count = $this->getFollowerCount($user);  // inbound followers
+        $download_count = $this->getDownloadCount($user);
+        $account_age    = $this->getAccountAgeInYears($user);
+
+        return
+            ($upload_count   * self::WEIGHT_UPLOAD_COUNT)
+            + ($follower_count * self::WEIGHT_FOLLOWER_COUNT)
+            + ($download_count * self::WEIGHT_DOWNLOAD_COUNT)
+            + ($account_age   * self::WEIGHT_ACCOUNT_AGE);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private function getUploadCount(User $user): int
+    {
+        return $this->program_repository->countPublicUserProjects($user->getId());
+    }
+
+    /**
+     * Counts the number of users who follow $user (inbound follower count).
+     *
+     * Previously used `f.follower = :user` which counted how many accounts
+     * $user themselves follow (outbound), producing an inverted signal.
+     * Corrected to `f.following = :user` so we count incoming followers.
+     *
+     * @see https://github.com/Catrobat/Catroweb/issues/6299
+     */
+    private function getFollowerCount(User $user): int
+    {
+        return (int) $this->user_repository->createQueryBuilder('u')
+            ->select('COUNT(f)')
+            ->innerJoin('u.followers', 'f')        // UserFollowing rows where u is followed
+            ->innerJoin('f.following', 'followed') // the account being followed
+            ->where('followed = :user')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
+    }
+
+    private function getDownloadCount(User $user): int
+    {
+        return $user->getNumberOfProjects() > 0
+            ? $this->program_repository->getTotalDownloadsOfUser($user->getId())
+            : 0;
+    }
+
+    private function getAccountAgeInYears(User $user): float
+    {
+        $created_at = $user->getCreatedAt();
+        if (null === $created_at) {
+            return 0.0;
+        }
+
+        $diff = $created_at->diff(new \DateTimeImmutable());
+
+        return $diff->y + ($diff->m / 12);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #6299

The `getFollowers()` and `getFollowing()` methods in `FollowersApiLoader` had 
their DQL join conditions swapped, causing the API to return completely inverted 
results — the followers list showed who the user follows, and the following list 
showed who follows them.

The same inversion existed in `TrustScoreCalculator`, where `getFollowerCount()` 
was counting outbound follows (people the user follows) instead of inbound 
followers (people who follow the user), silently corrupting trust scores for any 
user with an asymmetric follower/following count.

## Root Cause
The `UserFollowing` entity has two sides:
- `f.follower` → the user who **initiated** the follow
- `f.following` → the user who **is being followed**

All three affected queries had these two fields used in the wrong direction.

## Changes
**`src/Api/Services/Followers/FollowersApiLoader.php`**
- `getFollowers()`: fixed join to correctly return users who follow the given user
- `getFollowing()`: fixed join to correctly return users the given user follows

**`src/Moderation/TrustScoreCalculator.php`**
- `getFollowerCount()`: fixed join to count inbound followers instead of outbound follows

## How to Test
1. Find a user profile with an asymmetric follower/following count
2. Call `GET /api/user/{username}/followers` — should return who follows them
3. Call `GET /api/user/{username}/following` — should return who they follow
4. Verify the profile page Followers and Following tabs match correctly