### PR TITLE
Add security headers to Apache configuration

### DIFF
--- a/docker/apache/catroweb.conf
+++ b/docker/apache/catroweb.conf
@@ -34,6 +34,20 @@
             </FilesMatch>
         </IfModule>
 
+        # Security headers
+        <IfModule mod_headers.c>
+            Header always set X-Content-Type-Options "nosniff"
+            Header always set X-Frame-Options "SAMEORIGIN"
+            Header always set Referrer-Policy "strict-origin-when-cross-origin"
+            Header always set Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()"
+
+            # HSTS: only sent over HTTPS connections (env=HTTPS)
+            Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains" env=HTTPS
+
+            # Content-Security-Policy in report-only mode for auditing (not enforcing)
+            Header always set Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https: blob:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self' https:; media-src 'self' blob:;"
+        </IfModule>
+
         ErrorLog ${APACHE_LOG_DIR}/error.log
         CustomLog ${APACHE_LOG_DIR}/access.log combined
 </VirtualHost>


### PR DESCRIPTION
## Summary
- Adds security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`) to the dev Apache config
- Adds conditional `Strict-Transport-Security` (HSTS) header, only sent over HTTPS via `env=HTTPS`
- Adds a permissive `Content-Security-Policy-Report-Only` header for auditing what would break before enforcing CSP

Note: This is the dev Docker Apache config only. The production server uses nginx (separate config).

Closes #6396

## Test plan
- [ ] Rebuild Docker container: `docker compose -f docker/docker-compose.dev.yaml build --no-cache app.catroweb`
- [ ] Start container and verify headers with `curl -I http://localhost:8080`
- [ ] Confirm `X-Content-Type-Options: nosniff` is present
- [ ] Confirm `X-Frame-Options: SAMEORIGIN` is present
- [ ] Confirm `Referrer-Policy: strict-origin-when-cross-origin` is present
- [ ] Confirm `Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()` is present
- [ ] Confirm `Content-Security-Policy-Report-Only` is present with permissive policy
- [ ] Confirm `Strict-Transport-Security` is NOT present over plain HTTP (conditional on HTTPS)
- [ ] Verify the application works normally (pages load, assets render, API calls succeed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)