### PR TITLE
Change comment ordering to newest first (DESC)

### DIFF
--- a/src/DB/EntityRepository/User/Comment/UserCommentRepository.php
+++ b/src/DB/EntityRepository/User/Comment/UserCommentRepository.php
@@ -142,18 +142,18 @@ class UserCommentRepository extends ServiceEntityRepository
       ]))
       ->andWhere('c.auto_hidden = false')
       ->setParameter('program', $project)
-      ->orderBy('c.uploadDate', 'ASC')
-      ->addOrderBy('c.id', 'ASC')
+      ->orderBy('c.uploadDate', 'DESC')
+      ->addOrderBy('c.id', 'DESC')
       ->setMaxResults($limit + 1)
     ;
 
     if ($cursor_date instanceof \DateTimeInterface && null !== $cursor_id) {
       $qb->andWhere(
         $qb->expr()->orX(
-          $qb->expr()->gt('c.uploadDate', ':cursorDate'),
+          $qb->expr()->lt('c.uploadDate', ':cursorDate'),
           $qb->expr()->andX(
             $qb->expr()->eq('c.uploadDate', ':cursorDate'),
-            $qb->expr()->gt('c.id', ':cursorId')
+            $qb->expr()->lt('c.id', ':cursorId')
           )
         )
       )
@@ -194,18 +194,18 @@ class UserCommentRepository extends ServiceEntityRepository
       ->where('c.parent_id = :parentId')
       ->andWhere('c.auto_hidden = false')
       ->setParameter('parentId', $comment_id)
-      ->orderBy('c.uploadDate', 'ASC')
-      ->addOrderBy('c.id', 'ASC')
+      ->orderBy('c.uploadDate', 'DESC')
+      ->addOrderBy('c.id', 'DESC')
       ->setMaxResults($limit + 1)
     ;
 
     if ($cursor_date instanceof \DateTimeInterface && null !== $cursor_id) {
       $qb->andWhere(
         $qb->expr()->orX(
-          $qb->expr()->gt('c.uploadDate', ':cursorDate'),
+          $qb->expr()->lt('c.uploadDate', ':cursorDate'),
           $qb->expr()->andX(
             $qb->expr()->eq('c.uploadDate', ':cursorDate'),
-            $qb->expr()->gt('c.id', ':cursorId')
+            $qb->expr()->lt('c.id', ':cursorId')
           )
         )
       )

--- a/tests/BehatFeatures/api/comments/comments.feature
+++ b/tests/BehatFeatures/api/comments/comments.feature
@@ -20,13 +20,13 @@ Feature: Comments API
   # GET /api/project/{id}/comments
   # ---------------------------------------------------------------------------
 
-  Scenario: Get project comments with cursor pagination
+  Scenario: Get project comments with cursor pagination returns newest first
     Given I request "GET" "/api/project/1/comments?limit=2"
     Then the response status code should be "200"
     And the response should be in json format
     And the client response should contain "has_more"
     And the client response should contain "next_cursor"
-    And the client response should contain "first comment"
+    And the client response should contain "third comment"
     And the client response should contain "second comment"
 
   Scenario: Get project comments returns 404 for non-existent project
@@ -41,11 +41,11 @@ Feature: Comments API
   # GET /api/comments/{id}/replies
   # ---------------------------------------------------------------------------
 
-  Scenario: Get comment replies with cursor pagination
+  Scenario: Get comment replies with cursor pagination returns newest first
     Given I request "GET" "/api/comments/10/replies?limit=1"
     Then the response status code should be "200"
     And the response should be in json format
-    And the client response should contain "reply comment 1"
+    And the client response should contain "reply comment 2"
 
   Scenario: Get replies returns 404 for non-existent comment
     Given I request "GET" "/api/comments/9999/replies"

--- a/tests/BehatFeatures/web/comments/project_comments.feature
+++ b/tests/BehatFeatures/web/comments/project_comments.feature
@@ -135,15 +135,15 @@ Feature: As a visitor I want to write, see and report comments.
     Given I am on "/app/project/2"
     And I wait for the page to be loaded
     And I wait for AJAX to finish
-    Then I should see "c2"
-    And I should see "c3"
-    And I should see "c4"
-    And I should see "c5"
+    Then I should see "c8"
+    And I should see "c7"
     And I should see "c6"
+    And I should see "c5"
+    And I should see "c4"
 
-    And none of the ".comment-replies-count span" elements should contain "3"
-    But I should not see "c7"
-    And I should not see "c8"
+    And one of the ".comment-replies-count span" elements should contain "3"
+    But I should not see "c3"
+    And I should not see "c2"
     And I should not see "c9"
     And I should not see "c10"
     And I should not see "c11"
@@ -152,9 +152,8 @@ Feature: As a visitor I want to write, see and report comments.
     And I wait 500 milliseconds
     And I wait for AJAX to finish
 
-    Then I should see "c7"
-    And I should see "c8"
-    And one of the ".comment-replies-count span" elements should contain "3"
+    Then I should see "c3"
+    And I should see "c2"
     But I should not see "c9"
     But I should not see "c10"
     But I should not see "c11"
@@ -187,12 +186,12 @@ Feature: As a visitor I want to write, see and report comments.
     Given I am on "/app/project/2"
     And I wait for the page to be loaded
     And I wait for AJAX to finish
-    Then I should see "c2"
-    And I should see "c3"
-    And I should see "c4"
-    And I should see "c5"
+    Then I should see "c8"
+    And I should see "c7"
     And I should see "c6"
-    But I should not see "c7"
+    And I should see "c5"
+    And I should see "c4"
+    But I should not see "c3"
 
   Scenario: I can't report my own comment
     Given I log in as "Catrobat"


### PR DESCRIPTION
## Summary
- Change project comments and comment replies ordering from ASC (oldest first) to DESC (newest first)
- Update cursor pagination logic to use `lt` (less than) instead of `gt` (greater than) for both date and ID comparisons
- Update Behat API tests to reflect the new ordering

## Test plan
- [ ] Verify `GET /api/project/{id}/comments` returns newest comments first
- [ ] Verify `GET /api/comments/{id}/replies` returns newest replies first
- [ ] Verify cursor pagination correctly fetches older comments/replies on subsequent pages
- [ ] Run `api-comments` Behat suite: `docker exec app.catroweb bin/behat -f pretty -s api-comments`
- [ ] Run `web-project-details` Behat suite to ensure no regressions
- [ ] Verify the project page UI displays comments in newest-first order

🤖 Generated with [Claude Code](https://claude.com/claude-code)