### PR TITLE
Add safeguards against default secrets in production

### DIFF
--- a/.github/workflows/code_quality.yaml
+++ b/.github/workflows/code_quality.yaml
@@ -239,3 +239,16 @@ jobs:
       - name: 'Setup PHP and composer packages'
         uses: ./.github/actions/setup-php-composer
       - run: bin/console lint:container
+
+  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  # ** Secrets **
+  #
+  #  - Ensures committed .env files contain only known dev defaults
+  #  - Prevents accidental commit of production secrets
+  #
+  check-secrets:
+    name: Secrets [Check Default Secrets]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: bin/check-default-secrets

--- a/bin/check-default-secrets
+++ b/bin/check-default-secrets
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Checks that committed .env files do not contain production-ready secrets.
+# The default values in .env are intentionally insecure (dev-only defaults).
+# This script verifies they remain recognizable as dev defaults and warns
+# if someone accidentally commits real secrets into tracked .env files.
+#
+# Usage: bin/check-default-secrets
+# Exit codes:
+#   0 = OK (only known dev defaults found, or properly overridden in .env.prod.local)
+#   1 = Real-looking secrets found in committed files (potential leak)
+
+set -euo pipefail
+
+ERRORS=0
+
+# Known development-only defaults that are EXPECTED in .env
+# If these change to something else, someone may have committed a real secret.
+KNOWN_DEV_DEFAULTS=(
+  "APP_SECRET=93055246cfa39f62f5be97928084989a"
+  "JWT_PASSPHRASE=catroweb"
+  "DATABASE_PASSWORD=root"
+  "GOOGLE_CLIENT_SECRET='secret'"
+  "JENKINS_TOKEN='token'"
+  "JENKINS_UPLOAD_TOKEN='secret'"
+  "CAPTCHA_SECRET='default-secret'"
+)
+
+echo "Checking committed .env files for accidentally leaked secrets..."
+echo ""
+
+for default in "${KNOWN_DEV_DEFAULTS[@]}"; do
+  key="${default%%=*}"
+  expected_value="${default#*=}"
+
+  # Check if the key exists in .env with a DIFFERENT value than the known default
+  if [ -f .env ]; then
+    actual_line=$(grep -E "^${key}=" .env 2>/dev/null || true)
+    if [ -n "$actual_line" ]; then
+      actual_value="${actual_line#*=}"
+      if [ "$actual_value" != "$expected_value" ]; then
+        echo "WARNING: $key in .env has been changed from the known dev default."
+        echo "  Expected dev default: $expected_value"
+        echo "  Found: $actual_value"
+        echo "  If this is a real secret, do NOT commit it. Use .env.local or .env.prod.local instead."
+        echo ""
+        ERRORS=$((ERRORS + 1))
+      fi
+    fi
+  fi
+done
+
+# Check that .env.prod does NOT contain sensitive secrets
+PROD_SENSITIVE_KEYS=("APP_SECRET" "JWT_PASSPHRASE" "DATABASE_PASSWORD" "DATABASE_URL" "GOOGLE_CLIENT_SECRET" "GOOGLE_SECRET" "FB_SECRET" "APPLE_SECRET" "MAILER_DSN")
+
+if [ -f .env.prod ]; then
+  for key in "${PROD_SENSITIVE_KEYS[@]}"; do
+    if grep -qE "^${key}=" .env.prod 2>/dev/null; then
+      echo "DANGER: $key is defined in .env.prod (a committed file)."
+      echo "  Production secrets must go in .env.prod.local (gitignored), not .env.prod."
+      echo ""
+      ERRORS=$((ERRORS + 1))
+    fi
+  done
+fi
+
+# Verify .env.local is gitignored
+if ! grep -q '\.env\.local$' .gitignore 2>/dev/null; then
+  echo "WARNING: .env.local does not appear to be gitignored."
+  ERRORS=$((ERRORS + 1))
+fi
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo "Found $ERRORS potential secret issue(s). See above for details."
+  exit 1
+else
+  echo "OK: All committed .env files contain only known dev defaults."
+  echo "    Production secrets should be in .env.prod.local (gitignored)."
+  exit 0
+fi

--- a/docker/app/init-jwt-config.sh
+++ b/docker/app/init-jwt-config.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 
 # Jwt tokens need openssl keys with full access
+# Uses JWT_PASSPHRASE from environment, falls back to dev default "catroweb"
+JWT_PASS="${JWT_PASSPHRASE:-catroweb}"
+
 mkdir -p .jwt
 if [ -f ".jwt/private.pem" ] && [ -f ".jwt/public.pem" ]; then
   echo "JWT already initialized"
 else
-  openssl genpkey -out .jwt/private.pem -aes256 -algorithm rsa -pkeyopt rsa_keygen_bits:4096 -pass pass:catroweb
-  openssl pkey -in .jwt/private.pem -out .jwt/public.pem -pubout -passin pass:catroweb
+  openssl genpkey -out .jwt/private.pem -aes256 -algorithm rsa -pkeyopt rsa_keygen_bits:4096 -pass "pass:${JWT_PASS}"
+  openssl pkey -in .jwt/private.pem -out .jwt/public.pem -pubout -passin "pass:${JWT_PASS}"
   echo "JWT keys initialized"
 fi
 chmod -R 777 .jwt

--- a/docs/operations/Secret-Management.md
+++ b/docs/operations/Secret-Management.md
@@ -1,0 +1,125 @@
+# Secret Management
+
+## Overview
+
+Catroweb uses Symfony's `.env` file hierarchy for configuration. The committed `.env` file contains
+**intentionally insecure development-only defaults** so that developers can run the project locally
+without any extra setup. These defaults **must be overridden** in production.
+
+## Environment File Hierarchy
+
+Symfony loads environment files in this order (later files override earlier ones):
+
+1. `.env` -- committed, contains dev defaults
+2. `.env.local` -- **gitignored**, local overrides for any environment
+3. `.env.{APP_ENV}` -- committed, environment-specific defaults (e.g., `.env.prod`)
+4. `.env.{APP_ENV}.local` -- **gitignored**, environment-specific local overrides
+
+Real environment variables always take precedence over all `.env` files.
+
+## Secrets That Must Be Overridden in Production
+
+| Variable               | Dev Default                           | How to Override                   |
+| ---------------------- | ------------------------------------- | --------------------------------- |
+| `APP_SECRET`           | `93055246cfa39f62f5be97928084989a`    | `.env.prod.local` or real env var |
+| `JWT_PASSPHRASE`       | `catroweb`                            | `.env.prod.local` or real env var |
+| `DATABASE_URL`         | `pdo-mysql://root:root@localhost/...` | `.env.prod.local` or real env var |
+| `DATABASE_PASSWORD`    | `root`                                | `.env.prod.local` or real env var |
+| `GOOGLE_CLIENT_SECRET` | `'secret'`                            | `.env.prod.local` or real env var |
+| `MAILER_DSN`           | `null://null`                         | `.env.prod.local` or real env var |
+
+## Production Setup
+
+### 1. Create `.env.prod.local` on the Server
+
+This file is shared between deployments (configured in `deploy.php` as a shared file).
+
+```bash
+# On the production server, in the shared directory:
+nano /var/www/share/shared/.env.prod.local
+```
+
+Example contents:
+
+```env
+APP_SECRET=<generate-with: php -r "echo bin2hex(random_bytes(16));">
+JWT_PASSPHRASE=<generate-with: openssl rand -base64 32>
+DATABASE_URL=pdo-mysql://catroweb:<db-password>@localhost/catroweb
+DATABASE_PASSWORD=<db-password>
+GOOGLE_CLIENT_SECRET=<from-google-console>
+MAILER_DSN=<your-mailer-dsn>
+```
+
+### 2. Generate JWT Keys with the Production Passphrase
+
+The JWT keys in `.jwt/` (also a shared directory) must be generated with the **production** passphrase:
+
+```bash
+mkdir -p .jwt
+openssl genpkey -out .jwt/private.pem -aes256 -algorithm rsa -pkeyopt rsa_keygen_bits:4096 -pass pass:<YOUR_JWT_PASSPHRASE>
+openssl pkey -in .jwt/private.pem -out .jwt/public.pem -pubout -passin pass:<YOUR_JWT_PASSPHRASE>
+chmod 600 .jwt/private.pem
+chmod 644 .jwt/public.pem
+```
+
+**Important:** The `JWT_PASSPHRASE` in `.env.prod.local` must match the passphrase used to generate the keys.
+
+### 3. Generate a Secure `APP_SECRET`
+
+```bash
+php -r "echo bin2hex(random_bytes(16)) . PHP_EOL;"
+```
+
+This secret is used by Symfony for CSRF tokens, remember-me cookies, and other security features.
+
+## Safety Checks
+
+### Runtime Warning
+
+The `DefaultSecretsWarningListener` (in `src/Security/`) logs a `CRITICAL` message on the first
+request if it detects default dev secrets in a non-dev environment. Monitor your logs for:
+
+```
+SECURITY: Default development secrets detected in "prod" environment: APP_SECRET, JWT_PASSPHRASE
+```
+
+### CI Check
+
+The `bin/check-default-secrets` script runs in CI (Static Analysis workflow) and verifies:
+
+- Committed `.env` files contain only known dev defaults (not real secrets)
+- `.env.prod` does not define sensitive secrets (those belong in `.env.prod.local`)
+- `.env.local` is properly gitignored
+
+### Running Locally
+
+```bash
+bin/check-default-secrets
+```
+
+## What NOT to Do
+
+- **Never** put production secrets in `.env`, `.env.prod`, or any other committed file
+- **Never** commit `.env.local` or `.env.prod.local`
+- **Never** use the default `JWT_PASSPHRASE=catroweb` in production
+- **Never** use the default `APP_SECRET` in production
+- **Never** hardcode the production database password in committed files
+
+## Deployer Integration
+
+The `deploy.php` file configures these as shared files (persisted across deployments):
+
+```php
+add('shared_files', [
+    '.env.prod.local',
+    'google_cloud_key.json',
+    '.dkim/private.key',
+]);
+
+set('shared_dirs', [
+    '.jwt',  // JWT keys persist across deployments
+]);
+```
+
+This means `.env.prod.local` and `.jwt/` are symlinked from the shared directory into each release,
+so production secrets only need to be set up once.

--- a/src/Security/DefaultSecretsWarningListener.php
+++ b/src/Security/DefaultSecretsWarningListener.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Detects when known development-only default secrets are used in non-dev environments
+ * and logs critical warnings. These defaults are safe for local development but must
+ * be overridden in production via .env.prod.local or real environment variables.
+ */
+#[AsEventListener(event: KernelEvents::REQUEST, priority: 512)]
+class DefaultSecretsWarningListener
+{
+  /** @var array<string, string> Maps env var names to their known insecure default values */
+  private const array DEFAULT_SECRETS = [
+    'APP_SECRET' => '93055246cfa39f62f5be97928084989a',
+    'JWT_PASSPHRASE' => 'catroweb',
+  ];
+
+  private bool $already_warned = false;
+
+  public function __construct(
+    #[Autowire('%kernel.environment%')]
+    private readonly string $environment,
+    #[Autowire('%env(APP_SECRET)%')]
+    private readonly string $app_secret,
+    #[Autowire('%env(JWT_PASSPHRASE)%')]
+    private readonly string $jwt_passphrase,
+    private readonly LoggerInterface $logger,
+  ) {
+  }
+
+  public function __invoke(RequestEvent $event): void
+  {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+
+    if (\in_array($this->environment, ['dev', 'test'], true)) {
+      return;
+    }
+
+    if ($this->already_warned) {
+      return;
+    }
+
+    $this->already_warned = true;
+
+    $insecure = $this->detectInsecureDefaults();
+    if ([] === $insecure) {
+      return;
+    }
+
+    $names = implode(', ', $insecure);
+    $this->logger->critical(
+      'SECURITY: Default development secrets detected in "{env}" environment: {names}. '
+      .'Override these values in .env.prod.local or via real environment variables. '
+      .'See docs/operations/Secret-Management.md for instructions.',
+      [
+        'env' => $this->environment,
+        'names' => $names,
+      ]
+    );
+  }
+
+  /**
+   * @return list<string> names of env vars still using insecure defaults
+   */
+  private function detectInsecureDefaults(): array
+  {
+    $insecure = [];
+
+    if (hash_equals(self::DEFAULT_SECRETS['APP_SECRET'], $this->app_secret)) {
+      $insecure[] = 'APP_SECRET';
+    }
+
+    if (hash_equals(self::DEFAULT_SECRETS['JWT_PASSPHRASE'], $this->jwt_passphrase)) {
+      $insecure[] = 'JWT_PASSPHRASE';
+    }
+
+    return $insecure;
+  }
+}

--- a/tests/PhpUnit/Security/DefaultSecretsWarningListenerTest.php
+++ b/tests/PhpUnit/Security/DefaultSecretsWarningListenerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Security;
+
+use App\Security\DefaultSecretsWarningListener;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(DefaultSecretsWarningListener::class)]
+class DefaultSecretsWarningListenerTest extends TestCase
+{
+  private const string DEFAULT_APP_SECRET = '93055246cfa39f62f5be97928084989a';
+  private const string DEFAULT_JWT_PASSPHRASE = 'catroweb';
+  private const string SAFE_SECRET = 'a-real-production-secret-value-here';
+
+  public function testLogsWarningInProdWithDefaultSecrets(): void
+  {
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('critical')
+      ->with(
+        $this->stringContains('Default development secrets detected'),
+        $this->callback(static fn (array $ctx): bool => 'prod' === $ctx['env']
+          && str_contains($ctx['names'], 'APP_SECRET')
+          && str_contains($ctx['names'], 'JWT_PASSPHRASE'))
+      )
+    ;
+
+    $listener = new DefaultSecretsWarningListener(
+      'prod',
+      self::DEFAULT_APP_SECRET,
+      self::DEFAULT_JWT_PASSPHRASE,
+      $logger,
+    );
+
+    $listener($this->createRequestEvent());
+  }
+
+  public function testSkipsWarningInDevEnvironment(): void
+  {
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->never())->method('critical');
+
+    $listener = new DefaultSecretsWarningListener(
+      'dev',
+      self::DEFAULT_APP_SECRET,
+      self::DEFAULT_JWT_PASSPHRASE,
+      $logger,
+    );
+
+    $listener($this->createRequestEvent());
+  }
+
+  public function testSkipsWarningInTestEnvironment(): void
+  {
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->never())->method('critical');
+
+    $listener = new DefaultSecretsWarningListener(
+      'test',
+      self::DEFAULT_APP_SECRET,
+      self::DEFAULT_JWT_PASSPHRASE,
+      $logger,
+    );
+
+    $listener($this->createRequestEvent());
+  }
+
+  public function testNoWarningWhenSecretsAreOverridden(): void
+  {
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->never())->method('critical');
+
+    $listener = new DefaultSecretsWarningListener(
+      'prod',
+      self::SAFE_SECRET,
+      self::SAFE_SECRET,
+      $logger,
+    );
+
+    $listener($this->createRequestEvent());
+  }
+
+  public function testWarnsOnlyForSecretsThatMatchDefaults(): void
+  {
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('critical')
+      ->with(
+        $this->anything(),
+        $this->callback(static fn (array $ctx): bool => 'JWT_PASSPHRASE' === $ctx['names'])
+      )
+    ;
+
+    $listener = new DefaultSecretsWarningListener(
+      'prod',
+      self::SAFE_SECRET,
+      self::DEFAULT_JWT_PASSPHRASE,
+      $logger,
+    );
+
+    $listener($this->createRequestEvent());
+  }
+
+  public function testWarnsOnlyOncePerProcessLifetime(): void
+  {
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())->method('critical');
+
+    $listener = new DefaultSecretsWarningListener(
+      'prod',
+      self::DEFAULT_APP_SECRET,
+      self::DEFAULT_JWT_PASSPHRASE,
+      $logger,
+    );
+
+    $listener($this->createRequestEvent());
+    $listener($this->createRequestEvent());
+    $listener($this->createRequestEvent());
+  }
+
+  public function testSkipsSubRequests(): void
+  {
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->never())->method('critical');
+
+    $listener = new DefaultSecretsWarningListener(
+      'prod',
+      self::DEFAULT_APP_SECRET,
+      self::DEFAULT_JWT_PASSPHRASE,
+      $logger,
+    );
+
+    $kernel = $this->createStub(HttpKernelInterface::class);
+    $event = new RequestEvent($kernel, new Request(), HttpKernelInterface::SUB_REQUEST);
+
+    $listener($event);
+  }
+
+  private function createRequestEvent(): RequestEvent
+  {
+    $kernel = $this->createStub(HttpKernelInterface::class);
+
+    return new RequestEvent($kernel, new Request(), HttpKernelInterface::MAIN_REQUEST);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a runtime `DefaultSecretsWarningListener` that logs a CRITICAL warning on the first request if known dev-default secrets (`APP_SECRET`, `JWT_PASSPHRASE`) are detected in non-dev environments
- Adds a CI check (`bin/check-default-secrets`) to the Static Analysis workflow that verifies committed `.env` files only contain known dev defaults and no real secrets have been accidentally committed
- Adds `docs/operations/Secret-Management.md` documenting which secrets must be overridden, how to set up `.env.prod.local`, and how to generate production JWT keys
- Updates `docker/app/init-jwt-config.sh` to read `JWT_PASSPHRASE` from environment variable instead of hardcoding `catroweb`

Closes #6328

## Test plan
- [ ] PHPUnit tests pass for `DefaultSecretsWarningListenerTest` (7 tests covering prod/dev/test envs, partial overrides, sub-requests, and single-warning behavior)
- [ ] `bin/check-default-secrets` exits 0 on current codebase
- [ ] CI Static Analysis workflow includes the new `check-secrets` job
- [ ] PHPStan and Psalm pass on the new listener class

🤖 Generated with [Claude Code](https://claude.com/claude-code)