### PR TITLE
Fix reset command ignoring --limit option

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -556,7 +556,6 @@
     </PossiblyFalseArgument>
     <PossiblyNullArgument>
       <code><![CDATA[$this->getApplication()]]></code>
-      <code><![CDATA[$this->getApplication()]]></code>
     </PossiblyNullArgument>
   </file>
   <file src="src/System/Commands/ImportProjects/ProgramImportCommand.php">

--- a/src/System/Commands/ImportProjects/ImportProjectsFromShare.php
+++ b/src/System/Commands/ImportProjects/ImportProjectsFromShare.php
@@ -11,7 +11,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -110,13 +109,6 @@ class ImportProjectsFromShare extends Command
    */
   private function importProjects(string $import_dir, string $username, int $remix_layout, OutputInterface $output): void
   {
-    CommandHelper::executeSymfonyCommand('catrobat:import', $this->getApplication(),
-      [
-        'directory' => $import_dir,
-        'user' => $username,
-      ],
-      new NullOutput()
-    );
     CommandHelper::executeSymfonyCommand('catrobat:import', $this->getApplication(),
       [
         'directory' => $import_dir,

--- a/src/System/Commands/ImportProjects/ProgramImportCommand.php
+++ b/src/System/Commands/ImportProjects/ProgramImportCommand.php
@@ -42,6 +42,9 @@ class ProgramImportCommand extends Command
       ->addOption('remix-layout', null, InputOption::VALUE_REQUIRED,
         'Generates remix graph based on given layout',
         self::REMIX_GRAPH_NO_LAYOUT)
+      ->addOption('limit', 'l', InputOption::VALUE_REQUIRED,
+        'Maximum number of programs to import',
+        '0')
     ;
   }
 
@@ -59,6 +62,8 @@ class ProgramImportCommand extends Command
     $all_layouts = RemixGraphLayout::$REMIX_GRAPH_MAPPING;
     $num_of_layouts = count($all_layouts);
     $remix_graph_mapping = (($layout_idx >= 0) && ($layout_idx < $num_of_layouts)) ? $all_layouts[$layout_idx] : [];
+
+    $limit = intval($input->getOption('limit'));
 
     $this->remix_manipulation_program_manager->useRemixManipulationFileExtractor($remix_graph_mapping);
 
@@ -79,14 +84,21 @@ class ProgramImportCommand extends Command
       return 1;
     }
 
+    $imported = 0;
+
     /** @var SplFileInfo $file */
     foreach ($finder as $file) {
+      if ($limit > 0 && $imported >= $limit) {
+        break;
+      }
+
       try {
         $output->writeln('Importing file '.$file->getFilename());
         $add_program_request = new AddProjectRequest($user, new File($file->__toString()));
         $program = $this->remix_manipulation_program_manager->addProject($add_program_request);
         $program->setViews(random_int(0, 10));
         $output->writeln('Added program <'.$program->getName().'> for user: <'.$username.'>');
+        ++$imported;
       } catch (InvalidCatrobatFileException $e) {
         $output->writeln('FAILED to add program!');
         $output->writeln($e->getMessage().' ('.$e->getCode().')');

--- a/src/System/Commands/Reset/ResetCommand.php
+++ b/src/System/Commands/Reset/ResetCommand.php
@@ -222,9 +222,9 @@ class ResetCommand extends Command
       $limit = 0;
     }
 
-    $projects_to_download = $limit;
-    while ($projects_to_download > 0) {
-      $amount = random_int(1, max(1, intval(floor($projects_to_download / 5)) + 1));
+    $projects_remaining = $limit;
+    while ($projects_remaining > 0) {
+      $amount = random_int(1, max(1, intval(floor($projects_remaining / 5)) + 1));
       $username = $user_array[random_int(0, count($user_array) - 1)];
 
       CommandHelper::executeSymfonyCommand('catrobat:import', $this->getApplicationOrFail(),
@@ -232,10 +232,11 @@ class ResetCommand extends Command
           'directory' => $local_projects_dir,
           'user' => $username,
           '--remix-layout' => $remix_layout,
+          '--limit' => $amount,
         ],
         $output
       );
-      $projects_to_download -= $amount;
+      $projects_remaining -= $amount;
     }
 
     $projects_count = count($this->program_manager->findAll());


### PR DESCRIPTION
## Summary
- **`catrobat:import` now supports `--limit`**: Added a `--limit` option that caps how many `.catrobat` files are imported from the directory. Default `0` means unlimited (backward compatible).
- **Removed duplicate import in `ImportProjectsFromShare`**: The `importProjects()` method was calling `catrobat:import` twice on the same directory — once with `NullOutput` and once with regular output — importing every project twice.
- **`ResetCommand::importLocalProjects` now passes `--limit`**: Previously called `catrobat:import` in a loop but each call imported *all* files, ignoring the intended limit entirely.

## Test plan
- [ ] Run `bin/console catrobat:reset --hard --limit 5` and verify only ~5 projects are imported
- [ ] Run `bin/console catrobat:import <dir> <user> --limit 3` and verify only 3 files are imported
- [ ] Run `bin/console catrobat:import <dir> <user>` (no limit) and verify all files are still imported

🤖 Generated with [Claude Code](https://claude.com/claude-code)