### PR TITLE
Add translatable noscript warning banner

### DIFF
--- a/assets/Layout/Base.scss
+++ b/assets/Layout/Base.scss
@@ -18,3 +18,4 @@
 @import './ProgressBar';
 @import './LegacyBase';
 @import './CookieConsent';
+@import './Noscript';

--- a/assets/Layout/Noscript.scss
+++ b/assets/Layout/Noscript.scss
@@ -1,0 +1,9 @@
+.noscript-warning {
+  background-color: #fff3cd;
+  color: #664d03;
+  text-align: center;
+  padding: 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  border-bottom: 1px solid #ffecb5;
+}

--- a/templates/Layout/Base.html.twig
+++ b/templates/Layout/Base.html.twig
@@ -45,8 +45,8 @@
 <body class="body-with-sidebar">
 
 <noscript>
-  <div class="noscript-warning" style="background-color: #fff3cd; color: #856404; text-align: center; padding: 1rem; font-size: 1rem;">
-    This site requires JavaScript to function. Please enable JavaScript in your browser.
+  <div class="noscript-warning">
+    {{ 'noscript.warning'|trans({}, 'catroweb') }}
   </div>
 </noscript>
 

--- a/translations/catroweb.en.yaml
+++ b/translations/catroweb.en.yaml
@@ -852,6 +852,9 @@ flavor:
 
 copyright: 'Copyright &copy; %year% <a href="http://www.catrobat.org">Catrobat</a>. All rights reserved.'
 
+noscript:
+  warning: "This website needs JavaScript to work. Please enable JavaScript in your browser or ask an adult to help you."
+
 cookie-consent:
   message: "We use cookies to help improve our services. No data is sold or shared."
   accept: "Accept"


### PR DESCRIPTION
## Summary
- Replaces the hardcoded English `<noscript>` message in `Base.html.twig` with a translatable string using Symfony's translation system
- Moves inline styles to a dedicated `Noscript.scss` file imported via `Base.scss`
- Adds child-friendly warning message: "This website needs JavaScript to work. Please enable JavaScript in your browser or ask an adult to help you."

Closes #6352

## Test plan
- [ ] Disable JavaScript in browser and verify the yellow warning banner appears at the top of every page
- [ ] Verify the message is translatable by checking it uses the `noscript.warning` translation key
- [ ] Verify no visual regression with JavaScript enabled (banner should not appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)