### PR TITLE
Add GDPR data export button to profile settings

### DIFF
--- a/assets/User/MyProfilePage.js
+++ b/assets/User/MyProfilePage.js
@@ -9,7 +9,7 @@ import { PasswordVisibilityToggle } from '../Components/PasswordVisibilityToggle
 import { OwnProjectList } from '../Project/OwnProjectList'
 import Swal from 'sweetalert2'
 import MessageDialogs from '../Components/MessageDialogs'
-import { ApiDeleteFetch, ApiPutFetch } from '../Api/ApiHelper'
+import { ApiFetch, ApiDeleteFetch, ApiPutFetch } from '../Api/ApiHelper'
 import VerifyAccountHandler from './VerifyAccountHandler'
 
 require('./Profile.scss')
@@ -73,6 +73,7 @@ class OwnProfile {
     this.initProfilePictureChange()
     this.initSaveProfileSettings()
     this.initSaveSecuritySettings()
+    this.initExportData()
     this.initDeleteAccount()
   }
 
@@ -203,6 +204,58 @@ class OwnProfile {
           )
         }
       }
+    })
+  }
+
+  initExportData() {
+    const btn = document.getElementById('btn-export-data')
+    if (!btn) return
+
+    const originalHTML = btn.innerHTML
+    const loadingText = btn.dataset.transExportLoading
+    const errorText = btn.dataset.transExportError
+    const rateLimitedText = btn.dataset.transExportRateLimited
+
+    btn.addEventListener('click', async () => {
+      btn.disabled = true
+      btn.innerHTML =
+        '<span class="spinner-border spinner-border-sm me-1" role="status"></span> ' + loadingText
+
+      try {
+        const response = await new ApiFetch(
+          this.baseUrl + '/api/user/data-export',
+          'GET',
+          undefined,
+          'none',
+        ).generateAuthenticatedFetch()
+
+        if (response.ok) {
+          const data = await response.json()
+          const blob = new Blob([JSON.stringify(data, null, 2)], {
+            type: 'application/json',
+          })
+          const url = URL.createObjectURL(blob)
+          const a = document.createElement('a')
+          a.href = url
+          a.download = 'my-data-export.json'
+          document.body.appendChild(a)
+          a.click()
+          document.body.removeChild(a)
+          URL.revokeObjectURL(url)
+        } else if (response.status === 401) {
+          window.location.href = this.baseUrl + '/app/login'
+          return
+        } else if (response.status === 429) {
+          MessageDialogs.showErrorMessage(rateLimitedText)
+        } else {
+          MessageDialogs.showErrorMessage(errorText)
+        }
+      } catch {
+        MessageDialogs.showErrorMessage(errorText)
+      }
+
+      btn.innerHTML = originalHTML
+      btn.disabled = false
     })
   }
 

--- a/templates/User/Profile/Settings/AccountSettings.html.twig
+++ b/templates/User/Profile/Settings/AccountSettings.html.twig
@@ -2,7 +2,7 @@
 {% set modal =
   {
     id: 'account-settings-modal',
-    title: '' ~ 'myprofile.deleteAccount'|trans({}, 'catroweb'),
+    title: '' ~ 'myprofile.accountSettings'|trans({}, 'catroweb'),
     left_action:
     {
       id: 'account_settings-cancel_action',
@@ -12,6 +12,19 @@
     },
   } %}
 {% block content %}
+  <h6 class="mt-3 mb-2">{{ 'myprofile.exportData'|trans({}, 'catroweb') }}</h6>
+  <p class="text-muted small">{{ 'myprofile.exportDataDescription'|trans({}, 'catroweb') }}</p>
+  <button id="btn-export-data" class="btn btn-outline-primary w-100 mb-4"
+          data-trans-export-loading="{{ 'myprofile.exportDataLoading'|trans({}, 'catroweb') }}"
+          data-trans-export-error="{{ 'myprofile.exportDataError'|trans({}, 'catroweb') }}"
+          data-trans-export-rate-limited="{{ 'myprofile.exportDataRateLimited'|trans({}, 'catroweb') }}">
+    <span class="material-icons align-middle me-1" style="font-size: 18px;">download</span>
+    {{ 'myprofile.exportData'|trans({}, 'catroweb') }}
+  </button>
+
+  <hr>
+
+  <h6 class="mt-3 mb-2">{{ 'myprofile.deleteAccount'|trans({}, 'catroweb') }}</h6>
   {% set text_parts = 'myprofile.deleteAccountWarning'
     |trans({'%num_projects%': app.user.programs|length, '%num_followers%': app.user.followers|length}, 'catroweb')
     |split('\n') %}

--- a/tests/BehatFeatures/web/profile/profile_data_export.feature
+++ b/tests/BehatFeatures/web/profile/profile_data_export.feature
@@ -1,0 +1,41 @@
+@web @profile_page
+Feature:
+  As a logged in user
+  I want to see a data export button in my account settings
+  So that I can download a copy of my personal data
+
+  Background:
+    Given there are users:
+      | id | name     |
+      | 1  | Catrobat |
+    And there are projects:
+      | id | name      | owned by | upload time      |
+      | 1  | project 1 | Catrobat | 01.01.2013 12:00 |
+
+  Scenario: Logged in user sees the data export button in account settings
+    Given I log in as "Catrobat"
+    And I am on "/app/user"
+    And I wait for the page to be loaded
+    When I click "#top-app-bar__btn-settings"
+    And I wait for the element "#user-settings-modal" to be visible
+    And I click ".profile__user-settings .nav-link[data-bs-target='#account-settings-modal']"
+    And I wait for the element "#account-settings-modal" to be visible
+    Then the element "#btn-export-data" should be visible
+    And I should see "Download my data"
+    And I should see "You have the right to receive a copy of your personal data."
+
+  Scenario: Logged in user also sees delete account button alongside data export
+    Given I log in as "Catrobat"
+    And I am on "/app/user"
+    And I wait for the page to be loaded
+    When I click "#top-app-bar__btn-settings"
+    And I wait for the element "#user-settings-modal" to be visible
+    And I click ".profile__user-settings .nav-link[data-bs-target='#account-settings-modal']"
+    And I wait for the element "#account-settings-modal" to be visible
+    Then the element "#btn-export-data" should be visible
+    And the element "#btn-delete-account" should be visible
+
+  Scenario: Guest user cannot access the profile page
+    Given I am on "/app/user"
+    And I wait for the page to be loaded
+    Then I should not see "Download my data"

--- a/translations/catroweb.en.yaml
+++ b/translations/catroweb.en.yaml
@@ -357,7 +357,7 @@ myprofile:
   userSettings: User settings
   profileSettings: Edit profile
   securitySettings: Change password
-  accountSettings: Delete account
+  accountSettings: Account settings
   accountVerification: Verify account
   account: Account
   editProfile: Edit profile
@@ -372,6 +372,11 @@ myprofile:
     Be aware:
     You created %num_projects% project(s) and have %num_followers% follower(s). All of your projects will be removed. You won’t be able to login anymore and your projects will disappear from all lists. Deleting your profile cannot be undone!
     Are you sure you want to leave us?
+  exportData: Download my data
+  exportDataDescription: You have the right to receive a copy of your personal data. This includes your profile information, projects, comments, reactions, and followers.
+  exportDataLoading: Downloading...
+  exportDataError: Something went wrong while exporting your data. Please try again later.
+  exportDataRateLimited: You can only export your data once per day. Please try again tomorrow.
   editAccountSettings: Edit account settings
   profileChangeSuccess: Your profile has been successfully changed.
   unspecifiedError: Something did not work while changing your profile. Please try again or let us know if it keeps happening!


### PR DESCRIPTION
## Summary
- Adds a "Download my data" button to the account settings modal in the user profile page, placed above the existing "Delete account" section
- The button calls `GET /api/user/data-export` (merged in #6384) and triggers a `.json` file download with the user's personal data
- Handles loading state (spinner), 401 (redirect to login), 429 (rate limit -- "try again tomorrow"), and generic error messages
- Renames account settings modal title from "Delete account" to "Account settings" since it now contains two sections
- Adds Behat tests for button visibility

Closes #6335

## Changes
- `templates/User/Profile/Settings/AccountSettings.html.twig` -- Added data export section with button and description text
- `assets/User/MyProfilePage.js` -- Added `initExportData()` method using `ApiFetch` for the download flow
- `translations/catroweb.en.yaml` -- Added 5 new translation keys for export UI; updated `accountSettings` label
- `tests/BehatFeatures/web/profile/profile_data_export.feature` -- 3 scenarios testing button visibility

## Test plan
- [ ] Logged-in user sees "Download my data" button in Account Settings modal
- [ ] Clicking the button downloads a `my-data-export.json` file
- [ ] Button shows spinner during download
- [ ] 429 rate limit shows friendly error message
- [ ] "Delete account" button still works as before
- [ ] Guest users redirected to login (no access to profile page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)