### PR TITLE
Remove unused animate.css CDN dependency

### DIFF
--- a/templates/Project/RemixGraphPage.html.twig
+++ b/templates/Project/RemixGraphPage.html.twig
@@ -7,7 +7,6 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery-contextmenu@2.9.2/dist/jquery.contextMenu.min.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vis@4.21.0-EOL/dist/vis.min.css"/>
     <link rel="stylesheet" href="{{ asset('build/css/Remixgraph.css') }}"/>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/animate.css@4.1.1/animate.min.css"/>
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
## Summary
- Removes the unused `animate.css` CDN link (`~80KB`) from `RemixGraphPage.html.twig`
- No `animate__` classes are used anywhere in the codebase -- this was a dead dependency on the legacy (feature-flag-disabled) remix graph page
- Eliminates one unnecessary HTTP request and ~80KB of unneeded CSS

Closes #6406

## Test plan
- [ ] Verify webpack build succeeds (`yarn run dev`)
- [ ] Verify no animate.css classes are referenced anywhere (`grep -r "animate__" assets/ templates/ src/`)
- [ ] Remix graph page (if enabled) still renders correctly without animate.css

🤖 Generated with [Claude Code](https://claude.com/claude-code)