### PR TITLE
Fix back button skipping list views and not closing search bar

### DIFF
--- a/assets/Index/DefaultProjectLists.js
+++ b/assets/Index/DefaultProjectLists.js
@@ -23,13 +23,7 @@ export class DefaultProjectLists {
         url += `&flavor=${flavor}`
       }
 
-      projectList.dataset.list = new ProjectList(
-        projectList,
-        category,
-        url,
-        property,
-        theme,
-      ).toString()
+      new ProjectList(projectList, category, url, property, theme)
     })
   }
 }

--- a/assets/Layout/TopBar.js
+++ b/assets/Layout/TopBar.js
@@ -125,13 +125,25 @@ function hideTopBars() {
 }
 
 const PREVIOUS_NON_SEARCH_URL_KEY = 'previousNonSearchUrl'
+let searchBarPushedState = false
+
+function closeSearchBar() {
+  searchBarPushedState = false
+  sessionStorage.removeItem(PREVIOUS_NON_SEARCH_URL_KEY)
+  showTopBarDefault()
+}
 
 function handleSearchBackButton() {
   const previousUrl = sessionStorage.getItem(PREVIOUS_NON_SEARCH_URL_KEY)
 
   if (!isOnSearchPage()) {
     // Only the search bar was shown, no navigation happened
-    showTopBarDefault()
+    if (searchBarPushedState) {
+      // Pop the state we pushed when opening the search bar
+      window.history.back()
+    } else {
+      closeSearchBar()
+    }
     return
   }
 
@@ -145,6 +157,12 @@ function handleSearchBackButton() {
   }
 }
 
+window.addEventListener('popstate', function (event) {
+  if (searchBarPushedState && (!event.state || event.state.type !== 'search-bar-open')) {
+    closeSearchBar()
+  }
+})
+
 function showTopBarOptions() {
   if (optionsMenu) {
     optionsMenu.open = true
@@ -157,6 +175,10 @@ export function showTopBarSearch() {
   searchInput.focus()
   if (!isOnSearchPage()) {
     sessionStorage.setItem(PREVIOUS_NON_SEARCH_URL_KEY, window.location.href)
+    if (!searchBarPushedState) {
+      searchBarPushedState = true
+      window.history.pushState({ type: 'search-bar-open' }, '', window.location.href)
+    }
   }
 }
 

--- a/assets/Project/ProjectList.js
+++ b/assets/Project/ProjectList.js
@@ -2,6 +2,12 @@ import { showDefaultTopBarTitle, showCustomTopBarTitle } from '../Layout/TopBar'
 
 require('./ProjectList.scss')
 
+const projectListRegistry = new Map()
+
+export function getProjectListInstance(containerId) {
+  return projectListRegistry.get(containerId) || null
+}
+
 export class ProjectList {
   constructor(
     container,
@@ -29,6 +35,10 @@ export class ProjectList {
     this.$chevronRight = container.querySelector('.project-list__chevrons__right')
     this.apiUrl = this.formatApiUrl(apiUrl)
     this.popStateHandler = this.closeFullView.bind(this)
+
+    if (container.id) {
+      projectListRegistry.set(container.id, this)
+    }
 
     this.fetchMore(true)
     this.initListeners()
@@ -202,7 +212,10 @@ export class ProjectList {
 
   handlePopState(event) {
     if (event.state && event.state.type === 'ProjectList' && event.state.full === true) {
-      document.querySelector(`#${event.state.id}`).data('list').openFullView()
+      const list = getProjectListInstance(event.state.id)
+      if (list) {
+        list.openFullView()
+      }
     }
   }
 

--- a/assets/Project/ProjectPage.js
+++ b/assets/Project/ProjectPage.js
@@ -307,8 +307,7 @@ function initProjects() {
       url += `&flavor=${flavor}`
     }
 
-    const list = new ProjectList(element, category, url, property, theme)
-    element.dataset.list = list
+    new ProjectList(element, category, url, property, theme)
   })
 }
 

--- a/assets/User/ProfilePage.js
+++ b/assets/User/ProfilePage.js
@@ -94,9 +94,7 @@ function initUserProjects() {
 
     const url = `${baseUrl}/api/projects/user/${userId}`
 
-    projectList.dataset.list = JSON.stringify(
-      new ProjectList(projectList, 'user-projects', url, property, theme, 999, emptyMessage),
-    )
+    new ProjectList(projectList, 'user-projects', url, property, theme, 999, emptyMessage)
   })
 }
 

--- a/assets/User/UserList.js
+++ b/assets/User/UserList.js
@@ -2,6 +2,12 @@ import { showDefaultTopBarTitle, showCustomTopBarTitle } from '../Layout/TopBar'
 
 import './UserList.scss'
 
+const userListRegistry = new Map()
+
+export function getUserListInstance(containerId) {
+  return userListRegistry.get(containerId) || null
+}
+
 export class UserList {
   constructor(
     container,
@@ -34,6 +40,10 @@ export class UserList {
     const self = this
     this.popStateHandler = function () {
       self.closeFullView()
+    }
+
+    if (container.id) {
+      userListRegistry.set(container.id, this)
     }
 
     this.fetchMore(true)
@@ -138,7 +148,10 @@ export class UserList {
     window.addEventListener('popstate', function (event) {
       if (event.state != null) {
         if (event.state.type === 'UserList' && event.state.full === true) {
-          document.getElementById(event.state.id).dataset.list.openFullView()
+          const list = getUserListInstance(event.state.id)
+          if (list) {
+            list.openFullView()
+          }
         }
       }
     })


### PR DESCRIPTION
## Summary
Three back-button navigation bugs fixed:

1. **Home → List → Project → Back** skipped the list and went to home
2. **Search → List → Project → Back** skipped the list and went to search
3. **Search bar open → Back** navigated away instead of closing the search bar

## Root Cause
`popstate` handlers in `ProjectList.js` and `UserList.js` were silently broken:
- `ProjectList.js` used jQuery `.data()` on plain DOM elements (always `undefined`)
- `UserList.js` called `.openFullView()` on a stringified object (always failed)
- `TopBar.js` never pushed a history state when opening the search bar

## Changes (6 files)
- **ProjectList.js / UserList.js**: Added module-level `Map` registries for instances, fixed `popstate` handlers
- **TopBar.js**: Push state on search bar open, `popstate` listener closes it
- **DefaultProjectLists.js / ProfilePage.js / ProjectPage.js**: Removed dead `dataset.list = toString()` code

## Test plan
- [ ] Home → "Most Downloaded" list → click project → Back → returns to list (not home)
- [ ] Search → "Projects" list → click project → Back → returns to list (not search)
- [ ] Open search bar → browser Back → search bar closes, header restored
- [ ] Normal back navigation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)