### PR TITLE
Log API 500 errors instead of silently swallowing them

### DIFF
--- a/src/Api/Exceptions/ApiExceptionEventListener.php
+++ b/src/Api/Exceptions/ApiExceptionEventListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Api\Exceptions;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
@@ -13,6 +14,11 @@ use Symfony\Component\HttpKernel\KernelEvents;
 #[AsEventListener(event: KernelEvents::EXCEPTION, method: 'setExceptionResponse')]
 class ApiExceptionEventListener
 {
+  public function __construct(
+    private readonly LoggerInterface $logger,
+  ) {
+  }
+
   public function setExceptionResponse(ExceptionEvent $event): void
   {
     if (!str_starts_with($event->getRequest()->getPathInfo(), '/api')) {
@@ -23,6 +29,19 @@ class ApiExceptionEventListener
     $statusCode = $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : Response::HTTP_INTERNAL_SERVER_ERROR;
     $type = ApiErrorResponse::httpStatusToErrorType($statusCode);
     $message = $exception instanceof HttpExceptionInterface ? $exception->getMessage() : 'An unexpected error occurred.';
+
+    if ($statusCode >= 500) {
+      $this->logger->error('API {status}: {class}: {error} at {file}:{line}', [
+        'status' => $statusCode,
+        'class' => $exception::class,
+        'error' => $exception->getMessage(),
+        'file' => $exception->getFile(),
+        'line' => $exception->getLine(),
+        'url' => $event->getRequest()->getUri(),
+        'method' => $event->getRequest()->getMethod(),
+        'exception' => $exception,
+      ]);
+    }
 
     if ('' === $message) {
       $message = Response::$statusTexts[$statusCode] ?? 'An unexpected error occurred.';

--- a/tests/PhpUnit/Api/ErrorResponseTest.php
+++ b/tests/PhpUnit/Api/ErrorResponseTest.php
@@ -67,7 +67,7 @@ class ErrorResponseTest extends TestCase
 
   public function testListenerReturnsStructuredJsonForHttpException(): void
   {
-    $listener = new ApiExceptionEventListener();
+    $listener = new ApiExceptionEventListener(new \Psr\Log\NullLogger());
     $kernel = $this->createStub(HttpKernelInterface::class);
     $request = Request::create('/api/test');
     $exception = new NotFoundHttpException('Resource not found');
@@ -87,7 +87,7 @@ class ErrorResponseTest extends TestCase
 
   public function testListenerReturns500ForGenericException(): void
   {
-    $listener = new ApiExceptionEventListener();
+    $listener = new ApiExceptionEventListener(new \Psr\Log\NullLogger());
     $kernel = $this->createStub(HttpKernelInterface::class);
     $request = Request::create('/api/test');
     $exception = new \RuntimeException('Something broke');
@@ -107,7 +107,7 @@ class ErrorResponseTest extends TestCase
 
   public function testListenerIgnoresNonApiRequests(): void
   {
-    $listener = new ApiExceptionEventListener();
+    $listener = new ApiExceptionEventListener(new \Psr\Log\NullLogger());
     $kernel = $this->createStub(HttpKernelInterface::class);
     $request = Request::create('/some/web/page');
     $exception = new \RuntimeException('Something broke');
@@ -120,7 +120,7 @@ class ErrorResponseTest extends TestCase
 
   public function testListenerUsesStatusTextForEmptyMessage(): void
   {
-    $listener = new ApiExceptionEventListener();
+    $listener = new ApiExceptionEventListener(new \Psr\Log\NullLogger());
     $kernel = $this->createStub(HttpKernelInterface::class);
     $request = Request::create('/api/test');
     $exception = new BadRequestHttpException('');


### PR DESCRIPTION
## Problem
The `ApiExceptionEventListener` catches all exceptions on `/api` routes and converts them to generic JSON 500 responses, but **never logged the actual exception**. This made server errors invisible — e.g., Elasticsearch going down caused login failures with zero trace in logs.

## Fix
Inject `LoggerInterface` and log all 500+ errors with full context:
- Exception class, message, file:line
- Request URL and method
- Full stack trace (via Symfony's `exception` context key)

## Impact
Every API 500 error will now appear in `var/log/prod/prod-*.log` with enough detail to diagnose immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)