### PR TITLE
Fix missing permission check in admin trimAction

### DIFF
--- a/src/Admin/Statistics/Translation/Controller/AbstractMachineTranslationAdminController.php
+++ b/src/Admin/Statistics/Translation/Controller/AbstractMachineTranslationAdminController.php
@@ -98,7 +98,7 @@ abstract class AbstractMachineTranslationAdminController extends CRUDController
 
   public function trimAction(Request $request): Response
   {
-    // TODO check permission
+    $this->admin->checkAccess('list');
 
     $days = (string) $request->query->get('days');
 


### PR DESCRIPTION
## Summary
- Replaces `// TODO check permission` in `AbstractMachineTranslationAdminController::trimAction()` with `$this->admin->checkAccess('list')`, matching the pattern already used in `listAction()`
- Without this check, the trim endpoint (which deletes old machine translation records) could potentially be accessed without proper Sonata Admin authorization

Closes #6407

## Test plan
- [ ] Verify admin machine translation pages still load correctly
- [ ] Verify the trim action works for authorized admins
- [ ] Verify non-admin users cannot access the trim endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)