### PR TITLE
Fix profile settings buttons invisible in dark mode

### DIFF
--- a/assets/User/Profile.scss
+++ b/assets/User/Profile.scss
@@ -173,13 +173,13 @@
       justify-content: flex-start;
       padding-top: 1rem;
       padding-bottom: 1rem;
-      color: #222;
+      color: light-dark(#222, #ddd);
       text-decoration: none;
       cursor: pointer;
 
       &:hover {
         text-decoration: none;
-        background: rgb(0 0 0 / 20%);
+        background: light-dark(rgb(0 0 0 / 20%), rgb(255 255 255 / 20%));
       }
 
       &:active,


### PR DESCRIPTION
## Summary
- The user settings nav links (Edit profile, Change password, Account settings) had hardcoded `color: #222` and a dark-only hover background, making them invisible in dark mode
- Replaced with `light-dark()` to provide appropriate colors for both light and dark color schemes

## Test plan
- [ ] Open profile page in dark mode -- settings buttons should be visible with light text (#ddd)
- [ ] Open profile page in light mode -- settings buttons unchanged (dark text #222)
- [ ] Hover over buttons in both modes -- hover background adapts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)