### PR TITLE
Fix deployment smoke test: add Host header for nginx

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -143,7 +143,7 @@ task('smoke_test', function () {
   $maxRetries = 5;
   $retryDelay = 5;
   for ($i = 1; $i <= $maxRetries; ++$i) {
-    $result = run('curl -sf -o /dev/null -w "%{http_code}" http://localhost/api/health --max-time 10 || echo "000"');
+    $result = run('curl -sf -o /dev/null -w "%{http_code}" -H "Host: share.catrob.at" http://localhost/api/health --max-time 10 || echo "000"');
     if ('200' === trim($result)) {
       info("Health check passed (attempt {$i})");
 


### PR DESCRIPTION
## Problem
The deployment smoke test fails with 404 because `curl http://localhost/api/health` doesn't include a `Host` header, and nginx's `server_name share.catrob.at` doesn't match `localhost`.

## Root Cause
nginx requires `Host: share.catrob.at` to route to the correct server block. Without it, requests fall through to a default handler that returns a JSON 404.

## Fix
Add `-H "Host: share.catrob.at"` to the curl command in the smoke test.

## Also found during investigation
The user's login 500 error is caused by **Cloudflare's managed challenge** intercepting POST requests to `/api/authentication`. The server-side auth works correctly (tested via localhost with Host header). This needs to be fixed in the Cloudflare dashboard by creating a WAF rule to skip managed challenges for `/api/*` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)