### PR TITLE
Auto-cancel redundant CI runs on new push

### DIFF
--- a/.github/workflows/code_quality.yaml
+++ b/.github/workflows/code_quality.yaml
@@ -44,6 +44,10 @@ on:
       - '**' # all branches
       - '!main' # excludes main to prevent double test runs during release prep.
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # ** Javascript **

--- a/.github/workflows/container_tests.yaml
+++ b/.github/workflows/container_tests.yaml
@@ -27,6 +27,10 @@ on:
       - '**' # all branches
       - '!main' # excludes main to prevent double test runs during release prep.
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Developer Container:

--- a/.github/workflows/deploy_api_spec.yaml
+++ b/.github/workflows/deploy_api_spec.yaml
@@ -7,6 +7,10 @@ on:
       - 'src/Api/OpenAPI/specification.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: deploy-api-spec
+  cancel-in-progress: false
+
 jobs:
   deploy-swagger-ui:
     runs-on: ubuntu-latest

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -16,8 +16,11 @@ on:
     branches:
       - main
 
-# The concurrency: production_environment is important as it prevents concurrent deploys.
-concurrency: production_environment
+# The concurrency group prevents concurrent deploys. cancel-in-progress is false
+# to avoid leaving the server in a half-deployed state.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
 
 env:
   # Opt in to Node.js 24 for all actions (Node.js 20 is deprecated, deadline June 2nd, 2026)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,10 @@ on:
     - cron: '0 4 * * *' # Every day at 04:00 UTC
   workflow_dispatch: # Allow manual trigger
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: catrobat/catroweb-test


### PR DESCRIPTION
## Summary
- Add `concurrency` groups with `cancel-in-progress: true` to all PR-triggered workflows (Dynamic analysis, Static analysis, Docker Container tests) so pushing a new commit cancels stale in-progress runs for the same branch
- Deployment workflows (`deployment.yaml`, `deploy_api_spec.yaml`) use `cancel-in-progress: false` to prevent half-deployed states
- Schedule-only workflows (Crowdin sync, brick checks, release PR) are left unchanged since they don't suffer from stale PR runs

## How it works
Each workflow + branch combo forms a concurrency group via `${{ github.workflow }}-${{ github.head_ref || github.ref }}`. When a new run starts for the same group, GitHub automatically cancels the old one.

## Test plan
- [ ] Push two commits in quick succession to a PR and verify the first CI run is cancelled
- [ ] Verify scheduled runs (daily tests at 04:00 UTC) still work normally
- [ ] Verify deployment workflow queues rather than cancels concurrent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)