### PR TITLE
Add admin project upload page

### DIFF
--- a/config/packages/sonata_admin.php
+++ b/config/packages/sonata_admin.php
@@ -83,6 +83,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
               'admin.block.projects.approve',
               'admin.block.featured.projects',
               'admin.block.example.projects',
+              'admin.block.projects.upload',
             ],
           ],
           'sonata.admin.group.user' => [

--- a/config/services.php
+++ b/config/services.php
@@ -17,6 +17,8 @@ use App\Admin\Projects\ApproveProjects\ApproveProjectsController;
 use App\Admin\Projects\ProjectsAdmin;
 use App\Admin\Projects\SpecialProjects\ExampleProjectAdmin;
 use App\Admin\Projects\SpecialProjects\FeaturedProjectAdmin;
+use App\Admin\Projects\UploadProject\UploadProjectAdmin;
+use App\Admin\Projects\UploadProject\UploadProjectController;
 use App\Admin\Statistics\Translation\CommentMachineTranslationAdmin;
 use App\Admin\Statistics\Translation\Controller\CommentMachineTranslationAdminController;
 use App\Admin\Statistics\Translation\Controller\ProjectMachineTranslationAdminController;
@@ -333,6 +335,18 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'code' => null,
         'model_class' => ExampleProgram::class,
         'controller' => null,
+      ]
+    )
+  ;
+  $services->set('admin.block.projects.upload', UploadProjectAdmin::class)
+    ->tag(
+      'sonata.admin',
+      [
+        'manager_type' => 'orm',
+        'label' => 'Upload Project',
+        'code' => null,
+        'model_class' => Program::class,
+        'controller' => UploadProjectController::class,
       ]
     )
   ;

--- a/src/Admin/Projects/UploadProject/UploadProjectAdmin.php
+++ b/src/Admin/Projects/UploadProject/UploadProjectAdmin.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Projects\UploadProject;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Route\RouteCollectionInterface;
+
+/**
+ * @phpstan-extends AbstractAdmin<\stdClass>
+ */
+class UploadProjectAdmin extends AbstractAdmin
+{
+  #[\Override]
+  protected function generateBaseRouteName(bool $isChildAdmin = false): string
+  {
+    return 'admin_upload_project';
+  }
+
+  #[\Override]
+  protected function generateBaseRoutePattern(bool $isChildAdmin = false): string
+  {
+    return 'projects/upload';
+  }
+
+  #[\Override]
+  protected function configureRoutes(RouteCollectionInterface $collection): void
+  {
+    $collection->clearExcept(['list']);
+    $collection->add('upload');
+  }
+}

--- a/src/Admin/Projects/UploadProject/UploadProjectController.php
+++ b/src/Admin/Projects/UploadProject/UploadProjectController.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Projects\UploadProject;
+
+use App\DB\Entity\Flavor;
+use App\DB\Entity\User\User;
+use App\Project\AddProjectRequest;
+use App\Project\ProjectManager;
+use App\User\UserManager;
+use Psr\Log\LoggerInterface;
+use Sonata\AdminBundle\Controller\CRUDController;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @phpstan-extends CRUDController<\stdClass>
+ */
+class UploadProjectController extends CRUDController
+{
+  private const int MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+
+  public function __construct(
+    private readonly ProjectManager $project_manager,
+    private readonly UserManager $user_manager,
+    private readonly LoggerInterface $logger,
+  ) {
+  }
+
+  #[\Override]
+  public function listAction(Request $request): Response
+  {
+    return $this->render('Admin/Projects/UploadProject/upload.html.twig', [
+      'flavors' => Flavor::ALL,
+    ]);
+  }
+
+  public function uploadAction(Request $request): Response
+  {
+    if (!$request->isMethod('POST')) {
+      return $this->redirectToRoute('admin_upload_project_list');
+    }
+
+    $username = trim((string) $request->request->get('username'));
+    if ('' === $username) {
+      $this->addFlash('sonata_flash_error', 'Please enter a username.');
+
+      return $this->redirectToRoute('admin_upload_project_list');
+    }
+
+    $user = $this->user_manager->findUserByUsername($username);
+    if (!$user instanceof User) {
+      $this->addFlash('sonata_flash_error', sprintf('User "%s" not found.', $username));
+
+      return $this->redirectToRoute('admin_upload_project_list');
+    }
+
+    /** @var UploadedFile|null $file */
+    $file = $request->files->get('project_file');
+    if (!$file instanceof UploadedFile) {
+      $this->addFlash('sonata_flash_error', 'Please select a .catrobat file to upload.');
+
+      return $this->redirectToRoute('admin_upload_project_list');
+    }
+
+    if (!$file->isValid()) {
+      $this->addFlash('sonata_flash_error', sprintf('File upload error: %s', $file->getErrorMessage()));
+
+      return $this->redirectToRoute('admin_upload_project_list');
+    }
+
+    if ($file->getSize() > self::MAX_FILE_SIZE_BYTES) {
+      $this->addFlash('sonata_flash_error', sprintf('File size exceeds the 100 MB limit (uploaded: %s MB).', round($file->getSize() / (1024 * 1024), 2)));
+
+      return $this->redirectToRoute('admin_upload_project_list');
+    }
+
+    $extension = $file->getClientOriginalExtension();
+    if (!in_array(strtolower($extension), ['catrobat', 'zip'], true)) {
+      $this->addFlash('sonata_flash_error', 'Invalid file type. Only .catrobat files are accepted.');
+
+      return $this->redirectToRoute('admin_upload_project_list');
+    }
+
+    $flavor = (string) $request->request->get('flavor', Flavor::POCKETCODE);
+    if (!in_array($flavor, Flavor::ALL, true)) {
+      $flavor = Flavor::POCKETCODE;
+    }
+
+    $private = (bool) $request->request->get('private', false);
+
+    try {
+      $add_request = new AddProjectRequest(
+        $user,
+        $file,
+        $request->getClientIp() ?? '127.0.0.1',
+        $request->getLocale(),
+        $flavor,
+      );
+
+      $project = $this->project_manager->addProject($add_request);
+
+      if (null === $project) {
+        $this->addFlash('sonata_flash_error', 'Upload failed: project could not be created.');
+
+        return $this->redirectToRoute('admin_upload_project_list');
+      }
+
+      $project->setPrivate($private);
+      $this->project_manager->save($project);
+
+      $this->addFlash('sonata_flash_success', sprintf(
+        'Project "%s" (ID: %s) uploaded successfully for user "%s".',
+        $project->getName(),
+        (string) $project->getId(),
+        (string) $user->getUsername(),
+      ));
+    } catch (\Exception $e) {
+      $this->logger->error('Admin project upload failed', [
+        'error' => $e->getMessage(),
+        'username' => $username,
+      ]);
+      $this->addFlash('sonata_flash_error', sprintf('Upload failed: %s', $e->getMessage()));
+    }
+
+    return $this->redirectToRoute('admin_upload_project_list');
+  }
+}

--- a/src/Admin/Projects/UploadProject/UploadProjectController.php
+++ b/src/Admin/Projects/UploadProject/UploadProjectController.php
@@ -14,6 +14,7 @@ use Sonata\AdminBundle\Controller\CRUDController;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * @phpstan-extends CRUDController<\stdClass>
@@ -32,6 +33,10 @@ class UploadProjectController extends CRUDController
   #[\Override]
   public function listAction(Request $request): Response
   {
+    if (!$this->admin->isGranted('LIST')) {
+      throw new AccessDeniedException();
+    }
+
     return $this->render('Admin/Projects/UploadProject/upload.html.twig', [
       'flavors' => Flavor::ALL,
     ]);
@@ -39,6 +44,10 @@ class UploadProjectController extends CRUDController
 
   public function uploadAction(Request $request): Response
   {
+    if (!$this->admin->isGranted('LIST')) {
+      throw new AccessDeniedException();
+    }
+
     if (!$request->isMethod('POST')) {
       return $this->redirectToRoute('admin_upload_project_list');
     }

--- a/templates/Admin/Projects/UploadProject/upload.html.twig
+++ b/templates/Admin/Projects/UploadProject/upload.html.twig
@@ -41,7 +41,7 @@
           <div class="form-group">
             <div class="checkbox">
               <label>
-                <input type="checkbox" name="private" value="1"> Private project
+                <input type="checkbox" id="private" name="private" value="1"> Private project
               </label>
               <p class="help-block">
                 If checked, the project will not be visible to other users.

--- a/templates/Admin/Projects/UploadProject/upload.html.twig
+++ b/templates/Admin/Projects/UploadProject/upload.html.twig
@@ -1,0 +1,61 @@
+{% extends base_template %}
+
+{% block list_table %}
+  <div class="col-xs-12 col-md-8">
+    <div class="box box-primary">
+      <div class="box-header with-border">
+        <h3 class="box-title">Upload Project</h3>
+      </div>
+      <div class="box-body">
+        <p class="text-muted">
+          Upload a <code>.catrobat</code> project file on behalf of a user.
+          Maximum file size: <strong>100 MB</strong>.
+        </p>
+
+        <form method="post" action="{{ path('admin_upload_project_upload') }}" enctype="multipart/form-data">
+          <div class="form-group">
+            <label for="project_file">Project File (.catrobat) <span class="text-danger">*</span></label>
+            <input type="file" class="form-control" id="project_file" name="project_file" accept=".catrobat,.zip" required>
+            <p class="help-block">
+              The project name, description, and credits will be extracted from the uploaded file.
+            </p>
+          </div>
+
+          <div class="form-group">
+            <label for="username">Owner (Username) <span class="text-danger">*</span></label>
+            <input type="text" class="form-control" id="username" name="username" placeholder="Enter the username of the project owner" required>
+            <p class="help-block">
+              The project will be uploaded as this user.
+            </p>
+          </div>
+
+          <div class="form-group">
+            <label for="flavor">Flavor</label>
+            <select class="form-control" id="flavor" name="flavor">
+              {% for f in flavors %}
+                <option value="{{ f }}" {{ f == 'pocketcode' ? 'selected' : '' }}>{{ f }}</option>
+              {% endfor %}
+            </select>
+          </div>
+
+          <div class="form-group">
+            <div class="checkbox">
+              <label>
+                <input type="checkbox" name="private" value="1"> Private project
+              </label>
+              <p class="help-block">
+                If checked, the project will not be visible to other users.
+              </p>
+            </div>
+          </div>
+
+          <hr>
+
+          <button type="submit" class="btn btn-primary">
+            <i class="fa fa-upload"></i> Upload Project
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/tests/BehatFeatures/web/admin/upload_project.feature
+++ b/tests/BehatFeatures/web/admin/upload_project.feature
@@ -13,13 +13,12 @@ Feature: Admin project upload page
     Given I log in as "Admin" with the password "123456"
     And I am on "/admin/projects/upload/list"
     And I wait for the page to be loaded
-    Then the response status code should be "200"
-    And I should see "Upload Project"
+    Then I should see "Upload Project"
 
   Scenario: Non-admin cannot access the upload page
-    Given I log in as "Catrobat" with the password "123456"
-    And I am on "/admin/projects/upload/list"
-    Then I should see "Access Denied"
+    Given I am logged in as normal user
+    When I GET "/admin/projects/upload/list"
+    Then the client response should contain "Access Denied"
 
   Scenario: Upload form has required fields
     Given I log in as "Admin" with the password "123456"

--- a/tests/BehatFeatures/web/admin/upload_project.feature
+++ b/tests/BehatFeatures/web/admin/upload_project.feature
@@ -1,59 +1,47 @@
-@admin
+@web @admin
 Feature: Admin project upload page
-  As an admin I want to upload .catrobat project files on behalf of users.
 
   Background:
-    Given there are admins:
-      | name  | password | email                | id |
-      | Admin | 123456   | admin@pocketcode.org | 1  |
-    And there are users:
-      | name     | password | email               | id |
-      | Catrobat | 123456   | dev1@pocketcode.org | 2  |
+    Given there are users:
+      | id | name     |
+      | 1  | Catrobat |
+    And there are admins:
+      | name  |
+      | Admin |
 
   Scenario: Admin can access the upload page
     Given I log in as "Admin" with the password "123456"
     And I am on "/admin/projects/upload/list"
     And I wait for the page to be loaded
-    Then I should see "Upload Project"
+    Then the response status code should be "200"
+    And I should see "Upload Project"
 
-  Scenario: Non-admin user cannot access the upload page
+  Scenario: Non-admin cannot access the upload page
     Given I log in as "Catrobat" with the password "123456"
-    And I GET "/admin/projects/upload/list"
-    Then the client response should contain "Access Denied"
+    And I am on "/admin/projects/upload/list"
+    Then I should see "Access Denied"
 
-  Scenario: Upload form displays required fields and labels
+  Scenario: Upload form has required fields
     Given I log in as "Admin" with the password "123456"
     And I am on "/admin/projects/upload/list"
     And I wait for the page to be loaded
-    Then I should see "Maximum file size"
-    And I should see "100 MB"
+    Then I should see "Maximum file size: 100 MB"
     And I should see an "#project_file" element
     And I should see an "#username" element
     And I should see an "#flavor" element
-    And I should see "Owner (Username)"
-    And I should see "Project File (.catrobat)"
 
-  Scenario: Upload form shows all flavor options
+  Scenario: Flavor options are available
     Given I log in as "Admin" with the password "123456"
     And I am on "/admin/projects/upload/list"
     And I wait for the page to be loaded
     Then I should see "pocketcode"
     And I should see "arduino"
-    And I should see "luna"
     And I should see "embroidery"
+    And I should see "luna"
 
-  Scenario: Upload form has a private project checkbox
+  Scenario: Private checkbox is available
     Given I log in as "Admin" with the password "123456"
     And I am on "/admin/projects/upload/list"
     And I wait for the page to be loaded
     Then I should see "Private project"
-    And I should see "If checked, the project will not be visible to other users."
-
-  Scenario: Upload form has description text
-    Given I log in as "Admin" with the password "123456"
-    And I am on "/admin/projects/upload/list"
-    And I wait for the page to be loaded
-    Then I should see "Upload a"
-    And I should see "project file on behalf of a user."
-    And I should see "The project name, description, and credits will be extracted from the uploaded file."
-    And I should see "The project will be uploaded as this user."
+    And I should see an "#private" element

--- a/tests/BehatFeatures/web/admin/upload_project.feature
+++ b/tests/BehatFeatures/web/admin/upload_project.feature
@@ -1,0 +1,59 @@
+@admin
+Feature: Admin project upload page
+  As an admin I want to upload .catrobat project files on behalf of users.
+
+  Background:
+    Given there are admins:
+      | name  | password | email                | id |
+      | Admin | 123456   | admin@pocketcode.org | 1  |
+    And there are users:
+      | name     | password | email               | id |
+      | Catrobat | 123456   | dev1@pocketcode.org | 2  |
+
+  Scenario: Admin can access the upload page
+    Given I log in as "Admin" with the password "123456"
+    And I am on "/admin/projects/upload/list"
+    And I wait for the page to be loaded
+    Then I should see "Upload Project"
+
+  Scenario: Non-admin user cannot access the upload page
+    Given I log in as "Catrobat" with the password "123456"
+    And I GET "/admin/projects/upload/list"
+    Then the client response should contain "Access Denied"
+
+  Scenario: Upload form displays required fields and labels
+    Given I log in as "Admin" with the password "123456"
+    And I am on "/admin/projects/upload/list"
+    And I wait for the page to be loaded
+    Then I should see "Maximum file size"
+    And I should see "100 MB"
+    And I should see an "#project_file" element
+    And I should see an "#username" element
+    And I should see an "#flavor" element
+    And I should see "Owner (Username)"
+    And I should see "Project File (.catrobat)"
+
+  Scenario: Upload form shows all flavor options
+    Given I log in as "Admin" with the password "123456"
+    And I am on "/admin/projects/upload/list"
+    And I wait for the page to be loaded
+    Then I should see "pocketcode"
+    And I should see "arduino"
+    And I should see "luna"
+    And I should see "embroidery"
+
+  Scenario: Upload form has a private project checkbox
+    Given I log in as "Admin" with the password "123456"
+    And I am on "/admin/projects/upload/list"
+    And I wait for the page to be loaded
+    Then I should see "Private project"
+    And I should see "If checked, the project will not be visible to other users."
+
+  Scenario: Upload form has description text
+    Given I log in as "Admin" with the password "123456"
+    And I am on "/admin/projects/upload/list"
+    And I wait for the page to be loaded
+    Then I should see "Upload a"
+    And I should see "project file on behalf of a user."
+    And I should see "The project name, description, and credits will be extracted from the uploaded file."
+    And I should see "The project will be uploaded as this user."


### PR DESCRIPTION
## Summary
New admin-only page for uploading .catrobat project files from the Sonata admin interface.

## Features
- File upload with 100MB size limit validation
- Username field (uploads on behalf of the specified user)
- Flavor selection dropdown (all 9 flavors)
- Private project checkbox
- .catrobat/.zip extension validation
- Success/error flash messages
- Accessible from admin sidebar under Projects → Upload Project

## Test plan
- [ ] Admin can access the upload page
- [ ] Non-admin cannot access (403)
- [ ] Upload a valid .catrobat file → project created
- [ ] Upload file > 100MB → error shown
- [ ] Upload non-.catrobat file → error shown
- [ ] Invalid username → error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)