### PR TITLE
Fix featured image upload crash when directory missing

### DIFF
--- a/src/Storage/FileHelper.php
+++ b/src/Storage/FileHelper.php
@@ -18,6 +18,22 @@ class FileHelper
     }
   }
 
+  /**
+   * @throws \Exception
+   */
+  public static function ensureDirectoryExists(?string $dir): void
+  {
+    if (null === $dir || '' === $dir) {
+      throw new \Exception('Directory path must not be null or empty');
+    }
+
+    if (!is_dir($dir)) {
+      if (!mkdir($dir, 0777, true) && !is_dir($dir)) {
+        throw new \Exception('Failed to create directory: '.$dir);
+      }
+    }
+  }
+
   public static function copyDirectory(string $src, string $dst): void
   {
     $dir = opendir($src);

--- a/src/Storage/ImageRepository.php
+++ b/src/Storage/ImageRepository.php
@@ -35,8 +35,8 @@ class ImageRepository
     /** @var string $featured_path */
     $featured_path = $parameter_bag->get('catrobat.featuredimage.path');
 
-    FileHelper::verifyDirectoryExists($example_dir);
-    FileHelper::verifyDirectoryExists($featured_dir);
+    FileHelper::ensureDirectoryExists($example_dir);
+    FileHelper::ensureDirectoryExists($featured_dir);
 
     $this->example_dir = $example_dir;
     $this->example_path = $example_path;


### PR DESCRIPTION
## Summary
- **ImageRepository constructor** called `verifyDirectoryExists()` which throws an exception if the featured/example image directories don't exist (e.g. after a fresh deployment), preventing the service from instantiating at all
- Added `FileHelper::ensureDirectoryExists()` that creates missing directories recursively instead of throwing
- Replaced `verifyDirectoryExists()` calls in `ImageRepository` constructor with `ensureDirectoryExists()`
- The previous commit on this branch added `mkdir` in `ImageRepository::save()`, but the constructor failure happened earlier, before `save()` could ever be reached

## Test plan
- [ ] Deploy to a fresh environment without `public/resources/featured/` directory
- [ ] Upload a featured project image via admin panel
- [ ] Verify the directory is created automatically and the image is saved
- [ ] Verify existing deployments with directories already present are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)