### PR TITLE
Optimize Behat CI pipeline: split bottlenecks, combine fast jobs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -388,23 +388,36 @@ docker exec app.catroweb bin/behat -f pretty -s web-admin "tests/BehatFeatures/w
 
 ### Common Suites
 
-| Suite               | Path                                    |
-| ------------------- | --------------------------------------- |
-| web-admin           | tests/BehatFeatures/web/admin           |
-| web-profile         | tests/BehatFeatures/web/profile         |
-| web-general         | tests/BehatFeatures/web/general         |
-| web-translation     | tests/BehatFeatures/web/translation     |
-| web-project-details | tests/BehatFeatures/web/project-details |
-| web-reactions       | tests/BehatFeatures/web/reactions       |
-| api-projects        | tests/BehatFeatures/api/projects        |
-| api-authentication  | tests/BehatFeatures/api/authentication  |
-| api-comments        | tests/BehatFeatures/api/comments        |
-| api-notifications   | tests/BehatFeatures/api/notifications   |
-| api-achievements    | tests/BehatFeatures/api/achievements    |
-| web-notifications   | tests/BehatFeatures/web/notifications   |
-| web-achievements    | tests/BehatFeatures/web/achievements    |
-| api-moderation      | tests/BehatFeatures/api/moderation      |
-| web-reports         | tests/BehatFeatures/web/reports         |
+| Suite               | Path                                                                               |
+| ------------------- | ---------------------------------------------------------------------------------- |
+| api-achievements    | tests/BehatFeatures/api/achievements                                               |
+| api-authentication  | tests/BehatFeatures/api/authentication                                             |
+| api-comments        | tests/BehatFeatures/api/comments                                                   |
+| api-followers       | tests/BehatFeatures/api/followers                                                  |
+| api-media-library   | tests/BehatFeatures/api/media-library                                              |
+| api-moderation      | tests/BehatFeatures/api/moderation                                                 |
+| api-notifications   | tests/BehatFeatures/api/notifications                                              |
+| api-projects        | tests/BehatFeatures/api/projects                                                   |
+| api-projects-get    | (split) api/projects/GET\_\* dirs                                                  |
+| api-projects-write  | (split) api/projects/POST,DELETE,PUT,reactions                                     |
+| api-search          | tests/BehatFeatures/api/search                                                     |
+| api-studio          | tests/BehatFeatures/api/studio                                                     |
+| api-translation     | tests/BehatFeatures/api/translation                                                |
+| api-user            | tests/BehatFeatures/api/user                                                       |
+| api-utility         | tests/BehatFeatures/api/utility                                                    |
+| web-achievements    | tests/BehatFeatures/web/achievements                                               |
+| web-admin           | tests/BehatFeatures/web/admin                                                      |
+| web-admin-1         | (split) admin: projects, featured, approve, login, moderation, maintenance         |
+| web-admin-2         | (split) admin: apk, db_updater, example, flags, mail, media, survey, upload, users |
+| web-general         | tests/BehatFeatures/web/general                                                    |
+| web-notifications   | tests/BehatFeatures/web/notifications                                              |
+| web-profile         | tests/BehatFeatures/web/profile                                                    |
+| web-profile-1       | (split) profile: edit, profile, image, data_export                                 |
+| web-profile-2       | (split) profile: follow, user_projects, verification, suspended, many_follower     |
+| web-project-details | tests/BehatFeatures/web/project-details                                            |
+| web-reactions       | tests/BehatFeatures/web/reactions                                                  |
+| web-reports         | tests/BehatFeatures/web/reports                                                    |
+| web-translation     | tests/BehatFeatures/web/translation                                                |
 
 Suite configuration is in `behat.yaml.dist`.
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -222,33 +222,27 @@ jobs:
       matrix:
         testSuite:
           # --- API suites ---
-          - api-authentication
-          - api-achievements api-notifications # 11 + 13 scenarios
-          - api-comments
-          - api-media-library
+          - api-achievements api-notifications api-media-library api-studio # ~10m combined
+          - api-authentication api-comments api-followers api-utility # ~8m combined
           - api-moderation
-          - api-projects
-          - api-search api-translation # 24 + 17 scenarios
-          - api-followers api-utility # 14 + 12 scenarios
-          - api-studio
+          - api-projects-get # split from api-projects (~10m)
+          - api-projects-write # split from api-projects (~10m)
+          - api-search api-translation
           - api-user
 
           # --- Web suites ---
           - web-achievements
-          - web-admin
-          - web-apk-generation web-media-library # 13 + 14 scenarios
-          - web-authentication
-          - web-code-statistics
-          - web-code-view web-scratch-integration web-system web-recommendations # 5 + 4 + 6 + 3 scenarios
-          - web-comments
-          - web-general
-          - web-notifications
-          - web-profile
-          - web-project
+          - web-admin-1 # split: projects_overview, featured_programs, approve_projects, login, moderation, maintenance (~7m)
+          - web-admin-2 # split: apk, db_updater, example, feature_flag, mail, media_library, survey, upload, users (~7m)
+          - web-authentication web-apk-generation web-media-library # ~8m combined
+          - web-code-statistics web-project web-code-view web-scratch-integration web-system web-recommendations # ~9m combined
+          - web-comments web-reports # ~9m combined
+          - web-general web-notifications # ~10m combined
+          - web-profile-1 # split: profile_edit, profile, profile_image, data_export (~9m)
+          - web-profile-2 # split: follow, user_projects, verification, suspended, many_follower (~9m)
           - web-project-details
-          - web-project-list web-remix-system web-reactions # 8 + 11 + 12 scenarios
-          - web-reports
-          - web-search web-top-bar # 17 + 18 scenarios
+          - web-project-list web-remix-system web-reactions
+          - web-search web-top-bar
           - web-studio
           - web-translation
 

--- a/behat.yaml.dist
+++ b/behat.yaml.dist
@@ -101,6 +101,39 @@ default:
                 - App\System\Testing\Behat\Context\ApiContext
                 - App\System\Testing\Behat\Context\CatrowebBrowserContext
 
+        api-projects-get:
+            paths:
+                - tests/BehatFeatures/api/projects/GET_project_id
+                - tests/BehatFeatures/api/projects/GET_project_id_catrobat
+                - tests/BehatFeatures/api/projects/GET_project_id_code_statistics
+                - tests/BehatFeatures/api/projects/GET_project_id_recommendations
+                - tests/BehatFeatures/api/projects/GET_projects
+                - tests/BehatFeatures/api/projects/GET_projects_categories
+                - tests/BehatFeatures/api/projects/GET_projects_extensions
+                - tests/BehatFeatures/api/projects/GET_projects_featured
+                - tests/BehatFeatures/api/projects/GET_projects_search
+                - tests/BehatFeatures/api/projects/GET_projects_tags
+                - tests/BehatFeatures/api/projects/GET_projects_user
+                - tests/BehatFeatures/api/projects/GET_projects_user_id
+            contexts:
+                - App\System\Testing\Behat\Context\RefreshEnvironmentContext
+                - App\System\Testing\Behat\Context\DataFixturesContext
+                - App\System\Testing\Behat\Context\ApiContext
+                - App\System\Testing\Behat\Context\CatrowebBrowserContext
+
+        api-projects-write:
+            paths:
+                - tests/BehatFeatures/api/projects/POST_projects
+                - tests/BehatFeatures/api/projects/DELETE_project_id
+                - tests/BehatFeatures/api/projects/PUT_project_id
+                - tests/BehatFeatures/api/projects/reactions
+                - tests/BehatFeatures/api/projects/flavor_use_extension.feature
+            contexts:
+                - App\System\Testing\Behat\Context\RefreshEnvironmentContext
+                - App\System\Testing\Behat\Context\DataFixturesContext
+                - App\System\Testing\Behat\Context\ApiContext
+                - App\System\Testing\Behat\Context\CatrowebBrowserContext
+
         api-user:
             paths:
                 - tests/BehatFeatures/api/user
@@ -135,14 +168,6 @@ default:
                 - App\System\Testing\Behat\Context\DataFixturesContext
                 - App\System\Testing\Behat\Context\ApiContext
                 - App\System\Testing\Behat\Context\CatrowebBrowserContext
-
-        api-tag:
-            paths:
-                - tests/BehatFeatures/api/tag
-            contexts:
-                - App\System\Testing\Behat\Context\RefreshEnvironmentContext
-                - App\System\Testing\Behat\Context\DataFixturesContext
-                - App\System\Testing\Behat\Context\ApiContext
 
         api-translation:
             paths:
@@ -189,6 +214,41 @@ default:
         web-admin:
             paths:
                 - tests/BehatFeatures/web/admin
+            contexts:
+                - App\System\Testing\Behat\Context\RefreshEnvironmentContext
+                - App\System\Testing\Behat\Context\DataFixturesContext
+                - App\System\Testing\Behat\Context\CatrowebBrowserContext
+                - App\System\Testing\Behat\Context\ApiContext
+
+        web-admin-1:
+            paths:
+                - tests/BehatFeatures/web/admin/projects_overview.feature
+                - tests/BehatFeatures/web/admin/featured_programs.feature
+                - tests/BehatFeatures/web/admin/approve_projects.feature
+                - tests/BehatFeatures/web/admin/login_basics.feature
+                - tests/BehatFeatures/web/admin/moderation_queue.feature
+                - tests/BehatFeatures/web/admin/server_maintenance.feature
+            contexts:
+                - App\System\Testing\Behat\Context\RefreshEnvironmentContext
+                - App\System\Testing\Behat\Context\DataFixturesContext
+                - App\System\Testing\Behat\Context\CatrowebBrowserContext
+                - App\System\Testing\Behat\Context\ApiContext
+
+        web-admin-2:
+            paths:
+                - tests/BehatFeatures/web/admin/apk_generation_pending.feature
+                - tests/BehatFeatures/web/admin/apk_generation_ready.feature
+                - tests/BehatFeatures/web/admin/broadcast_notification.feature
+                - tests/BehatFeatures/web/admin/db_updater
+                - tests/BehatFeatures/web/admin/example_programs.feature
+                - tests/BehatFeatures/web/admin/feature_flag.feature
+                - tests/BehatFeatures/web/admin/mail_preview.feature
+                - tests/BehatFeatures/web/admin/maintenance_information.feature
+                - tests/BehatFeatures/web/admin/media_library_assets.feature
+                - tests/BehatFeatures/web/admin/media_library_categories.feature
+                - tests/BehatFeatures/web/admin/survey.feature
+                - tests/BehatFeatures/web/admin/upload_project.feature
+                - tests/BehatFeatures/web/admin/users_users.feature
             contexts:
                 - App\System\Testing\Behat\Context\RefreshEnvironmentContext
                 - App\System\Testing\Behat\Context\DataFixturesContext
@@ -270,6 +330,31 @@ default:
         web-profile:
             paths:
                 - tests/BehatFeatures/web/profile
+            contexts:
+                - App\System\Testing\Behat\Context\RefreshEnvironmentContext
+                - App\System\Testing\Behat\Context\DataFixturesContext
+                - App\System\Testing\Behat\Context\CatrowebBrowserContext
+                - App\System\Testing\Behat\Context\ApiContext
+
+        web-profile-1:
+            paths:
+                - tests/BehatFeatures/web/profile/profile_edit.feature
+                - tests/BehatFeatures/web/profile/profile.feature
+                - tests/BehatFeatures/web/profile/profile_image.feature
+                - tests/BehatFeatures/web/profile/profile_data_export.feature
+            contexts:
+                - App\System\Testing\Behat\Context\RefreshEnvironmentContext
+                - App\System\Testing\Behat\Context\DataFixturesContext
+                - App\System\Testing\Behat\Context\CatrowebBrowserContext
+                - App\System\Testing\Behat\Context\ApiContext
+
+        web-profile-2:
+            paths:
+                - tests/BehatFeatures/web/profile/follow.feature
+                - tests/BehatFeatures/web/profile/profile_user_projects.feature
+                - tests/BehatFeatures/web/profile/profile_verification.feature
+                - tests/BehatFeatures/web/profile/profile_suspended.feature
+                - tests/BehatFeatures/web/profile/many_follower.feature
             contexts:
                 - App\System\Testing\Behat\Context\RefreshEnvironmentContext
                 - App\System\Testing\Behat\Context\DataFixturesContext


### PR DESCRIPTION
## Summary

- **Split 3 bottleneck suites** to halve the critical path from 21m → ~10.5m:
  - `api-projects` (21m, 237 scenarios) → `api-projects-get` + `api-projects-write`
  - `web-profile` (19m, 59 scenarios) → `web-profile-1` + `web-profile-2`
  - `web-admin` (15m, 103 scenarios) → `web-admin-1` + `web-admin-2`
- **Combine 17 fast jobs (<4m each) into 6**, saving ~18m of setup overhead across 6 fewer runner allocations
- **Remove dead `api-tag` suite** (test directory does not exist)
- **27 → 21 Behat jobs**, all targeting 7-10.5m runtime — much more balanced

Original suites preserved in `behat.yaml.dist` for local use (`bin/behat -s api-projects` still works).

### Before vs After

| Metric | Before | After |
|--------|--------|-------|
| Behat jobs | 27 | 21 |
| Critical path | 21.1m (api-projects) | ~10.5m |
| Fastest job | 2.5m (wasted setup) | ~7m |
| Runner slots saved | — | 6 |

## Test plan

- [ ] All 21 Behat matrix jobs pass in CI
- [ ] No suites missing (compare scenario counts before/after)
- [ ] Split suites cover all feature files (no orphaned tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)