### PR TITLE
Fix GitHub Actions Node.js 20 deprecation warnings

### DIFF
--- a/.github/actions/setup-php-composer/action.yaml
+++ b/.github/actions/setup-php-composer/action.yaml
@@ -14,7 +14,7 @@ runs:
 
     - name: 'Use caching action to improve performance'
       id: composer-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           vendor

--- a/.github/actions/setup-yarn-node-modules/action.yaml
+++ b/.github/actions/setup-yarn-node-modules/action.yaml
@@ -15,7 +15,7 @@ runs:
         corepack prepare yarn@4.12.0 --activate
 
     - name: 'Restore yarn and node_modules cache'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           node_modules

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -19,6 +19,10 @@ on:
 # The concurrency: production_environment is important as it prevents concurrent deploys.
 concurrency: production_environment
 
+env:
+  # Opt in to Node.js 24 for all actions (Node.js 20 is deprecated, deadline June 2nd, 2026)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Deployment:


### PR DESCRIPTION
## Summary
- Upgrade `actions/cache` from v4 to v5 in both composite actions (setup-php-composer, setup-yarn-node-modules) to use Node.js 24 runtime
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to deployment workflow to force `deployphp/action@v1` to run on Node.js 24 (no v2 available yet)

## Context
GitHub is deprecating Node.js 20 actions with a deadline of June 2nd, 2026. This addresses the warning:
> "Node.js 20 actions are deprecated. actions/cache@v4, deployphp/action@v1 may not work."

## Test plan
- [ ] Verify static analysis CI jobs pass (they use the setup-php-composer and setup-yarn-node-modules composite actions with the updated cache)
- [ ] Verify dynamic analysis CI jobs pass
- [ ] Deployment workflow will be tested on next merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)