### PR TITLE
Add ClamAV malware scanning for project uploads (#6349)

### DIFF
--- a/.env
+++ b/.env
@@ -136,3 +136,10 @@ CAPTCHA_PUBLIC_URL='http://localhost:3000'
 CAPTCHA_SITE_KEY='default'
 CAPTCHA_SECRET='default-secret'
 ###< captcha ###
+
+###> malware scanning (ClamAV) ###
+MALWARE_SCAN_ENABLED=false
+CLAMAV_HOST=clamav
+CLAMAV_PORT=3310
+MALWARE_SCAN_FAIL_OPEN=true
+###< malware scanning (ClamAV) ###

--- a/.env.prod
+++ b/.env.prod
@@ -12,3 +12,8 @@ GTM_CONTAINER_ID='GTM-5T99FCLM'
 ###> captcha ###
 CAPTCHA_ENABLED=true
 ###< captcha ###
+
+###> malware scanning (ClamAV) ###
+MALWARE_SCAN_ENABLED=true
+MALWARE_SCAN_FAIL_OPEN=false
+###< malware scanning (ClamAV) ###

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -153,6 +153,17 @@ services:
       - cap-data:/usr/src/app/.data
     restart: unless-stopped
 
+  # --- Malware scanning:
+
+  clamav:
+    image: clamav/clamav:stable
+    container_name: clamav.catroweb
+    ports:
+      - '3310:3310'
+    volumes:
+      - clamav-data:/var/lib/clamav
+    restart: unless-stopped
+
   # --- Tools:
 
   phpmyadmin.catroweb.dev:
@@ -198,4 +209,6 @@ volumes:
   esdata1:
     driver: local
   cap-data:
+    driver: local
+  clamav-data:
     driver: local

--- a/docs/operations/Malware-Scanning.md
+++ b/docs/operations/Malware-Scanning.md
@@ -1,0 +1,282 @@
+# Malware Scanning
+
+## Overview
+
+Catroweb scans uploaded project files for malware using [ClamAV](https://www.clamav.net/), an open-source antivirus engine. Every `.catrobat` file is scanned **before extraction** -- if malware is detected, the upload is rejected with HTTP 422 and the file is never written to disk.
+
+## How It Works
+
+1. A user uploads a `.catrobat` file via the project upload API.
+2. `ProjectManager` passes the uploaded file path to `MalwareScanner::scanFile()`.
+3. `MalwareScanner` opens a TCP connection to the ClamAV daemon (`clamd`).
+4. The file is streamed to `clamd` using the **INSTREAM** protocol:
+   - Send `zINSTREAM\0` command
+   - Send file data in chunks (8 KB each), each prefixed by a 4-byte big-endian length
+   - Send a zero-length terminator chunk (`\x00\x00\x00\x00`)
+5. `clamd` responds with one of:
+   - `stream: OK` -- file is clean
+   - `stream: <threat_name> FOUND` -- malware detected
+   - `stream: ... ERROR` -- scan error
+6. If the file is not clean, `ProjectManager` throws an exception and the upload is rejected.
+
+**Key advantage of INSTREAM:** The application streams the file over TCP, so `clamd` does not need filesystem access to the uploaded file. This works across containers, servers, and network boundaries without shared volumes.
+
+## Configuration Reference
+
+All configuration is done via environment variables:
+
+| Variable                 | Type    | Default  | Description                                                                                      |
+| ------------------------ | ------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `MALWARE_SCAN_ENABLED`   | boolean | `false`  | Master switch. Set to `true` to enable scanning.                                                 |
+| `CLAMAV_HOST`            | string  | `clamav` | Hostname or IP address of the `clamd` daemon.                                                    |
+| `CLAMAV_PORT`            | integer | `3310`   | TCP port that `clamd` listens on.                                                                |
+| `MALWARE_SCAN_FAIL_OPEN` | boolean | `true`   | Behavior when `clamd` is unreachable. See [Fail-Open vs Fail-Closed](#fail-open-vs-fail-closed). |
+
+### Where to Set Values
+
+| Environment | File                            | Typical values                                                                    |
+| ----------- | ------------------------------- | --------------------------------------------------------------------------------- |
+| Development | `.env` (committed)              | `MALWARE_SCAN_ENABLED=false`, `CLAMAV_HOST=clamav`, `MALWARE_SCAN_FAIL_OPEN=true` |
+| Production  | `.env.prod` (committed)         | `MALWARE_SCAN_ENABLED=true`, `MALWARE_SCAN_FAIL_OPEN=false`                       |
+| Production  | `.env.prod.local` (server only) | `CLAMAV_HOST=127.0.0.1` (override if clamd runs locally)                          |
+
+## Docker Development Setup
+
+The ClamAV container is already defined in `docker/docker-compose.dev.yaml`:
+
+```yaml
+clamav:
+  image: clamav/clamav:stable
+  container_name: clamav.catroweb
+  ports:
+    - '3310:3310'
+  volumes:
+    - clamav-data:/var/lib/clamav
+  restart: unless-stopped
+```
+
+To enable scanning in development:
+
+1. Start the Docker environment as usual:
+
+   ```bash
+   docker compose -f docker/docker-compose.dev.yaml up -d
+   ```
+
+2. Wait for `clamd` to finish loading virus definitions (first startup takes 1-2 minutes):
+
+   ```bash
+   docker logs -f clamav.catroweb
+   # Wait until you see: "Listening daemon: TCP port 3310"
+   ```
+
+3. Override `MALWARE_SCAN_ENABLED` locally:
+
+   ```bash
+   echo "MALWARE_SCAN_ENABLED=true" >> .env.local
+   ```
+
+4. Test with the EICAR test file (a harmless test string that all antivirus engines detect):
+   ```bash
+   echo 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*' > /tmp/eicar.txt
+   docker exec clamav.catroweb clamdscan /tmp/eicar.txt
+   # Expected: /tmp/eicar.txt: Win.Test.EICAR_HDB-1 FOUND
+   ```
+
+The default `.env` uses `CLAMAV_HOST=clamav`, which resolves to the ClamAV container via Docker DNS.
+
+## Production Setup
+
+In production, ClamAV runs directly on the server (not in Docker) as a systemd service.
+
+### 1. Install ClamAV
+
+```bash
+sudo apt-get update
+sudo apt-get install -y clamav clamav-daemon
+```
+
+### 2. Configure clamd for TCP
+
+Edit `/etc/clamav/clamd.conf`:
+
+```bash
+# Enable TCP socket on localhost only
+TCPSocket 3310
+TCPAddr 127.0.0.1
+```
+
+Remove or comment out `LocalSocket` if you only want TCP (the default Ubuntu config uses a Unix socket).
+
+### 3. Update Virus Definitions
+
+```bash
+# Stop freshclam if it's running (it conflicts with manual updates)
+sudo systemctl stop clamav-freshclam
+
+# Update definitions
+sudo freshclam
+
+# Restart freshclam for automatic updates
+sudo systemctl start clamav-freshclam
+sudo systemctl enable clamav-freshclam
+```
+
+### 4. Start and Enable the Daemon
+
+```bash
+sudo systemctl enable clamav-daemon
+sudo systemctl start clamav-daemon
+```
+
+### 5. Verify the Daemon Is Running
+
+```bash
+# Check service status
+sudo systemctl status clamav-daemon
+
+# Ping the daemon
+echo 'PING' | nc 127.0.0.1 3310
+# Expected response: PONG
+```
+
+### 6. Set Environment Variables
+
+Add the ClamAV variables to `.env.prod.local` on the server (in the Deployer shared directory):
+
+```bash
+nano /var/www/share/shared/.env.prod.local
+```
+
+Add:
+
+```env
+CLAMAV_HOST=127.0.0.1
+CLAMAV_PORT=3310
+```
+
+`MALWARE_SCAN_ENABLED=true` and `MALWARE_SCAN_FAIL_OPEN=false` are already set in the committed `.env.prod`, so they do not need to be repeated in `.env.prod.local` unless you want to override them.
+
+### 7. Test End-to-End
+
+```bash
+# Create EICAR test file
+echo 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*' > /tmp/eicar.txt
+
+# Scan via clamdscan CLI
+clamdscan /tmp/eicar.txt
+# Expected: /tmp/eicar.txt: Win.Test.EICAR_HDB-1 FOUND
+
+# Clean up
+rm /tmp/eicar.txt
+```
+
+## Fail-Open vs Fail-Closed
+
+The `MALWARE_SCAN_FAIL_OPEN` variable controls what happens when `clamd` is unreachable or returns an error:
+
+| Mode                         | Value   | Behavior                                                              |
+| ---------------------------- | ------- | --------------------------------------------------------------------- |
+| **Fail-open** (development)  | `true`  | Upload is **allowed** with a warning logged. Scanning is best-effort. |
+| **Fail-closed** (production) | `false` | Upload is **rejected**. No file is accepted without a clean scan.     |
+
+**Development** uses fail-open so that developers can work without a running ClamAV container. Uploads proceed normally with a log warning.
+
+**Production** uses fail-closed to ensure every upload is scanned. If ClamAV goes down, uploads fail until the service is restored. This is the secure default for user-facing environments.
+
+## Monitoring
+
+### Check clamd Is Running
+
+```bash
+sudo systemctl status clamav-daemon
+# or
+echo 'PING' | nc 127.0.0.1 3310
+```
+
+### Check Virus Definitions Are Updated
+
+`freshclam` runs automatically via systemd and updates definitions multiple times per day.
+
+```bash
+# Check freshclam status
+sudo systemctl status clamav-freshclam
+
+# Check when definitions were last updated
+ls -la /var/lib/clamav/
+
+# View freshclam log
+sudo journalctl -u clamav-freshclam --since today
+```
+
+### Application Logs
+
+The `MalwareScanner` logs to Symfony's logger:
+
+- **WARNING** `Malware detected in uploaded file` -- a file was rejected (includes threat name)
+- **WARNING** `Malware scan failed but fail-open is enabled, allowing upload` -- clamd was unreachable in fail-open mode
+- **ERROR** `Malware scan failed` -- clamd connection or communication error
+
+Check Symfony logs at `var/log/prod.log` or via your log aggregation system.
+
+## Troubleshooting
+
+### "Cannot connect to ClamAV" Error
+
+**Symptoms:** Upload fails with 422, logs show `Cannot connect to ClamAV at <host>:<port>`.
+
+**Causes and fixes:**
+
+- **clamd is not running:** `sudo systemctl start clamav-daemon`
+- **Wrong host/port:** Verify `CLAMAV_HOST` and `CLAMAV_PORT` in `.env.prod.local`
+- **Firewall blocking:** Ensure port 3310 is open on localhost (production runs on 127.0.0.1)
+- **Docker DNS:** In development, ensure the ClamAV container is running and named `clamav`
+
+### "Empty response from ClamAV" Error
+
+**Symptoms:** Logs show `Empty response from ClamAV`.
+
+**Causes:**
+
+- `clamd` is still loading virus definitions (first startup can take 1-2 minutes)
+- `clamd` ran out of memory or crashed mid-scan
+- Network timeout (file too large for the 30-second socket timeout)
+
+**Fix:** Check `clamd` logs: `sudo journalctl -u clamav-daemon -n 50`
+
+### Uploads Fail in Development but ClamAV Is Not Running
+
+If `MALWARE_SCAN_ENABLED=true` in your local env but no ClamAV container is running:
+
+- **With `MALWARE_SCAN_FAIL_OPEN=true`** (default): Uploads succeed with a warning
+- **With `MALWARE_SCAN_FAIL_OPEN=false`**: Uploads are rejected
+
+To fix, either start the ClamAV container (`docker compose up -d clamav`) or set `MALWARE_SCAN_ENABLED=false` in `.env.local`.
+
+### High Memory Usage
+
+ClamAV loads its entire virus definition database into memory. Expect ~300-500 MB of RAM usage. If the server is memory-constrained, monitor with:
+
+```bash
+ps aux | grep clamd
+```
+
+### Virus Definitions Not Updating
+
+```bash
+# Check freshclam log for errors
+sudo journalctl -u clamav-freshclam -n 20
+
+# Common issue: freshclam and clamd both try to lock the DB
+# Fix: restart freshclam
+sudo systemctl restart clamav-freshclam
+```
+
+## Source Code
+
+| File                                                    | Purpose                                 |
+| ------------------------------------------------------- | --------------------------------------- |
+| `src/Security/Malware/MalwareScanner.php`               | ClamAV client (INSTREAM protocol)       |
+| `src/Security/Malware/MalwareScanResult.php`            | Value object for scan results           |
+| `src/Project/ProjectManager.php`                        | Calls scanner before extracting uploads |
+| `tests/PhpUnit/Security/Malware/MalwareScannerTest.php` | Unit tests for the scanner              |

--- a/docs/operations/Secret-Management.md
+++ b/docs/operations/Secret-Management.md
@@ -27,6 +27,8 @@ Real environment variables always take precedence over all `.env` files.
 | `DATABASE_PASSWORD`    | `root`                                | `.env.prod.local` or real env var |
 | `GOOGLE_CLIENT_SECRET` | `'secret'`                            | `.env.prod.local` or real env var |
 | `MAILER_DSN`           | `null://null`                         | `.env.prod.local` or real env var |
+| `CLAMAV_HOST`          | `clamav`                              | `.env.prod.local` or real env var |
+| `CLAMAV_PORT`          | `3310`                                | `.env.prod.local` or real env var |
 
 ## Production Setup
 

--- a/src/Project/ProjectManager.php
+++ b/src/Project/ProjectManager.php
@@ -22,6 +22,7 @@ use App\Project\CatrobatFile\ProjectFileRepository;
 use App\Project\Event\ProjectAfterInsertEvent;
 use App\Project\Event\ProjectBeforeInsertEvent;
 use App\Project\Event\ProjectBeforePersistEvent;
+use App\Security\Malware\MalwareScanner;
 use App\Storage\ScreenshotRepository;
 use App\User\Notification\NotificationManager;
 use App\Utils\RequestHelper;
@@ -57,6 +58,7 @@ class ProjectManager
     protected NotificationManager $notification_service,
     private readonly ?UrlHelper $urlHelper,
     protected Security $security,
+    private readonly MalwareScanner $malware_scanner,
   ) {
   }
 
@@ -126,6 +128,15 @@ class ProjectManager
   public function addProject(AddProjectRequest $request): ?Program
   {
     $file = $request->getProjectFile();
+
+    $scan_result = $this->malware_scanner->scanFile($file->getPathname());
+    if (!$scan_result->is_clean) {
+      $this->logger->error('Malware scan rejected upload', [
+        'threat' => $scan_result->threat_name,
+        'error' => $scan_result->error_message,
+      ]);
+      throw new InvalidCatrobatFileException('errors.file.malware', 422, $scan_result->threat_name ?? $scan_result->error_message ?? 'Malware detected');
+    }
 
     $extracted_file = $this->file_extractor->extract($file);
 

--- a/src/Security/Malware/MalwareScanResult.php
+++ b/src/Security/Malware/MalwareScanResult.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security\Malware;
+
+/**
+ * Value object representing the result of a malware scan.
+ */
+final readonly class MalwareScanResult
+{
+  private function __construct(
+    public bool $is_clean,
+    public ?string $threat_name,
+    public bool $scan_performed,
+    public ?string $error_message,
+  ) {
+  }
+
+  public static function clean(): self
+  {
+    return new self(is_clean: true, threat_name: null, scan_performed: true, error_message: null);
+  }
+
+  public static function infected(string $threat_name): self
+  {
+    return new self(is_clean: false, threat_name: $threat_name, scan_performed: true, error_message: null);
+  }
+
+  public static function skipped(string $reason): self
+  {
+    return new self(is_clean: true, threat_name: null, scan_performed: false, error_message: $reason);
+  }
+
+  public static function error(string $message): self
+  {
+    return new self(is_clean: false, threat_name: null, scan_performed: false, error_message: $message);
+  }
+}

--- a/src/Security/Malware/MalwareScanner.php
+++ b/src/Security/Malware/MalwareScanner.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security\Malware;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Scans uploaded files for malware using ClamAV's clamd TCP socket.
+ *
+ * Uses the INSTREAM command to stream the file to clamd without requiring
+ * shared filesystem access between the app and ClamAV containers.
+ */
+class MalwareScanner
+{
+  private const int CHUNK_SIZE = 8192;
+
+  private const int SOCKET_TIMEOUT_SECONDS = 30;
+
+  public function __construct(
+    private readonly LoggerInterface $logger,
+    #[Autowire('%env(bool:MALWARE_SCAN_ENABLED)%')]
+    private readonly bool $enabled,
+    #[Autowire('%env(string:CLAMAV_HOST)%')]
+    private readonly string $host,
+    #[Autowire('%env(int:CLAMAV_PORT)%')]
+    private readonly int $port,
+    #[Autowire('%env(bool:MALWARE_SCAN_FAIL_OPEN)%')]
+    private readonly bool $fail_open,
+  ) {
+  }
+
+  /**
+   * Scan a file for malware. Returns a MalwareScanResult indicating whether
+   * the file is clean, infected, or if the scan could not be performed.
+   */
+  public function scanFile(string $file_path): MalwareScanResult
+  {
+    if (!$this->enabled) {
+      return MalwareScanResult::skipped('Malware scanning is disabled');
+    }
+
+    if (!file_exists($file_path) || !is_readable($file_path)) {
+      return MalwareScanResult::error('File not found or not readable: '.$file_path);
+    }
+
+    try {
+      return $this->performScan($file_path);
+    } catch (\Exception $e) {
+      $this->logger->error('Malware scan failed', [
+        'file' => $file_path,
+        'error' => $e->getMessage(),
+      ]);
+
+      if ($this->fail_open) {
+        $this->logger->warning('Malware scan failed but fail-open is enabled, allowing upload', [
+          'file' => $file_path,
+        ]);
+
+        return MalwareScanResult::skipped('ClamAV unavailable (fail-open): '.$e->getMessage());
+      }
+
+      return MalwareScanResult::error('ClamAV unavailable: '.$e->getMessage());
+    }
+  }
+
+  /**
+   * @throws \RuntimeException if connection or communication with clamd fails
+   */
+  private function performScan(string $file_path): MalwareScanResult
+  {
+    $socket = $this->connect();
+
+    try {
+      return $this->scanViaInstream($socket, $file_path);
+    } finally {
+      @fclose($socket);
+    }
+  }
+
+  /**
+   * @return resource
+   *
+   * @throws \RuntimeException
+   */
+  private function connect()
+  {
+    $socket = @fsockopen($this->host, $this->port, $errno, $errstr, self::SOCKET_TIMEOUT_SECONDS);
+    if (false === $socket) {
+      throw new \RuntimeException(sprintf('Cannot connect to ClamAV at %s:%d — %s (%d)', $this->host, $this->port, $errstr, $errno));
+    }
+
+    stream_set_timeout($socket, self::SOCKET_TIMEOUT_SECONDS);
+
+    return $socket;
+  }
+
+  /**
+   * Stream the file to clamd using the INSTREAM command.
+   *
+   * Protocol: send "zINSTREAM\0", then chunks as [4-byte big-endian length][data],
+   * terminated by a zero-length chunk [0x00000000]. Read response line.
+   *
+   * @param resource $socket
+   *
+   * @throws \RuntimeException
+   */
+  private function scanViaInstream($socket, string $file_path): MalwareScanResult
+  {
+    // Send INSTREAM command (null-terminated)
+    fwrite($socket, "zINSTREAM\0");
+
+    $handle = fopen($file_path, 'rb');
+    if (false === $handle) {
+      throw new \RuntimeException('Cannot open file for reading: '.$file_path);
+    }
+
+    try {
+      while (!feof($handle)) {
+        $chunk = fread($handle, self::CHUNK_SIZE);
+        if (false === $chunk || '' === $chunk) {
+          break;
+        }
+
+        // Send chunk length as 4-byte big-endian unsigned int, then the data
+        $length = strlen($chunk);
+        fwrite($socket, pack('N', $length));
+        fwrite($socket, $chunk);
+      }
+    } finally {
+      fclose($handle);
+    }
+
+    // Send zero-length terminator chunk
+    fwrite($socket, pack('N', 0));
+
+    // Read response
+    $response = '';
+    while (!feof($socket)) {
+      $data = fread($socket, 4096);
+      if (false === $data || '' === $data) {
+        break;
+      }
+
+      $response .= $data;
+    }
+
+    $response = trim($response);
+
+    return $this->parseResponse($response);
+  }
+
+  /**
+   * Parse ClamAV's response string.
+   *
+   * Clean:    "stream: OK"
+   * Infected: "stream: Win.Test.EICAR_HDB-1 FOUND"
+   * Error:    "stream: ... ERROR"
+   */
+  private function parseResponse(string $response): MalwareScanResult
+  {
+    if ('' === $response) {
+      throw new \RuntimeException('Empty response from ClamAV');
+    }
+
+    if (str_ends_with($response, 'OK')) {
+      return MalwareScanResult::clean();
+    }
+
+    if (str_ends_with($response, 'FOUND')) {
+      // Extract threat name: "stream: <threat_name> FOUND"
+      $threat_name = trim(substr($response, (int) strpos($response, ':') + 1, -5));
+      $this->logger->warning('Malware detected in uploaded file', [
+        'threat' => $threat_name,
+        'response' => $response,
+      ]);
+
+      return MalwareScanResult::infected($threat_name);
+    }
+
+    if (str_ends_with($response, 'ERROR')) {
+      throw new \RuntimeException('ClamAV scan error: '.$response);
+    }
+
+    throw new \RuntimeException('Unexpected ClamAV response: '.$response);
+  }
+}

--- a/tests/PhpUnit/Project/ProjectManagerTest.php
+++ b/tests/PhpUnit/Project/ProjectManagerTest.php
@@ -22,6 +22,8 @@ use App\Project\Event\ProjectAfterInsertEvent;
 use App\Project\Event\ProjectBeforeInsertEvent;
 use App\Project\Event\ProjectBeforePersistEvent;
 use App\Project\ProjectManager;
+use App\Security\Malware\MalwareScanner;
+use App\Security\Malware\MalwareScanResult;
 use App\Storage\ScreenshotRepository;
 use App\User\Notification\NotificationManager;
 use App\Utils\RequestHelper;
@@ -120,6 +122,7 @@ class ProjectManagerTest extends TestCase
     ?EntityManager $entity_manager = null,
     ?EventDispatcherInterface $event_dispatcher = null,
     ?ExtractedCatrobatFile $extracted_file = null,
+    ?MalwareScanner $malware_scanner = null,
   ): ProjectManager {
     $file_extractor = $this->createStub(CatrobatFileExtractor::class);
     $program_repository = $this->createStub(ProgramRepository::class);
@@ -133,6 +136,11 @@ class ProjectManagerTest extends TestCase
     $notification_service = $this->createStub(NotificationManager::class);
     $security = $this->createStub(Security::class);
     $url_helper = new UrlHelper(new RequestStack());
+
+    if (null === $malware_scanner) {
+      $malware_scanner = $this->createStub(MalwareScanner::class);
+      $malware_scanner->method('scanFile')->willReturn(MalwareScanResult::clean());
+    }
 
     $this->createStub(User::class);
     $extracted = $extracted_file ?? $this->extracted_file;
@@ -157,7 +165,8 @@ class ProjectManagerTest extends TestCase
       $catrobat_file_sanitizer,
       $notification_service,
       $url_helper,
-      $security
+      $security,
+      $malware_scanner,
     );
   }
 
@@ -337,6 +346,82 @@ class ProjectManagerTest extends TestCase
     );
 
     $program_manager->addProject($this->request);
+  }
+
+  /**
+   * @throws ORMException
+   * @throws Exception
+   */
+  public function testRejectsUploadWhenMalwareDetected(): void
+  {
+    $malware_scanner = $this->createStub(MalwareScanner::class);
+    $malware_scanner->method('scanFile')->willReturn(MalwareScanResult::infected('Win.Test.EICAR_HDB-1'));
+
+    $this->expectException(InvalidCatrobatFileException::class);
+    $this->expectExceptionMessage('errors.file.malware');
+
+    $program_manager = $this->createProjectManagerWithMocks(
+      malware_scanner: $malware_scanner,
+    );
+
+    $program_manager->addProject($this->request);
+  }
+
+  /**
+   * @throws ORMException
+   * @throws Exception
+   */
+  public function testRejectsUploadWhenMalwareScanErrors(): void
+  {
+    $malware_scanner = $this->createStub(MalwareScanner::class);
+    $malware_scanner->method('scanFile')->willReturn(MalwareScanResult::error('ClamAV unavailable'));
+
+    $this->expectException(InvalidCatrobatFileException::class);
+    $this->expectExceptionMessage('errors.file.malware');
+
+    $program_manager = $this->createProjectManagerWithMocks(
+      malware_scanner: $malware_scanner,
+    );
+
+    $program_manager->addProject($this->request);
+  }
+
+  /**
+   * @throws ORMException
+   * @throws Exception
+   */
+  public function testAllowsUploadWhenMalwareScanSkipped(): void
+  {
+    $func = static function (Program $project): Program {
+      $project->setId('1');
+
+      return $project;
+    };
+
+    $entity_manager = $this->createMock(EntityManager::class);
+    $entity_manager->expects($this->atLeastOnce())->method('persist')->with($this->isInstanceOf(Program::class))
+      ->willReturnCallback($func)
+    ;
+    $entity_manager->expects($this->atLeastOnce())->method('flush');
+    $entity_manager->expects($this->atLeastOnce())->method('refresh')
+      ->with($this->isInstanceOf(Program::class))
+    ;
+
+    $event_dispatcher = $this->createMock(EventDispatcherInterface::class);
+    $event_dispatcher->expects($this->atLeastOnce())->method('dispatch')
+      ->willReturn($this->programBeforeInsertEvent)
+    ;
+
+    $malware_scanner = $this->createStub(MalwareScanner::class);
+    $malware_scanner->method('scanFile')->willReturn(MalwareScanResult::skipped('Scanning disabled'));
+
+    $program_manager = $this->createProjectManagerWithMocks(
+      entity_manager: $entity_manager,
+      event_dispatcher: $event_dispatcher,
+      malware_scanner: $malware_scanner,
+    );
+
+    $this->assertInstanceOf(Program::class, $program_manager->addProject($this->request));
   }
 
   /**

--- a/tests/PhpUnit/Security/Malware/MalwareScanResultTest.php
+++ b/tests/PhpUnit/Security/Malware/MalwareScanResultTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Security\Malware;
+
+use App\Security\Malware\MalwareScanResult;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \App\Security\Malware\MalwareScanResult
+ */
+class MalwareScanResultTest extends TestCase
+{
+  public function testClean(): void
+  {
+    $result = MalwareScanResult::clean();
+
+    self::assertTrue($result->is_clean);
+    self::assertNull($result->threat_name);
+    self::assertTrue($result->scan_performed);
+    self::assertNull($result->error_message);
+  }
+
+  public function testInfected(): void
+  {
+    $result = MalwareScanResult::infected('Win.Test.EICAR_HDB-1');
+
+    self::assertFalse($result->is_clean);
+    self::assertSame('Win.Test.EICAR_HDB-1', $result->threat_name);
+    self::assertTrue($result->scan_performed);
+    self::assertNull($result->error_message);
+  }
+
+  public function testSkipped(): void
+  {
+    $result = MalwareScanResult::skipped('Scanning disabled');
+
+    self::assertTrue($result->is_clean);
+    self::assertNull($result->threat_name);
+    self::assertFalse($result->scan_performed);
+    self::assertSame('Scanning disabled', $result->error_message);
+  }
+
+  public function testError(): void
+  {
+    $result = MalwareScanResult::error('Connection refused');
+
+    self::assertFalse($result->is_clean);
+    self::assertNull($result->threat_name);
+    self::assertFalse($result->scan_performed);
+    self::assertSame('Connection refused', $result->error_message);
+  }
+}

--- a/tests/PhpUnit/Security/Malware/MalwareScannerTest.php
+++ b/tests/PhpUnit/Security/Malware/MalwareScannerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Security\Malware;
+
+use App\Security\Malware\MalwareScanner;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * @internal
+ *
+ * @covers \App\Security\Malware\MalwareScanner
+ */
+class MalwareScannerTest extends TestCase
+{
+  public function testScanSkippedWhenDisabled(): void
+  {
+    $scanner = new MalwareScanner(
+      logger: new NullLogger(),
+      enabled: false,
+      host: 'localhost',
+      port: 3310,
+      fail_open: true,
+    );
+
+    $result = $scanner->scanFile('/any/path');
+
+    self::assertTrue($result->is_clean);
+    self::assertFalse($result->scan_performed);
+    self::assertSame('Malware scanning is disabled', $result->error_message);
+  }
+
+  public function testScanReturnsErrorForNonexistentFile(): void
+  {
+    $scanner = new MalwareScanner(
+      logger: new NullLogger(),
+      enabled: true,
+      host: 'localhost',
+      port: 3310,
+      fail_open: false,
+    );
+
+    $result = $scanner->scanFile('/nonexistent/file.catrobat');
+
+    self::assertFalse($result->is_clean);
+    self::assertFalse($result->scan_performed);
+    self::assertStringContainsString('File not found or not readable', $result->error_message ?? '');
+  }
+
+  public function testScanFailOpenWhenClamavUnavailable(): void
+  {
+    $scanner = new MalwareScanner(
+      logger: new NullLogger(),
+      enabled: true,
+      host: '127.0.0.1',
+      port: 19999, // unlikely to have ClamAV here
+      fail_open: true,
+    );
+
+    $temp_file = tempnam(sys_get_temp_dir(), 'malware_test_');
+    self::assertNotFalse($temp_file);
+    file_put_contents($temp_file, 'harmless test content');
+
+    try {
+      $result = $scanner->scanFile($temp_file);
+
+      self::assertTrue($result->is_clean);
+      self::assertFalse($result->scan_performed);
+      self::assertStringContainsString('ClamAV unavailable (fail-open)', $result->error_message ?? '');
+    } finally {
+      @unlink($temp_file);
+    }
+  }
+
+  public function testScanFailClosedWhenClamavUnavailable(): void
+  {
+    $scanner = new MalwareScanner(
+      logger: new NullLogger(),
+      enabled: true,
+      host: '127.0.0.1',
+      port: 19999, // unlikely to have ClamAV here
+      fail_open: false,
+    );
+
+    $temp_file = tempnam(sys_get_temp_dir(), 'malware_test_');
+    self::assertNotFalse($temp_file);
+    file_put_contents($temp_file, 'harmless test content');
+
+    try {
+      $result = $scanner->scanFile($temp_file);
+
+      self::assertFalse($result->is_clean);
+      self::assertFalse($result->scan_performed);
+      self::assertStringContainsString('ClamAV unavailable', $result->error_message ?? '');
+    } finally {
+      @unlink($temp_file);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds ClamAV integration to scan `.catrobat` ZIP uploads for malware **before** extraction
- New `MalwareScanner` service connects to ClamAV via TCP socket using the `INSTREAM` protocol (no shared filesystem needed)
- Configurable via environment variables: `MALWARE_SCAN_ENABLED`, `CLAMAV_HOST`, `CLAMAV_PORT`, `MALWARE_SCAN_FAIL_OPEN`
- Scanning disabled by default in dev, enabled in prod with fail-closed behavior
- Adds ClamAV container to `docker-compose.dev.yaml` with persistent virus definition volume

## Architecture
- `src/Security/Malware/MalwareScanner.php` -- ClamAV client using `INSTREAM` command over TCP
- `src/Security/Malware/MalwareScanResult.php` -- Value object (clean/infected/skipped/error)
- Hook point: `ProjectManager::addProject()`, before `CatrobatFileExtractor::extract()`
- Infected files are rejected with `InvalidCatrobatFileException` (422)
- When ClamAV is unavailable: fail-open (dev) logs a warning and allows upload; fail-closed (prod) rejects with error

## Configuration
| Variable | Default | Prod |
|---|---|---|
| `MALWARE_SCAN_ENABLED` | `false` | `true` |
| `CLAMAV_HOST` | `clamav` | `clamav` |
| `CLAMAV_PORT` | `3310` | `3310` |
| `MALWARE_SCAN_FAIL_OPEN` | `true` | `false` |

## Test plan
- [x] PHPUnit: `MalwareScanResultTest` -- all 4 factory methods
- [x] PHPUnit: `MalwareScannerTest` -- disabled scan, nonexistent file, fail-open, fail-closed
- [x] PHPUnit: `ProjectManagerTest` -- malware rejection, error rejection, skipped scan allows upload
- [x] All existing `ProjectManagerTest` tests pass (MalwareScanner stubbed to return clean)
- [x] PHP CS Fixer, PHPStan, Psalm all pass
- [ ] Manual: start ClamAV container, enable scanning, upload EICAR test file to verify rejection
- [ ] Manual: stop ClamAV container, verify fail-open allows upload in dev

Closes #6349

🤖 Generated with [Claude Code](https://claude.com/claude-code)