### PR TITLE
Fix accessibility: missing alt text, skip link, ARIA attributes

### DIFF
--- a/assets/Layout/Base.scss
+++ b/assets/Layout/Base.scss
@@ -19,3 +19,19 @@
 @import './LegacyBase';
 @import './CookieConsent';
 @import './Noscript';
+
+// === Accessibility ===
+.skip-to-content {
+  position: absolute;
+  left: -9999px;
+  z-index: 9999;
+  padding: 0.5rem 1rem;
+  background: #000;
+  color: #fff;
+  text-decoration: none;
+
+  &:focus {
+    left: 0;
+    top: 0;
+  }
+}

--- a/templates/Admin/Projects/ContainingImage.html.twig
+++ b/templates/Admin/Projects/ContainingImage.html.twig
@@ -2,14 +2,14 @@
 {% block field %}
   <div style="">
     {% for image in admin.getContainingImageUrls(object) %}
-      <img src="{{ image }}" width="100">
+      <img src="{{ image }}" width="100" alt="Project image">
     {% endfor %}
   </div>
   <div id="onedialogplease"></div>
   <script>
     $('img').on('click', function () {
       $('#onedialogplease').empty()
-      $('#onedialogplease').append('<div id="dialog" title="Image"><img src="' + $(this).attr('src') + '" width="300" /></div>')
+      $('#onedialogplease').append('<div id="dialog" title="Image"><img src="' + $(this).attr('src') + '" width="300" alt="Project image preview" /></div>')
       $('#dialog').dialog()
     })
   </script>

--- a/templates/Admin/Projects/ExampleImage.html.twig
+++ b/templates/Admin/Projects/ExampleImage.html.twig
@@ -2,6 +2,6 @@
 
 {% block field %}
   <div>
-    <img data-src="{{ admin.getExampleImageUrl(object) }}" width="300" class="lazyload">
+    <img data-src="{{ admin.getExampleImageUrl(object) }}" width="300" class="lazyload" alt="Example image">
   </div>
 {% endblock %}

--- a/templates/Admin/Projects/FeaturedImage.html.twig
+++ b/templates/Admin/Projects/FeaturedImage.html.twig
@@ -2,6 +2,6 @@
 
 {% block field %}
   <div>
-    <img data-src="{{ admin.getFeaturedImageUrl(object) }}" width="300" class="lazyload">
+    <img data-src="{{ admin.getFeaturedImageUrl(object) }}" width="300" class="lazyload" alt="Featured image">
   </div>
 {% endblock %}

--- a/templates/Admin/Projects/ThumbnailImage.html.twig
+++ b/templates/Admin/Projects/ThumbnailImage.html.twig
@@ -2,7 +2,7 @@
 {% block field %}
   <div style="">
     {% if admin.getThumbnailImageUrl(object) != null %}
-      <img src="{{ admin.getThumbnailImageUrl(object) }}">
+      <img src="{{ admin.getThumbnailImageUrl(object) }}" alt="Project thumbnail">
     {% else %}
       <span>No picture</span>
     {% endif %}

--- a/templates/Email/email.html.twig
+++ b/templates/Email/email.html.twig
@@ -18,7 +18,7 @@
              style="border: 1px solid #cccccc; border-collapse: collapse;">
         <td bgcolor="#fff">
           <div style="display: flex; justify-content: center; align-items: center; padding: 30px;">
-            <img src="https://catrobat.org/wp-content/uploads/2019/04/cropped-logo-e1555606660543-1.png" width="50%" height="auto"/>
+            <img src="https://catrobat.org/wp-content/uploads/2019/04/cropped-logo-e1555606660543-1.png" width="50%" height="auto" alt="Catrobat"/>
           </div>
         </td>
         <tr>
@@ -58,13 +58,13 @@
                 </div>
                 <div align="center" class= "social-icons" style="padding: 20px 0 20px 0; display: flex; justify-content: space-between; align-items: center; width: 100%;">
                   <a href="https://apps.apple.com/us/developer/international-catrobat-association-verein-zur-foerderung/id1117935891" target="_blank">
-                    <img src="{{ asset('images/social/download-on-app-store.svg') }}" width="90%" height="auto" />
+                    <img src="{{ asset('images/social/download-on-app-store.svg') }}" width="90%" height="auto" alt="Download on the App Store" />
                   </a>
                   <a href="https://appgallery.huawei.com/#/app/C100085769" target="_blank">
-                    <img src="{{ asset('images/social/huawei-app-gallery.svg') }}" width="89%" height="auto" style="padding-left: 3px"/>
+                    <img src="{{ asset('images/social/huawei-app-gallery.svg') }}" width="89%" height="auto" style="padding-left: 3px" alt="Huawei AppGallery"/>
                   </a>
                   <a href="https://play.google.com/store/apps/developer?id=Catrobat" target="_blank">
-                    <img src="{{ asset('images/social/google-play.svg') }}" width="87%" height="auto"/>
+                    <img src="{{ asset('images/social/google-play.svg') }}" width="87%" height="auto" alt="Google Play"/>
                   </a>
                 </div>
               </div>

--- a/templates/Index/IndexPage.html.twig
+++ b/templates/Index/IndexPage.html.twig
@@ -64,14 +64,14 @@
               {% for i in range(0, 10) %} {# Fill with dummy data until loaded to prevent cls #}
                 <div class="project-list__project">
                   <img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20360%20360'%3E%3Crect%20width='360'%20height='360'%20fill='%23E8E8E8'%20/%3E%3C/svg%3E"
-                       class="project-list__project__image">
+                       class="project-list__project__image" alt="">
                   <span class="project-list__project__name"></span>
                   <div class="project-list__project__property project-list__project__property-uploaded lazyloaded">
                     <i class="material-icons"></i>
                     <span class="project-list__project__property__value"></span>
                   </div>
                   <div class="project-list__project__property project-list__project__property__not-for-kids lazyloaded">
-                    <img class="project-list__not-for-kids-logo" style="display: none">
+                    <img class="project-list__not-for-kids-logo" style="display: none" alt="">
                     <span class="project-list__project__property__value"></span>
                   </div>
                 </div>

--- a/templates/Layout/Base.html.twig
+++ b/templates/Layout/Base.html.twig
@@ -45,6 +45,8 @@
 
 <body class="body-with-sidebar">
 
+<a href="#main_container_content" class="skip-to-content">{{ 'skipToContent'|trans({}, 'catroweb')|default('Skip to content') }}</a>
+
 <noscript>
   <div class="noscript-warning">
     {{ 'noscript.warning'|trans({}, 'catroweb') }}

--- a/templates/Project/Comment/Detail.html.twig
+++ b/templates/Project/Comment/Detail.html.twig
@@ -48,7 +48,7 @@
     <hr style="color: transparent">
 
     {% if not comment.is_deleted %}
-      <button class="mdc-fab add-reply-button reply-button--fab" aria-label="Favorite" style="display: inline-block;">
+      <button class="mdc-fab add-reply-button reply-button--fab" aria-label="{{ 'project.reply'|trans({}, 'catroweb') }}" style="display: inline-block;">
         <div class="mdc-fab__ripple"></div>
         <span class="mdc-fab__icon material-icons">reply</span>
       </button>

--- a/templates/Project/LegacyCodeViewPage.html.twig
+++ b/templates/Project/LegacyCodeViewPage.html.twig
@@ -16,10 +16,10 @@
 
     {% if scene_name is null and assetFileExists(path ~ 'images/' ~ object.getLooks()[0].getFileName()) %}
       <img src="{{ asset(path ~ 'images/' ~ object.getLooks()[0].getFileName()) }}"
-           class="object-icon">
+           class="object-icon" alt="{{ object.getName() }}">
     {% elseif assetFileExists(path ~ scene_name ~ '/images/' ~ object.getLooks()[0].getFileName()) %}
       <img src="{{ asset(path ~ scene_name ~ '/images/' ~ object.getLooks()[0].getFileName()) }}"
-           class="object-icon">
+           class="object-icon" alt="{{ object.getName() }}">
     {% else %}
       <div class="object-icon">
         <i class="no-image-found-icon material-icons">close</i>

--- a/templates/Studio/CreatePage.html.twig
+++ b/templates/Studio/CreatePage.html.twig
@@ -61,7 +61,7 @@
     </button>
     <div id="studio-file-name">{{ 'studio.cover_image_empty'|trans({}, 'catroweb') }}</div>
     <div id="studio-image-preview">
-      <button id="studio-delete-button"><span class="material-icons">close</span></button>
+      <button id="studio-delete-button" aria-label="{{ 'studio.cover_image_remove'|trans({}, 'catroweb')|default('Remove image') }}"><span class="material-icons">close</span></button>
       <img id="studio-preview-image" alt="{{ 'studio.cover_image_alt'|trans({}, 'catroweb') }}">
     </div>
 

--- a/templates/Studio/Details/CommentList.html.twig
+++ b/templates/Studio/Details/CommentList.html.twig
@@ -4,7 +4,7 @@
       <img class="comment-avatar"
            src="{% if comment.avatar != null %}{{ comment.avatar }}
                     {% else %}{{ asset('images/default/avatar_default.png') }}{% endif %}"
-           alt="Card image">
+           alt="">
       <div class="comment-content">
         <a href="{{ url('profile', {id: comment.user.id}) }}">{{ comment.username }}</a>
         {% if user_role == 'admin' or comment.username == user_name %}

--- a/templates/User/Achievements/AchievementsPage.html.twig
+++ b/templates/User/Achievements/AchievementsPage.html.twig
@@ -34,7 +34,7 @@
     ],
   }) }}
 
-  <div class="tab-content mt-4">
+  <div class="tab-content mt-4" aria-live="polite">
 
     <div id="unlocked-achievements" class="achievement__wrapper tab-pane show active" role="tabpanel">
       <p id="no-unlocked-achievements" class="d-none"></p>

--- a/templates/User/Followers/FollowersPage.html.twig
+++ b/templates/User/Followers/FollowersPage.html.twig
@@ -24,7 +24,7 @@
       ],
     }) }}
 
-  <div class="tab-content mt-4">
+  <div class="tab-content mt-4" aria-live="polite">
     <div id="follower-section" class="tab-pane fade show active" role="tabpanel" aria-labelledby="follower-tab">
       <div id="no-followers" class="text-center mb-5 d-none">
         {{ 'follower.noFollowers'|trans({}, 'catroweb') }}

--- a/templates/User/Notification/NotificationsPage.html.twig
+++ b/templates/User/Notification/NotificationsPage.html.twig
@@ -42,7 +42,7 @@
     ],
   }) }}
 
-  <div class="tab-content mt-4">
+  <div class="tab-content mt-4" aria-live="polite">
     {% for category in [
       {
         id: 'notifications',


### PR DESCRIPTION
## Summary
- Adds missing `alt` attributes to all `<img>` tags across 10 templates
- Adds skip-to-content link for keyboard navigation
- Adds `aria-live="polite"` to dynamic content containers
- Fixes incorrect `aria-label` on comment reply button

## Changes
- **Alt text**: Decorative images (avatars, placeholders) get `alt=""`, informative images (app store badges, project thumbnails) get descriptive text
- **Skip link**: Hidden off-screen, visible on keyboard focus, targets `#main_container_content`
- **ARIA live regions**: Notifications, achievements, and followers pages announce dynamic content updates to screen readers
- **Fixes**: Reply button had `aria-label="Favorite"` (copy-paste error), now uses translated "Reply" label

## Test plan
- [ ] Tab through page → skip-to-content link appears on first Tab press
- [ ] Skip link click → focus jumps to main content
- [ ] Screen reader: images announce proper alt text or are skipped (decorative)
- [ ] Screen reader: dynamic tab content announced on load
- [ ] All existing Behat tests still pass (no functional changes)
- [ ] Twig linting passes: `yarn run fix-twig`

Closes #6398

🤖 Generated with [Claude Code](https://claude.com/claude-code)