### PR TITLE
Fix follower card avatar/text overlap on mobile

### DIFF
--- a/assets/User/FollowerOverview.js
+++ b/assets/User/FollowerOverview.js
@@ -72,25 +72,23 @@ document.addEventListener('DOMContentLoaded', () => {
     return `
       <div class="col-12 my-3 ${itemClass}">
         <div class="follower-item">
-          <div class="row no-gutters">
-            <div class="col-2 my-auto">
-              <a href="${profileUrl}">
-                <img class="img-fluid round" src="${escapeAttr(avatarSrc)}" alt="">
-              </a>
-            </div>
-            <div class="col-6 ps-3 my-auto">
-              <a href="${profileUrl}">
-                <span class="h4">${escapeHtml(user.username)}</span>
-                <div class="text-dark">
-                  <span>${user.project_count} ${escapeHtml(trans.projects)}</span>
-                </div>
-                <div class="text-muted text-uppercase follower-item__info">
-                  ${followsMeHtml}
-                </div>
-              </a>
-            </div>
-            ${buttonHtml ? `<div class="col-4 text-end my-auto"><div>${buttonHtml}</div></div>` : ''}
+          <div class="follower-item__avatar">
+            <a href="${profileUrl}">
+              <img class="round" src="${escapeAttr(avatarSrc)}" alt="">
+            </a>
           </div>
+          <div class="follower-item__text">
+            <a href="${profileUrl}">
+              <span class="h4">${escapeHtml(user.username)}</span>
+              <div class="text-dark">
+                <span>${user.project_count} ${escapeHtml(trans.projects)}</span>
+              </div>
+              <div class="text-muted text-uppercase follower-item__info">
+                ${followsMeHtml}
+              </div>
+            </a>
+          </div>
+          ${buttonHtml ? `<div class="follower-item__action">${buttonHtml}</div>` : ''}
         </div>
       </div>`
   }

--- a/assets/User/Profile.scss
+++ b/assets/User/Profile.scss
@@ -41,17 +41,47 @@
 
 /* follower section */
 .follower-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+
   a {
     &:hover {
       text-decoration: none;
     }
   }
 
-  img.round {
-    max-width: 4rem;
-    max-height: 4rem;
-    aspect-ratio: 1;
-    object-fit: cover;
+  &__avatar {
+    flex-shrink: 0;
+    width: 3.5rem;
+
+    img.round {
+      width: 100%;
+      height: auto;
+      aspect-ratio: 1;
+      object-fit: cover;
+    }
+
+    @include media-breakpoint-up(sm) {
+      width: 4rem;
+    }
+  }
+
+  &__text {
+    flex: 1;
+    min-width: 0;
+
+    .h4 {
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  &__action {
+    flex-shrink: 0;
+    text-align: end;
   }
 
   &__info {


### PR DESCRIPTION
## Summary
- Replaced Bootstrap grid layout (col-2/col-6/col-4) with flexbox for follower cards
- Avatar uses fixed width (3.5rem mobile, 4rem on sm+) with flex-shrink: 0 to prevent compression
- Text container gets min-width: 0 and text-overflow: ellipsis to truncate long usernames instead of overlapping
- Removed Bootstrap 4 `no-gutters` class (not native to Bootstrap 5)

## Test plan
- [ ] View followers page on mobile (320px, 375px, 414px widths)
- [ ] Avatar and username no longer overlap
- [ ] Long usernames truncate with ellipsis
- [ ] Follow/unfollow buttons remain properly aligned
- [ ] Desktop layout unchanged
- [ ] Cards with "follows me" badge display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)