### PR TITLE
Fix Share button on profile page to share public URL

### DIFF
--- a/assets/Layout/ColorScheme.js
+++ b/assets/Layout/ColorScheme.js
@@ -78,7 +78,7 @@ const initializeShareButton = () => {
   const shareSuccess = shareItem.dataset.transShareSuccess
 
   shareItem.addEventListener('click', async () => {
-    const url = window.location.href
+    const url = shareItem.dataset.shareUrl || window.location.href
     const title = document.title
 
     if (navigator.share) {
@@ -97,14 +97,35 @@ const initializeShareButton = () => {
 }
 
 function copyToClipboard(text, successMessage, failMessage) {
-  navigator.clipboard
-    .writeText(text)
-    .then(() => {
-      showSnackbar('#share-snackbar', successMessage)
-    })
-    .catch(() => {
-      showSnackbar('#share-snackbar', failMessage, SnackbarDuration.error)
-    })
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        showSnackbar('#share-snackbar', successMessage)
+      })
+      .catch(() => {
+        fallbackCopyToClipboard(text, successMessage, failMessage)
+      })
+  } else {
+    fallbackCopyToClipboard(text, successMessage, failMessage)
+  }
+}
+
+function fallbackCopyToClipboard(text, successMessage, failMessage) {
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.style.position = 'fixed'
+  textarea.style.left = '-9999px'
+  textarea.style.top = '-9999px'
+  document.body.appendChild(textarea)
+  textarea.select()
+  try {
+    document.execCommand('copy')
+    showSnackbar('#share-snackbar', successMessage)
+  } catch {
+    showSnackbar('#share-snackbar', failMessage, SnackbarDuration.error)
+  }
+  document.body.removeChild(textarea)
 }
 
 if (document.readyState === 'loading') {

--- a/templates/Layout/Header/Options.html.twig
+++ b/templates/Layout/Header/Options.html.twig
@@ -4,7 +4,7 @@
   {% set page_context = 'studio' %}
 {% elseif '/user/' in app.request.pathinfo and profile|default(false) and profile.id|default(false) %}
   {% set page_context = 'user' %}
-{% elseif app.request.pathinfo == '/app/user' %}
+{% elseif app.request.attributes.get('_route') == 'profile' and app.request.attributes.get('id', 0) == 0 %}
   {% set page_context = 'my_profile' %}
 {% else %}
   {% set page_context = 'default' %}

--- a/templates/Layout/Header/Options.html.twig
+++ b/templates/Layout/Header/Options.html.twig
@@ -61,6 +61,9 @@
 
         {# Share current page (always shown) #}
         <li id="top-app-bar__btn-share-page" class="mdc-deprecated-list-item" role="menuitem"
+            {% if page_context == 'my_profile' and app.user.id|default(false) %}
+              data-share-url="{{ url('profile', {id: app.user.id}) }}"
+            {% endif %}
             data-trans-share-success="{{ 'share.success'|trans({}, 'catroweb') }}"
             data-trans-clipboard-success="{{ 'clipboard.success'|trans({}, 'catroweb') }}"
             data-trans-clipboard-fail="{{ 'clipboard.fail'|trans({}, 'catroweb') }}">

--- a/templates/Layout/Header/Options.html.twig
+++ b/templates/Layout/Header/Options.html.twig
@@ -4,7 +4,7 @@
   {% set page_context = 'studio' %}
 {% elseif '/user/' in app.request.pathinfo and profile|default(false) and profile.id|default(false) %}
   {% set page_context = 'user' %}
-{% elseif app.request.pathinfo ends with '/user' %}
+{% elseif app.request.pathinfo == '/app/user' %}
   {% set page_context = 'my_profile' %}
 {% else %}
   {% set page_context = 'default' %}


### PR DESCRIPTION
## Summary
- When on `/app/user` (own profile), the Share button now shares the public profile URL (`/app/user/{id}`) instead of the current page URL
- Adds a `data-share-url` attribute to the share menu item on the my-profile page context, populated with the absolute URL to the user's public profile
- JS reads `data-share-url` if present, falling back to `window.location.href` for all other pages

## Test plan
- [ ] Log in and go to your profile (`/app/user`)
- [ ] Click the overflow menu and tap Share
- [ ] Verify the shared/copied URL is `/app/user/{your-id}` (the public profile), not `/app/user`
- [ ] Visit another user's profile and verify Share still shares the current page URL
- [ ] Verify Share works on project pages, studio pages, and the homepage (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)