### PR TITLE
Fix featured image upload crash and cascade error

### DIFF
--- a/src/Admin/System/FeatureFlag/FeatureFlagManager.php
+++ b/src/Admin/System/FeatureFlag/FeatureFlagManager.php
@@ -34,27 +34,35 @@ class FeatureFlagManager
       return;
     }
 
-    $flagRepository = $this->entityManager->getRepository(FeatureFlag::class);
-
-    $existingFlags = [];
-    foreach ($flagRepository->findAll() as $flag) {
-      $existingFlags[(string) $flag->getName()] = $flag;
+    if (!$this->entityManager->isOpen()) {
+      return;
     }
 
-    foreach ($this->defaultFlags as $name => $value) {
-      if (!isset($existingFlags[$name])) {
-        $this->entityManager->persist(new FeatureFlag($name, $value));
+    try {
+      $flagRepository = $this->entityManager->getRepository(FeatureFlag::class);
+
+      $existingFlags = [];
+      foreach ($flagRepository->findAll() as $flag) {
+        $existingFlags[(string) $flag->getName()] = $flag;
       }
-    }
 
-    foreach ($existingFlags as $name => $flag) {
-      if (!array_key_exists($name, $this->defaultFlags)) {
-        $this->entityManager->remove($flag);
+      foreach ($this->defaultFlags as $name => $value) {
+        if (!isset($existingFlags[$name])) {
+          $this->entityManager->persist(new FeatureFlag($name, $value));
+        }
       }
-    }
 
-    $this->entityManager->flush();
-    $this->defaultsSynchronized = true;
+      foreach ($existingFlags as $name => $flag) {
+        if (!array_key_exists($name, $this->defaultFlags)) {
+          $this->entityManager->remove($flag);
+        }
+      }
+
+      $this->entityManager->flush();
+      $this->defaultsSynchronized = true;
+    } catch (\Throwable) {
+      // Prevent cascade failures when called during error page rendering
+    }
   }
 
   public function setFlagValue(string $flagName, bool $value): void

--- a/src/Storage/ImageRepository.php
+++ b/src/Storage/ImageRepository.php
@@ -58,6 +58,11 @@ class ImageRepository
       $filename = $this->example_dir.$this->generateFileNameFromId($id, $extension, false);
     }
 
+    $dir = dirname($filename);
+    if (!is_dir($dir)) {
+      mkdir($dir, 0777, true);
+    }
+
     if (file_exists($filename)) {
       unlink($filename);
     }

--- a/tests/PhpUnit/Admin/System/FeatureFlag/FeatureFlagManagerTest.php
+++ b/tests/PhpUnit/Admin/System/FeatureFlag/FeatureFlagManagerTest.php
@@ -26,6 +26,8 @@ final class FeatureFlagManagerTest extends TestCase
     $existingFlag = new FeatureFlag('Sidebar-Studio-Link-Feature', false);
     $staleFlag = new FeatureFlag('Deprecated-Flag', true);
 
+    $entityManager->method('isOpen')->willReturn(true);
+
     $entityManager
       ->expects($this->once())
       ->method('getRepository')


### PR DESCRIPTION
## Summary
- `ImageRepository::save()` crashes with `ImagickException: WriteBlob Failed` when the `resources/featured/` directory doesn't exist (e.g. after a fresh deployment with `releases/` symlink structure)
- This closes the Doctrine EntityManager, which then cascades into `FeatureFlagManager::synchronizeDefaults()` when Twig renders the error page via `Sidebar.html.twig` → `isFeatureFlagEnabled()` → double crash
- **Fix 1**: Create target directory if missing before `Imagick::writeImage()`
- **Fix 2**: Guard `synchronizeDefaults()` against closed EntityManager + wrap in try/catch to prevent cascade failures during error page rendering

Observed on production: `https://share.catrob.at/admin/project/featured/create`

## Test plan
- [ ] Create a featured project in admin panel — image should save successfully
- [ ] If image save fails for other reasons, error page should render without cascade crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)