### PR TITLE
Refresh code statistics with rubric scoring

### DIFF
--- a/assets/Project/CodeStatisticsInline.js
+++ b/assets/Project/CodeStatisticsInline.js
@@ -9,17 +9,35 @@ const CHARACTERS = [
   { url: penguinSvgUrl, className: 'code-stats-animation--penguin' },
 ]
 
+const MAX_LEVELS = 3
+
 const SCORE_KEYS = [
-  { key: 'score_abstraction', transAttr: 'transAbstraction' },
-  { key: 'score_parallelism', transAttr: 'transParallelism' },
-  { key: 'score_logical_thinking', transAttr: 'transLogicalThinking' },
-  { key: 'score_synchronization', transAttr: 'transSynchronization' },
-  { key: 'score_flow_control', transAttr: 'transFlowControl' },
-  { key: 'score_user_interactivity', transAttr: 'transUserInteractivity' },
-  { key: 'score_data_representation', transAttr: 'transDataRepresentation' },
+  { key: 'score_abstraction', transAttr: 'transAbstraction', icon: 'extension' },
+  { key: 'score_parallelism', transAttr: 'transParallelism', icon: 'call_split' },
+  { key: 'score_logical_thinking', transAttr: 'transLogicalThinking', icon: 'psychology' },
+  { key: 'score_synchronization', transAttr: 'transSynchronization', icon: 'sync' },
+  { key: 'score_flow_control', transAttr: 'transFlowControl', icon: 'loop' },
+  { key: 'score_user_interactivity', transAttr: 'transUserInteractivity', icon: 'touch_app' },
+  { key: 'score_data_representation', transAttr: 'transDataRepresentation', icon: 'storage' },
 ]
 
-const BONUS_POINTS = 5
+function normalizeScoreValue(value) {
+  const numericValue = Number.parseInt(String(value ?? 0), 10)
+
+  return Number.isNaN(numericValue) ? 0 : numericValue
+}
+
+/**
+ * Map a 0–6 rubric score to a level count (0–3).
+ * basic = 1 pt, developing = 2 pts, proficiency = 3 pts.
+ * Thresholds: >= 1 -> level 1, >= 3 -> level 2, >= 6 -> level 3.
+ */
+function scoreToLevelCount(score) {
+  if (score >= 6) return 3
+  if (score >= 3) return 2
+  if (score >= 1) return 1
+  return 0
+}
 
 function animateNumber(el, from, to, duration) {
   if (from === to) {
@@ -79,12 +97,13 @@ function buildScoreArea(container) {
 }
 
 function buildTable(container) {
+  const levelLabel = escapeHtml(container.dataset.transLevel || 'Level')
   return (
     '<div class="code-stats-table">' +
     '<div class="code-stats-table-header">' +
     '<span></span>' +
     '<span>' +
-    escapeHtml(container.dataset.transPoints || 'points') +
+    levelLabel +
     '</span>' +
     '</div>' +
     '<div id="code-stats-detail-table"></div>' +
@@ -92,15 +111,59 @@ function buildTable(container) {
   )
 }
 
-function createRow(label, value, extraClass) {
+function createRow(label, score, icon) {
+  const levelCount = scoreToLevelCount(score)
   const row = document.createElement('div')
-  row.className = 'code-stats-row' + (extraClass ? ' ' + extraClass : '')
+  row.className = 'code-stats-row code-stats-row--level-' + levelCount
+
+  let segmentsHtml = ''
+  for (let i = 0; i < MAX_LEVELS; i++) {
+    const filled = i < levelCount
+    segmentsHtml +=
+      '<div class="code-stats-segment' +
+      (filled ? ' code-stats-segment--filled' : '') +
+      '">' +
+      '<div class="code-stats-segment__fill"></div>' +
+      '</div>'
+  }
+
   row.innerHTML =
     '<div class="code-stats-category">' +
+    '<i class="material-icons code-stats-icon">' +
+    escapeHtml(icon) +
+    '</i>' +
+    '<span class="code-stats-label">' +
     escapeHtml(label) +
+    '</span>' +
     '</div>' +
-    '<div class="code-stats-value">' +
-    escapeHtml(String(value)) +
+    '<div class="code-stats-level">' +
+    '<div class="code-stats-bar">' +
+    segmentsHtml +
+    '</div>' +
+    '<span class="code-stats-fraction">' +
+    levelCount +
+    '/' +
+    MAX_LEVELS +
+    '</span>' +
+    '</div>'
+
+  return row
+}
+
+function createBonusRow(label, score) {
+  const row = document.createElement('div')
+  row.className = 'code-stats-row code-stats-row--bonus'
+  row.innerHTML =
+    '<div class="code-stats-category">' +
+    '<i class="material-icons code-stats-icon">star</i>' +
+    '<span class="code-stats-label">' +
+    escapeHtml(label) +
+    '</span>' +
+    '</div>' +
+    '<div class="code-stats-level">' +
+    '<span class="code-stats-bonus-value">+' +
+    escapeHtml(String(score)) +
+    '</span>' +
     '</div>'
   return row
 }
@@ -108,61 +171,98 @@ function createRow(label, value, extraClass) {
 async function runAnimation(data, container) {
   const scores = SCORE_KEYS.map((s) => ({
     label: container.dataset[s.transAttr] || s.key,
-    value: data[s.key] || 0,
+    value: normalizeScoreValue(data[s.key]),
+    icon: s.icon,
   }))
 
-  const baseTotal = scores.reduce((sum, s) => sum + s.value, 0)
-  const finalTotal = baseTotal + BONUS_POINTS
+  const bonusScore = normalizeScoreValue(data.score_bonus)
+  const baseTotal = normalizeScoreValue(data.score_total)
+  const scoreBeforeBonus = baseTotal - bonusScore
 
-  // Animate total score (base only first)
+  // Animate total score to base (before bonus)
   const totalEl = container.querySelector('#code-stats-total-number')
-  const scorePromise = animateNumber(totalEl, 0, baseTotal, 900)
+  const scorePromise = animateNumber(
+    totalEl,
+    0,
+    bonusScore > 0 ? scoreBeforeBonus : baseTotal,
+    1000,
+  )
 
-  // Load random character (runs in parallel with score animation)
+  // Load random character
   const animEl = container.querySelector('#code-stats-animation')
   const randomIndex = Math.floor(Math.random() * CHARACTERS.length)
   loadCharacterSvg(animEl, CHARACTERS[randomIndex])
 
-  // Build category rows with staggered entrance
+  // Build category rows (without bonus — bonus gets its own phase)
   const tableEl = container.querySelector('#code-stats-detail-table')
   tableEl.innerHTML = ''
 
+  const categoryRows = []
   for (let i = 0; i < scores.length; i++) {
-    const row = createRow(scores[i].label, scores[i].value)
-    row.style.animationDelay = i * 60 + 'ms'
-    row.classList.add('code-stats-row-enter')
-    tableEl.appendChild(row)
+    categoryRows.push(createRow(scores[i].label, scores[i].value, scores[i].icon))
   }
 
-  // Wait for score animation + row stagger to settle
+  // Stagger entrance for category rows
+  for (let i = 0; i < categoryRows.length; i++) {
+    categoryRows[i].style.animationDelay = i * 80 + 'ms'
+    categoryRows[i].classList.add('code-stats-row-enter')
+    tableEl.appendChild(categoryRows[i])
+  }
+
+  // Wait for row entrance animations to settle
+  await sleep(categoryRows.length * 80 + 350)
+
+  // Animate bar segments filling in (cascade across rows and segments)
+  const rowEls = tableEl.querySelectorAll('.code-stats-row')
+  for (let i = 0; i < rowEls.length; i++) {
+    const fills = rowEls[i].querySelectorAll(
+      '.code-stats-segment--filled .code-stats-segment__fill',
+    )
+    fills.forEach((fill, j) => {
+      setTimeout(
+        () => {
+          fill.classList.add('code-stats-fill--active')
+        },
+        i * 120 + j * 180,
+      )
+    })
+  }
+
+  // Wait for score count-up and bar animations to finish
   await scorePromise
-  await sleep(500)
+  await sleep(800)
 
-  // --- Bonus points phase ---
-  // Show the star burst
-  const scoreArea = container.querySelector('.code-stats-score-area')
-  const starEl = document.createElement('div')
-  starEl.className = 'code-stats-star'
-  starEl.innerHTML =
-    '<svg viewBox="0 0 24 24" class="star-svg">' +
-    '<path d="M12 2l3.09 6.26L22 9.27l-5 4.87L18.18 22 12 18.27 5.82 22 7 14.14l-5-4.87 6.91-1.01z"/>' +
-    '</svg>'
-  scoreArea.appendChild(starEl)
+  // --- Bonus phase: star burst + score bump ---
+  if (bonusScore > 0) {
+    // Show the star burst
+    const scoreArea = container.querySelector('.code-stats-score-area')
+    const starEl = document.createElement('div')
+    starEl.className = 'code-stats-star'
+    starEl.innerHTML =
+      '<svg viewBox="0 0 24 24" class="star-svg">' +
+      '<path d="M12 2l3.09 6.26L22 9.27l-5 4.87L18.18 22 12 18.27 5.82 22 7 14.14l-5-4.87 6.91-1.01z"/>' +
+      '</svg>'
+    scoreArea.appendChild(starEl)
 
-  await sleep(600)
+    await sleep(600)
 
-  // Animate score from base to final
-  totalEl.classList.add('score-bump')
-  await animateNumber(totalEl, baseTotal, finalTotal, 600)
+    // Bump score from base to final total
+    totalEl.classList.add('score-bump')
+    await animateNumber(totalEl, scoreBeforeBonus, baseTotal, 600)
 
-  await sleep(200)
-  totalEl.classList.remove('score-bump')
+    await sleep(200)
+    totalEl.classList.remove('score-bump')
 
-  // Add bonus row to table
-  const bonusLabel = container.dataset.transBonus || 'Bonus'
-  const bonusRow = createRow(bonusLabel, '+' + BONUS_POINTS, 'code-stats-row-bonus')
-  bonusRow.classList.add('code-stats-row-enter')
-  tableEl.appendChild(bonusRow)
+    // Add bonus row to table with entrance animation
+    const bonusRow = createBonusRow(container.dataset.transBonus || 'Bonus', bonusScore)
+    bonusRow.classList.add('code-stats-row-enter')
+    tableEl.appendChild(bonusRow)
+
+    await sleep(400)
+  }
+
+  // Final celebration pulse
+  totalEl.classList.add('score-celebration')
 }
 
 async function loadStats(url, container, panel) {

--- a/assets/Project/CodeStatisticsInline.scss
+++ b/assets/Project/CodeStatisticsInline.scss
@@ -111,7 +111,212 @@
   }
 }
 
-// ─── Star Animation ──────────────────────────────────────────
+// ─── Table ───────────────────────────────────────────────────
+.code-stats-table {
+  margin-top: 0.75rem;
+  background: light-dark(rgb(255 255 255 / 85%), rgb(30 30 30 / 85%));
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 1px 4px rgb(0 0 0 / 8%);
+}
+
+.code-stats-table-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 1rem;
+  border-bottom: 2px solid light-dark(#e0e0e0, #444);
+
+  span:last-child {
+    font-weight: 700;
+    font-size: 0.9rem;
+    color: light-dark(#333, #ddd);
+    min-width: 10rem;
+    text-align: right;
+  }
+}
+
+// ─── Category Row ────────────────────────────────────────────
+.code-stats-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.65rem 1rem;
+  border-bottom: 1px solid light-dark(#f0f0f0, #333);
+  opacity: 0;
+  animation: code-stats-row-fade-in 0.3s ease-out forwards;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:nth-child(even) {
+    background: light-dark(rgb(0 0 0 / 2.5%), rgb(255 255 255 / 3%));
+  }
+}
+
+.code-stats-category {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.code-stats-icon {
+  font-size: 1.1rem;
+  color: var(--primary);
+  opacity: 0.65;
+  flex-shrink: 0;
+}
+
+.code-stats-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: light-dark(#333, #ddd);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  @media (width <= 576px) {
+    font-size: 0.8rem;
+  }
+}
+
+// ─── Level Bars ──────────────────────────────────────────────
+.code-stats-level {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-shrink: 0;
+}
+
+.code-stats-bar {
+  display: flex;
+  gap: 3px;
+  width: 100px;
+
+  @media (width <= 576px) {
+    width: 72px;
+  }
+}
+
+.code-stats-segment {
+  flex: 1;
+  height: 22px;
+  background: light-dark(#e8e8e8, #3a3a3a);
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+
+  @media (width <= 576px) {
+    height: 18px;
+    border-radius: 3px;
+  }
+}
+
+.code-stats-segment__fill {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  border-radius: 4px;
+  transition: width 0.5s ease-out;
+
+  @media (width <= 576px) {
+    border-radius: 3px;
+  }
+}
+
+.code-stats-fill--active {
+  width: 100% !important;
+}
+
+// ─── Level Colors ────────────────────────────────────────────
+$segment-stripe: repeating-linear-gradient(
+  -45deg,
+  transparent,
+  transparent 3px,
+  rgb(255 255 255 / 20%) 3px,
+  rgb(255 255 255 / 20%) 6px
+);
+
+// Level 1 — red
+.code-stats-row--level-1 .code-stats-segment--filled {
+  box-shadow: 0 0 6px rgb(239 83 80 / 35%);
+}
+
+.code-stats-row--level-1 .code-stats-segment__fill {
+  background-color: #ef5350;
+  background-image: $segment-stripe;
+}
+
+// Level 2 — orange
+.code-stats-row--level-2 .code-stats-segment--filled {
+  box-shadow: 0 0 6px rgb(255 152 0 / 35%);
+}
+
+.code-stats-row--level-2 .code-stats-segment__fill {
+  background-color: #ff9800;
+  background-image: $segment-stripe;
+}
+
+// Level 3 — green
+.code-stats-row--level-3 .code-stats-segment--filled {
+  box-shadow: 0 0 6px rgb(76 175 80 / 35%);
+}
+
+.code-stats-row--level-3 .code-stats-segment__fill {
+  background-color: #4caf50;
+  background-image: $segment-stripe;
+}
+
+// Fraction label colors
+.code-stats-fraction {
+  font-weight: 700;
+  font-size: 0.85rem;
+  min-width: 2rem;
+  text-align: right;
+}
+
+.code-stats-row--level-0 .code-stats-fraction {
+  color: light-dark(#999, #666);
+}
+
+.code-stats-row--level-1 .code-stats-fraction {
+  color: #ef5350;
+}
+
+.code-stats-row--level-2 .code-stats-fraction {
+  color: #e68a00;
+}
+
+.code-stats-row--level-3 .code-stats-fraction {
+  color: #4caf50;
+}
+
+// ─── Bonus Row ───────────────────────────────────────────────
+.code-stats-row--bonus {
+  background: light-dark(rgb(255 193 7 / 8%), rgb(255 193 7 / 10%)) !important;
+  border-top: 2px solid #ffc107;
+
+  .code-stats-icon {
+    color: #ffc107;
+    opacity: 1;
+  }
+
+  .code-stats-label {
+    color: light-dark(#b8860b, #ffd54f);
+    font-weight: 600;
+  }
+}
+
+.code-stats-bonus-value {
+  font-weight: 800;
+  font-size: 1rem;
+  color: light-dark(#b8860b, #ffd54f);
+}
+
+// ─── Star Burst Animation ────────────────────────────────────
 .code-stats-star {
   position: absolute;
   top: 0;
@@ -138,82 +343,6 @@
 
 .score-bump {
   animation: score-bump-pulse 0.4s ease-out;
-}
-
-// ─── Table ───────────────────────────────────────────────────
-.code-stats-table {
-  margin-top: 0.75rem;
-  background: light-dark(rgb(255 255 255 / 85%), rgb(30 30 30 / 85%));
-  border-radius: 10px;
-  overflow: hidden;
-  box-shadow: 0 1px 4px rgb(0 0 0 / 8%);
-}
-
-.code-stats-table-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.6rem 1rem;
-  border-bottom: 2px solid light-dark(#e0e0e0, #444);
-
-  span:last-child {
-    font-weight: 700;
-    font-size: 0.9rem;
-    color: light-dark(#333, #ddd);
-    min-width: 3rem;
-    text-align: right;
-  }
-}
-
-.code-stats-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.65rem 1rem;
-  border-bottom: 1px solid light-dark(#f0f0f0, #333);
-  opacity: 0;
-  animation: code-stats-row-fade-in 0.3s ease-out forwards;
-
-  &:last-child {
-    border-bottom: none;
-  }
-
-  &:nth-child(even) {
-    background: light-dark(rgb(0 0 0 / 2.5%), rgb(255 255 255 / 3%));
-  }
-}
-
-.code-stats-row-bonus {
-  background: light-dark(rgb(255 193 7 / 12%), rgb(255 193 7 / 15%)) !important;
-  border-top: 2px solid #ffc107;
-
-  .code-stats-category {
-    font-weight: 700;
-    color: light-dark(#b8860b, #ffd54f);
-  }
-
-  .code-stats-value {
-    color: light-dark(#b8860b, #ffd54f);
-    font-weight: 800;
-  }
-}
-
-.code-stats-category {
-  font-size: 0.9rem;
-  font-weight: 500;
-  color: light-dark(#333, #ddd);
-
-  @media (width <= 576px) {
-    font-size: 0.82rem;
-  }
-}
-
-.code-stats-value {
-  min-width: 2.5rem;
-  text-align: right;
-  font-weight: 700;
-  font-size: 1rem;
-  color: var(--primary);
 }
 
 // ─── Loading / Error ─────────────────────────────────────────
@@ -629,6 +758,11 @@
   }
 }
 
+.score-animate-in {
+  animation: code-stats-count-up 0.5s ease-out;
+}
+
+// ─── Star Keyframes ──────────────────────────────────────────
 @keyframes star-entrance {
   0% {
     opacity: 0;
@@ -673,6 +807,26 @@
   }
 }
 
-.score-animate-in {
-  animation: code-stats-count-up 0.5s ease-out;
+// ─── Celebration ─────────────────────────────────────────────
+.score-celebration {
+  animation: score-celebration-pulse 0.6s ease-out;
+  text-shadow: 0 0 24px custom-alpha(--color-primary, 0.45);
+}
+
+@keyframes score-celebration-pulse {
+  0% {
+    transform: scale(1);
+  }
+
+  30% {
+    transform: scale(1.15);
+  }
+
+  60% {
+    transform: scale(0.95);
+  }
+
+  100% {
+    transform: scale(1);
+  }
 }

--- a/migrations/2026/Version20260329220000.php
+++ b/migrations/2026/Version20260329220000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260329220000 extends AbstractMigration
+{
+  #[\Override]
+  public function getDescription(): string
+  {
+    return 'Add scoring version and bonus points to project_code_statistics';
+  }
+
+  #[\Override]
+  public function up(Schema $schema): void
+  {
+    $this->addSql("ALTER TABLE project_code_statistics ADD score_bonus INT DEFAULT 0 NOT NULL, ADD scoring_version VARCHAR(64) DEFAULT 'rubric_2021_v2' NOT NULL");
+    $this->addSql("UPDATE project_code_statistics SET scoring_version = 'legacy_keyword_counts_v1'");
+  }
+
+  #[\Override]
+  public function down(Schema $schema): void
+  {
+    $this->addSql('ALTER TABLE project_code_statistics DROP score_bonus, DROP scoring_version');
+  }
+}

--- a/src/Api/OpenAPI/Server/Model/CodeStatisticsResponse.php
+++ b/src/Api/OpenAPI/Server/Model/CodeStatisticsResponse.php
@@ -42,7 +42,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class CodeStatisticsResponse
 {
   /**
-   * Abstraction score (0-3).
+   * Abstraction score (0-6).
    *
    * @SerializedName("score_abstraction")
    *
@@ -53,7 +53,7 @@ class CodeStatisticsResponse
   protected ?int $score_abstraction = null;
 
   /**
-   * Parallelism score (0-3).
+   * Parallelism score (0-6).
    *
    * @SerializedName("score_parallelism")
    *
@@ -64,7 +64,7 @@ class CodeStatisticsResponse
   protected ?int $score_parallelism = null;
 
   /**
-   * Synchronization score (0-3).
+   * Synchronization score (0-6).
    *
    * @SerializedName("score_synchronization")
    *
@@ -75,7 +75,7 @@ class CodeStatisticsResponse
   protected ?int $score_synchronization = null;
 
   /**
-   * Logical thinking score (0-3).
+   * Logical thinking score (0-6).
    *
    * @SerializedName("score_logical_thinking")
    *
@@ -86,7 +86,7 @@ class CodeStatisticsResponse
   protected ?int $score_logical_thinking = null;
 
   /**
-   * Flow control score (0-3).
+   * Flow control score (0-6).
    *
    * @SerializedName("score_flow_control")
    *
@@ -97,7 +97,7 @@ class CodeStatisticsResponse
   protected ?int $score_flow_control = null;
 
   /**
-   * User interactivity score (0-3).
+   * User interactivity score (0-6).
    *
    * @SerializedName("score_user_interactivity")
    *
@@ -108,7 +108,7 @@ class CodeStatisticsResponse
   protected ?int $score_user_interactivity = null;
 
   /**
-   * Data representation score (0-3).
+   * Data representation score (0-6).
    *
    * @SerializedName("score_data_representation")
    *
@@ -117,6 +117,39 @@ class CodeStatisticsResponse
    * @Type("int")
    */
   protected ?int $score_data_representation = null;
+
+  /**
+   * Bonus points awarded for physics or extension usage.
+   *
+   * @SerializedName("score_bonus")
+   *
+   * @Assert\Type("int")
+   *
+   * @Type("int")
+   */
+  protected ?int $score_bonus = null;
+
+  /**
+   * Sum of all category scores and bonus points.
+   *
+   * @SerializedName("score_total")
+   *
+   * @Assert\Type("int")
+   *
+   * @Type("int")
+   */
+  protected ?int $score_total = null;
+
+  /**
+   * Identifier of the rubric version used to compute the scores.
+   *
+   * @SerializedName("scoring_version")
+   *
+   * @Assert\Type("string")
+   *
+   * @Type("string")
+   */
+  protected ?string $scoring_version = null;
 
   /**
    * Constructor.
@@ -133,6 +166,9 @@ class CodeStatisticsResponse
       $this->score_flow_control = array_key_exists('score_flow_control', $data) ? $data['score_flow_control'] : $this->score_flow_control;
       $this->score_user_interactivity = array_key_exists('score_user_interactivity', $data) ? $data['score_user_interactivity'] : $this->score_user_interactivity;
       $this->score_data_representation = array_key_exists('score_data_representation', $data) ? $data['score_data_representation'] : $this->score_data_representation;
+      $this->score_bonus = array_key_exists('score_bonus', $data) ? $data['score_bonus'] : $this->score_bonus;
+      $this->score_total = array_key_exists('score_total', $data) ? $data['score_total'] : $this->score_total;
+      $this->scoring_version = array_key_exists('scoring_version', $data) ? $data['scoring_version'] : $this->scoring_version;
     }
   }
 
@@ -147,7 +183,7 @@ class CodeStatisticsResponse
   /**
    * Sets score_abstraction.
    *
-   * @param int|null $score_abstraction Abstraction score (0-3)
+   * @param int|null $score_abstraction Abstraction score (0-6)
    *
    * @return $this
    */
@@ -169,7 +205,7 @@ class CodeStatisticsResponse
   /**
    * Sets score_parallelism.
    *
-   * @param int|null $score_parallelism Parallelism score (0-3)
+   * @param int|null $score_parallelism Parallelism score (0-6)
    *
    * @return $this
    */
@@ -191,7 +227,7 @@ class CodeStatisticsResponse
   /**
    * Sets score_synchronization.
    *
-   * @param int|null $score_synchronization Synchronization score (0-3)
+   * @param int|null $score_synchronization Synchronization score (0-6)
    *
    * @return $this
    */
@@ -213,7 +249,7 @@ class CodeStatisticsResponse
   /**
    * Sets score_logical_thinking.
    *
-   * @param int|null $score_logical_thinking Logical thinking score (0-3)
+   * @param int|null $score_logical_thinking Logical thinking score (0-6)
    *
    * @return $this
    */
@@ -235,7 +271,7 @@ class CodeStatisticsResponse
   /**
    * Sets score_flow_control.
    *
-   * @param int|null $score_flow_control Flow control score (0-3)
+   * @param int|null $score_flow_control Flow control score (0-6)
    *
    * @return $this
    */
@@ -257,7 +293,7 @@ class CodeStatisticsResponse
   /**
    * Sets score_user_interactivity.
    *
-   * @param int|null $score_user_interactivity User interactivity score (0-3)
+   * @param int|null $score_user_interactivity User interactivity score (0-6)
    *
    * @return $this
    */
@@ -279,13 +315,79 @@ class CodeStatisticsResponse
   /**
    * Sets score_data_representation.
    *
-   * @param int|null $score_data_representation Data representation score (0-3)
+   * @param int|null $score_data_representation Data representation score (0-6)
    *
    * @return $this
    */
   public function setScoreDataRepresentation(?int $score_data_representation = null): self
   {
     $this->score_data_representation = $score_data_representation;
+
+    return $this;
+  }
+
+  /**
+   * Gets score_bonus.
+   */
+  public function getScoreBonus(): ?int
+  {
+    return $this->score_bonus;
+  }
+
+  /**
+   * Sets score_bonus.
+   *
+   * @param int|null $score_bonus Bonus points awarded for physics or extension usage
+   *
+   * @return $this
+   */
+  public function setScoreBonus(?int $score_bonus = null): self
+  {
+    $this->score_bonus = $score_bonus;
+
+    return $this;
+  }
+
+  /**
+   * Gets score_total.
+   */
+  public function getScoreTotal(): ?int
+  {
+    return $this->score_total;
+  }
+
+  /**
+   * Sets score_total.
+   *
+   * @param int|null $score_total Sum of all category scores and bonus points
+   *
+   * @return $this
+   */
+  public function setScoreTotal(?int $score_total = null): self
+  {
+    $this->score_total = $score_total;
+
+    return $this;
+  }
+
+  /**
+   * Gets scoring_version.
+   */
+  public function getScoringVersion(): ?string
+  {
+    return $this->scoring_version;
+  }
+
+  /**
+   * Sets scoring_version.
+   *
+   * @param string|null $scoring_version Identifier of the rubric version used to compute the scores
+   *
+   * @return $this
+   */
+  public function setScoringVersion(?string $scoring_version = null): self
+  {
+    $this->scoring_version = $scoring_version;
 
     return $this;
   }

--- a/src/Api/OpenAPI/specification.yaml
+++ b/src/Api/OpenAPI/specification.yaml
@@ -5058,29 +5058,41 @@ components:
       properties:
         score_abstraction:
           type: integer
-          description: 'Abstraction score (0-3)'
-          example: 2
+          description: 'Abstraction score (0-6)'
+          example: 6
         score_parallelism:
           type: integer
-          description: 'Parallelism score (0-3)'
-          example: 1
+          description: 'Parallelism score (0-6)'
+          example: 3
         score_synchronization:
           type: integer
-          description: 'Synchronization score (0-3)'
+          description: 'Synchronization score (0-6)'
           example: 3
         score_logical_thinking:
           type: integer
-          description: 'Logical thinking score (0-3)'
-          example: 2
+          description: 'Logical thinking score (0-6)'
+          example: 3
         score_flow_control:
           type: integer
-          description: 'Flow control score (0-3)'
-          example: 2
+          description: 'Flow control score (0-6)'
+          example: 4
         score_user_interactivity:
           type: integer
-          description: 'User interactivity score (0-3)'
-          example: 1
+          description: 'User interactivity score (0-6)'
+          example: 3
         score_data_representation:
           type: integer
-          description: 'Data representation score (0-3)'
-          example: 3
+          description: 'Data representation score (0-6)'
+          example: 6
+        score_bonus:
+          type: integer
+          description: 'Bonus points awarded for physics or extension usage'
+          example: 2
+        score_total:
+          type: integer
+          description: 'Sum of all category scores and bonus points'
+          example: 27
+        scoring_version:
+          type: string
+          description: 'Identifier of the rubric version used to compute the scores'
+          example: 'rubric_2021_v1'

--- a/src/Api/Services/Projects/ProjectsResponseManager.php
+++ b/src/Api/Services/Projects/ProjectsResponseManager.php
@@ -345,6 +345,9 @@ class ProjectsResponseManager extends AbstractResponseManager
       'score_flow_control' => $stats->getScoreFlowControl(),
       'score_user_interactivity' => $stats->getScoreUserInteractivity(),
       'score_data_representation' => $stats->getScoreDataRepresentation(),
+      'score_bonus' => $stats->getScoreBonus(),
+      'score_total' => $stats->getScoreTotal(),
+      'scoring_version' => $stats->getScoringVersion(),
     ]);
   }
 

--- a/src/DB/Entity/Project/ProjectCodeStatistics.php
+++ b/src/DB/Entity/Project/ProjectCodeStatistics.php
@@ -77,6 +77,12 @@ class ProjectCodeStatistics
   #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
   private int $score_data_representation = 0;
 
+  #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
+  private int $score_bonus = 0;
+
+  #[ORM\Column(type: Types::STRING, length: 64, options: ['default' => 'rubric_2021_v2'])]
+  private string $scoring_version = 'rubric_2021_v2';
+
   public function __construct()
   {
     $this->created_at = new \DateTime();
@@ -324,5 +330,44 @@ class ProjectCodeStatistics
     $this->score_data_representation = $score_data_representation;
 
     return $this;
+  }
+
+  public function getScoreBonus(): int
+  {
+    return $this->score_bonus;
+  }
+
+  public function setScoreBonus(int $score_bonus): self
+  {
+    $this->score_bonus = $score_bonus;
+
+    return $this;
+  }
+
+  public function getScoringVersion(): string
+  {
+    return $this->scoring_version;
+  }
+
+  public function setScoringVersion(string $scoring_version): self
+  {
+    $this->scoring_version = $scoring_version;
+
+    return $this;
+  }
+
+  /**
+   * Derived on read so the stored category scores remain the single source of truth.
+   */
+  public function getScoreTotal(): int
+  {
+    return $this->score_abstraction
+      + $this->score_parallelism
+      + $this->score_synchronization
+      + $this->score_logical_thinking
+      + $this->score_flow_control
+      + $this->score_user_interactivity
+      + $this->score_data_representation
+      + $this->score_bonus;
   }
 }

--- a/src/Project/CodeStatistics/CodeStatisticsParser.php
+++ b/src/Project/CodeStatistics/CodeStatisticsParser.php
@@ -5,115 +5,188 @@ declare(strict_types=1);
 namespace App\Project\CodeStatistics;
 
 use App\DB\Entity\Project\ProjectCodeStatistics;
+use App\Project\CatrobatCode\Parser\Constants;
 
 /**
- * A lightweight regex-based parser for code.xml files that counts bricks, scripts,
- * objects, looks, sounds, and variables without building a full DOM tree.
+ * @phpstan-type RubricContext array{
+ *   duplicate_background_targets: bool,
+ *   duplicate_broadcast_messages: bool,
+ *   duplicate_condition_keys: bool,
+ *   has_advanced_sensor: bool,
+ *   has_developing_sensor: bool,
+ *   has_logical_operator: bool,
+ *   has_script_with_brick: bool,
+ *   tapped_scripts_same_object: bool,
+ *   uses_extension: bool,
+ *   uses_physics: bool
+ * }
+ *
+ * @psalm-type RubricContext = array{
+ *   duplicate_background_targets: bool,
+ *   duplicate_broadcast_messages: bool,
+ *   duplicate_condition_keys: bool,
+ *   has_advanced_sensor: bool,
+ *   has_developing_sensor: bool,
+ *   has_logical_operator: bool,
+ *   has_script_with_brick: bool,
+ *   tapped_scripts_same_object: bool,
+ *   uses_extension: bool,
+ *   uses_physics: bool
+ * }
+ *
+ * A lightweight parser for code.xml files that keeps the fast aggregate counts
+ * but derives computational thinking scores from the rubric levels discussed
+ * in the original CT spreadsheet.
  */
 class CodeStatisticsParser
 {
-  /**
-   * Script types that indicate parallelism (multiple entry points).
-   */
-  private const array PARALLELISM_SCRIPTS = [
-    'WhenClonedScript',
-    'BroadcastScript',
-    'WhenBackgroundChangesScript',
-    'WhenConditionScript',
-    'WhenBounceOffScript',
-    'CollisionScript',
-    'WhenGamepadButtonScript',
-    'RaspiInterruptScript',
-    'WhenNfcScript',
+  final public const string CURRENT_SCORING_VERSION = 'rubric_2021_v2';
+
+  final public const string LEGACY_SCORING_VERSION = 'legacy_keyword_counts_v1';
+
+  private const array ABSTRACTION_TYPES = [
+    Constants::USER_DEFINED_SCRIPT,
+    'UserDefinedBrick',
+    'UserDefinedReceiverBrick',
+    Constants::CLONE_BRICK,
+    Constants::DELETE_THIS_CLONE_BRICK,
   ];
 
-  /**
-   * Brick types that indicate synchronization (broadcast/wait communication).
-   */
-  private const array SYNCHRONIZATION_BRICKS = [
-    'BroadcastBrick',
-    'BroadcastWaitBrick',
-    'BroadcastReceiverBrick',
-    'WaitBrick',
-    'WaitUntilBrick',
-  ];
-
-  /**
-   * Brick types that indicate logical thinking (conditionals).
-   */
   private const array LOGICAL_THINKING_BRICKS = [
-    'IfLogicBeginBrick',
-    'IfThenLogicBeginBrick',
-    'IfLogicElseBrick',
-    'PhiroIfLogicBeginBrick',
-    'RaspiIfLogicBeginBrick',
+    Constants::IF_BRICK,
+    Constants::IF_THEN_BRICK,
+    Constants::PHIRO_IF_LOGIC_BEGIN_BRICK,
+    Constants::RASPI_IF_LOGIC_BEGIN_BRICK,
   ];
 
-  /**
-   * Brick types that indicate flow control (loops).
-   */
-  private const array FLOW_CONTROL_BRICKS = [
-    'ForeverBrick',
-    'RepeatBrick',
-    'RepeatUntilBrick',
-    'ForVariableFromToBrick',
-    'ForItemInUserListBrick',
+  private const array FLOW_CONTROL_DEVELOPING_BRICKS = [
+    Constants::FOREVER_BRICK,
+    Constants::REPEAT_BRICK,
   ];
 
-  /**
-   * Brick/script types that indicate user interactivity (sensors/input/touch).
-   */
-  private const array USER_INTERACTIVITY_TYPES = [
-    'WhenScript',
-    'WhenTouchDownScript',
-    'WhenTouchDownBrick',
-    'WhenBrick',
-    'AskBrick',
-    'AskSpeechBrick',
-    'TouchAndSlideBrick',
-    'TapAtBrick',
-    'TapForBrick',
-    'WhenConditionScript',
-    'WhenConditionBrick',
+  private const array FLOW_CONTROL_PROFICIENCY_BRICKS = [
+    Constants::REPEAT_UNTIL_BRICK,
   ];
 
-  /**
-   * Brick types that indicate data representation (variables/lists).
-   */
-  private const array DATA_REPRESENTATION_BRICKS = [
+  private const array DATA_REPRESENTATION_BASIC_BRICKS = [
+    Constants::PLACE_AT_BRICK,
+    Constants::SET_X_BRICK,
+    Constants::SET_Y_BRICK,
+    Constants::GO_TO_BRICK,
+    Constants::CHANGE_X_BY_N_BRICK,
+    Constants::CHANGE_Y_BY_N_BRICK,
+    Constants::MOVE_N_STEPS_BRICK,
+    Constants::SET_SIZE_TO_BRICK,
+    Constants::CHANGE_SIZE_BY_N_BRICK,
+    Constants::SET_LOOK_BRICK,
+    Constants::SET_LOOK_BY_INDEX_BRICK,
+    Constants::NEXT_LOOK_BRICK,
+    Constants::PREV_LOOK_BRICK,
+    Constants::HIDE_BRICK,
+    Constants::SHOW_BRICK,
+  ];
+
+  private const array DATA_REPRESENTATION_DEVELOPING_BRICKS = [
     'SetVariableBrick',
     'ChangeVariableBrick',
-    'ShowTextBrick',
-    'ShowTextColorSizeAlignmentBrick',
-    'HideTextBrick',
+  ];
+
+  private const array DATA_REPRESENTATION_PROFICIENCY_BRICKS = [
     'AddItemToUserListBrick',
     'DeleteItemOfUserListBrick',
     'InsertItemIntoUserListBrick',
     'ReplaceItemInUserListBrick',
     'ClearUserListBrick',
-    'ReadVariableFromDeviceBrick',
-    'WriteVariableOnDeviceBrick',
-    'ReadListFromDeviceBrick',
-    'WriteListOnDeviceBrick',
-    'StoreCSVIntoUserListBrick',
-    'WebRequestBrick',
-    'ReadVariableFromFileBrick',
-    'WriteVariableToFileBrick',
-    'UserVariableBrick',
-    'UserListBrick',
   ];
 
-  /**
-   * Brick/script types that indicate abstraction (user-defined procedures/clones).
-   */
-  private const array ABSTRACTION_TYPES = [
-    'UserDefinedScript',
-    'UserDefinedBrick',
-    'UserDefinedReceiverBrick',
-    'CloneBrick',
-    'DeleteThisCloneBrick',
-    'WhenClonedScript',
-    'WhenClonedBrick',
+  private const array USER_INTERACTIVITY_DEVELOPING_TYPES = [
+    Constants::ASK_BRICK,
+    Constants::WHEN_TOUCH_SCRIPT,
+    Constants::WHEN_TOUCH_BRICK,
+  ];
+
+  private const array USER_INTERACTIVITY_PROFICIENCY_TYPES = [
+    Constants::ASK_SPEECH_BRICK,
+    Constants::START_LISTENING_BRICK,
+    Constants::CAMERA_BRICK,
+    Constants::CHOOSE_CAMERA_BRICK,
+  ];
+
+  private const array SYNCHRONIZATION_BASIC_BRICKS = [
+    Constants::WAIT_BRICK,
+  ];
+
+  private const array SYNCHRONIZATION_DEVELOPING_BRICKS = [
+    Constants::BROADCAST_BRICK,
+    Constants::STOP_SCRIPT_BRICK,
+  ];
+
+  private const array SYNCHRONIZATION_PROFICIENCY_TYPES = [
+    Constants::WAIT_UNTIL_BRICK,
+    Constants::BROADCAST_WAIT_BRICK,
+    Constants::WHEN_BG_CHANGE_SCRIPT,
+  ];
+
+  private const array PHYSICS_BRICKS = [
+    Constants::SET_PHYSICS_OBJECT_TYPE_BRICK,
+    Constants::SET_VELOCITY_BRICK,
+    Constants::TURN_LEFT_SPEED_BRICK,
+    Constants::TURN_RIGHT_SPEED_BRICK,
+    Constants::SET_GRAVITY_BRICK,
+    Constants::SET_MASS_BRICK,
+    Constants::SET_BOUNCE_BRICK,
+    Constants::SET_FRICTION_BRICK,
+  ];
+
+  private const array LOGICAL_OPERATOR_VALUES = [
+    Constants::AND_OPERATOR,
+    Constants::OR_OPERATOR,
+    Constants::NOT_OPERATOR,
+  ];
+
+  private const array DEVELOPING_INTERACTIVITY_SENSOR_VALUES = [
+    'FINGER_TOUCHED',
+    'COLLIDES_WITH_FINGER',
+    'FINGER_X',
+    'FINGER_Y',
+    'MULTI_FINGER_X',
+    'MULTI_FINGER_Y',
+    'MULTI_FINGER_TOUCHED',
+    'X_INCLINATION',
+    'Y_INCLINATION',
+    'LAST_FINGER_INDEX',
+    'X_ACCELERATION',
+    'Y_ACCELERATION',
+    'Z_ACCELERATION',
+    'LONGITUDE',
+    'LATITUDE',
+    'ALTITUDE',
+    'LOCATION_ACCURACY',
+    'COMPASS_DIRECTION',
+  ];
+
+  private const array ADVANCED_INTERACTIVITY_SENSOR_VALUES = [
+    'FACE_X_POSITION',
+    'FACE_Y_POSITION',
+    'FACE_DETECTED',
+    'FACE_SIZE',
+    'TEXT_FROM_CAMERA',
+    'TEXT_BLOCKS_NUMBER',
+    'LOUDNESS',
+    'SPEECH_RECOGNITION_LANGUAGE',
+  ];
+
+  private const array EXTENSION_TYPE_PREFIXES = [
+    'Drone',
+    'Phiro',
+    'Arduino',
+    'Raspi',
+    'Lego',
+    'WhenNfc',
+    'SetNfc',
+    'WhenGamepad',
+    'Gamepad',
+    'Embroidery',
   ];
 
   /**
@@ -135,6 +208,7 @@ class CodeStatisticsParser
     $xml_content = str_replace('&#x0;', '', $xml_content);
 
     $stats = new ProjectCodeStatistics();
+    $stats->setScoringVersion(self::CURRENT_SCORING_VERSION);
 
     // Count scenes
     $stats->setScenes($this->countScenes($xml_content));
@@ -161,9 +235,8 @@ class CodeStatisticsParser
     // Count variables
     $this->countVariables($xml_content, $stats);
 
-    // Compute computational thinking scores
-    $all_type_counts = array_merge($script_counts, $brick_counts);
-    $this->computeScores($all_type_counts, $stats);
+    // Compute rubric-based computational thinking scores
+    $this->computeScores($xml_content, $script_counts, $brick_counts, $stats);
 
     return $stats;
   }
@@ -174,9 +247,7 @@ class CodeStatisticsParser
    */
   private function countScenes(string $xml_content): int
   {
-    // Match <scene> (but not <scenes> or <sceneToStart>)
     if (preg_match_all('/<scene\b[^>]*>/', $xml_content, $matches)) {
-      // Filter out <scenes> and <sceneToStart> tags
       $count = 0;
       foreach ($matches[0] as $match) {
         if (!str_starts_with($match, '<scenes') && !str_starts_with($match, '<sceneToStart')) {
@@ -199,7 +270,6 @@ class CodeStatisticsParser
   {
     $counts = [];
 
-    // Match <tagName type="TypeName"> patterns
     if (preg_match_all('/<'.$tag_name.'\s+type="([^"]+)"/', $xml_content, $matches)) {
       foreach ($matches[1] as $type_name) {
         $counts[$type_name] = ($counts[$type_name] ?? 0) + 1;
@@ -210,25 +280,19 @@ class CodeStatisticsParser
   }
 
   /**
-   * Counts object/sprite elements. Objects can be represented as:
-   * - <object type="SingleSprite" ...>
-   * - <object type="GroupItemSprite" ...>
-   * - <object type="GroupSprite" ...>
-   * - <pointedObject ...> (references, not actual objects)
+   * Counts object/sprite elements.
    */
   private function countObjects(string $xml_content): int
   {
     $count = 0;
     if (preg_match_all('/<object\s+type="([^"]+)"/', $xml_content, $matches)) {
       foreach ($matches[1] as $type) {
-        // Count actual sprite types, not group containers
-        if ('SingleSprite' === $type || 'GroupItemSprite' === $type) {
+        if (Constants::SINGLE_SPRITE_TYPE === $type || Constants::GROUP_ITEM_SPRITE_TYPE === $type) {
           ++$count;
         }
       }
     }
 
-    // Also count objects without a type attribute (older format)
     if (preg_match_all('/<object\s+name="[^"]*"(?!\s+type=)/', $xml_content, $matches)) {
       $count += count($matches[0]);
     }
@@ -242,10 +306,8 @@ class CodeStatisticsParser
    */
   private function countTag(string $xml_content, string $tag_name): int
   {
-    // Match opening tags that have a name or fileName attribute (actual definitions, not references)
     $count = 0;
 
-    // Match <look fileName="..."> or <look name="...">
     if (preg_match_all('/<'.$tag_name.'\b[^>]*(?:fileName|name)="[^"]*"/', $xml_content, $matches)) {
       $count = count($matches[0]);
     }
@@ -258,7 +320,6 @@ class CodeStatisticsParser
    */
   private function countVariables(string $xml_content, ProjectCodeStatistics $stats): void
   {
-    // Global variables: in programVariableList or programListOfLists
     $global_vars = 0;
     if (preg_match_all('/<programVariableList>(.*?)<\/programVariableList>/s', $xml_content, $matches)) {
       foreach ($matches[1] as $block) {
@@ -273,12 +334,9 @@ class CodeStatisticsParser
 
     $stats->setGlobalVariables($global_vars);
 
-    // Count all userVariable occurrences, then subtract globals to get locals
     $total_vars = preg_match_all('/<userVariable>/', $xml_content);
-
     $local_vars = $total_vars - $global_vars;
     if ($local_vars <= 0) {
-      // Fallback for old format
       $local_vars = 0;
       if (preg_match_all('/<objectVariableList>(.*?)<\/objectVariableList>/s', $xml_content, $matches)) {
         foreach ($matches[1] as $block) {
@@ -296,34 +354,359 @@ class CodeStatisticsParser
   }
 
   /**
-   * Computes computational thinking scores based on brick/script type counts.
+   * Computes rubric-based computational thinking scores.
    *
-   * @param array<string, int> $type_counts Combined brick and script type counts
+   * @param array<string, int> $script_counts
+   * @param array<string, int> $brick_counts
    */
-  private function computeScores(array $type_counts, ProjectCodeStatistics $stats): void
+  private function computeScores(string $xml_content, array $script_counts, array $brick_counts, ProjectCodeStatistics $stats): void
   {
-    $stats->setScoreAbstraction($this->sumTypeCounts($type_counts, self::ABSTRACTION_TYPES));
-    $stats->setScoreParallelism($this->sumTypeCounts($type_counts, self::PARALLELISM_SCRIPTS));
-    $stats->setScoreSynchronization($this->sumTypeCounts($type_counts, self::SYNCHRONIZATION_BRICKS));
-    $stats->setScoreLogicalThinking($this->sumTypeCounts($type_counts, self::LOGICAL_THINKING_BRICKS));
-    $stats->setScoreFlowControl($this->sumTypeCounts($type_counts, self::FLOW_CONTROL_BRICKS));
-    $stats->setScoreUserInteractivity($this->sumTypeCounts($type_counts, self::USER_INTERACTIVITY_TYPES));
-    $stats->setScoreDataRepresentation($this->sumTypeCounts($type_counts, self::DATA_REPRESENTATION_BRICKS));
+    $type_counts = array_merge($script_counts, $brick_counts);
+    $context = $this->buildRubricContext($xml_content, $script_counts, $brick_counts);
+
+    $stats->setScoreAbstraction($this->sumRubricLevels(
+      array_sum($script_counts) > 1,
+      $this->hasAnyTypeCount($type_counts, self::ABSTRACTION_TYPES),
+      ($script_counts[Constants::WHEN_CLONED_SCRIPT] ?? 0) > 0,
+    ));
+
+    $stats->setScoreParallelism($this->sumRubricLevels(
+      ($script_counts[Constants::START_SCRIPT] ?? 0) > 1,
+      $context['tapped_scripts_same_object'],
+      $context['duplicate_broadcast_messages']
+        || $context['duplicate_background_targets']
+        || $context['duplicate_condition_keys'],
+    ));
+
+    $stats->setScoreLogicalThinking($this->sumRubricLevels(
+      $this->hasAnyTypeCount($brick_counts, self::LOGICAL_THINKING_BRICKS),
+      ($brick_counts['IfLogicElseBrick'] ?? 0) > 0,
+      $context['has_logical_operator'],
+    ));
+
+    $stats->setScoreSynchronization($this->sumRubricLevels(
+      $this->hasAnyTypeCount($brick_counts, self::SYNCHRONIZATION_BASIC_BRICKS),
+      $this->hasAnyTypeCount($brick_counts, self::SYNCHRONIZATION_DEVELOPING_BRICKS),
+      $this->hasAnyTypeCount($type_counts, self::SYNCHRONIZATION_PROFICIENCY_TYPES),
+    ));
+
+    $stats->setScoreFlowControl($this->sumRubricLevels(
+      $context['has_script_with_brick'],
+      $this->hasAnyTypeCount($brick_counts, self::FLOW_CONTROL_DEVELOPING_BRICKS),
+      $this->hasAnyTypeCount($brick_counts, self::FLOW_CONTROL_PROFICIENCY_BRICKS),
+    ));
+
+    $stats->setScoreUserInteractivity($this->sumRubricLevels(
+      ($script_counts[Constants::START_SCRIPT] ?? 0) > 0,
+      $this->hasAnyTypeCount($type_counts, self::USER_INTERACTIVITY_DEVELOPING_TYPES)
+        || $context['tapped_scripts_same_object']
+        || $context['has_developing_sensor'],
+      $this->hasAnyTypeCount($type_counts, self::USER_INTERACTIVITY_PROFICIENCY_TYPES)
+        || $context['has_advanced_sensor'],
+    ));
+
+    $stats->setScoreDataRepresentation($this->sumRubricLevels(
+      $this->hasAnyTypeCount($brick_counts, self::DATA_REPRESENTATION_BASIC_BRICKS),
+      $this->hasAnyTypeCount($brick_counts, self::DATA_REPRESENTATION_DEVELOPING_BRICKS),
+      $this->hasAnyTypeCount($brick_counts, self::DATA_REPRESENTATION_PROFICIENCY_BRICKS),
+    ));
+
+    // Breadth bonus: +1 if at least 5 of 7 categories have a score >= 1
+    $category_scores = [
+      $stats->getScoreAbstraction(),
+      $stats->getScoreParallelism(),
+      $stats->getScoreLogicalThinking(),
+      $stats->getScoreSynchronization(),
+      $stats->getScoreFlowControl(),
+      $stats->getScoreUserInteractivity(),
+      $stats->getScoreDataRepresentation(),
+    ];
+    $active_categories = count(array_filter($category_scores, static fn (int $s): bool => $s >= 1));
+    $breadth_bonus = $active_categories >= 5 ? 1 : 0;
+
+    $stats->setScoreBonus(
+      $breadth_bonus
+      + ($context['uses_physics'] ? 1 : 0)
+      + ($context['uses_extension'] ? 1 : 0),
+    );
   }
 
   /**
-   * Sums counts from the type_counts map for the given type names.
+   * @param array<string, int> $script_counts
+   * @param array<string, int> $brick_counts
    *
-   * @param array<string, int> $type_counts Map of type name to count
-   * @param string[]           $type_names  List of type names to sum
+   * @return RubricContext
    */
-  private function sumTypeCounts(array $type_counts, array $type_names): int
+  private function buildRubricContext(string $xml_content, array $script_counts, array $brick_counts): array
   {
-    $total = 0;
-    foreach ($type_names as $name) {
-      $total += $type_counts[$name] ?? 0;
+    /** @var RubricContext $context */
+    $context = [
+      'duplicate_background_targets' => false,
+      'duplicate_broadcast_messages' => false,
+      'duplicate_condition_keys' => false,
+      'has_advanced_sensor' => false,
+      'has_developing_sensor' => false,
+      'has_logical_operator' => false,
+      'has_script_with_brick' => false,
+      'tapped_scripts_same_object' => false,
+      'uses_extension' => $this->usesExtensionType(array_merge(array_keys($script_counts), array_keys($brick_counts))),
+      'uses_physics' => $this->hasAnyTypeCount($brick_counts, self::PHYSICS_BRICKS),
+    ];
+
+    $xml = @simplexml_load_string($xml_content);
+    if (!$xml instanceof \SimpleXMLElement) {
+      return $context;
     }
 
-    return $total;
+    $broadcast_counts = [];
+    foreach ($xml->xpath('//script[@type="'.Constants::BROADCAST_SCRIPT.'"]/receivedMessage') ?: [] as $message_node) {
+      $message = $this->normalizeText((string) $message_node);
+      if ('' !== $message) {
+        $broadcast_counts[$message] = ($broadcast_counts[$message] ?? 0) + 1;
+      }
+    }
+    $context['duplicate_broadcast_messages'] = $this->hasDuplicateCount($broadcast_counts);
+
+    $background_counts = [];
+    foreach ($xml->xpath('//script[@type="'.Constants::WHEN_BG_CHANGE_SCRIPT.'"]') ?: [] as $script) {
+      $key = $this->extractBackgroundChangeKey($script);
+      if ('' !== $key) {
+        $background_counts[$key] = ($background_counts[$key] ?? 0) + 1;
+      }
+    }
+    $context['duplicate_background_targets'] = $this->hasDuplicateCount($background_counts);
+
+    $condition_counts = [];
+    foreach ($xml->xpath('//script[@type="'.Constants::WHEN_CONDITION_SCRIPT.'"]') ?: [] as $script) {
+      $formula_nodes = $script->xpath('./formulaMap/formula');
+      $formula = is_array($formula_nodes) ? ($formula_nodes[0] ?? null) : null;
+      foreach ($this->extractConditionKeys($formula) as $key) {
+        $condition_counts[$key] = ($condition_counts[$key] ?? 0) + 1;
+      }
+    }
+    $context['duplicate_condition_keys'] = $this->hasDuplicateCount($condition_counts);
+
+    foreach ($xml->xpath('//object') ?: [] as $object) {
+      $this->analyzeObjectScripts($object, $context);
+      if ($context['tapped_scripts_same_object'] && $context['has_script_with_brick']) {
+        break;
+      }
+    }
+
+    $has_logical_operator = false;
+    $sensor_values = [];
+    foreach ($xml->xpath('//formula') ?: [] as $formula) {
+      $this->collectFormulaSignals($formula, $sensor_values, $has_logical_operator);
+    }
+
+    $context['has_logical_operator'] = $has_logical_operator;
+    $context['has_developing_sensor'] = $this->hasAnySensorValue($sensor_values, self::DEVELOPING_INTERACTIVITY_SENSOR_VALUES);
+    $context['has_advanced_sensor'] = $this->hasAnySensorValue($sensor_values, self::ADVANCED_INTERACTIVITY_SENSOR_VALUES);
+
+    return $context;
+  }
+
+  /**
+   * @param RubricContext $context
+   */
+  private function analyzeObjectScripts(\SimpleXMLElement $object, array &$context): void
+  {
+    $script_list = $object->scriptList;
+    if (!$script_list instanceof \SimpleXMLElement || !isset($script_list->script)) {
+      return;
+    }
+
+    $tap_script_count = 0;
+    foreach ($script_list->script as $script) {
+      $script_type = (string) $script['type'];
+      if (isset($script->brickList) && count($script->brickList->brick) > 0) {
+        $context['has_script_with_brick'] = true;
+      }
+
+      if (Constants::WHEN_TOUCH_SCRIPT === $script_type) {
+        ++$tap_script_count;
+        continue;
+      }
+
+      if (Constants::WHEN_SCRIPT === $script_type) {
+        $action = $this->normalizeText((string) $script->action);
+        if ('' === $action || 'Tapped' === $action) {
+          ++$tap_script_count;
+        }
+      }
+    }
+
+    if ($tap_script_count > 1) {
+      $context['tapped_scripts_same_object'] = true;
+    }
+  }
+
+  private function extractBackgroundChangeKey(\SimpleXMLElement $script): string
+  {
+    if (isset($script->look)) {
+      $reference = $this->normalizeText((string) $script->look['reference']);
+      if ('' !== $reference) {
+        return 'look-ref:'.$reference;
+      }
+
+      $value = $this->normalizeText((string) $script->look);
+      if ('' !== $value) {
+        return 'look-name:'.$value;
+      }
+    }
+
+    return '<any-background>';
+  }
+
+  /**
+   * @return string[]
+   */
+  private function extractConditionKeys(\SimpleXMLElement|array|null $formula): array
+  {
+    if (is_array($formula)) {
+      $formula = $formula[0] ?? null;
+    }
+
+    if (!$formula instanceof \SimpleXMLElement) {
+      return [];
+    }
+
+    $keys = [];
+    $this->collectConditionIdentifiers($formula, $keys);
+    $keys = array_values(array_unique(array_filter($keys)));
+
+    if ([] !== $keys) {
+      return $keys;
+    }
+
+    $xml = $formula->asXML();
+
+    return false === $xml ? [] : ['formula:'.md5($xml)];
+  }
+
+  /**
+   * @param string[] $keys
+   */
+  private function collectConditionIdentifiers(\SimpleXMLElement $formula, array &$keys): void
+  {
+    $type = $this->normalizeText((string) $formula->type);
+    $value = $this->normalizeText((string) $formula->value);
+
+    if (('USER_VARIABLE' === $type || 'USER_LIST' === $type) && '' !== $value) {
+      $keys[] = 'var:'.$value;
+    }
+
+    if ('SENSOR' === $type && '' !== $value) {
+      $keys[] = 'sensor:'.$value;
+    }
+
+    foreach (['leftChild', 'rightChild'] as $child_name) {
+      if (isset($formula->{$child_name})) {
+        foreach ($formula->{$child_name} as $child) {
+          $this->collectConditionIdentifiers($child, $keys);
+        }
+      }
+    }
+  }
+
+  /**
+   * @param string[] $sensor_values
+   */
+  private function collectFormulaSignals(\SimpleXMLElement $formula, array &$sensor_values, bool &$has_logical_operator): void
+  {
+    $type = $this->normalizeText((string) $formula->type);
+    $value = $this->normalizeText((string) $formula->value);
+
+    if ('OPERATOR' === $type && in_array($value, self::LOGICAL_OPERATOR_VALUES, true)) {
+      $has_logical_operator = true;
+    }
+
+    if (('SENSOR' === $type || 'FUNCTION' === $type) && '' !== $value) {
+      $sensor_values[] = $value;
+    }
+
+    foreach (['leftChild', 'rightChild'] as $child_name) {
+      if (isset($formula->{$child_name})) {
+        foreach ($formula->{$child_name} as $child) {
+          $this->collectFormulaSignals($child, $sensor_values, $has_logical_operator);
+        }
+      }
+    }
+  }
+
+  /**
+   * @param string[] $all_type_names
+   */
+  private function usesExtensionType(array $all_type_names): bool
+  {
+    foreach ($all_type_names as $type_name) {
+      foreach (self::EXTENSION_TYPE_PREFIXES as $prefix) {
+        if (str_starts_with($type_name, $prefix)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * @param string[] $wanted_values
+   * @param string[] $sensor_values
+   */
+  private function hasAnySensorValue(array $sensor_values, array $wanted_values): bool
+  {
+    foreach ($sensor_values as $sensor_value) {
+      if (in_array($sensor_value, $wanted_values, true)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * @param array<string, int> $counts
+   * @param string[]           $type_names
+   */
+  private function hasAnyTypeCount(array $counts, array $type_names): bool
+  {
+    foreach ($type_names as $type_name) {
+      if (($counts[$type_name] ?? 0) > 0) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * @param array<string, int> $counts
+   */
+  private function hasDuplicateCount(array $counts): bool
+  {
+    foreach ($counts as $count) {
+      if ($count > 1) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Rubric levels are additive: basic contributes 1 point, developing 2 points,
+   * and proficiency 3 points, for a maximum of 6 per category.
+   */
+  private function sumRubricLevels(bool $basic, bool $developing, bool $proficiency): int
+  {
+    return ($basic ? 1 : 0)
+      + ($developing ? 2 : 0)
+      + ($proficiency ? 3 : 0);
+  }
+
+  private function normalizeText(string $value): string
+  {
+    return trim($value);
   }
 }

--- a/src/Project/CodeStatistics/CodeStatisticsService.php
+++ b/src/Project/CodeStatistics/CodeStatisticsService.php
@@ -30,12 +30,21 @@ class CodeStatisticsService
    */
   public function getStatistics(Program $project): ?ProjectCodeStatistics
   {
-    $latest = $project->getLatestCodeStatistics();
-    if (null !== $latest) {
+    // Query the latest row directly so lazy collections do not hand us an older
+    // in-memory snapshot after additional statistics rows have been persisted.
+    /** @var ?ProjectCodeStatistics $latest */
+    $latest = $this->entity_manager->getRepository(ProjectCodeStatistics::class)->findOneBy(
+      ['program' => $project],
+      ['created_at' => 'DESC'],
+    );
+
+    if (null !== $latest && CodeStatisticsParser::CURRENT_SCORING_VERSION === $latest->getScoringVersion()) {
       return $latest;
     }
 
-    return $this->parseAndPersist($project);
+    $refreshed = $this->parseAndPersist($project);
+
+    return $refreshed ?? $latest;
   }
 
   /**

--- a/src/System/Testing/Behat/Context/DataFixturesContext.php
+++ b/src/System/Testing/Behat/Context/DataFixturesContext.php
@@ -39,6 +39,7 @@ use App\DB\Entity\User\User;
 use App\DB\Enum\AppealState;
 use App\DB\Enum\ReportState;
 use App\DB\Generator\MyUuidGenerator;
+use App\Project\CodeStatistics\CodeStatisticsParser;
 use App\System\Commands\DBUpdater\UpdateAchievementsCommand;
 use App\System\Commands\Helpers\CommandHelper;
 use App\System\Testing\Behat\ContextTrait;
@@ -412,9 +413,18 @@ class DataFixturesContext implements Context
   public function thereAreProjectCodeStatistics(TableNode $table): void
   {
     $em = $this->getManager();
+    $cleared_project_ids = [];
     foreach ($table->getHash() as $config) {
       $project = $em->getRepository(Program::class)->find($config['project_id']);
       Assert::assertNotNull($project, sprintf('Project "%s" not found for code statistics fixture', $config['project_id']));
+
+      if (!in_array($config['project_id'], $cleared_project_ids, true)) {
+        foreach ($em->getRepository(ProjectCodeStatistics::class)->findBy(['program' => $project]) as $existing_stats) {
+          $em->remove($existing_stats);
+        }
+
+        $cleared_project_ids[] = $config['project_id'];
+      }
 
       $stats = new ProjectCodeStatistics();
       $stats->setProgram($project);
@@ -433,6 +443,8 @@ class DataFixturesContext implements Context
       $stats->setScoreFlowControl((int) ($config['score_flow_control'] ?? 0));
       $stats->setScoreUserInteractivity((int) ($config['score_user_interactivity'] ?? 0));
       $stats->setScoreDataRepresentation((int) ($config['score_data_representation'] ?? 0));
+      $stats->setScoreBonus((int) ($config['score_bonus'] ?? 0));
+      $stats->setScoringVersion((string) ($config['scoring_version'] ?? CodeStatisticsParser::CURRENT_SCORING_VERSION));
 
       $em->persist($stats);
     }

--- a/templates/Project/CodeStatisticsInline.html.twig
+++ b/templates/Project/CodeStatisticsInline.html.twig
@@ -2,7 +2,7 @@
      class="code-stats-inline d-none"
      data-stats-url="{{ path('open_api_server_projects_projectidcodestatisticsget', {id: project.id}) }}"
      data-trans-your-score="{{ 'codeStatistics.yourScore'|trans({}, 'catroweb') }}"
-     data-trans-points="{{ 'codeStatistics.points'|trans({}, 'catroweb') }}"
+     data-trans-level="{{ 'codeStatistics.level'|trans({}, 'catroweb') }}"
      data-trans-abstraction="{{ 'codeStatistics.abstraction'|trans({}, 'catroweb') }}"
      data-trans-parallelism="{{ 'codeStatistics.parallelism'|trans({}, 'catroweb') }}"
      data-trans-logical-thinking="{{ 'codeStatistics.logicalThinking'|trans({}, 'catroweb') }}"
@@ -10,9 +10,9 @@
      data-trans-flow-control="{{ 'codeStatistics.flowControl'|trans({}, 'catroweb') }}"
      data-trans-user-interactivity="{{ 'codeStatistics.userInteractivity'|trans({}, 'catroweb') }}"
      data-trans-data-representation="{{ 'codeStatistics.dataRepresentation'|trans({}, 'catroweb') }}"
+     data-trans-bonus="{{ 'codeStatistics.bonus'|trans({}, 'catroweb') }}"
      data-trans-loading="{{ 'codeStatistics.loading'|trans({}, 'catroweb') }}"
      data-trans-error="{{ 'codeStatistics.error'|trans({}, 'catroweb') }}"
-     data-trans-bonus="{{ 'codeStatistics.bonus'|trans({}, 'catroweb') }}"
 >
   <button id="code-stats-toggle" type="button" aria-expanded="false" aria-controls="code-stats-panel">
     <i class="material-icons">show_chart</i>

--- a/tests/BehatFeatures/api/projects/GET_project_id_code_statistics/code_statistics.feature
+++ b/tests/BehatFeatures/api/projects/GET_project_id_code_statistics/code_statistics.feature
@@ -12,8 +12,8 @@ Feature: Get project code statistics via API
 
   Scenario: Get code statistics for a project with persisted stats
     Given there are project code statistics:
-      | project_id | scenes | scripts | bricks | objects | looks | sounds | score_abstraction | score_parallelism | score_logical_thinking | score_synchronization | score_flow_control | score_user_interactivity | score_data_representation |
-      | 1          | 1      | 3       | 10     | 2       | 1     | 0      | 2                 | 3                 | 1                      | 0                     | 2                  | 0                        | 2                         |
+      | project_id | scenes | scripts | bricks | objects | looks | sounds | score_abstraction | score_parallelism | score_logical_thinking | score_synchronization | score_flow_control | score_user_interactivity | score_data_representation | score_bonus | scoring_version |
+      | 1          | 1      | 3       | 10     | 2       | 1     | 0      | 2                 | 3                 | 1                      | 0                     | 2                  | 0                        | 2                         | 2           | rubric_2021_v2  |
     And I have a request header "HTTP_ACCEPT" with value "application/json"
     And I request "GET" "/api/project/1/code-statistics"
     Then the response status code should be "200"
@@ -24,16 +24,23 @@ Feature: Get project code statistics via API
     And the client response should contain "score_flow_control"
     And the client response should contain "score_user_interactivity"
     And the client response should contain "score_data_representation"
+    And the client response should contain "score_bonus"
+    And the client response should contain "score_total"
+    And the client response should contain "scoring_version"
+    And the client response should contain "12"
+    And the client response should contain "rubric_2021_v2"
 
   Scenario: Code statistics returns correct score values
     Given there are project code statistics:
-      | project_id | scenes | scripts | bricks | objects | looks | sounds | score_abstraction | score_parallelism | score_logical_thinking | score_synchronization | score_flow_control | score_user_interactivity | score_data_representation |
-      | 1          | 1      | 5       | 20     | 3       | 2     | 1      | 3                 | 2                 | 1                      | 0                     | 2                  | 1                        | 3                         |
+      | project_id | scenes | scripts | bricks | objects | looks | sounds | score_abstraction | score_parallelism | score_logical_thinking | score_synchronization | score_flow_control | score_user_interactivity | score_data_representation | score_bonus |
+      | 1          | 1      | 5       | 20     | 3       | 2     | 1      | 3                 | 2                 | 1                      | 0                     | 2                  | 1                        | 3                         | 1           |
     And I have a request header "HTTP_ACCEPT" with value "application/json"
     And I request "GET" "/api/project/1/code-statistics"
     Then the response status code should be "200"
     And the client response should contain "score_abstraction"
     And the client response should contain "score_data_representation"
+    And the client response should contain "score_total"
+    And the client response should contain "13"
 
   Scenario: Code statistics for nonexistent project returns 404
     And I have a request header "HTTP_ACCEPT" with value "application/json"
@@ -45,21 +52,24 @@ Feature: Get project code statistics via API
     And I request "GET" "/api/project/2/code-statistics"
     Then the response status code should be "404"
 
-  Scenario: Code statistics is accessible without authentication
+  Scenario: Legacy code statistics are refreshed to the current rubric when project files are available
     Given there are project code statistics:
-      | project_id | scenes | scripts | bricks | objects | looks | sounds | score_abstraction | score_parallelism | score_logical_thinking |
-      | 1          | 1      | 1       | 5      | 1       | 0     | 0      | 0                 | 0                 | 0                      |
+      | project_id | scenes | scripts | bricks | objects | looks | sounds | score_abstraction | score_parallelism | score_logical_thinking | scoring_version |
+      | 1          | 1      | 1       | 5      | 1       | 0     | 0      | 0                 | 0                 | 0                      | legacy_keyword_counts_v1 |
     And I have a request header "HTTP_ACCEPT" with value "application/json"
     And I request "GET" "/api/project/1/code-statistics"
     Then the response status code should be "200"
     And the client response should contain "score_abstraction"
+    And the client response should contain "score_total"
+    And the client response should contain "rubric_2021_v2"
 
   Scenario: Code statistics with all zero scores returns zeros
     Given there are project code statistics:
-      | project_id | scenes | scripts | bricks | objects | looks | sounds | score_abstraction | score_parallelism | score_logical_thinking | score_synchronization | score_flow_control | score_user_interactivity | score_data_representation |
-      | 1          | 1      | 1       | 5      | 1       | 0     | 0      | 0                 | 0                 | 0                      | 0                     | 0                  | 0                        | 0                         |
+      | project_id | scenes | scripts | bricks | objects | looks | sounds | score_abstraction | score_parallelism | score_logical_thinking | score_synchronization | score_flow_control | score_user_interactivity | score_data_representation | score_bonus |
+      | 1          | 1      | 1       | 5      | 1       | 0     | 0      | 0                 | 0                 | 0                      | 0                     | 0                  | 0                        | 0                         | 0           |
     And I have a request header "HTTP_ACCEPT" with value "application/json"
     And I request "GET" "/api/project/1/code-statistics"
     Then the response status code should be "200"
     And the client response should contain "score_abstraction"
     And the client response should contain "score_flow_control"
+    And the client response should contain "score_total"

--- a/tests/BehatFeatures/web/code-statistics/project_code_statistics.feature
+++ b/tests/BehatFeatures/web/code-statistics/project_code_statistics.feature
@@ -28,8 +28,8 @@ Feature: As a visitor I want to see inline code statistics on the project page
       | id | name    | owned by |
       | 1  | Project | Catrobat |
     And there are project code statistics:
-      | project_id | scenes | scripts | bricks | objects | looks | sounds | score_abstraction | score_parallelism | score_logical_thinking | score_synchronization | score_flow_control | score_user_interactivity | score_data_representation |
-      | 1          | 1      | 3       | 10     | 2       | 1     | 0      | 2                 | 3                 | 1                      | 0                     | 2                  | 0                        | 2                         |
+      | project_id | scenes | scripts | bricks | objects | looks | sounds | score_abstraction | score_parallelism | score_logical_thinking | score_synchronization | score_flow_control | score_user_interactivity | score_data_representation | score_bonus |
+      | 1          | 1      | 3       | 10     | 2       | 1     | 0      | 2                 | 3                 | 1                      | 0                     | 2                  | 0                        | 2                         | 2           |
     And I am on "/app/project/1"
     And I wait for the page to be loaded
     When I click "#code-stats-toggle"
@@ -38,19 +38,20 @@ Feature: As a visitor I want to see inline code statistics on the project page
     Then the element "#code-stats-panel" should be visible
     And the element "#code-stats-animation" should exist
 
-  Scenario: Inline code statistics show correct base score total
+  Scenario: Inline code statistics show the real score total
     Given there are projects:
       | id | name    | owned by |
       | 1  | Project | Catrobat |
     And there are project code statistics:
-      | project_id | scenes | scripts | bricks | objects | looks | sounds | score_abstraction | score_parallelism | score_logical_thinking | score_synchronization | score_flow_control | score_user_interactivity | score_data_representation |
-      | 1          | 1      | 3       | 10     | 2       | 1     | 0      | 2                 | 3                 | 1                      | 0                     | 2                  | 0                        | 2                         |
+      | project_id | scenes | scripts | bricks | objects | looks | sounds | score_abstraction | score_parallelism | score_logical_thinking | score_synchronization | score_flow_control | score_user_interactivity | score_data_representation | score_bonus |
+      | 1          | 1      | 3       | 10     | 2       | 1     | 0      | 2                 | 3                 | 1                      | 0                     | 2                  | 0                        | 2                         | 2           |
     And I am on "/app/project/1"
     And I wait for the page to be loaded
     When I click "#code-stats-toggle"
     And I wait for AJAX to finish
     And I wait 3000 milliseconds
-    Then I wait for the element "#code-stats-total-number" to contain "15"
+    Then I wait for the element "#code-stats-total-number" to contain "12"
+    And the element ".code-stats-row--bonus" should exist
 
   Scenario: Inline code statistics show zero score when no pre-persisted stats exist
     Given there are projects:
@@ -62,7 +63,7 @@ Feature: As a visitor I want to see inline code statistics on the project page
     And I wait for AJAX to finish
     And I wait 3000 milliseconds
     Then the element "#code-stats-panel" should be visible
-    And I wait for the element "#code-stats-total-number" to contain "5"
+    And I wait for the element "#code-stats-total-number" to contain "0"
 
   Scenario: Clicking toggle again hides the code statistics panel
     Given there are projects:
@@ -80,16 +81,16 @@ Feature: As a visitor I want to see inline code statistics on the project page
     When I click "#code-stats-toggle"
     Then the element "#code-stats-panel" should not be visible
 
-  Scenario: Inline code statistics with all zero scores shows zero
+  Scenario: Inline code statistics with all zero scores stays at zero
     Given there are projects:
       | id | name    | owned by |
       | 1  | Project | Catrobat |
     And there are project code statistics:
-      | project_id | scenes | scripts | bricks | objects | looks | sounds | score_abstraction | score_parallelism | score_logical_thinking | score_synchronization | score_flow_control | score_user_interactivity | score_data_representation |
-      | 1          | 1      | 1       | 5      | 1       | 0     | 0      | 0                 | 0                 | 0                      | 0                     | 0                  | 0                        | 0                         |
+      | project_id | scenes | scripts | bricks | objects | looks | sounds | score_abstraction | score_parallelism | score_logical_thinking | score_synchronization | score_flow_control | score_user_interactivity | score_data_representation | score_bonus |
+      | 1          | 1      | 1       | 5      | 1       | 0     | 0      | 0                 | 0                 | 0                      | 0                     | 0                  | 0                        | 0                         | 0           |
     And I am on "/app/project/1"
     And I wait for the page to be loaded
     When I click "#code-stats-toggle"
     And I wait for AJAX to finish
     And I wait 3000 milliseconds
-    Then I wait for the element "#code-stats-total-number" to contain "5"
+    Then I wait for the element "#code-stats-total-number" to contain "0"

--- a/tests/PhpUnit/Project/CodeStatistics/CodeStatisticsParserTest.php
+++ b/tests/PhpUnit/Project/CodeStatistics/CodeStatisticsParserTest.php
@@ -84,26 +84,32 @@ class CodeStatisticsParserTest extends TestCase
   {
     $stats = $this->parser->parse($this->fixtures_path.'sample_code.xml');
 
-    // Abstraction: UserDefinedScript(1) + UserDefinedBrick(1) + CloneBrick(1) + DeleteThisCloneBrick(1) + WhenClonedScript(1) = 5
-    self::assertSame(5, $stats->getScoreAbstraction());
+    self::assertSame(CodeStatisticsParser::CURRENT_SCORING_VERSION, $stats->getScoringVersion());
 
-    // Parallelism: BroadcastScript(1) + WhenClonedScript(1) = 2 (only script types in PARALLELISM_SCRIPTS)
-    self::assertSame(2, $stats->getScoreParallelism());
+    // Abstraction: multiple scripts + abstraction bricks/scripts + clone handling
+    self::assertSame(6, $stats->getScoreAbstraction());
 
-    // Synchronization: BroadcastBrick(1) + WaitBrick(1) = 2
-    self::assertSame(2, $stats->getScoreSynchronization());
+    // Parallelism: multiple start scripts + multiple tap entry points on the same object
+    self::assertSame(3, $stats->getScoreParallelism());
 
-    // Logical thinking: IfLogicBeginBrick(1) + IfLogicElseBrick(1) = 2
-    self::assertSame(2, $stats->getScoreLogicalThinking());
+    // Synchronization: Wait + Broadcast
+    self::assertSame(3, $stats->getScoreSynchronization());
 
-    // Flow control: ForeverBrick(1) + RepeatBrick(1) = 2
-    self::assertSame(2, $stats->getScoreFlowControl());
+    // Logical thinking: If + Else, no formula-level logical operator
+    self::assertSame(3, $stats->getScoreLogicalThinking());
 
-    // User interactivity: WhenScript(1) + WhenTouchDownScript(1) + AskBrick(1) = 3
+    // User interactivity: start script + tap-oriented entries on the same object
     self::assertSame(3, $stats->getScoreUserInteractivity());
 
-    // Data representation: SetVariableBrick(1) + ChangeVariableBrick(1) + AddItemToUserListBrick(1) = 3
-    self::assertSame(3, $stats->getScoreDataRepresentation());
+    // Flow control: script with bricks + forever/repeat
+    self::assertSame(3, $stats->getScoreFlowControl());
+
+    // Data representation: looks/motion + variables + user list
+    self::assertSame(6, $stats->getScoreDataRepresentation());
+
+    // Breadth bonus: all 7 categories >= 1
+    self::assertSame(1, $stats->getScoreBonus());
+    self::assertSame(28, $stats->getScoreTotal());
   }
 
   public function testParseEmptyProject(): void
@@ -122,6 +128,8 @@ class CodeStatisticsParserTest extends TestCase
     self::assertSame([], $stats->getBrickCounts());
     self::assertSame(0, $stats->getScoreAbstraction());
     self::assertSame(0, $stats->getScoreFlowControl());
+    self::assertSame(0, $stats->getScoreBonus());
+    self::assertSame(0, $stats->getScoreTotal());
   }
 
   public function testParseSceneProject(): void
@@ -149,14 +157,27 @@ class CodeStatisticsParserTest extends TestCase
     // 1 global variable
     self::assertSame(1, $stats->getGlobalVariables());
 
-    // Flow control score: RepeatUntilBrick(1) = 1
-    self::assertSame(1, $stats->getScoreFlowControl());
+    // Abstraction: only the "more than one script" basic criterion is met
+    self::assertSame(1, $stats->getScoreAbstraction());
 
-    // Synchronization score: BroadcastWaitBrick(1) = 1
-    self::assertSame(1, $stats->getScoreSynchronization());
+    self::assertSame(0, $stats->getScoreParallelism());
+    self::assertSame(0, $stats->getScoreLogicalThinking());
 
-    // Data representation: SetVariableBrick(1) = 1
-    self::assertSame(1, $stats->getScoreDataRepresentation());
+    // Synchronization: BroadcastWait qualifies for proficiency directly
+    self::assertSame(3, $stats->getScoreSynchronization());
+
+    // Flow control: script body + RepeatUntil
+    self::assertSame(4, $stats->getScoreFlowControl());
+
+    // User interactivity: start script is enough for the basic level
+    self::assertSame(1, $stats->getScoreUserInteractivity());
+
+    // Data representation: sprite state brick + variable brick
+    self::assertSame(3, $stats->getScoreDataRepresentation());
+
+    // Breadth bonus: 5 of 7 categories >= 1
+    self::assertSame(1, $stats->getScoreBonus());
+    self::assertSame(13, $stats->getScoreTotal());
   }
 
   public function testParseNonexistentFile(): void
@@ -188,5 +209,14 @@ class CodeStatisticsParserTest extends TestCase
     $script_counts = $stats->getScriptCounts();
     $sum = array_sum($script_counts);
     self::assertSame($stats->getScripts(), $sum);
+  }
+
+  public function testPhysicsAndExtensionsAwardBonusPoints(): void
+  {
+    $stats = $this->parser->parse($this->fixtures_path.'bonus_code.xml');
+
+    self::assertSame(2, $stats->getScoreBonus());
+    self::assertSame(CodeStatisticsParser::CURRENT_SCORING_VERSION, $stats->getScoringVersion());
+    self::assertSame(4, $stats->getScoreTotal());
   }
 }

--- a/tests/PhpUnit/Project/CodeStatistics/CodeStatisticsServiceTest.php
+++ b/tests/PhpUnit/Project/CodeStatistics/CodeStatisticsServiceTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Project\CodeStatistics;
+
+use App\DB\Entity\Project\Program;
+use App\DB\Entity\Project\ProjectCodeStatistics;
+use App\Project\CatrobatFile\ExtractedCatrobatFile;
+use App\Project\CatrobatFile\ExtractedFileRepository;
+use App\Project\CodeStatistics\CodeStatisticsParser;
+use App\Project\CodeStatistics\CodeStatisticsService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(CodeStatisticsService::class)]
+class CodeStatisticsServiceTest extends TestCase
+{
+  private string $temp_dir;
+
+  #[\Override]
+  protected function setUp(): void
+  {
+    $this->temp_dir = sys_get_temp_dir().'/code-statistics-service-'.uniqid('', true).'/';
+    mkdir($this->temp_dir, 0777, true);
+  }
+
+  #[\Override]
+  protected function tearDown(): void
+  {
+    if (is_file($this->temp_dir.'code.xml')) {
+      unlink($this->temp_dir.'code.xml');
+    }
+
+    if (is_dir($this->temp_dir)) {
+      rmdir($this->temp_dir);
+    }
+  }
+
+  public function testGetStatisticsRebuildsLegacyScores(): void
+  {
+    $legacy_stats = (new ProjectCodeStatistics())
+      ->setScoreAbstraction(5)
+      ->setScoringVersion(CodeStatisticsParser::LEGACY_SCORING_VERSION)
+    ;
+
+    $fresh_stats = (new ProjectCodeStatistics())
+      ->setScoreAbstraction(6)
+      ->setScoreBonus(2)
+      ->setScoringVersion(CodeStatisticsParser::CURRENT_SCORING_VERSION)
+    ;
+
+    $project = $this->createStub(Program::class);
+    $project->method('getLatestCodeStatistics')->willReturn($legacy_stats);
+
+    $parser = $this->createMock(CodeStatisticsParser::class);
+    $parser->expects(self::once())
+      ->method('parse')
+      ->with($this->temp_dir.'code.xml')
+      ->willReturn($fresh_stats)
+    ;
+
+    $repository = $this->createMock(ExtractedFileRepository::class);
+    $repository->expects(self::once())
+      ->method('loadProjectExtractedFile')
+      ->with($project)
+      ->willReturn($this->createExtractedFile())
+    ;
+
+    $statistics_repository = $this->createMock(EntityRepository::class);
+    $statistics_repository->expects(self::once())
+      ->method('findOneBy')
+      ->with(['program' => $project], ['created_at' => 'DESC'])
+      ->willReturn($legacy_stats)
+    ;
+
+    $entity_manager = $this->createMock(EntityManagerInterface::class);
+    $entity_manager->expects(self::once())
+      ->method('getRepository')
+      ->with(ProjectCodeStatistics::class)
+      ->willReturn($statistics_repository)
+    ;
+    $entity_manager->expects(self::once())
+      ->method('persist')
+      ->with($fresh_stats)
+    ;
+    $entity_manager->expects(self::once())
+      ->method('flush')
+    ;
+
+    $service = new CodeStatisticsService(
+      $parser,
+      $repository,
+      $entity_manager,
+      $this->createStub(LoggerInterface::class),
+    );
+
+    $actual = $service->getStatistics($project);
+
+    self::assertSame($fresh_stats, $actual);
+  }
+
+  public function testGetStatisticsFallsBackToLegacyScoresWhenRefreshFails(): void
+  {
+    $legacy_stats = (new ProjectCodeStatistics())
+      ->setScoreAbstraction(5)
+      ->setScoringVersion(CodeStatisticsParser::LEGACY_SCORING_VERSION)
+    ;
+
+    $project = $this->createStub(Program::class);
+    $project->method('getLatestCodeStatistics')->willReturn($legacy_stats);
+
+    $repository = $this->createMock(ExtractedFileRepository::class);
+    $repository->expects(self::once())
+      ->method('loadProjectExtractedFile')
+      ->with($project)
+      ->willReturn(null)
+    ;
+
+    $statistics_repository = $this->createMock(EntityRepository::class);
+    $statistics_repository->expects(self::once())
+      ->method('findOneBy')
+      ->with(['program' => $project], ['created_at' => 'DESC'])
+      ->willReturn($legacy_stats)
+    ;
+
+    $entity_manager = $this->createMock(EntityManagerInterface::class);
+    $entity_manager->expects(self::once())
+      ->method('getRepository')
+      ->with(ProjectCodeStatistics::class)
+      ->willReturn($statistics_repository)
+    ;
+    $entity_manager->expects(self::never())->method('persist');
+    $entity_manager->expects(self::never())->method('flush');
+
+    $service = new CodeStatisticsService(
+      $this->createStub(CodeStatisticsParser::class),
+      $repository,
+      $entity_manager,
+      $this->createStub(LoggerInterface::class),
+    );
+
+    $actual = $service->getStatistics($project);
+
+    self::assertSame($legacy_stats, $actual);
+  }
+
+  private function createExtractedFile(): ExtractedCatrobatFile
+  {
+    file_put_contents($this->temp_dir.'code.xml', <<<'XML'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<program>
+  <header>
+    <programName>Service Test</programName>
+    <catrobatLanguageVersion>0.998</catrobatLanguageVersion>
+  </header>
+</program>
+XML);
+
+    return new ExtractedCatrobatFile($this->temp_dir, '/tmp/', 'service-test');
+  }
+}

--- a/tests/PhpUnit/Project/CodeStatistics/Fixtures/bonus_code.xml
+++ b/tests/PhpUnit/Project/CodeStatistics/Fixtures/bonus_code.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<program>
+  <header>
+    <programName>Bonus Project</programName>
+    <catrobatLanguageVersion>0.998</catrobatLanguageVersion>
+  </header>
+  <objectList>
+    <object type="SingleSprite" name="Drone Sprite">
+      <lookList/>
+      <soundList/>
+      <scriptList>
+        <script type="StartScript">
+          <brickList>
+            <brick type="SetPhysicsObjectTypeBrick"/>
+            <brick type="DroneTakeOffLandBrick"/>
+          </brickList>
+        </script>
+      </scriptList>
+    </object>
+  </objectList>
+</program>

--- a/translations/catroweb.en.yaml
+++ b/translations/catroweb.en.yaml
@@ -806,6 +806,7 @@ codeStatistics:
   flowControl: 'Flow control'
   userInteractivity: 'User interactivity'
   dataRepresentation: 'Data representation'
+  level: 'Level'
   loading: 'Loading...'
   bonus: 'Bonus'
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -157,7 +157,7 @@ Encore
       ]),
       content: ['**/*.twig', '**/*.js'],
       safelist: {
-        standard: [/^swal2/, /^modal/, /^mdc/, /^data-bs-theme/, /^cookie-consent/],
+        standard: [/^swal2/, /^modal/, /^mdc/, /^data-bs-theme/, /^cookie-consent/, /^code-stats-row--level-/],
       },
       defaultExtractor: (content) => {
         return content.match(/[\w-/:]+(?<!:)/g) || []


### PR DESCRIPTION
## Summary
- replace the legacy keyword-count CT scoring with a rubric-style evaluator that maps the 2021 stakeholder spreadsheet into basic/developing/proficiency checks
- persist `score_bonus`, `score_total`, and `scoring_version`, plus add a migration that marks existing rows as `legacy_keyword_counts_v1`
- refresh outdated persisted rows on read by reparsing current `code.xml` and exposing the upgraded scores through the API and inline project-page widget
- show backend-computed totals in the inline UI and render a real bonus row only when bonus points are actually earned
- expand parser/service coverage and tighten the code-statistics Behat fixtures around exact response values

## Why
Issue #6463 called out that the current implementation solved caching/storage, but not score quality or explainability. The old parser path was effectively raw keyword accumulation, the frontend invented `+5` bonus points on its own, and there was no way to distinguish legacy persisted rows from rubric-backed ones.

This PR turns the draft into a real follow-up slice: persisted statistics can now tell you which scoring model produced them, legacy rows can be upgraded lazily, and the UI/API are driven by stored backend totals instead of frontend guesses.

## Impact
- CT category scores now follow a versioned rubric model with `0-6` ranges per category
- projects can earn explicit bonus points for physics and extension usage
- API consumers get `score_bonus`, `score_total`, and `scoring_version`
- older persisted rows are transparently refreshed to the new rubric when current project files are available
- Behat fixture setup now clears previous code-stat rows for the same project, which makes exact-value assertions deterministic across reruns

## Validation
- `php -l src/Project/CodeStatistics/CodeStatisticsParser.php`
- `php -l src/Project/CodeStatistics/CodeStatisticsService.php`
- `php -l src/DB/Entity/Project/ProjectCodeStatistics.php`
- `php -l src/Api/Services/Projects/ProjectsResponseManager.php`
- `php -l src/Api/OpenAPI/Server/Model/CodeStatisticsResponse.php`
- `php -l src/System/Testing/Behat/Context/DataFixturesContext.php`
- `php -l tests/PhpUnit/Project/CodeStatistics/CodeStatisticsParserTest.php`
- `php -l tests/PhpUnit/Project/CodeStatistics/CodeStatisticsServiceTest.php`
- `php -l migrations/2026/Version20260329220000.php`
- `yarn eslint assets/Project/CodeStatisticsInline.js --no-warn-ignored`
- `yarn stylelint assets/Project/CodeStatisticsInline.scss`
- `yarn prettier assets/Project/CodeStatisticsInline.js assets/Project/CodeStatisticsInline.scss --check`
- `php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml.dist tests/PhpUnit/Project/CodeStatistics/`
- `php vendor/behat/behat/bin/behat tests/BehatFeatures/api/projects/GET_project_id_code_statistics/code_statistics.feature --format progress --no-interaction`
- `git diff --check`

## Notes
- The targeted API Behat feature exercised cleanly with all scenarios progressing green, but the local Behat process did not return promptly after finishing in this environment, so I stopped there instead of waiting on teardown indefinitely.
- The browser-side Behat feature was not reliable enough to use as a gate from this isolated worktree; the parser/service PHPUnit slice and API Behat run provided the main verification signal here.
