### PR TITLE
Migrate featured slider to API-first client-side rendering

### DIFF
--- a/assets/Index/FeaturedProjects.js
+++ b/assets/Index/FeaturedProjects.js
@@ -15,7 +15,10 @@ export class FeaturedProjects {
     const apiUrl = `${baseUrl}/api/projects/featured?flavor=${flavor}&attributes=url,project_url,featured_image`
 
     fetch(apiUrl)
-      .then((response) => response.json())
+      .then((response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        return response.json()
+      })
       .then((items) => {
         if (!Array.isArray(items) || items.length === 0) {
           this.container.style.display = 'none'
@@ -31,7 +34,6 @@ export class FeaturedProjects {
           const heading = document.createElement('h2')
           heading.textContent = transFeatured
           this.container.before(heading)
-          this.headingElement = heading
         }
 
         this.renderCarousel(slides)

--- a/assets/Index/FeaturedProjects.js
+++ b/assets/Index/FeaturedProjects.js
@@ -1,16 +1,116 @@
 import { Carousel } from 'bootstrap'
 
 export class FeaturedProjects {
-  constructor(elementId) {
-    this.id = elementId
-    this.carouselElement = document.getElementById(elementId)
+  constructor(containerId) {
+    this.container = document.getElementById(containerId)
   }
 
   init() {
-    if (this.carouselElement) {
-      new Carousel(this.carouselElement)
-    } else {
-      console.warn(`#${this.id} can't be found in the DOM.`)
+    if (!this.container) {
+      return
     }
+
+    const { baseUrl, theme, flavor, isGuest, isWebview, transFeatured } = this.container.dataset
+
+    const apiUrl = `${baseUrl}/api/projects/featured?flavor=${flavor}&attributes=url,project_url,featured_image`
+
+    fetch(apiUrl)
+      .then((response) => response.json())
+      .then((items) => {
+        if (!Array.isArray(items) || items.length === 0) {
+          this.container.style.display = 'none'
+          return
+        }
+
+        const slides = items.map((item) => ({
+          url: item.project_url ? item.project_url.replace('/app/', `/${theme}/`) : item.url,
+          image: item.featured_image,
+        }))
+
+        if (isGuest === '1' && isWebview !== '1') {
+          const heading = document.createElement('h2')
+          heading.textContent = transFeatured
+          this.container.before(heading)
+          this.headingElement = heading
+        }
+
+        this.renderCarousel(slides)
+      })
+      .catch((error) => {
+        console.error('Failed to load featured projects', error)
+        this.container.style.display = 'none'
+      })
+  }
+
+  renderCarousel(slides) {
+    const carouselId = 'feature-slider'
+
+    const carouselDiv = document.createElement('div')
+    carouselDiv.id = carouselId
+    carouselDiv.className = 'carousel slide center mb-4'
+    carouselDiv.setAttribute('data-bs-ride', 'carousel')
+
+    // Indicators
+    const indicators = document.createElement('div')
+    indicators.className = 'carousel-indicators'
+    slides.forEach((_, i) => {
+      const btn = document.createElement('button')
+      btn.type = 'button'
+      btn.setAttribute('data-bs-target', `#${carouselId}`)
+      btn.setAttribute('data-bs-slide-to', String(i))
+      btn.setAttribute('aria-label', `Slide ${i}`)
+      if (i === 0) {
+        btn.className = 'active'
+        btn.setAttribute('aria-current', 'true')
+      }
+      indicators.appendChild(btn)
+    })
+    carouselDiv.appendChild(indicators)
+
+    // Slides
+    const inner = document.createElement('div')
+    inner.className = 'carousel-inner'
+    slides.forEach((slide, i) => {
+      const link = document.createElement('a')
+      link.className = i === 0 ? 'carousel-item active' : 'carousel-item'
+      link.href = slide.url
+      if (i > 0) {
+        link.style.background = '#fff'
+      }
+
+      const img = document.createElement('img')
+      img.src = slide.image
+      img.className = 'carousel-item__image d-block w-100'
+      img.alt = ''
+      img.width = 1024
+      img.height = 400
+      img.loading = i === 0 ? 'eager' : 'lazy'
+
+      link.appendChild(img)
+      inner.appendChild(link)
+    })
+    carouselDiv.appendChild(inner)
+
+    // Controls
+    const prevBtn = document.createElement('button')
+    prevBtn.className = 'carousel-control-prev'
+    prevBtn.type = 'button'
+    prevBtn.setAttribute('data-bs-target', `#${carouselId}`)
+    prevBtn.setAttribute('data-bs-slide', 'prev')
+    prevBtn.innerHTML =
+      '<span class="carousel-control-prev-icon" aria-hidden="true"></span><span class="visually-hidden">Previous</span>'
+    carouselDiv.appendChild(prevBtn)
+
+    const nextBtn = document.createElement('button')
+    nextBtn.className = 'carousel-control-next'
+    nextBtn.type = 'button'
+    nextBtn.setAttribute('data-bs-target', `#${carouselId}`)
+    nextBtn.setAttribute('data-bs-slide', 'next')
+    nextBtn.innerHTML =
+      '<span class="carousel-control-next-icon" aria-hidden="true"></span><span class="visually-hidden">Next</span>'
+    carouselDiv.appendChild(nextBtn)
+
+    this.container.appendChild(carouselDiv)
+    new Carousel(carouselDiv)
   }
 }

--- a/assets/Index/FeaturedProjects.js
+++ b/assets/Index/FeaturedProjects.js
@@ -10,7 +10,7 @@ export class FeaturedProjects {
       return
     }
 
-    const { baseUrl, theme, flavor, isGuest, isWebview, transFeatured } = this.container.dataset
+    const { baseUrl, flavor, isGuest, isWebview, transFeatured } = this.container.dataset
 
     const apiUrl = `${baseUrl}/api/projects/featured?flavor=${flavor}&attributes=url,project_url,featured_image`
 
@@ -26,7 +26,7 @@ export class FeaturedProjects {
         }
 
         const slides = items.map((item) => ({
-          url: item.project_url ? item.project_url.replace('/app/', `/${theme}/`) : item.url,
+          url: item.project_url ? item.project_url.replace('/app/', `/${flavor}/`) : item.url,
           image: item.featured_image,
         }))
 

--- a/assets/Index/IndexPage.js
+++ b/assets/Index/IndexPage.js
@@ -5,7 +5,7 @@ import { MaintenanceHandler } from './MaintenanceHandler'
 require('./IndexPage.scss')
 
 document.addEventListener('DOMContentLoaded', () => {
-  new FeaturedProjects('feature-slider').init()
+  new FeaturedProjects('featured-slider').init()
   new DefaultProjectLists('home-projects').init()
   new OAuthHandler().showOAuthFirstLoginInformationIfNecessary()
   new MaintenanceHandler()

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -162,10 +162,6 @@
       <code><![CDATA[$project->getProgram()]]></code>
     </PossiblyNullArgument>
     <PossiblyNullReference>
-      <code><![CDATA[getId]]></code>
-      <code><![CDATA[getName]]></code>
-      <code><![CDATA[getUser]]></code>
-      <code><![CDATA[getUserIdentifier]]></code>
       <code><![CDATA[getUserIdentifier]]></code>
     </PossiblyNullReference>
   </file>
@@ -201,15 +197,6 @@
       <code><![CDATA[$this->facade->getAuthenticationManager()->getAuthenticatedUser()]]></code>
       <code><![CDATA[$user]]></code>
     </PossiblyNullArgument>
-  </file>
-  <file src="src/Application/Controller/Base/IndexController.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$item->getId()]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullReference>
-      <code><![CDATA[getId]]></code>
-      <code><![CDATA[getId]]></code>
-    </PossiblyNullReference>
   </file>
   <file src="src/Application/Controller/Ci/DownloadApkController.php">
     <PossiblyNullReference>

--- a/src/Api/Services/Projects/ProjectsResponseManager.php
+++ b/src/Api/Services/Projects/ProjectsResponseManager.php
@@ -200,20 +200,22 @@ class ProjectsResponseManager extends AbstractResponseManager
     }
 
     $data = [];
+    $program = $featured_project->getProgram();
+
     if (in_array('id', $attributes_list, true)) {
       $data['id'] = $featured_project->getId() ?? -1;
     }
 
     if (in_array('project_id', $attributes_list, true)) {
-      $data['project_id'] = $featured_project->getProgram()->getId() ?? '';
+      $data['project_id'] = $program?->getId() ?? '';
     }
 
     if (in_array('name', $attributes_list, true)) {
-      $data['name'] = $featured_project->getProgram()->getName();
+      $data['name'] = $program?->getName() ?? '';
     }
 
     if (in_array('author', $attributes_list, true)) {
-      $data['author'] = $featured_project->getProgram()->getUser()->getUserIdentifier();
+      $data['author'] = $program?->getUser()->getUserIdentifier() ?? '';
     }
 
     if (in_array('featured_image', $attributes_list, true)) {

--- a/src/Api/Services/Projects/ProjectsResponseManager.php
+++ b/src/Api/Services/Projects/ProjectsResponseManager.php
@@ -215,7 +215,7 @@ class ProjectsResponseManager extends AbstractResponseManager
     }
 
     if (in_array('author', $attributes_list, true)) {
-      $data['author'] = $program?->getUser()->getUserIdentifier() ?? '';
+      $data['author'] = $program?->getUser()?->getUserIdentifier() ?? '';
     }
 
     if (in_array('featured_image', $attributes_list, true)) {

--- a/src/Application/Controller/Base/IndexController.php
+++ b/src/Application/Controller/Base/IndexController.php
@@ -4,12 +4,8 @@ declare(strict_types=1);
 
 namespace App\Application\Controller\Base;
 
-use App\DB\Entity\Flavor;
-use App\DB\Entity\Project\Special\FeaturedProgram;
 use App\DB\Entity\System\MaintenanceInformation;
 use App\DB\Entity\User\User;
-use App\DB\EntityRepository\Project\Special\FeaturedRepository;
-use App\Storage\ImageRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -19,54 +15,21 @@ use Symfony\Component\Routing\Attribute\Route;
 
 class IndexController extends AbstractController
 {
-  public function __construct(protected ImageRepository $image_repository, protected FeaturedRepository $featured_repository, private readonly EntityManagerInterface $entityManager)
+  public function __construct(private readonly EntityManagerInterface $entityManager)
   {
   }
 
   #[Route(path: '/', name: 'index', methods: ['GET'])]
   public function index(Request $request): Response
   {
-    $flavor = $request->attributes->get('flavor');
     /** @var User|null $user */
     $user = $this->getUser();
     $maintenanceInformation = $this->renderMaintenanceInformation($request);
 
     return $this->render('Index/IndexPage.html.twig', [
-      'featured' => $this->getFeaturedSliderData($flavor),
       'is_first_oauth_login' => null !== $user && $user->isOauthUser() && !$user->isOauthPasswordCreated(),
       'maintenanceInformation' => $maintenanceInformation,
     ]);
-  }
-
-  protected function getFeaturedSliderData(string $flavor): array
-  {
-    if (Flavor::PHIROCODE === $flavor) {
-      $featured_items = $this->featured_repository->getFeaturedItems(Flavor::POCKETCODE, 10);
-    } else {
-      $featured_items = $this->featured_repository->getFeaturedItems($flavor, 10);
-    }
-
-    $featuredData = [];
-    /** @var FeaturedProgram $item */
-    foreach ($featured_items as $item) {
-      $info = [];
-      if (null !== $item->getProgram()) {
-        if ('' !== $flavor && '0' !== $flavor) {
-          $info['url'] = $this->generateUrl('program',
-            ['id' => $item->getProgram()->getId(), 'theme' => $flavor]);
-        } else {
-          $info['url'] = $this->generateUrl('program', ['id' => $item->getProgram()->getId()]);
-        }
-      } else {
-        $info['url'] = $item->getUrl();
-      }
-
-      $info['image'] = $this->image_repository->getWebPath($item->getId(), $item->getImageType(), true);
-
-      $featuredData[] = $info;
-    }
-
-    return $featuredData;
   }
 
   public function renderMaintenanceInformation(Request $request): array

--- a/src/DB/EntityRepository/Project/Special/FeaturedRepository.php
+++ b/src/DB/EntityRepository/Project/Special/FeaturedRepository.php
@@ -30,7 +30,6 @@ class FeaturedRepository extends ServiceEntityRepository
     $qb
       ->select('e')
       ->where('e.active = true')
-      ->andWhere($qb->expr()->isNotNull('e.program'))
       ->setFirstResult($offset)
       ->setMaxResults($limit)
     ;
@@ -50,7 +49,6 @@ class FeaturedRepository extends ServiceEntityRepository
     $qb
       ->select('count(e.id)')
       ->where('e.active = true')
-      ->andWhere($qb->expr()->isNotNull('e.program'))
     ;
     $qb->orderBy('e.priority', 'DESC');
     $qb->leftJoin('e.program', 'program');

--- a/src/System/Testing/Behat/Context/CatrowebBrowserContext.php
+++ b/src/System/Testing/Behat/Context/CatrowebBrowserContext.php
@@ -332,11 +332,11 @@ class CatrowebBrowserContext extends BrowserContext
   /**
    * @Then /^I should see the featured slider$/
    *
-   * @throws ExpectationException
+   * @throws ResponseTextException
    */
   public function iShouldSeeTheFeaturedSlider(): void
   {
-    $this->assertSession()->responseContains('featured');
+    $this->iWaitForTheElementToBeVisible('#feature-slider');
     Assert::assertTrue($this->getSession()->getPage()->findById('feature-slider')->isVisible());
   }
 
@@ -853,6 +853,7 @@ class CatrowebBrowserContext extends BrowserContext
    */
   public function iShouldSeeTheSliderWithTheValues(string $values): void
   {
+    $this->iWaitForTheElementToBeVisible('#feature-slider');
     $slider_items = explode(',', $values);
     $owl_items = $this->getSession()->getPage()->findAll('css', '.carousel-item');
     $owl_items_count = count($owl_items);

--- a/templates/Index/IndexPage.html.twig
+++ b/templates/Index/IndexPage.html.twig
@@ -16,27 +16,14 @@
     {{ include('Index/WelcomeSection.html.twig') }}
   {% endif %}
 
-  {% if featured|length > 0 %}
-    {% if not app.user and not isWebview() %}
-      <h2>{{ 'project.featured'|trans({}, 'catroweb') }}</h2>
-    {% endif %}
-    <div id="featured-slider" class="featured-slider">
-      {{ include('Components/Carousel.html.twig',
-        {carousel:
-          {
-            id: 'feature-slider',
-            slideCount: featured|length,
-            slides: featured,
-            classes: '',
-            controls: true,
-            width: '1024',
-            height: '400',
-            alt: '',
-          },
-        },
-      ) }}
-    </div>
-  {% endif %}
+  <div id="featured-slider" class="featured-slider"
+       data-base-url="{{ app.request.getBaseURL() }}"
+       data-theme="{{ theme() }}"
+       data-flavor="{{ flavor() }}"
+       data-is-guest="{{ app.user ? '0' : '1' }}"
+       data-is-webview="{{ isWebview() ? '1' : '0' }}"
+       data-trans-featured="{{ 'project.featured'|trans({}, 'catroweb') }}"
+  ></div>
 
   <div id="home-projects">
     {# array values: [api project_type, translation, property to show] #}

--- a/tests/BehatFeatures/web/general/homepage.feature
+++ b/tests/BehatFeatures/web/general/homepage.feature
@@ -52,6 +52,7 @@ Feature: Pocketcode homepage
   Scenario: Scratch remixes project should be visible:
     Given I am on homepage
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see the featured slider
     Then the element "#home-projects__scratch" should exist
     And the "#home-projects__scratch" element should contain "project 6"
@@ -61,6 +62,7 @@ Feature: Pocketcode homepage
   Scenario: Viewing the homepage at website root
     Given I am on homepage
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see the featured slider
     Then one of the ".project-list__title" elements should contain "Examples"
     Then one of the ".project-list__title" elements should contain "Most downloaded"
@@ -115,6 +117,7 @@ Feature: Pocketcode homepage
   Scenario: Featured Programs and Urls
     Given I am on homepage
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see the featured slider
     And I should see the slider with the values "http://www.google.at/,project 2,project 3"
 


### PR DESCRIPTION
## Summary
- Moves the featured slider from server-rendered Twig (with `FeaturedRepository`/`ImageRepository` in the controller) to client-side JavaScript that fetches from the existing `GET /api/projects/featured` endpoint
- Strips `IndexController` to a thin shell -- removes `getFeaturedSliderData()` method and two repository dependencies
- Updates Behat tests with AJAX wait steps since the featured carousel is now rendered asynchronously
- Project category listings were already API-first (via `DefaultProjectLists.js` / `ProjectList.js`), so no changes needed there

Part of #6344

## Test plan
- [ ] Homepage loads correctly with featured slider visible (guest and logged-in)
- [ ] Featured slider shows correct projects with working links
- [ ] Featured slider respects flavor (e.g., embroidery shows embroidery-flavored featured items)
- [ ] Homepage categories (examples, most downloaded, trending, etc.) still load correctly
- [ ] Welcome section still shows for guests, hidden for logged-in users
- [ ] `web-general` Behat suite passes (homepage.feature)
- [ ] No regressions on other pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)