### PR TITLE
ci: support fork PRs in dynamic analysis workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,11 @@
 # are mainly UI-tests and a few unit tests. Hence, the tests take multiple hours. To reduce the run time, the tests
 # are executed in multiple independent jobs. However, all jobs use the same Catroweb Docker image to reduce build time.
 #
+# Fork PR support:
+#   PRs from forks cannot push to GHCR (the GITHUB_TOKEN is read-only for the upstream org's packages).
+#   For fork PRs the build job exports the image as a tarball artifact instead. Downstream jobs detect which
+#   delivery method was used and pull/load accordingly. Internal PRs continue to use the fast GHCR path.
+#
 name: 'Dynamic analysis'
 
 permissions:
@@ -39,23 +44,36 @@ jobs:
   #     computation time for this workflow can be highly reduced. This is important since we do not have unlimited
   #     resources/machines to run the jobs.
   #
-  #   - The image is pushed to GHCR instead of using artifact upload/download. This avoids the slow
-  #     docker save/gzip/upload + download/gunzip/docker load cycle (~2-3 min per job).
-  #     GHCR pulls are fast since GitHub runners have direct access to the registry.
+  #   - For internal PRs the image is pushed to GHCR. GHCR pulls are fast since GitHub runners have direct
+  #     access to the registry.
+  #
+  #   - For fork PRs the image is exported as a tarball and uploaded as a GitHub Actions artifact, because
+  #     fork PR tokens lack write access to the upstream org's package registry.
   #
   build:
     name: Build Catroweb Image
     runs-on: ubuntu-latest
     outputs:
       image-tag: ${{ steps.meta.outputs.tags }}
+      is-fork: ${{ steps.fork-check.outputs.is_fork }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Check if fork PR
+        id: fork-check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
+        if: steps.fork-check.outputs.is_fork == 'false'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -68,7 +86,8 @@ jobs:
           TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.pull_request.head.sha || github.sha }}"
           echo "tags=${TAG}" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push Catroweb App Image
+      - name: Build and push Catroweb App Image (internal)
+        if: steps.fork-check.outputs.is_fork == 'false'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -78,6 +97,29 @@ jobs:
           build-args: APP_ENVIRONMENT=test
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Build Catroweb App Image (fork)
+        if: steps.fork-check.outputs.is_fork == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: APP_ENVIRONMENT=test
+          cache-from: type=gha
+
+      - name: Export image as tarball (fork)
+        if: steps.fork-check.outputs.is_fork == 'true'
+        run: docker save ${{ steps.meta.outputs.tags }} | gzip > /tmp/catroweb-image.tar.gz
+
+      - name: Upload image artifact (fork)
+        if: steps.fork-check.outputs.is_fork == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: catroweb-image
+          path: /tmp/catroweb-image.tar.gz
+          retention-days: 1
 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # PhpUnit:
@@ -98,14 +140,27 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
+        if: needs.build.outputs.is-fork == 'false'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull Docker Image
+      - name: Pull Docker Image (internal)
+        if: needs.build.outputs.is-fork == 'false'
         run: docker pull ${{ needs.build.outputs.image-tag }}
+
+      - name: Download image artifact (fork)
+        if: needs.build.outputs.is-fork == 'true'
+        uses: actions/download-artifact@v7
+        with:
+          name: catroweb-image
+          path: /tmp
+
+      - name: Load Docker Image (fork)
+        if: needs.build.outputs.is-fork == 'true'
+        run: gunzip -c /tmp/catroweb-image.tar.gz | docker load
 
       - name: Tag image for docker-compose
         run: docker tag ${{ needs.build.outputs.image-tag }} app.catroweb
@@ -202,14 +257,27 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
+        if: needs.build.outputs.is-fork == 'false'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull Docker Image
+      - name: Pull Docker Image (internal)
+        if: needs.build.outputs.is-fork == 'false'
         run: docker pull ${{ needs.build.outputs.image-tag }}
+
+      - name: Download image artifact (fork)
+        if: needs.build.outputs.is-fork == 'true'
+        uses: actions/download-artifact@v7
+        with:
+          name: catroweb-image
+          path: /tmp
+
+      - name: Load Docker Image (fork)
+        if: needs.build.outputs.is-fork == 'true'
+        run: gunzip -c /tmp/catroweb-image.tar.gz | docker load
 
       - name: Tag image for docker-compose
         run: docker tag ${{ needs.build.outputs.image-tag }} app.catroweb


### PR DESCRIPTION
## Summary
- Fork PRs cannot push Docker images to GHCR because the `GITHUB_TOKEN` is read-only for the upstream org's package registry. This caused the **Build Catroweb Image** job to fail and all downstream tests (PHPUnit, Behat) to be skipped for external contributors (e.g. #6454).
- For fork PRs, the build job now exports the image as a tarball and uploads it as a GitHub Actions artifact. Downstream jobs detect the fork flag and download+load the artifact instead of pulling from GHCR.
- Internal PRs continue using the fast GHCR push/pull path — no change in behavior or performance.

## How it works
1. Build job detects fork PRs via `github.event.pull_request.head.repo.full_name != github.repository`
2. **Internal PRs**: push to GHCR as before
3. **Fork PRs**: `docker save | gzip` → `upload-artifact` → each downstream job does `download-artifact` → `docker load`
4. The `is-fork` output propagates to PHPUnit and Behat jobs via `needs.build.outputs.is-fork`

## Test plan
- [ ] Verify internal PRs still use GHCR path (check build logs for "Build and push" step running)
- [ ] Ask an external contributor to rebase/re-push their fork PR to verify the artifact path works
- [ ] Verify scheduled runs and manual triggers work (they set `is_fork=false` since `event_name != pull_request`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)