### PR TITLE
Add auto-cleanup of extracted project files (#6500)

### DIFF
--- a/src/Project/CatrobatFile/ExtractedFileRepository.php
+++ b/src/Project/CatrobatFile/ExtractedFileRepository.php
@@ -9,6 +9,8 @@ use App\Project\ProjectManager;
 use App\Storage\FileHelper;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\File\File;
 
 class ExtractedFileRepository
 {
@@ -16,11 +18,14 @@ class ExtractedFileRepository
 
   private readonly string $web_path;
 
+  private readonly string $storage_path;
+
   /**
    * @throws \Exception
    */
   public function __construct(ParameterBagInterface $parameter_bag,
     private readonly ProjectManager $project_manager,
+    private readonly CatrobatFileExtractor $file_extractor,
     private readonly LoggerInterface $logger)
   {
     /** @var string $local_extracted_path */
@@ -35,6 +40,7 @@ class ExtractedFileRepository
 
     $this->local_path = $local_extracted_path;
     $this->web_path = $web_extracted_path;
+    $this->storage_path = $local_storage_path;
   }
 
   public function getBaseDir(string $id): string
@@ -50,7 +56,13 @@ class ExtractedFileRepository
         return null;
       }
 
-      return new ExtractedCatrobatFile($this->getBaseDir($project_id), $this->web_path.$project_id.'/', $project_id);
+      $base_dir = $this->getBaseDir($project_id);
+
+      if (!is_dir($base_dir)) {
+        $this->reExtractProject($project_id);
+      }
+
+      return new ExtractedCatrobatFile($base_dir, $this->web_path.$project_id.'/', $project_id);
     } catch (InvalidCatrobatFileException) {
       return null;
     }
@@ -84,6 +96,35 @@ class ExtractedFileRepository
     $file_overwritten = $extracted_file->getProjectXmlProperties()->asXML($extracted_file->getPath().'code.xml');
     if (!$file_overwritten) {
       throw new \Exception("Can't overwrite code.xml file");
+    }
+  }
+
+  /**
+   * Re-extracts a project from its .catrobat zip file into the extract directory.
+   */
+  private function reExtractProject(string $project_id): void
+  {
+    $zip_path = $this->storage_path.$project_id.'.catrobat';
+
+    if (!file_exists($zip_path)) {
+      $this->logger->warning('Cannot re-extract project '.$project_id.': zip file not found at '.$zip_path);
+
+      return;
+    }
+
+    try {
+      $extracted = $this->file_extractor->extract(new File($zip_path));
+
+      $target_dir = $this->local_path.$project_id;
+      $filesystem = new Filesystem();
+
+      if (is_dir($target_dir)) {
+        $filesystem->remove($target_dir);
+      }
+
+      $filesystem->rename($extracted->getPath(), $target_dir);
+    } catch (\Exception $e) {
+      $this->logger->error('Failed to re-extract project '.$project_id.': '.$e->getMessage());
     }
   }
 }

--- a/src/System/Commands/DBUpdater/CronJobCommand.php
+++ b/src/System/Commands/DBUpdater/CronJobCommand.php
@@ -143,6 +143,16 @@ class CronJobCommand extends Command
       $output
     );
 
+    // Storage cleanup
+
+    $this->runCronJob(
+      'Clean old extracted project files',
+      ['bin/console', 'catrobat:clean:extracts'],
+      ['timeout' => self::ONE_HOUR_IN_SECONDS],
+      '1 day',
+      $output
+    );
+
     return 0;
   }
 

--- a/src/System/Commands/Maintenance/CleanExtractsCommand.php
+++ b/src/System/Commands/Maintenance/CleanExtractsCommand.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\System\Commands\Maintenance;
+
+use App\Storage\FileHelper;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Finder\Finder;
+
+#[AsCommand(name: 'catrobat:clean:extracts', description: 'Delete extracted project directories older than N days')]
+class CleanExtractsCommand extends Command
+{
+  private const int DEFAULT_DAYS = 7;
+
+  private const int BATCH_SIZE = 100;
+
+  public function __construct(
+    #[Autowire('%catrobat.file.extract.dir%')]
+    private readonly string $extract_dir,
+  ) {
+    parent::__construct();
+  }
+
+  #[\Override]
+  protected function configure(): void
+  {
+    $this
+      ->addOption('days', 'd', InputOption::VALUE_REQUIRED, 'Delete directories older than this many days', (string) self::DEFAULT_DAYS)
+      ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Preview what would be deleted without actually deleting')
+    ;
+  }
+
+  #[\Override]
+  protected function execute(InputInterface $input, OutputInterface $output): int
+  {
+    $days = (int) $input->getOption('days');
+    if ($days < 1) {
+      $output->writeln('<error>Days must be a positive integer.</error>');
+
+      return Command::FAILURE;
+    }
+
+    $dry_run = (bool) $input->getOption('dry-run');
+
+    if (!is_dir($this->extract_dir)) {
+      $output->writeln('<error>Extract directory does not exist: '.$this->extract_dir.'</error>');
+
+      return Command::FAILURE;
+    }
+
+    $cutoff = new \DateTimeImmutable('-'.$days.' days');
+    $cutoff_timestamp = $cutoff->getTimestamp();
+
+    $output->writeln(($dry_run ? '[DRY RUN] ' : '').'Cleaning extracted project directories older than '.$days.' days...');
+
+    $finder = new Finder();
+    $finder->in($this->extract_dir)->directories()->depth(0);
+
+    $deleted_count = 0;
+    $total_bytes_freed = 0;
+    $batch_count = 0;
+
+    foreach ($finder as $dir) {
+      if ($dir->getMTime() >= $cutoff_timestamp) {
+        continue;
+      }
+
+      $dir_size = $this->getDirectorySize($dir->getPathname());
+
+      if ($dry_run) {
+        $output->writeln('  Would delete: '.$dir->getFilename().' ('.self::formatBytes($dir_size).')');
+      } else {
+        try {
+          FileHelper::removeDirectory($dir->getPathname());
+          $output->writeln('  Deleted: '.$dir->getFilename().' ('.self::formatBytes($dir_size).')', OutputInterface::VERBOSITY_VERBOSE);
+        } catch (\Exception $e) {
+          $output->writeln('<error>  Failed to delete '.$dir->getFilename().': '.$e->getMessage().'</error>');
+          continue;
+        }
+      }
+
+      $total_bytes_freed += $dir_size;
+      ++$deleted_count;
+      ++$batch_count;
+
+      if ($batch_count >= self::BATCH_SIZE) {
+        $batch_count = 0;
+        gc_collect_cycles();
+      }
+    }
+
+    $output->writeln(($dry_run ? '[DRY RUN] ' : '').'Done. Directories deleted: '.$deleted_count.'. Disk space reclaimed: '.self::formatBytes($total_bytes_freed));
+
+    return Command::SUCCESS;
+  }
+
+  private function getDirectorySize(string $path): int
+  {
+    $size = 0;
+
+    $finder = new Finder();
+    $finder->in($path)->files();
+
+    foreach ($finder as $file) {
+      $size += $file->getSize();
+    }
+
+    return $size;
+  }
+
+  private static function formatBytes(int $bytes): string
+  {
+    if ($bytes < 1024) {
+      return $bytes.' B';
+    }
+
+    $units = ['KB', 'MB', 'GB'];
+    $value = (float) $bytes;
+    $unit_index = -1;
+
+    while ($value >= 1024 && $unit_index < 2) {
+      $value /= 1024;
+      ++$unit_index;
+    }
+
+    return round($value, 2).' '.$units[$unit_index];
+  }
+}

--- a/tests/BehatFeatures/web/admin/db_updater/admin_cron_jobs.feature
+++ b/tests/BehatFeatures/web/admin/db_updater/admin_cron_jobs.feature
@@ -20,6 +20,7 @@ Feature: The admin cron jobs view provides a detailed list about all cron jobs a
       | Add perfect_profile UserAchievements                         | idle  | 1 week        |          |        | 0           |
       | Add silver_user UserAchievements                             | idle  | 1 week        |          |        | 0           |
       | Add verified_developer UserAchievements                      | idle  | 1 year        |          |        | 0           |
+      | Clean old extracted project files                            | idle  | 1 day         |          |        | 0           |
       | Delete old entries in machine translation table              | idle  | 1 month       |          |        | 0           |
       | Remove and add new projects to the random projects' category | idle  | 1 week        |          |        | 0           |
       | Retroactively unlock custom translation achievements         | idle  | 1 month       |          |        | 0           |
@@ -36,7 +37,7 @@ Feature: The admin cron jobs view provides a detailed list about all cron jobs a
     Then I should see "Cron jobs finished successfully"
     When I am on "/admin/system/cron-job/list"
     And I wait for the page to be loaded
-    And there should be "11" cron jobs in the database
+    And there should be "12" cron jobs in the database
 
   Scenario: Cron jobs can be reset
     Given I log in as "Admin"

--- a/tests/PhpUnit/System/Commands/CleanExtractsTest.php
+++ b/tests/PhpUnit/System/Commands/CleanExtractsTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\System\Commands;
+
+use App\System\Commands\Maintenance\CleanExtractsCommand;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+#[CoversClass(CleanExtractsCommand::class)]
+class CleanExtractsTest extends KernelTestCase
+{
+  private CommandTester $command_tester;
+
+  private string $extract_dir;
+
+  private Filesystem $filesystem;
+
+  #[\Override]
+  protected function setUp(): void
+  {
+    $kernel = static::createKernel();
+    $container = static::getContainer();
+    $application = new Application($kernel);
+    $command = $application->find('catrobat:clean:extracts');
+    $this->command_tester = new CommandTester($command);
+    $extract_dir_param = $container->getParameter('catrobat.file.extract.dir');
+    \assert(\is_string($extract_dir_param));
+    $this->extract_dir = $extract_dir_param;
+    $this->filesystem = new Filesystem();
+  }
+
+  #[\Override]
+  protected function tearDown(): void
+  {
+    // Clean up any test directories we created
+    foreach (['old_project_1', 'old_project_2', 'recent_project'] as $dir) {
+      $path = $this->extract_dir.$dir;
+      if (is_dir($path)) {
+        $this->filesystem->remove($path);
+      }
+    }
+
+    parent::tearDown();
+  }
+
+  public function testDeletesOldDirectories(): void
+  {
+    $old_dir = $this->extract_dir.'old_project_1';
+    $this->filesystem->mkdir($old_dir);
+    $this->filesystem->touch($old_dir.'/code.xml');
+    // Set modification time to 10 days ago
+    touch($old_dir, time() - 10 * 86400);
+
+    $recent_dir = $this->extract_dir.'recent_project';
+    $this->filesystem->mkdir($recent_dir);
+    $this->filesystem->touch($recent_dir.'/code.xml');
+
+    $return = $this->command_tester->execute(['--days' => '7']);
+
+    $this->assertSame(0, $return);
+    $this->assertDirectoryDoesNotExist($old_dir);
+    $this->assertDirectoryExists($recent_dir);
+    $this->assertStringContainsString('Directories deleted: 1', $this->command_tester->getDisplay());
+  }
+
+  public function testDryRunDoesNotDelete(): void
+  {
+    $old_dir = $this->extract_dir.'old_project_2';
+    $this->filesystem->mkdir($old_dir);
+    $this->filesystem->touch($old_dir.'/code.xml');
+    touch($old_dir, time() - 10 * 86400);
+
+    $return = $this->command_tester->execute(['--days' => '7', '--dry-run' => true]);
+
+    $this->assertSame(0, $return);
+    $this->assertDirectoryExists($old_dir);
+    $this->assertStringContainsString('[DRY RUN]', $this->command_tester->getDisplay());
+    $this->assertStringContainsString('Would delete: old_project_2', $this->command_tester->getDisplay());
+  }
+
+  public function testRejectsInvalidDays(): void
+  {
+    $return = $this->command_tester->execute(['--days' => '0']);
+
+    $this->assertSame(1, $return);
+    $this->assertStringContainsString('Days must be a positive integer', $this->command_tester->getDisplay());
+  }
+
+  public function testNothingToDelete(): void
+  {
+    $return = $this->command_tester->execute(['--days' => '7']);
+
+    $this->assertSame(0, $return);
+    $this->assertStringContainsString('Directories deleted: 0', $this->command_tester->getDisplay());
+  }
+
+  public function testCustomDaysOption(): void
+  {
+    $dir = $this->extract_dir.'old_project_1';
+    $this->filesystem->mkdir($dir);
+    $this->filesystem->touch($dir.'/code.xml');
+    // Set modification time to 2 days ago
+    touch($dir, time() - 2 * 86400);
+
+    // Should NOT delete with 7-day threshold
+    $return = $this->command_tester->execute(['--days' => '7']);
+    $this->assertSame(0, $return);
+    $this->assertDirectoryExists($dir);
+
+    // Should delete with 1-day threshold
+    $return = $this->command_tester->execute(['--days' => '1']);
+    $this->assertSame(0, $return);
+    $this->assertDirectoryDoesNotExist($dir);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `catrobat:clean:extracts` command that deletes extracted project directories older than 7 days (configurable via `--days`), with `--dry-run` support and disk space reclaimed reporting
- Registers the command as a daily cron job in `CronJobCommand`
- Adds transparent re-extraction in `ExtractedFileRepository`: when a cleaned extract dir is accessed (e.g. code view), it automatically re-extracts from the `.catrobat` zip file
- Includes PHPUnit tests for the command (5 test cases)

Closes #6500

## Test plan
- [ ] Run `bin/phpunit --filter CleanExtractsTest` to verify all 5 tests pass
- [ ] Manually test `catrobat:clean:extracts --dry-run` to preview deletions
- [ ] Manually test `catrobat:clean:extracts --days=0` to verify invalid input is rejected
- [ ] Delete an extract directory manually, then access that project's code view to verify re-extraction works
- [ ] Verify `catrobat:cronjob` includes the new cleanup job

🤖 Generated with [Claude Code](https://claude.com/claude-code)