### PR TITLE
Fix code view error state Behat test

### DIFF
--- a/src/System/Testing/Behat/Context/DataFixturesContext.php
+++ b/src/System/Testing/Behat/Context/DataFixturesContext.php
@@ -40,6 +40,7 @@ use App\DB\Enum\AppealState;
 use App\DB\Enum\ReportState;
 use App\DB\Generator\MyUuidGenerator;
 use App\Project\CodeStatistics\CodeStatisticsParser;
+use App\Storage\FileHelper;
 use App\System\Commands\DBUpdater\UpdateAchievementsCommand;
 use App\System\Commands\Helpers\CommandHelper;
 use App\System\Testing\Behat\ContextTrait;
@@ -464,6 +465,18 @@ class DataFixturesContext implements Context
     }
 
     file_put_contents($extract_dir.'code.xml', (string) $xml);
+  }
+
+  /**
+   * @Given /^project "([^"]*)" has no extracted files$/
+   */
+  public function projectHasNoExtractedFiles(string $project_id): void
+  {
+    $extract_dir = $this->EXTRACT_RESOURCES_DIR.$project_id.'/';
+    if (is_dir($extract_dir)) {
+      FileHelper::emptyDirectory($extract_dir);
+      rmdir($extract_dir);
+    }
   }
 
   /**

--- a/tests/BehatFeatures/web/code-view/code_view.feature
+++ b/tests/BehatFeatures/web/code-view/code_view.feature
@@ -121,7 +121,8 @@ Feature: As a visitor I want to see inline code view on the project page
     Then the element "#code-view-panel" should not be visible
 
   Scenario: Code view shows error state when no extracted files exist
-    Given I am on "/app/project/1"
+    Given project "1" has no extracted files
+    And I am on "/app/project/1"
     And I wait for the page to be loaded
     When I click "#code-view-toggle"
     And I wait for AJAX to finish


### PR DESCRIPTION
## Summary
- The "Code view shows error state when no extracted files exist" Behat test was failing because `insertProject()` always copies base fixture files (including `code.xml`) into the extract directory for every project
- Added a new Behat step `project "X" has no extracted files` to explicitly remove extracted files
- Used the new step in the error-state scenario so the API correctly returns 422, triggering the JS error UI

## Test plan
- [x] `bin/behat -s web-code tests/BehatFeatures/web/code-view/code_view.feature` — all 6 scenarios pass
- [x] PHPStan, Psalm, PHP-CS-Fixer pass on changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)