### PR TITLE
Fix login redirect for invalid/expired JWT tokens

### DIFF
--- a/config/packages/security.php
+++ b/config/packages/security.php
@@ -59,6 +59,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
           'provider' => 'user_provider',
           'stateless' => false,
           'form_login' => [
+            'login_path' => '/app/login',
             'default_target_path' => '/',
             'success_handler' => FormLoginSuccessHandler::class,
             'enable_csrf' => true,
@@ -74,7 +75,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
               'facebook' => '/login/check-facebook',
               'apple' => '/login/check-apple',
             ],
-            'login_path' => '/login',
+            'login_path' => '/app/login',
             'use_forward' => false,
             'failure_path' => '/app/login',
             'success_handler' => OAuthSuccessHandler::class,

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -452,11 +452,7 @@
       <code><![CDATA[$user->getId()]]></code>
     </PossiblyNullArgument>
   </file>
-  <file src="src/Security/Authentication/WebView/WebviewJWTAuthenticator.php">
-    <PossiblyNullReference>
-      <code><![CDATA[getStatusCode]]></code>
-    </PossiblyNullReference>
-  </file>
+
   <file src="src/Security/OAuth/HwiOauthUserProvider.php">
     <PossiblyNullArgument>
       <code><![CDATA[$response->getEmail()]]></code>

--- a/src/Security/Authentication/WebView/WebviewJWTAuthenticator.php
+++ b/src/Security/Authentication/WebView/WebviewJWTAuthenticator.php
@@ -19,6 +19,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /** @psalm-suppress UnimplementedInterfaceMethod */
 class WebviewJWTAuthenticator extends JWTAuthenticator
 {
+  private const string LOGIN_PATH = '/app/login';
+
   public function __construct(
     private readonly CookieService $cookie_service,
     JWTTokenManagerInterface $jwtManager,
@@ -30,6 +32,12 @@ class WebviewJWTAuthenticator extends JWTAuthenticator
     parent::__construct($jwtManager, $dispatcher, $tokenExtractor, $userProvider, $translator);
   }
 
+  #[\Override]
+  public function start(Request $request, ?AuthenticationException $authException = null): Response
+  {
+    return new RedirectResponse(self::LOGIN_PATH);
+  }
+
   /**
    * @psalm-suppress ParamNameMismatch
    */
@@ -38,11 +46,11 @@ class WebviewJWTAuthenticator extends JWTAuthenticator
   {
     $response = parent::onAuthenticationFailure($request, $exception);
 
-    if (Response::HTTP_UNAUTHORIZED === $response->getStatusCode() && !$request->headers->get('Authorization')) {
+    if (null !== $response && Response::HTTP_UNAUTHORIZED === $response->getStatusCode() && !$request->headers->get('Authorization')) {
       $this->cookie_service->clearCookie('BEARER');
       // RefreshBearerCookieOnKernelResponse will try to create a new Bearer or is going to remove the refresh token!
 
-      return new RedirectResponse('' === $request->getBaseUrl() || '0' === $request->getBaseUrl() ? '/' : $request->getBaseUrl());
+      return new RedirectResponse(self::LOGIN_PATH);
     }
 
     return $response;

--- a/tests/BehatFeatures/web/authentication/webview_jwt_authentication.feature
+++ b/tests/BehatFeatures/web/authentication/webview_jwt_authentication.feature
@@ -17,7 +17,7 @@ Feature: Users should be logged in automatically when they are logged in in the 
     Given I set the cookie "BEARER" to "invalid"
     When I go to "/app/user"
     And I wait for the page to be loaded
-    Then I should be on "app/"
+    Then I should be on "/app/login"
 
   Scenario: Log in using Catrobat user and show profile
     Given I use a valid JWT token for "WebViewUser"


### PR DESCRIPTION
## Summary
- Fixed invalid/expired JWT tokens redirecting users to `/login/` (OAuth-only page with just 3 buttons) instead of `/app/login` (full login page with username/password form + OAuth)
- Set explicit `login_path` for both `form_login` and OAuth config in `security.php` to `/app/login`
- Overrode `WebviewJWTAuthenticator::start()` to redirect to `/app/login` instead of returning a JSON 401 response
- Changed `onAuthenticationFailure` redirect from `/` (homepage) to `/app/login`

## Test plan
- [ ] With an expired BEARER cookie, visit a protected page -- should redirect to `/app/login`
- [ ] With an invalid BEARER cookie (malformed), visit a protected page -- should redirect to `/app/login`  
- [ ] With no cookies at all, visit a protected page -- should redirect to `/app/login`
- [ ] OAuth login flow still works (Google/Facebook/Apple buttons redirect correctly)
- [ ] Normal login with username/password still works
- [ ] After successful login, user lands on the correct target page

🤖 Generated with [Claude Code](https://claude.com/claude-code)