### PR TITLE
Add bundle analyzer and fix duplicate webpack rules (#6347)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ bin/
 node_modules/
 .yarn/
 .pnp.*
+bundle-report.html
 
 ### public ###
 public/**

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build": "encore production --progress",
     "encore": "encore",
     "prod": "encore prod",
+    "analyze": "encore production --progress --env ANALYZE=true",
     "reset": "bin/console catro:reset --hard --limit 20"
   },
   "repository": {
@@ -74,6 +75,7 @@
     "stylelint-config-standard-scss": "^17.0.0",
     "webpack": "^5.105.4",
     "webpack-bugsnag-plugins": "^2.2.3",
+    "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^7.0.2",
     "webpack-notifier": "^1.15.0"
   },

--- a/templates/Layout/Base.html.twig
+++ b/templates/Layout/Base.html.twig
@@ -12,6 +12,13 @@
 
   <link rel="shortcut icon" href="{{ asset('images/favicon.ico') }}"/>
 
+  {% if bugsnag_api_key %}
+    <link rel="dns-prefetch" href="https://sessions.bugsnag.com">
+    <link rel="dns-prefetch" href="https://notify.bugsnag.com">
+    <link rel="preconnect" href="https://sessions.bugsnag.com" crossorigin>
+    <link rel="preconnect" href="https://notify.bugsnag.com" crossorigin>
+  {% endif %}
+
   {% block stylesheets %}
     {{ encore_entry_link_tags('base_layout') }}
     {{ encore_entry_link_tags('color_scheme') }}

--- a/templates/Project/RemixGraphPage.html.twig
+++ b/templates/Project/RemixGraphPage.html.twig
@@ -24,7 +24,6 @@
 {% block javascript %}
     <script src="{{ asset('js/modules/jquery.min.js') }}"></script>
     <script src="{{ asset('js/modules/jquery.contextMenu.min.js') }}"></script>
-    <script src="{{ asset('js/modules/jquery.contextMenu.min.js') }}"></script>
     <script src="{{ asset('js/modules/jquery.ui.position.min.js') }}"></script>
     <script src="{{ asset('vis/vis.min.js') }}"></script>
     <script src="{{ asset('js/RemixGraph/remixgraph.configuration.js') }}"></script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ const glob = require('glob-all')
 const path = require('path')
 const webpack = require('webpack')
 const noop = require('noop-webpack-plugin')
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 
 // Manually configure the runtime environment if not already configured yet by the "encore" command.
 // It's useful when you use tools that rely on webpack.config.js file.
@@ -55,11 +56,6 @@ Encore
     },
     {
       from: './node_modules/jquery-ui-dist/',
-      pattern: /\.js$/,
-      to: '../js/modules/[path][name].[ext]',
-    },
-    {
-      from: './node_modules/jquery-contextmenu/dist/',
       pattern: /\.js$/,
       to: '../js/modules/[path][name].[ext]',
     },
@@ -235,6 +231,16 @@ Encore
       failOnError: Encore.isProduction(),
       files: 'assets/',
     }),
+  )
+
+  .addPlugin(
+    process.env.ANALYZE
+      ? new BundleAnalyzerPlugin({
+          analyzerMode: 'static',
+          reportFilename: 'bundle-report.html',
+          openAnalyzer: true,
+        })
+      : noop(),
   )
 
 module.exports = Encore.getWebpackConfig()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,6 +1402,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@discoveryjs/json-ext@npm:0.5.7":
+  version: 0.5.7
+  resolution: "@discoveryjs/json-ext@npm:0.5.7"
+  checksum: 10c0/e10f1b02b78e4812646ddf289b7d9f2cb567d336c363b266bd50cd223cf3de7c2c74018d91cd2613041568397ef3a4a2b500aba588c6e5bd78c38374ba68f38c
+  languageName: node
+  linkType: hard
+
 "@discoveryjs/json-ext@npm:^1.0.0":
   version: 1.0.0
   resolution: "@discoveryjs/json-ext@npm:1.0.0"
@@ -2723,6 +2730,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polka/url@npm:^1.0.0-next.24":
+  version: 1.0.0-next.29
+  resolution: "@polka/url@npm:1.0.0-next.29"
+  checksum: 10c0/0d58e081844095cb029d3c19a659bfefd09d5d51a2f791bc61eba7ea826f13d6ee204a8a448c2f5a855c17df07b37517373ff916dd05801063c0568ae9937684
+  languageName: node
+  linkType: hard
+
 "@popperjs/core@npm:^2.11.8":
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
@@ -3385,21 +3399,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-walk@npm:^8.0.0":
+  version: 8.3.5
+  resolution: "acorn-walk@npm:8.3.5"
+  dependencies:
+    acorn: "npm:^8.11.0"
+  checksum: 10c0/e31bf5b5423ed1349437029d66d708b9fbd1b77a644b031501e2c753b028d13b56348210ed901d5b1d0d86eb3381c0a0fc0d0998511a9d546d1194936266a332
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.0.4, acorn@npm:^8.11.0, acorn@npm:^8.16.0":
+  version: 8.16.0
+  resolution: "acorn@npm:8.16.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 10c0/c9c52697227661b68d0debaf972222d4f622aa06b185824164e153438afa7b08273432ca43ea792cadb24dada1d46f6f6bb1ef8de9956979288cc1b96bf9914e
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^8.15.0, acorn@npm:^8.9.0":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
     acorn: bin/acorn
   checksum: 10c0/dec73ff59b7d6628a01eebaece7f2bdb8bb62b9b5926dcad0f8931f2b8b79c2be21f6c68ac095592adb5adb15831a3635d9343e6a91d028bbe85d564875ec3ec
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.16.0":
-  version: 8.16.0
-  resolution: "acorn@npm:8.16.0"
-  bin:
-    acorn: bin/acorn
-  checksum: 10c0/c9c52697227661b68d0debaf972222d4f622aa06b185824164e153438afa7b08273432ca43ea792cadb24dada1d46f6f6bb1ef8de9956979288cc1b96bf9914e
   languageName: node
   linkType: hard
 
@@ -4105,6 +4128,7 @@ __metadata:
     vis: "npm:^4.21.0-EOL"
     webpack: "npm:^5.105.4"
     webpack-bugsnag-plugins: "npm:^2.2.3"
+    webpack-bundle-analyzer: "npm:^4.10.2"
     webpack-cli: "npm:^7.0.2"
     webpack-notifier: "npm:^1.15.0"
   languageName: unknown
@@ -4683,6 +4707,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debounce@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "debounce@npm:1.2.1"
+  checksum: 10c0/6c9320aa0973fc42050814621a7a8a78146c1975799b5b3cc1becf1f77ba9a5aa583987884230da0842a03f385def452fad5d60db97c3d1c8b824e38a8edf500
+  languageName: node
+  linkType: hard
+
 "debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.1, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
@@ -4899,6 +4930,13 @@ __metadata:
     es-errors: "npm:^1.3.0"
     gopd: "npm:^1.2.0"
   checksum: 10c0/199f2a0c1c16593ca0a145dbf76a962f8033ce3129f01284d48c45ed4e14fea9bbacd7b3610b6cdc33486cef20385ac054948fefc6272fcce645c09468f93031
+  languageName: node
+  linkType: hard
+
+"duplexer@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "duplexer@npm:0.1.2"
+  checksum: 10c0/c57bcd4bdf7e623abab2df43a7b5b23d18152154529d166c1e0da6bee341d84c432d157d7e97b32fecb1bf3a8b8857dd85ed81a915789f550637ed25b8e64fc2
   languageName: node
   linkType: hard
 
@@ -6335,6 +6373,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gzip-size@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "gzip-size@npm:6.0.0"
+  dependencies:
+    duplexer: "npm:^0.1.2"
+  checksum: 10c0/4ccb924626c82125897a997d1c84f2377846a6ef57fbee38f7c0e6b41387fba4d00422274440747b58008b5d60114bac2349c2908e9aba55188345281af40a3f
+  languageName: node
+  linkType: hard
+
 "hammerjs@npm:^2.0.8":
   version: 2.0.8
   resolution: "hammerjs@npm:2.0.8"
@@ -6437,6 +6484,13 @@ __metadata:
   version: 1.15.1
   resolution: "hookified@npm:1.15.1"
   checksum: 10c0/6b691374fa97ae57169fb29f90e723499fda5e85494654fbe55c4768b3ccbf3e14c0adc8d0f365f32c503b60d7c06f907781f5966c03d41c423575eb5e16860c
+  languageName: node
+  linkType: hard
+
+"html-escaper@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "html-escaper@npm:2.0.2"
+  checksum: 10c0/208e8a12de1a6569edbb14544f4567e6ce8ecc30b9394fcaa4e7bb1e60c12a7c9a1ed27e31290817157e8626f3a4f29e76c8747030822eb84a6abb15c255f0a0
   languageName: node
   linkType: hard
 
@@ -7698,6 +7752,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mrmime@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mrmime@npm:2.0.1"
+  checksum: 10c0/af05afd95af202fdd620422f976ad67dc18e6ee29beb03dd1ce950ea6ef664de378e44197246df4c7cdd73d47f2e7143a6e26e473084b9e4aa2095c0ad1e1761
+  languageName: node
+  linkType: hard
+
 "ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -7947,6 +8008,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"opener@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "opener@npm:1.5.2"
+  bin:
+    opener: bin/opener-bin.js
+  checksum: 10c0/dd56256ab0cf796585617bc28e06e058adf09211781e70b264c76a1dbe16e90f868c974e5bf5309c93469157c7d14b89c35dc53fe7293b0e40b4d2f92073bc79
+  languageName: node
+  linkType: hard
+
 "optionator@npm:^0.9.3":
   version: 0.9.4
   resolution: "optionator@npm:0.9.4"
@@ -8159,7 +8229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
+"picocolors@npm:^1.0.0, picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -9428,6 +9498,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sirv@npm:^2.0.3":
+  version: 2.0.4
+  resolution: "sirv@npm:2.0.4"
+  dependencies:
+    "@polka/url": "npm:^1.0.0-next.24"
+    mrmime: "npm:^2.0.0"
+    totalist: "npm:^3.0.0"
+  checksum: 10c0/68f8ee857f6a9415e9c07a1f31c7c561df8d5f1b1ba79bee3de583fa37da8718def5309f6b1c6e2c3ef77de45d74f5e49efc7959214443aa92d42e9c99180a4e
+  languageName: node
+  linkType: hard
+
 "slash@npm:^5.1.0":
   version: 5.1.0
   resolution: "slash@npm:5.1.0"
@@ -10087,6 +10168,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"totalist@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "totalist@npm:3.0.1"
+  checksum: 10c0/4bb1fadb69c3edbef91c73ebef9d25b33bbf69afe1e37ce544d5f7d13854cda15e47132f3e0dc4cafe300ddb8578c77c50a65004d8b6e97e77934a69aa924863
+  languageName: node
+  linkType: hard
+
 "tr46@npm:~0.0.3":
   version: 0.0.3
   resolution: "tr46@npm:0.0.3"
@@ -10504,6 +10592,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webpack-bundle-analyzer@npm:^4.10.2":
+  version: 4.10.2
+  resolution: "webpack-bundle-analyzer@npm:4.10.2"
+  dependencies:
+    "@discoveryjs/json-ext": "npm:0.5.7"
+    acorn: "npm:^8.0.4"
+    acorn-walk: "npm:^8.0.0"
+    commander: "npm:^7.2.0"
+    debounce: "npm:^1.2.1"
+    escape-string-regexp: "npm:^4.0.0"
+    gzip-size: "npm:^6.0.0"
+    html-escaper: "npm:^2.0.2"
+    opener: "npm:^1.5.2"
+    picocolors: "npm:^1.0.0"
+    sirv: "npm:^2.0.3"
+    ws: "npm:^7.3.1"
+  bin:
+    webpack-bundle-analyzer: lib/bin/analyzer.js
+  checksum: 10c0/00603040e244ead15b2d92981f0559fa14216381349412a30070a7358eb3994cd61a8221d34a3b3fb8202dc3d1c5ee1fbbe94c5c52da536e5b410aa1cf279a48
+  languageName: node
+  linkType: hard
+
 "webpack-cli@npm:^7.0.2":
   version: 7.0.2
   resolution: "webpack-cli@npm:7.0.2"
@@ -10837,6 +10947,21 @@ __metadata:
   dependencies:
     signal-exit: "npm:^4.0.1"
   checksum: 10c0/69cebb64945e22928a24ae7e2a55bf54438c92d6f657c1fa5e96b7c7a50f6c022e7454ab5c259079bb35f60296242f3a21234c79320d64a8ad57675b56a2098d
+  languageName: node
+  linkType: hard
+
+"ws@npm:^7.3.1":
+  version: 7.5.10
+  resolution: "ws@npm:7.5.10"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/bd7d5f4aaf04fae7960c23dcb6c6375d525e00f795dd20b9385902bd008c40a94d3db3ce97d878acc7573df852056ca546328b27b39f47609f80fb22a0a9b61d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Add `webpack-bundle-analyzer` as a dev dependency with `yarn run analyze` script for inspecting bundle composition
- Fix duplicate `jquery-contextmenu` JS CopyPlugin rule in `webpack.config.js` (lines 62-69 were identical)
- Fix duplicate `jquery.contextMenu.min.js` script tag in `RemixGraphPage.html.twig`
- Add conditional Bugsnag resource hints (`dns-prefetch`, `preconnect`) to the base layout template for faster error reporting initialization
- Add `bundle-report.html` to `.gitignore`

### jQuery usage audit
Only the **legacy RemixGraph** feature uses jQuery:
- `assets/Legacy/RemixGraph/remixgraph.visualization.js` -- uses `$()` extensively
- `templates/Project/RemixGraphPage.html.twig` -- loads `jquery.min.js`, `jquery-contextmenu`, `jquery-ui`
- `assets/catblocks/CatBlocks.js` -- bundled/minified third-party, contains jQuery internally

All other pages use vanilla JS. jQuery removal should target the RemixGraph rewrite as a separate effort.

## Test plan
- [ ] `yarn run analyze` produces a `bundle-report.html` with an interactive treemap
- [ ] `yarn run dev` / `yarn run build` still succeed without the analyzer (ANALYZE env not set)
- [ ] RemixGraph page loads correctly (no missing jquery-contextmenu assets)
- [ ] Bugsnag resource hints appear in page source only when `bugsnag_api_key` is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)