### PR TITLE
Add email daily budget manager with priority system

### DIFF
--- a/migrations/2026/Version20260402080000_email_daily_budget.php
+++ b/migrations/2026/Version20260402080000_email_daily_budget.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260402080000_email_daily_budget extends AbstractMigration
+{
+  #[\Override]
+  public function getDescription(): string
+  {
+    return 'Create email_daily_budget table for tracking daily email sending limits (#6501)';
+  }
+
+  #[\Override]
+  public function up(Schema $schema): void
+  {
+    $this->addSql('CREATE TABLE email_daily_budget (
+      id INT AUTO_INCREMENT NOT NULL,
+      date DATE NOT NULL,
+      total_sent INT NOT NULL DEFAULT 0,
+      verification_sent INT NOT NULL DEFAULT 0,
+      reset_sent INT NOT NULL DEFAULT 0,
+      consent_sent INT NOT NULL DEFAULT 0,
+      admin_sent INT NOT NULL DEFAULT 0,
+      management_sent INT NOT NULL DEFAULT 0,
+      UNIQUE INDEX UNIQ_email_daily_budget_date (date),
+      PRIMARY KEY(id)
+    ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+  }
+
+  #[\Override]
+  public function down(Schema $schema): void
+  {
+    $this->addSql('DROP TABLE email_daily_budget');
+  }
+}

--- a/src/Admin/UserCommunication/SendMailToUser/SendMailToUserController.php
+++ b/src/Admin/UserCommunication/SendMailToUser/SendMailToUserController.php
@@ -71,7 +71,8 @@ class SendMailToUserController extends CRUDController
         'subject' => $subject,
         'title' => $title,
         'message' => $messageText,
-      ]
+      ],
+      'admin'
     );
 
     return new Response('OK - message sent', Response::HTTP_OK);

--- a/src/DB/Entity/System/EmailDailyBudget.php
+++ b/src/DB/Entity/System/EmailDailyBudget.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DB\Entity\System;
+
+use App\DB\EntityRepository\System\EmailDailyBudgetRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'email_daily_budget')]
+#[ORM\Entity(repositoryClass: EmailDailyBudgetRepository::class)]
+class EmailDailyBudget
+{
+  #[ORM\Id]
+  #[ORM\GeneratedValue]
+  #[ORM\Column(type: Types::INTEGER)]
+  protected ?int $id = null;
+
+  #[ORM\Column(name: 'date', type: Types::DATE_MUTABLE, unique: true, nullable: false)]
+  protected \DateTime $date;
+
+  #[ORM\Column(name: 'total_sent', type: Types::INTEGER, nullable: false, options: ['default' => 0])]
+  protected int $total_sent = 0;
+
+  #[ORM\Column(name: 'verification_sent', type: Types::INTEGER, nullable: false, options: ['default' => 0])]
+  protected int $verification_sent = 0;
+
+  #[ORM\Column(name: 'reset_sent', type: Types::INTEGER, nullable: false, options: ['default' => 0])]
+  protected int $reset_sent = 0;
+
+  #[ORM\Column(name: 'consent_sent', type: Types::INTEGER, nullable: false, options: ['default' => 0])]
+  protected int $consent_sent = 0;
+
+  #[ORM\Column(name: 'admin_sent', type: Types::INTEGER, nullable: false, options: ['default' => 0])]
+  protected int $admin_sent = 0;
+
+  #[ORM\Column(name: 'management_sent', type: Types::INTEGER, nullable: false, options: ['default' => 0])]
+  protected int $management_sent = 0;
+
+  public function __construct()
+  {
+    $this->date = new \DateTime('today');
+  }
+
+  public function getDate(): \DateTime
+  {
+    return $this->date;
+  }
+
+  public function setDate(\DateTime $date): self
+  {
+    $this->date = $date;
+
+    return $this;
+  }
+
+  public function getTotalSent(): int
+  {
+    return $this->total_sent;
+  }
+
+  public function setTotalSent(int $total_sent): self
+  {
+    $this->total_sent = $total_sent;
+
+    return $this;
+  }
+
+  public function getVerificationSent(): int
+  {
+    return $this->verification_sent;
+  }
+
+  public function setVerificationSent(int $verification_sent): self
+  {
+    $this->verification_sent = $verification_sent;
+
+    return $this;
+  }
+
+  public function getResetSent(): int
+  {
+    return $this->reset_sent;
+  }
+
+  public function setResetSent(int $reset_sent): self
+  {
+    $this->reset_sent = $reset_sent;
+
+    return $this;
+  }
+
+  public function getConsentSent(): int
+  {
+    return $this->consent_sent;
+  }
+
+  public function setConsentSent(int $consent_sent): self
+  {
+    $this->consent_sent = $consent_sent;
+
+    return $this;
+  }
+
+  public function getAdminSent(): int
+  {
+    return $this->admin_sent;
+  }
+
+  public function setAdminSent(int $admin_sent): self
+  {
+    $this->admin_sent = $admin_sent;
+
+    return $this;
+  }
+
+  public function getManagementSent(): int
+  {
+    return $this->management_sent;
+  }
+
+  public function setManagementSent(int $management_sent): self
+  {
+    $this->management_sent = $management_sent;
+
+    return $this;
+  }
+
+  public function incrementType(string $type): void
+  {
+    match ($type) {
+      'verification' => $this->verification_sent++,
+      'reset' => $this->reset_sent++,
+      'consent' => $this->consent_sent++,
+      'admin' => $this->admin_sent++,
+      'management' => $this->management_sent++,
+      default => throw new \InvalidArgumentException(sprintf('Unknown email type: %s', $type)),
+    };
+    ++$this->total_sent;
+  }
+
+  public function getSentByType(string $type): int
+  {
+    return match ($type) {
+      'verification' => $this->verification_sent,
+      'reset' => $this->reset_sent,
+      'consent' => $this->consent_sent,
+      'admin' => $this->admin_sent,
+      'management' => $this->management_sent,
+      default => throw new \InvalidArgumentException(sprintf('Unknown email type: %s', $type)),
+    };
+  }
+}

--- a/src/DB/EntityRepository/System/EmailDailyBudgetRepository.php
+++ b/src/DB/EntityRepository/System/EmailDailyBudgetRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DB\EntityRepository\System;
+
+use App\DB\Entity\System\EmailDailyBudget;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<EmailDailyBudget>
+ */
+class EmailDailyBudgetRepository extends ServiceEntityRepository
+{
+  public function __construct(ManagerRegistry $managerRegistry)
+  {
+    parent::__construct($managerRegistry, EmailDailyBudget::class);
+  }
+
+  public function findOrCreateToday(): EmailDailyBudget
+  {
+    $today = new \DateTime('today');
+    $budget = $this->findOneBy(['date' => $today]);
+
+    if (!$budget instanceof EmailDailyBudget) {
+      $budget = new EmailDailyBudget();
+      $budget->setDate($today);
+      $this->getEntityManager()->persist($budget);
+      $this->getEntityManager()->flush();
+    }
+
+    return $budget;
+  }
+}

--- a/src/Security/Authentication/ResetPasswordEmail.php
+++ b/src/Security/Authentication/ResetPasswordEmail.php
@@ -61,7 +61,8 @@ class ResetPasswordEmail
       $this->user->getEmail(),
       $this->translator->trans('passwordRecovery.subject', [], 'catroweb', $this->locale),
       $this->getTemplate(),
-      $this->getContext()
+      $this->getContext(),
+      'reset'
     );
   }
 }

--- a/src/Security/Authentication/VerifyEmail.php
+++ b/src/Security/Authentication/VerifyEmail.php
@@ -73,7 +73,8 @@ class VerifyEmail
       $this->user->getEmail(),
       $this->translator->trans('user.verification.email', [], 'catroweb'),
       $this->getTemplate(),
-      $this->getContext()
+      $this->getContext(),
+      'verification'
     );
   }
 }

--- a/src/System/Mail/EmailBudgetManager.php
+++ b/src/System/Mail/EmailBudgetManager.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\System\Mail;
+
+use App\DB\Entity\System\EmailDailyBudget;
+use App\DB\EntityRepository\System\EmailDailyBudgetRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+class EmailBudgetManager
+{
+  public const int DAILY_LIMIT = 300;
+
+  public const array TYPE_RESERVES = [
+    'verification' => 150,
+    'reset' => 30,
+    'consent' => 30,
+    'admin' => 50,
+    'management' => 40,
+  ];
+
+  public function __construct(
+    protected EmailDailyBudgetRepository $repository,
+    protected EntityManagerInterface $entityManager,
+    protected LoggerInterface $logger,
+  ) {
+  }
+
+  public function canSend(string $type): bool
+  {
+    $this->validateType($type);
+
+    $budget = $this->repository->findOrCreateToday();
+
+    if ($budget->getTotalSent() >= self::DAILY_LIMIT) {
+      return false;
+    }
+
+    $typeReserve = self::TYPE_RESERVES[$type];
+    $typeSent = $budget->getSentByType($type);
+
+    if ($typeSent >= $typeReserve) {
+      $sharedPool = self::DAILY_LIMIT - $this->getTotalReserved();
+      $totalUsedFromShared = $this->getSharedPoolUsage($budget);
+
+      return $totalUsedFromShared < $sharedPool;
+    }
+
+    return true;
+  }
+
+  public function recordSend(string $type): void
+  {
+    $this->validateType($type);
+
+    $budget = $this->repository->findOrCreateToday();
+    $budget->incrementType($type);
+    $this->entityManager->flush();
+  }
+
+  /**
+   * @return array<string, int>
+   */
+  public function getRemainingBudget(): array
+  {
+    $budget = $this->repository->findOrCreateToday();
+    $remaining = [];
+
+    foreach (self::TYPE_RESERVES as $type => $reserve) {
+      $sent = $budget->getSentByType($type);
+      $remaining[$type] = max(0, $reserve - $sent);
+    }
+
+    $remaining['total'] = max(0, self::DAILY_LIMIT - $budget->getTotalSent());
+
+    return $remaining;
+  }
+
+  private function validateType(string $type): void
+  {
+    if (!isset(self::TYPE_RESERVES[$type])) {
+      throw new \InvalidArgumentException(sprintf('Unknown email type: %s. Valid types: %s', $type, implode(', ', array_keys(self::TYPE_RESERVES))));
+    }
+  }
+
+  private function getTotalReserved(): int
+  {
+    return array_sum(self::TYPE_RESERVES);
+  }
+
+  private function getSharedPoolUsage(EmailDailyBudget $budget): int
+  {
+    $overflow = 0;
+    foreach (self::TYPE_RESERVES as $type => $reserve) {
+      $sent = $budget->getSentByType($type);
+      if ($sent > $reserve) {
+        $overflow += $sent - $reserve;
+      }
+    }
+
+    return $overflow;
+  }
+}

--- a/src/System/Mail/MailerAdapter.php
+++ b/src/System/Mail/MailerAdapter.php
@@ -23,14 +23,24 @@ class MailerAdapter
     protected Environment $templateWrapper,
     #[Autowire('%dkim.private.key%')]
     protected string $dkim_private_key_path,
+    protected EmailBudgetManager $budgetManager,
   ) {
   }
 
-  public function send(string $to, string $subject, string $template, array $context = []): void
+  public function send(string $to, string $subject, string $template, array $context = [], string $emailType = 'admin'): bool
   {
+    if (!$this->budgetManager->canSend($emailType)) {
+      $this->logger->warning(sprintf('Email budget exhausted for type "%s". Email to %s with subject "%s" was not sent.', $emailType, $to, $subject));
+
+      return false;
+    }
+
     $email = $this->buildEmail($to, $subject, $template, $context);
     // $email = $this->signEmail($email); // Signing is currently disabled due to breveo
     $this->sendEmail($email, $to);
+    $this->budgetManager->recordSend($emailType);
+
+    return true;
   }
 
   protected function buildEmail(string $to, string $subject, string $template, array $context): Message

--- a/tests/PhpUnit/System/Mail/EmailBudgetManagerTest.php
+++ b/tests/PhpUnit/System/Mail/EmailBudgetManagerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\System\Mail;
+
+use App\DB\Entity\System\EmailDailyBudget;
+use App\DB\EntityRepository\System\EmailDailyBudgetRepository;
+use App\System\Mail\EmailBudgetManager;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * @covers \App\System\Mail\EmailBudgetManager
+ *
+ * @internal
+ */
+class EmailBudgetManagerTest extends TestCase
+{
+  private EmailDailyBudget $budget;
+  private EmailBudgetManager $manager;
+
+  #[\Override]
+  protected function setUp(): void
+  {
+    $this->budget = new EmailDailyBudget();
+
+    $repository = $this->createStub(EmailDailyBudgetRepository::class);
+    $repository->method('findOrCreateToday')->willReturn($this->budget);
+
+    $entityManager = $this->createStub(EntityManagerInterface::class);
+
+    $this->manager = new EmailBudgetManager($repository, $entityManager, new NullLogger());
+  }
+
+  public function testCanSendReturnsTrueWhenBudgetAvailable(): void
+  {
+    self::assertTrue($this->manager->canSend('verification'));
+    self::assertTrue($this->manager->canSend('reset'));
+    self::assertTrue($this->manager->canSend('consent'));
+    self::assertTrue($this->manager->canSend('admin'));
+    self::assertTrue($this->manager->canSend('management'));
+  }
+
+  public function testCanSendReturnsFalseWhenDailyLimitReached(): void
+  {
+    $this->budget->setTotalSent(EmailBudgetManager::DAILY_LIMIT);
+
+    self::assertFalse($this->manager->canSend('verification'));
+    self::assertFalse($this->manager->canSend('reset'));
+  }
+
+  public function testCanSendRespectsTypeReserve(): void
+  {
+    // Fill up verification reserve (150)
+    $this->budget->setVerificationSent(150);
+    $this->budget->setTotalSent(150);
+
+    // Verification can still send from shared pool (300 - 300 reserves = 0 shared)
+    // Total reserved = 150 + 30 + 30 + 50 + 40 = 300, shared pool = 0
+    self::assertFalse($this->manager->canSend('verification'));
+
+    // Other types are still within their reserves
+    self::assertTrue($this->manager->canSend('reset'));
+  }
+
+  public function testCanSendAllowsOverflowIntoSharedPool(): void
+  {
+    // With total reserves = 300 and daily limit = 300, shared pool = 0
+    // So overflowing a reserve is NOT possible when reserves sum to daily limit
+    $this->budget->setVerificationSent(150);
+    $this->budget->setTotalSent(150);
+
+    self::assertFalse($this->manager->canSend('verification'));
+  }
+
+  public function testRecordSendIncrementsCounters(): void
+  {
+    $this->manager->recordSend('verification');
+
+    self::assertSame(1, $this->budget->getVerificationSent());
+    self::assertSame(1, $this->budget->getTotalSent());
+
+    $this->manager->recordSend('verification');
+    self::assertSame(2, $this->budget->getVerificationSent());
+    self::assertSame(2, $this->budget->getTotalSent());
+  }
+
+  public function testRecordSendIncrementsDifferentTypes(): void
+  {
+    $this->manager->recordSend('verification');
+    $this->manager->recordSend('reset');
+    $this->manager->recordSend('admin');
+
+    self::assertSame(1, $this->budget->getVerificationSent());
+    self::assertSame(1, $this->budget->getResetSent());
+    self::assertSame(1, $this->budget->getAdminSent());
+    self::assertSame(3, $this->budget->getTotalSent());
+  }
+
+  public function testGetRemainingBudget(): void
+  {
+    $this->manager->recordSend('verification');
+    $this->manager->recordSend('verification');
+    $this->manager->recordSend('reset');
+
+    $remaining = $this->manager->getRemainingBudget();
+
+    self::assertSame(148, $remaining['verification']);
+    self::assertSame(29, $remaining['reset']);
+    self::assertSame(30, $remaining['consent']);
+    self::assertSame(50, $remaining['admin']);
+    self::assertSame(40, $remaining['management']);
+    self::assertSame(297, $remaining['total']);
+  }
+
+  public function testGetRemainingBudgetNeverNegative(): void
+  {
+    $this->budget->setResetSent(100);
+    $this->budget->setTotalSent(100);
+
+    $remaining = $this->manager->getRemainingBudget();
+
+    self::assertSame(0, $remaining['reset']);
+    self::assertSame(200, $remaining['total']);
+  }
+
+  public function testCanSendThrowsOnInvalidType(): void
+  {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Unknown email type: invalid');
+    $this->manager->canSend('invalid');
+  }
+
+  public function testRecordSendThrowsOnInvalidType(): void
+  {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Unknown email type: invalid');
+    $this->manager->recordSend('invalid');
+  }
+
+  public function testBudgetExhaustionByType(): void
+  {
+    // Fill reset reserve completely
+    for ($i = 0; $i < 30; ++$i) {
+      self::assertTrue($this->manager->canSend('reset'));
+      $this->manager->recordSend('reset');
+    }
+
+    // Reset reserve exhausted, shared pool = 0 (reserves sum to 300 = daily limit)
+    self::assertFalse($this->manager->canSend('reset'));
+
+    // Other types still have budget within their reserves
+    self::assertTrue($this->manager->canSend('verification'));
+    self::assertTrue($this->manager->canSend('admin'));
+  }
+
+  public function testTotalLimitPreventsAllSending(): void
+  {
+    $this->budget->setTotalSent(300);
+    $this->budget->setVerificationSent(0);
+
+    self::assertFalse($this->manager->canSend('verification'));
+    self::assertFalse($this->manager->canSend('reset'));
+    self::assertFalse($this->manager->canSend('consent'));
+    self::assertFalse($this->manager->canSend('admin'));
+    self::assertFalse($this->manager->canSend('management'));
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `EmailDailyBudget` entity and repository to track daily email sending counts by type
- Adds `EmailBudgetManager` service with per-type reserves (verification=150, reset=30, consent=30, admin=50, management=40) and a 300/day total limit
- Modifies `MailerAdapter::send()` to check budget before sending and log warnings when exhausted (returns `bool` instead of `void`)
- Updates all callers (`VerifyEmail`, `ResetPasswordEmail`, `SendMailToUserController`) to pass their email type
- Includes database migration for the `email_daily_budget` table

## Test plan
- [x] PHPUnit tests for `EmailBudgetManager` (12 tests, all passing): priority logic, budget exhaustion, type reserves, invalid type handling, counter increments
- [ ] Manual: verify emails still send normally with budget available
- [ ] Manual: verify warning is logged when budget exhausted

Closes #6501

🤖 Generated with [Claude Code](https://claude.com/claude-code)