### PR TITLE
Enable CSRF protection for web forms

### DIFF
--- a/config/packages/framework.php
+++ b/config/packages/framework.php
@@ -14,7 +14,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
       'translator' => [
         'fallback' => 'en',
       ],
-      'csrf_protection' => false,
+      'csrf_protection' => true,
       'http_method_override' => false,
       'session' => [
         'handler_id' => null,

--- a/config/packages/security.php
+++ b/config/packages/security.php
@@ -61,6 +61,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
           'form_login' => [
             'default_target_path' => '/',
             'success_handler' => FormLoginSuccessHandler::class,
+            'enable_csrf' => true,
           ],
           'custom_authenticators' => [
             WebviewJWTAuthenticator::class,

--- a/src/Admin/System/Logs/DownloadLogController.php
+++ b/src/Admin/System/Logs/DownloadLogController.php
@@ -31,6 +31,10 @@ class DownloadLogController extends AbstractController
       throw new NotFoundHttpException();
     }
 
+    if (!$this->isCsrfTokenValid('log_download', $request->request->getString('_csrf_token'))) {
+      throw $this->createAccessDeniedException('Invalid CSRF token.');
+    }
+
     $fileName = (string) $request->request->get('file');
     $path = LogsController::LOG_DIR;
     $finder = new Finder();

--- a/src/Application/Controller/Studio/StudioController.php
+++ b/src/Application/Controller/Studio/StudioController.php
@@ -422,6 +422,10 @@ class StudioController extends AbstractController
   public function editStudioDetails(Request $request): Response
   {
     if ($request->isMethod('POST')) {
+      if (!$this->isCsrfTokenValid('studio_settings', $request->request->getString('_csrf_token'))) {
+        throw $this->createAccessDeniedException('Invalid CSRF token.');
+      }
+
       $studio_id = trim(strval($request->request->get('studio_id')));
       $studio = $this->studio_manager->findStudioById($studio_id);
       if (is_null($this->getUser()) || is_null($studio)) {
@@ -476,6 +480,10 @@ class StudioController extends AbstractController
   public function updateStudioProjects(Request $request): Response
   {
     if ($request->isMethod('POST')) {
+      if (!$this->isCsrfTokenValid('studio_projects', $request->request->getString('_csrf_token'))) {
+        throw $this->createAccessDeniedException('Invalid CSRF token.');
+      }
+
       $studio_id = trim(strval($request->request->get('studio_id')));
       $studio = $this->studio_manager->findStudioById($studio_id);
       if (is_null($this->getUser()) || is_null($studio)) {

--- a/templates/Admin/SystemManagement/Logs.html.twig
+++ b/templates/Admin/SystemManagement/Logs.html.twig
@@ -95,6 +95,7 @@
             <div id="current-file-container">
               <h5>Current file: <span id="currentFileName">{{ files[0] }}</span></h5>
               <form action="/admin/downloadLogs/" method="post">
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token('log_download') }}">
                 <input id="currentFile" name="file" type="hidden" value="{{ files[0] }}">
                 <input value="Download" type="submit" formtarget="_blank" class="btn">
               </form>

--- a/templates/Project/NewKeyStore.html.twig
+++ b/templates/Project/NewKeyStore.html.twig
@@ -22,6 +22,7 @@
             </div>
             <div class="modal-body">
                 <form action="" method="post" class="form-horizontal sign-app-form">
+                    <input type="hidden" name="_csrf_token" value="{{ csrf_token('new_key_store') }}">
                     <div class="row">
                         <div class="form-group col-lg-12">
                             <input id="key_store_path_text" readonly type="text" name="key_store_path_text"

--- a/templates/Project/SignAppModal.html.twig
+++ b/templates/Project/SignAppModal.html.twig
@@ -52,6 +52,7 @@
             </div>
             <div class="modal-body">
                 <form action="" method="post" class="form-horizontal sign-app-form">
+                    <input type="hidden" name="_csrf_token" value="{{ csrf_token('sign_app') }}">
                     <div class="row">
                         <div class="form-group col-lg-12">
                             <input id="package_name" type="text" name="package_name"

--- a/templates/Studio/Details/AdminSettings.html.twig
+++ b/templates/Studio/Details/AdminSettings.html.twig
@@ -21,6 +21,7 @@
 
       <form id="studio-settings" class="container-fluid justify-content-center" action="{{ path('update_studio_details') }}" method="post">
 
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token('studio_settings') }}">
         <input type="hidden" name="studio_id" value="{{ studio.id }}">
 
         {{ include('Components/TextField.html.twig', {

--- a/templates/Studio/StudioAddProjectDialog.html.twig
+++ b/templates/Studio/StudioAddProjectDialog.html.twig
@@ -21,6 +21,7 @@
             </div>
 
             <form id="studio-settings_projects" class="container-fluid justify-content-center page-content container" style="margin-top: 0px;" action="{{ path('update_studio_projects') }}" method="post">
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token('studio_projects') }}">
                 <input type="hidden" name="studio_id" value="{{ studio.id }}">
                 <h3 class="mt-3 mb-4">Your Projects</h3>
                 <div class="studio-projects-container project-list horizontal">


### PR DESCRIPTION
## Summary
- Re-enables CSRF protection globally (`csrf_protection => true` in `framework.php`) which was previously disabled
- Enables CSRF on the `form_login` authenticator in the `main` firewall
- Adds `_csrf_token` hidden fields to all traditional POST forms: studio settings, studio project management, admin log download, sign app modal, and new key store modal
- Adds server-side CSRF token validation in `StudioController` and `DownloadLogController`
- API endpoints (stateless JWT) are unaffected -- they don't use sessions or form submissions

## Context
CSRF protection was globally disabled in `config/packages/framework.php` (line 17). The API is stateless (JWT-based) so it doesn't need CSRF, but the web app uses session-based authentication (main firewall) which **is** vulnerable to CSRF without token protection.

### Forms protected
| Form | Template | Controller |
|------|----------|------------|
| Studio admin settings | `Studio/Details/AdminSettings.html.twig` | `StudioController::editStudioDetails` |
| Studio add/remove projects | `Studio/StudioAddProjectDialog.html.twig` | `StudioController::updateStudioProjects` |
| Admin log download | `Admin/SystemManagement/Logs.html.twig` | `DownloadLogController::downloadLogAction` |
| Sign app | `Project/SignAppModal.html.twig` | (form action="") |
| New key store | `Project/NewKeyStore.html.twig` | (form action="") |

### Forms NOT affected (already safe)
- **Login form**: Uses JS-based login via `LoginTokenHandler.js` -> `/api/authentication` (JWT, stateless)
- **Profile/Security settings**: JS-driven, submit via API with Bearer token
- **Studio create**: JS-driven, submit via API
- **Search form**: GET request (no state change)
- **Sonata Admin forms**: Sonata has its own CSRF handling via `sonata_form` config

## Test plan
- [ ] Verify login still works (JS-based, should be unaffected)
- [ ] Verify studio settings form submission works with CSRF token
- [ ] Verify studio project add/remove works with CSRF token
- [ ] Verify admin log download works with CSRF token
- [ ] Verify API endpoints still work (JWT auth, no CSRF needed)
- [ ] Verify Sonata admin panel still works

Closes #6353

🤖 Generated with [Claude Code](https://claude.com/claude-code)