### PR TITLE
Fix GDPR data export TypeError: pass DateTime objects instead of strings

### DIFF
--- a/config/packages/security.php
+++ b/config/packages/security.php
@@ -133,6 +133,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
           'requires_channel' => '%env(SECURE_SCHEME)%',
         ],
         [
+          'path' => '^/api/user/data-export/?$',
+          'roles' => 'IS_AUTHENTICATED_FULLY',
+          'methods' => ['GET'],
+          'requires_channel' => '%env(SECURE_SCHEME)%',
+        ],
+        [
           'path' => '^/api/user/reports/?$',
           'roles' => 'IS_AUTHENTICATED_FULLY',
           'methods' => ['GET'],

--- a/src/Api/UserApi.php
+++ b/src/Api/UserApi.php
@@ -270,7 +270,7 @@ class UserApi extends AbstractApiController implements UserApiInterface
       'email' => $user->getEmail(),
       'about' => $user->getAbout(),
       'currently_working_on' => $user->getCurrentlyWorkingOn(),
-      'created_at' => $user->getCreatedAt()?->format(\DateTimeInterface::ATOM),
+      'created_at' => $this->toDateTime($user->getCreatedAt()),
     ]);
 
     $projects = [];
@@ -279,7 +279,7 @@ class UserApi extends AbstractApiController implements UserApiInterface
         'id' => $program->getId(),
         'name' => $program->getName(),
         'description' => $program->getDescription(),
-        'uploaded_at' => $program->getUploadedAt()?->format(\DateTimeInterface::ATOM),
+        'uploaded_at' => $program->getUploadedAt(),
         'views' => $program->getViews(),
         'downloads' => $program->getDownloads(),
         'private' => $program->getPrivate(),
@@ -291,7 +291,7 @@ class UserApi extends AbstractApiController implements UserApiInterface
       $comments[] = new UserDataExportResponseCommentsInner([
         'id' => $comment->getId(),
         'text' => $comment->getText(),
-        'posted_at' => $comment->getUploadDate()?->format(\DateTimeInterface::ATOM),
+        'posted_at' => $comment->getUploadDate(),
         'parent_id' => 0 === $comment->getParentId() ? null : $comment->getParentId(),
       ]);
     }
@@ -301,7 +301,7 @@ class UserApi extends AbstractApiController implements UserApiInterface
       $reactions[] = new UserDataExportResponseReactionsInner([
         'project_id' => $like->getProgramId(),
         'type' => ProgramLike::$TYPE_NAMES[$like->getType()] ?? 'unknown',
-        'created_at' => $like->getCreatedAt()?->format(\DateTimeInterface::ATOM),
+        'created_at' => $like->getCreatedAt(),
       ]);
     }
 
@@ -309,7 +309,7 @@ class UserApi extends AbstractApiController implements UserApiInterface
     $following = $this->loadRelatedUsers($user, 'f.followers');
 
     return new UserDataExportResponse([
-      'exported_at' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+      'exported_at' => \DateTime::createFromInterface(new \DateTimeImmutable()),
       'profile' => $profile,
       'projects' => $projects,
       'comments' => $comments,
@@ -342,5 +342,18 @@ class UserApi extends AbstractApiController implements UserApiInterface
       ]),
       $users,
     );
+  }
+
+  private function toDateTime(?\DateTimeInterface $dateTime): ?\DateTime
+  {
+    if (null === $dateTime) {
+      return null;
+    }
+
+    if ($dateTime instanceof \DateTime) {
+      return $dateTime;
+    }
+
+    return \DateTime::createFromInterface($dateTime);
   }
 }

--- a/src/Api/UserApi.php
+++ b/src/Api/UserApi.php
@@ -309,7 +309,7 @@ class UserApi extends AbstractApiController implements UserApiInterface
     $following = $this->loadRelatedUsers($user, 'f.followers');
 
     return new UserDataExportResponse([
-      'exported_at' => \DateTime::createFromInterface(new \DateTimeImmutable()),
+      'exported_at' => new \DateTime(),
       'profile' => $profile,
       'projects' => $projects,
       'comments' => $comments,

--- a/src/Api/UserApi.php
+++ b/src/Api/UserApi.php
@@ -7,6 +7,7 @@ namespace App\Api;
 use App\Api\Services\Base\AbstractApiController;
 use App\Api\Services\User\UserApiFacade;
 use App\DB\Entity\Project\ProgramLike;
+use App\DB\Entity\User\Comment\UserComment;
 use App\DB\Entity\User\User;
 use App\Security\Captcha\CaptchaVerifier;
 use App\User\ResetPassword\PasswordResetRequestedEvent;
@@ -286,8 +287,18 @@ class UserApi extends AbstractApiController implements UserApiInterface
       ]);
     }
 
+    /** @var UserComment[] $userComments */
+    $userComments = $this->entity_manager->createQueryBuilder()
+      ->select('c')
+      ->from(UserComment::class, 'c')
+      ->where('c.user = :userId')
+      ->setParameter('userId', $user->getId())
+      ->getQuery()
+      ->getResult()
+    ;
+
     $comments = [];
-    foreach ($user->getComments() as $comment) {
+    foreach ($userComments as $comment) {
       $comments[] = new UserDataExportResponseCommentsInner([
         'id' => $comment->getId(),
         'text' => $comment->getText(),

--- a/src/System/Testing/Behat/ContextTrait.php
+++ b/src/System/Testing/Behat/ContextTrait.php
@@ -584,7 +584,9 @@ trait ContextTrait
     $project = $this->getProjectManager()->find($config['project_id']);
 
     /** @var User|null $user */
-    $user = $this->getUserManager()->find($config['user_id']);
+    $user = isset($config['user_id'])
+      ? $this->getUserManager()->find($config['user_id'])
+      : $this->getUserManager()->findUserByUsername($config['user']);
 
     $parent_id = $config['parent_id'] ?? null;
     $parent_id = ('NULL' === $parent_id || is_null($parent_id)) ? null : intval($parent_id);

--- a/tests/BehatFeatures/api/user/GET_user_data_export/gdpr_data_export.feature
+++ b/tests/BehatFeatures/api/user/GET_user_data_export/gdpr_data_export.feature
@@ -1,0 +1,47 @@
+@api @user
+Feature: GDPR personal data export
+
+  Background:
+    Given there are users:
+      | name     | password | id |
+      | Catrobat | 12345    | 1  |
+      | User1    | vwxyz    | 2  |
+    And there are followers:
+      | name     | following |
+      | User1    | Catrobat  |
+    And there are projects:
+      | id        | name       | owned by | version | private | visible |
+      | isxs-adkt | MyProject  | Catrobat | 0.8.5   | false   | true    |
+    And there are comments:
+      | id | user     | project_id | text          |
+      | 10 | Catrobat | isxs-adkt  | First comment |
+    And I wait 500 milliseconds
+
+  Scenario: Successfully export personal data
+    Given I use a valid JWT Bearer token for "Catrobat"
+    And I have a request header "HTTP_ACCEPT" with value "application/json"
+    When I request "GET" "/api/user/data-export"
+    Then the response status code should be "200"
+    And the client response should contain "exported_at"
+    And the client response should contain "profile"
+    And the client response should contain "Catrobat"
+    And the client response should contain "projects"
+    And the client response should contain "MyProject"
+    And the client response should contain "comments"
+    And the client response should contain "First comment"
+    And the client response should contain "followers"
+    And the client response should contain "User1"
+    And the client response should contain "reactions"
+    And the client response should contain "following"
+    And the client response should contain "created_at"
+
+  Scenario: Export data requires authentication
+    Given I have a request header "HTTP_ACCEPT" with value "application/json"
+    When I request "GET" "/api/user/data-export"
+    Then the response status code should be "401"
+
+  Scenario: Export data with invalid token returns 401
+    Given I use an invalid JWT Bearer token
+    And I have a request header "HTTP_ACCEPT" with value "application/json"
+    When I request "GET" "/api/user/data-export"
+    Then the response status code should be "401"


### PR DESCRIPTION
## Summary
- Fix 500 error on `GET /api/user/data-export` caused by passing formatted date strings to generated OpenAPI model properties typed as `?\DateTime`
- Pass `DateTime` objects directly instead of `->format()` strings -- JMS Serializer handles the serialization
- Add `toDateTime()` helper to safely convert `DateTimeInterface` (from User entity) to `DateTime` (required by generated model)
- Add Behat test coverage for the GDPR export endpoint (auth, success, response structure)

## Test plan
- [ ] `GET /api/user/data-export` returns 200 with valid JSON containing profile, projects, comments, reactions, followers, following
- [ ] Date fields (`created_at`, `uploaded_at`, `posted_at`, `exported_at`) are serialized as ISO 8601 strings in the response
- [ ] Unauthenticated requests return 401
- [ ] Run `api-user` Behat suite: `bin/behat -f pretty -s api-user tests/BehatFeatures/api/user/GET_user_data_export/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)