### PR TITLE
Improve achievements card spacing on mobile

### DIFF
--- a/assets/User/Achievements.scss
+++ b/assets/User/Achievements.scss
@@ -30,7 +30,12 @@
   justify-content: center;
   width: 50%;
   padding: 0 0.5rem;
+  margin-bottom: 1rem;
   text-align: center;
+
+  @media (width <= 767.98px) {
+    margin-bottom: 1.5rem;
+  }
 }
 
 .achievement__badge {


### PR DESCRIPTION
## Summary
- Added `margin-bottom: 1rem` to `.achievement` items for consistent vertical spacing
- Increased to `1.5rem` on mobile (< 768px) for extra breathing room between cards

## Test plan
- [ ] View achievements page on mobile — items have more breathing room
- [ ] Desktop layout unchanged (subtle 1rem gap)
- [ ] Both unlocked and locked tabs look good

🤖 Generated with [Claude Code](https://claude.com/claude-code)