### PR TITLE
Migrate Search page to API-first client-side rendering

### DIFF
--- a/assets/Search/Search.scss
+++ b/assets/Search/Search.scss
@@ -1,4 +1,6 @@
 @import '../Layout/Variables';
+@import '../Project/ProjectList';
+@import '../User/UserList';
 
 #search-results-text {
   padding-right: 10px;

--- a/assets/Search/SearchPage.js
+++ b/assets/Search/SearchPage.js
@@ -1,47 +1,275 @@
 import { controlTopBarSearchClearButton, showTopBarSearch } from '../Layout/TopBar'
-import { ProjectList } from '../Project/ProjectList'
-import { UserList } from '../User/UserList'
+import { escapeHtml, escapeAttr } from '../Components/HtmlEscape'
 import './Search.scss'
 
-class Search {
-  constructor() {
-    this.searchElement = document.querySelector('.js-search')
-    this.query = this.searchElement.dataset.query
-    this.searchInput = document.querySelector('#top-app-bar__search-input')
-    this.oldQuery = this.searchInput.innerHTML = this.query
-    this.searchInput.value = this.oldQuery
-    showTopBarSearch()
-    controlTopBarSearchClearButton()
-    this.initProjects()
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('search-results')
+  if (!container) return
+
+  const query = container.dataset.query || ''
+  const theme = container.dataset.theme || 'pocketcode'
+  const baseUrl = container.dataset.baseUrl || ''
+
+  const trans = {
+    searchResults: container.dataset.transSearchResults || 'Search results',
+    projects: container.dataset.transProjects || 'Projects',
+    users: container.dataset.transUsers || 'Users',
+    noProjects: container.dataset.transNoProjects || 'No projects found',
+    noUsers: container.dataset.transNoUsers || 'No users found',
+    showMore: container.dataset.transShowMore || 'Show more',
   }
 
-  initProjects() {
-    const searchProjects = document.querySelector('#search-projects')
-    const searchUsers = document.querySelector('#search-users')
-    const theme = this.searchElement.dataset.theme
-    const baseUrl = this.searchElement.dataset.baseUrl
-    const category = 'search'
-    const property = 'uploaded'
-    const query = this.searchElement.dataset.query
-    const projectString = this.searchElement.dataset.projectTranslated
-    const noUsers = this.searchElement.dataset.noUsers
-    const noProjects = this.searchElement.dataset.noProjects
-
-    const projectUrl = `${baseUrl}/api/projects/search?query=${query}`
-    const userUrl = `${baseUrl}/api/users/search?query=${query}`
-
-    this.list = new ProjectList(
-      searchProjects,
-      category,
-      projectUrl,
-      property,
-      theme,
-      30,
-      noProjects,
-    )
-
-    this.userList = new UserList(searchUsers, baseUrl, userUrl, theme, projectString, 30, noUsers)
+  const searchInput = document.querySelector('#top-app-bar__search-input')
+  if (searchInput) {
+    searchInput.value = query
+    searchInput.innerHTML = query
   }
+
+  showTopBarSearch()
+  controlTopBarSearchClearButton()
+
+  renderPage(container, query, theme, baseUrl, trans)
+})
+
+function renderPage(container, query, theme, baseUrl, trans) {
+  container.innerHTML = ''
+
+  const titleDiv = document.createElement('div')
+  titleDiv.className = 'search-results__title'
+  const h1 = document.createElement('h1')
+  const querySpan = document.createElement('span')
+  querySpan.id = 'search-results-text'
+  querySpan.textContent = query ? query + ' ' : ''
+  h1.appendChild(querySpan)
+  h1.appendChild(document.createTextNode(trans.searchResults))
+  titleDiv.appendChild(h1)
+  container.appendChild(titleDiv)
+
+  const projectsSection = createSection(
+    'search-projects',
+    'project-list',
+    trans.projects,
+    trans.showMore,
+  )
+  container.appendChild(projectsSection)
+
+  const usersSection = createSection('search-users', 'user-list', trans.users, trans.showMore)
+  container.appendChild(usersSection)
+
+  if (!query) {
+    showEmpty(projectsSection, trans.noProjects, 'project-list')
+    showEmpty(usersSection, trans.noUsers, 'user-list')
+    return
+  }
+
+  const apiUrl =
+    baseUrl + '/api/search?query=' + encodeURIComponent(query) + '&type=all&limit=30&offset=0'
+
+  projectsSection.classList.add('loading')
+  usersSection.classList.add('loading')
+
+  fetch(apiUrl)
+    .then((response) => response.json())
+    .then((data) => {
+      renderProjects(projectsSection, data.projects || [], theme, baseUrl, trans)
+      renderUsers(usersSection, data.users || [], theme, baseUrl, trans)
+    })
+    .catch((error) => {
+      console.error('Search API error:', error)
+      projectsSection.classList.remove('loading')
+      usersSection.classList.remove('loading')
+    })
 }
 
-new Search()
+function createSection(id, listClass, title, showMoreText) {
+  const section = document.createElement('div')
+  section.id = id
+  section.className = listClass + ' loading horizontal'
+
+  const containerDiv = document.createElement('div')
+  containerDiv.className = 'container'
+
+  const titleDiv = document.createElement('div')
+  titleDiv.className = listClass + '__title'
+
+  const h2 = document.createElement('h2')
+  h2.textContent = title
+  titleDiv.appendChild(h2)
+
+  const toggleBtn = document.createElement('div')
+  toggleBtn.className = listClass + '__title__btn-toggle btn-view-open'
+
+  const toggleText = document.createElement('div')
+  toggleText.className = listClass + '__title__btn-toggle__text'
+  toggleText.textContent = showMoreText
+
+  const toggleIcon = document.createElement('div')
+  toggleIcon.className = listClass + '__title__btn-toggle__icon material-icons'
+  toggleIcon.textContent = 'arrow_forward'
+
+  toggleBtn.appendChild(toggleText)
+  toggleBtn.appendChild(toggleIcon)
+  titleDiv.appendChild(toggleBtn)
+  containerDiv.appendChild(titleDiv)
+
+  const wrapper = document.createElement('div')
+  wrapper.className = listClass + '__wrapper'
+
+  const itemsContainer = document.createElement('div')
+  itemsContainer.className = listClass === 'project-list' ? 'projects-container' : 'users-container'
+  wrapper.appendChild(itemsContainer)
+
+  containerDiv.appendChild(wrapper)
+  section.appendChild(containerDiv)
+
+  return section
+}
+
+function renderProjects(section, projects, theme, baseUrl, trans) {
+  section.classList.remove('loading')
+
+  const itemsContainer = section.querySelector('.projects-container')
+  itemsContainer.innerHTML = ''
+
+  if (projects.length === 0) {
+    showEmpty(section, trans.noProjects, 'project-list')
+    return
+  }
+
+  projects.forEach((project) => {
+    const el = createProjectCard(project, theme)
+    itemsContainer.appendChild(el)
+  })
+}
+
+function createProjectCard(project, theme) {
+  const projectUrl = (project.project_url || '').replace('/app/', '/' + theme + '/')
+
+  const a = document.createElement('a')
+  a.className = 'project-list__project'
+  a.href = projectUrl
+  a.dataset.id = project.id
+
+  const img = document.createElement('img')
+  if (project.screenshot_small) {
+    img.setAttribute('data-src', project.screenshot_small)
+    img.setAttribute(
+      'data-srcset',
+      project.screenshot_small +
+        ' 80w, ' +
+        (project.screenshot_large || project.screenshot_small) +
+        ' 480w',
+    )
+    img.setAttribute('data-sizes', '(min-width: 768px) 10vw, 25vw')
+  }
+  img.className = 'lazyload project-list__project__image'
+  if (project.not_for_kids) {
+    img.style.filter = 'blur(10px)'
+  }
+  a.appendChild(img)
+
+  const nameSpan = document.createElement('span')
+  nameSpan.className = 'project-list__project__name'
+  nameSpan.textContent = project.name || ''
+  a.appendChild(nameSpan)
+
+  const propDiv = document.createElement('div')
+  propDiv.className =
+    'lazyload project-list__project__property project-list__project__property-uploaded'
+
+  const icon = document.createElement('i')
+  icon.className = 'material-icons'
+  icon.textContent = 'schedule'
+  propDiv.appendChild(icon)
+
+  const valueSpan = document.createElement('span')
+  valueSpan.className = 'project-list__project__property__value'
+  valueSpan.textContent = project.uploaded_string || ''
+  propDiv.appendChild(valueSpan)
+
+  a.appendChild(propDiv)
+
+  if (project.not_for_kids) {
+    const nfkDiv = document.createElement('div')
+    nfkDiv.className = 'lazyload project-list__project__property__not-for-kids'
+
+    const nfkImg = document.createElement('img')
+    nfkImg.className = 'lazyload project-list__not-for-kids-logo'
+    nfkImg.src = '/images/default/not_for_kids.svg'
+    nfkDiv.appendChild(nfkImg)
+
+    const nfkSpan = document.createElement('span')
+    nfkSpan.className = 'project-list__project__property__value'
+    nfkSpan.textContent = 'Not for kids'
+    nfkDiv.appendChild(nfkSpan)
+
+    a.appendChild(nfkDiv)
+  }
+
+  return a
+}
+
+function renderUsers(section, users, theme, baseUrl, trans) {
+  section.classList.remove('loading')
+
+  const itemsContainer = section.querySelector('.users-container')
+  itemsContainer.innerHTML = ''
+
+  if (users.length === 0) {
+    showEmpty(section, trans.noUsers, 'user-list')
+    return
+  }
+
+  users.forEach((user) => {
+    const el = createUserCard(user, baseUrl, trans)
+    itemsContainer.appendChild(el)
+  })
+}
+
+function createUserCard(user, baseUrl, trans) {
+  const userUrl = baseUrl + '/app/user/' + escapeAttr(String(user.id))
+
+  const a = document.createElement('a')
+  a.className = 'user-list__user'
+  a.href = userUrl
+  a.dataset.id = user.id
+
+  const img = document.createElement('img')
+  img.className = 'user-list__user__image'
+  if (typeof user.picture === 'string' && user.picture.length > 0) {
+    img.src = user.picture
+  } else {
+    img.setAttribute('data-src', '/images/default/avatar_default.png?v=3.7.1')
+    img.classList.add('lazyload')
+  }
+  a.appendChild(img)
+
+  const nameSpan = document.createElement('span')
+  nameSpan.className = 'user-list__user__name'
+  nameSpan.textContent = user.username || ''
+  a.appendChild(nameSpan)
+
+  const propDiv = document.createElement('div')
+  propDiv.className = 'lazyload user-list__user__property'
+
+  const valueSpan = document.createElement('span')
+  valueSpan.className = 'user-list__user__property__value'
+  valueSpan.textContent = (user.projects || 0) + ' ' + trans.projects
+  propDiv.appendChild(valueSpan)
+
+  a.appendChild(propDiv)
+
+  return a
+}
+
+function showEmpty(section, message, listClass) {
+  section.classList.remove('loading')
+
+  const itemsContainer = section.querySelector(
+    listClass === 'project-list' ? '.projects-container' : '.users-container',
+  )
+  if (itemsContainer) {
+    itemsContainer.innerHTML = escapeHtml(message)
+  }
+  section.classList.add('empty-with-text')
+}

--- a/templates/Search/SearchPage.html.twig
+++ b/templates/Search/SearchPage.html.twig
@@ -6,96 +6,18 @@
 
 {% block body %}
 
-  <div id="search-results">
-    <div class="search-results__title">
-      <h1><span id="search-results-text"></span>{{ 'search.results'|trans({}, 'catroweb') }}</h1>
-    </div>
-    <div id="search-projects" class="project-list loading horizontal">
-      <div class="container">
-        <div class="project-list__title">
-          <h2>{{ 'projects'|trans({}, 'catroweb') }}</h2>
-          <div class="project-list__title__btn-toggle btn-view-open">
-            <div class="project-list__title__btn-toggle__text">{{ 'show-more'|trans({}, 'catroweb') }}</div>
-            <div class="project-list__title__btn-toggle__icon material-icons">arrow_forward</div>
-          </div>
-        </div>
-        <div class="lazyload project-list__wrapper">
-          <div class="lazyload projects-container">
-
-            {% for i in range(0, 10) %}  {# Fill with dummy data until loaded to prevent cls #}
-              <div class="project-list__project">
-                <img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20360%20360'%3E%3Crect%20width='360'%20height='360'%20fill='%23E8E8E8'%20/%3E%3C/svg%3E"
-                     class="project-list__project__image">
-                <span class="project-list__project__name"></span>
-                <div class="project-list__project__property project-list__project__property-uploaded lazyloaded">
-                  <i class="material-icons"></i>
-                  <span class="project-list__project__property__value"></span>
-                </div>
-              </div>
-            {% endfor %}
-
-          </div>
-          <div class="lazyload project-list__chevrons">
-            <div class="lazyload project-list__chevrons__left material-icons mdc-icon-button" style="display: none;">
-              chevron_left
-            </div>
-            <div class="lazyload project-list__chevrons__right material-icons mdc-icon-button">chevron_right</div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <i class="material-icons d-none" id="project-opening-spinner" style="margin: auto;">
-      {{ include('Components/LoadingSpinner.html.twig', {spinner_id: 'project-opening-spinner' ~ suffix|default(), small: 'true'}) }}
-    </i>
-
-    <div id="search-users" class="user-list loading horizontal">
-      <div class="container">
-        <div class="user-list__title">
-          <h2>{{ 'users'|trans({}, 'catroweb') }}</h2>
-          <div class="user-list__title__btn-toggle btn-view-open">
-            <div class="user-list__title__btn-toggle__text">{{ 'show-more'|trans({}, 'catroweb') }}</div>
-            <div class="user-list__title__btn-toggle__icon material-icons">arrow_forward</div>
-          </div>
-        </div>
-        <div class="lazyload user-list__wrapper">
-          <div class="lazyload users-container">
-
-            {% for i in range(0, 10) %}  {# Fill with dummy data until loaded to prevent cls #}
-              <div class="user-list__user">
-                <img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20360%20360'%3E%3Crect%20width='360'%20height='360'%20fill='%23E8E8E8'%20/%3E%3C/svg%3E"
-                     class="user-list__user__image">
-                <span class="user-list__user__name"></span>
-                <div class="user-list__user__property lazyloaded">
-                  <span class="user-list__user__property__value"></span>
-                </div>
-              </div>
-            {% endfor %}
-
-          </div>
-          <div class="lazyload user-list__chevrons">
-            <div class="lazyload user-list__chevrons__left material-icons mdc-icon-button" style="display: none;">
-              chevron_left
-            </div>
-            <div class="lazyload user-list__chevrons__right material-icons mdc-icon-button">chevron_right</div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <i class="material-icons d-none" id="project-opening-spinner" style="margin: auto;">
-      {{ include('Components/LoadingSpinner.html.twig', {spinner_id: 'user-opening-spinner' ~ suffix|default(), small: 'true'}) }}
-    </i>
-  </div>
-
-  <div class="js-search"
-       data-result-container="#search-results"
+  <div id="search-results"
        data-query="{{ q }}"
        data-theme="{{ theme() }}"
-       data-flavor="{{ flavor() }}"
        data-base-url="{{ app.request.getBaseURL() }}"
-       data-project-translated="{{ 'projects'|trans({}, 'catroweb') }}"
-       data-no-users="{{ 'search.noUsers'|trans({}, 'catroweb') }}"
-       data-no-projects="{{ 'search.noProjects'|trans({}, 'catroweb') }}"
-  ></div>
+       data-trans-search-results="{{ 'search.results'|trans({}, 'catroweb') }}"
+       data-trans-projects="{{ 'projects'|trans({}, 'catroweb') }}"
+       data-trans-users="{{ 'users'|trans({}, 'catroweb') }}"
+       data-trans-no-projects="{{ 'search.noProjects'|trans({}, 'catroweb') }}"
+       data-trans-no-users="{{ 'search.noUsers'|trans({}, 'catroweb') }}"
+       data-trans-show-more="{{ 'show-more'|trans({}, 'catroweb') }}"
+  >
+  </div>
 
 {% endblock %}
 

--- a/tests/BehatFeatures/web/search/search.feature
+++ b/tests/BehatFeatures/web/search/search.feature
@@ -38,6 +38,7 @@ Feature: Searching for projects & users
   Scenario: search for projects, which contain the word "project"
     Given I am on "/app/search/project"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Search results"
     Then I should see "project 1"
     Then I should see "test project"
@@ -49,6 +50,7 @@ Feature: Searching for projects & users
   Scenario: search for projects, which contain the word "Test"
     Given I am on "/app/search/Test"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Search results"
     Then I should see "test advanced games"
     Then I should see "test advanced app"
@@ -61,6 +63,7 @@ Feature: Searching for projects & users
   Scenario: search for projects, which contain the word "test advanced"
     Given I am on "/app/search/Test%20advanced"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Search results"
     Then I should see "test advanced games"
     Then I should see "test advanced app"
@@ -68,6 +71,7 @@ Feature: Searching for projects & users
   Scenario: search for projects, which contain the word "game"
     Given I am on "/app/search/game"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Search results"
     Then I should see "test advanced games"
     Then I should see "project 1"
@@ -77,11 +81,13 @@ Feature: Searching for projects & users
   Scenario: search for projects, which contain the word "project and app"
     Given I am on "/app/search/project%20and%20app"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Search results"
 
   Scenario: search for projects, which contain the word "mindstorms"
     Given I am on "/app/search/mindstorms"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Search results"
     Then I should see "Test advanced games"
     Then I should see "Catrobat"
@@ -91,6 +97,7 @@ Feature: Searching for projects & users
   Scenario: search for gmail should find no project
     Given I am on "/app/search/gmail"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Search results"
     Then I should see "No projects found"
     Then I should see "No users found"
@@ -98,6 +105,7 @@ Feature: Searching for projects & users
   Scenario: search for gmx should find no project
     Given I am on "/app/search/gmx.at"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Search results"
     Then I should see "No projects found"
     Then I should see "No users found"
@@ -106,6 +114,7 @@ Feature: Searching for projects & users
   Scenario: search for projects, which contain the word "User"
     Given I am on "/app/search/user"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Search results"
     Then I should see "User1"
     Then I should see "User2"
@@ -120,6 +129,7 @@ Feature: Searching for projects & users
   Scenario: search for projects, which contain the word "Cat"
     Given I am on "/app/search/cat"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Search results"
     Then I should see "Cat"
     Then I should not see "User1"
@@ -138,6 +148,7 @@ Feature: Searching for projects & users
   Scenario: search for projects, which contain the word "Story"
     Given I am on "/app/search/story"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Test advanced app"
     Then I should see "Catrobat"
     Then I should see "test"
@@ -145,11 +156,6 @@ Feature: Searching for projects & users
   Scenario: search for projects with string "Test advanced app"
     Given I am on "/app/search/Test%20advanced%20app"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Test advanced app"
     Then I should see "No users found"
-
-
-
-
-
-

--- a/tests/BehatFeatures/web/search/search_projects_via_extensions.feature
+++ b/tests/BehatFeatures/web/search/search_projects_via_extensions.feature
@@ -28,6 +28,7 @@ Feature: Searching for projects with extensions
     And I should see "__phiro"
     When I press on the extension "__mindstorms"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Search results"
     Then I should see "project 1"
     And I should see "project 2"

--- a/tests/BehatFeatures/web/search/search_projects_via_projectowner.feature
+++ b/tests/BehatFeatures/web/search/search_projects_via_projectowner.feature
@@ -18,6 +18,7 @@ Feature: Searching for projects with ownername
   Scenario: search for projects with full name should work
     When I am on "/app/search/User3"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Search results"
     And I should not see "project 1"
     And I should not see "project 2"
@@ -26,6 +27,7 @@ Feature: Searching for projects with ownername
   Scenario: search for projects with parts of name should work
     When I am on "/app/search/User"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     Then I should see "Search results"
     And I should not see "project 1"
     And I should see "project 2"

--- a/tests/BehatFeatures/web/search/search_projects_via_tags.feature
+++ b/tests/BehatFeatures/web/search/search_projects_via_tags.feature
@@ -26,6 +26,7 @@ Feature: Searching for projects with tags
     And I should see "__Animation"
     When I press on the tag "__Animation"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     And I should see "project 1"
     And I should see "project 2"
     But I should not see "project 3"
@@ -33,6 +34,7 @@ Feature: Searching for projects with tags
   Scenario: search for tags should work
     When I am on "/app/search/Animation"
     And I wait for the page to be loaded
+    And I wait for AJAX to finish
     And I should see "project 1"
     And I should see "project 2"
     But I should not see "project 3"


### PR DESCRIPTION
## Summary
- Replaces two separate API calls (`/api/projects/search` + `/api/users/search`) with a single combined `/api/search?type=all` endpoint call
- Strips the Twig template from server-rendered skeleton HTML to a thin container with `data-*` attributes for translations and config
- Rewrites `SearchPage.js` to be self-contained: fetches from the combined search API, renders project cards and user cards client-side, handles empty/loading states
- Imports `ProjectList.scss` and `UserList.scss` in `Search.scss` to retain styles without importing the JS modules
- Adds `I wait for AJAX to finish` steps to all web search Behat tests for reliable assertions with client-side rendering

Closes #6344 (Search page migration)

## Test plan
- [ ] Verify search page renders project and user results for various queries
- [ ] Verify "No projects found" / "No users found" messages for queries with no matches
- [ ] Verify search via tags and extensions from project detail page
- [ ] Verify search via project owner name
- [ ] Run `web-search` Behat suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)