### PR TITLE
Fix N+1 query patterns in repositories

### DIFF
--- a/src/DB/EntityRepository/Project/ProgramRepository.php
+++ b/src/DB/EntityRepository/Project/ProgramRepository.php
@@ -40,6 +40,8 @@ class ProgramRepository extends ServiceEntityRepository
   {
     $query_builder = $this->createQueryBuilder('e');
     $query_builder
+      ->addSelect('u')
+      ->leftJoin('e.user', 'u')
       ->where($query_builder->expr()->eq('e.user', $query_builder->expr()->literal($user_id)))
     ;
 
@@ -57,6 +59,8 @@ class ProgramRepository extends ServiceEntityRepository
   {
     $query_builder = $this->createQueryBuilder('e');
     $query_builder
+      ->addSelect('u')
+      ->leftJoin('e.user', 'u')
       ->where($query_builder->expr()->eq('e.id', $query_builder->expr()->literal($program_id)))
     ;
 
@@ -442,7 +446,11 @@ class ProgramRepository extends ServiceEntityRepository
   //
   private function createQueryAllBuilder(): QueryBuilder
   {
-    return $this->createQueryBuilder('e')->select('e');
+    return $this->createQueryBuilder('e')
+      ->select('e')
+      ->addSelect('u')
+      ->leftJoin('e.user', 'u')
+    ;
   }
 
   private function createQueryCountBuilder(): QueryBuilder

--- a/src/DB/EntityRepository/Project/Special/ExampleRepository.php
+++ b/src/DB/EntityRepository/Project/Special/ExampleRepository.php
@@ -32,6 +32,7 @@ class ExampleRepository extends ServiceEntityRepository
 
     $qb
       ->select('e')
+      ->addSelect('program')
       ->where('e.active = true')
       ->andWhere($qb->expr()->isNotNull('e.program'))
       ->setFirstResult($offset)

--- a/src/DB/EntityRepository/Project/Special/FeaturedRepository.php
+++ b/src/DB/EntityRepository/Project/Special/FeaturedRepository.php
@@ -29,6 +29,7 @@ class FeaturedRepository extends ServiceEntityRepository
 
     $qb
       ->select('e')
+      ->addSelect('program')
       ->where('e.active = true')
       ->setFirstResult($offset)
       ->setMaxResults($limit)

--- a/src/DB/EntityRepository/User/Comment/UserCommentRepository.php
+++ b/src/DB/EntityRepository/User/Comment/UserCommentRepository.php
@@ -66,6 +66,8 @@ class UserCommentRepository extends ServiceEntityRepository
     $qb = $this->createQueryBuilder('uc');
 
     return $qb->select('uc')
+      ->addSelect('u')
+      ->leftJoin('uc.user', 'u')
       ->where('uc.program = :program_id')
       ->setParameter('program_id', $program_id)
       ->andWhere($qb->expr()->orX()->addMultiple([
@@ -82,6 +84,8 @@ class UserCommentRepository extends ServiceEntityRepository
     $qb = $this->createQueryBuilder('uc');
 
     return $qb->select('uc')
+      ->addSelect('u')
+      ->leftJoin('uc.user', 'u')
       ->where('uc.parent_id = :parent_id')
       ->setParameter('parent_id', $parent_id)
       ->orderBy('uc.uploadDate', 'DESC')

--- a/src/DB/EntityRepository/User/Notification/NotificationRepository.php
+++ b/src/DB/EntityRepository/User/Notification/NotificationRepository.php
@@ -36,7 +36,13 @@ class NotificationRepository extends ServiceEntityRepository
 
     $qb
       ->select('n')
+      ->addSelect('nu')
+      ->addSelect('lf')
+      ->addSelect('p')
       ->from(LikeNotification::class, 'n')
+      ->leftJoin('n.user', 'nu')
+      ->leftJoin('n.like_from', 'lf')
+      ->leftJoin('n.program', 'p')
       ->where($qb->expr()->eq('n.program', ':program_id'))
       ->setParameter(':program_id', $project->getId())
     ;
@@ -67,7 +73,11 @@ class NotificationRepository extends ServiceEntityRepository
 
     $qb
       ->select('n')
+      ->addSelect('nu')
+      ->addSelect('f')
       ->from(FollowNotification::class, 'n')
+      ->leftJoin('n.user', 'nu')
+      ->leftJoin('n.follower', 'f')
     ;
 
     if ($owner instanceof User) {
@@ -113,7 +123,9 @@ class NotificationRepository extends ServiceEntityRepository
 
     $qb
       ->select('n')
+      ->addSelect('nu')
       ->from(CatroNotification::class, 'n')
+      ->leftJoin('n.user', 'nu')
       ->where('n.user = :user')
       ->setParameter('user', $user)
       ->orderBy('n.id', 'DESC')


### PR DESCRIPTION
## Summary
- Add LEFT JOIN + addSelect for User association in project listing queries (ProgramRepository)
- Add LEFT JOIN + addSelect for User association in comment entity queries (UserCommentRepository)
- Add LEFT JOIN + addSelect for User, like_from, program, and follower in notification queries (NotificationRepository)
- Add addSelect for already-joined program association in FeaturedRepository and ExampleRepository
- Fixes #6402

## Test plan
- [ ] PHPStan passes
- [ ] Psalm passes
- [ ] PHP CS Fixer passes
- [ ] Existing Behat tests pass (no query result shape changes — addSelect with JOIN hydrates into root entity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)