### PR TITLE
Add storage lifecycle manager with auto-delete cron

### DIFF
--- a/src/Project/ProjectManager.php
+++ b/src/Project/ProjectManager.php
@@ -676,6 +676,39 @@ class ProjectManager
     $this->entity_manager->refresh($project);
   }
 
+  /**
+   * Permanently deletes a project: removes files from disk and the database record.
+   * Doctrine cascade handles related entities (comments, notifications, likes, etc.).
+   */
+  public function hardDeleteProject(Program $project): void
+  {
+    $projectId = $project->getId();
+    if (null === $projectId) {
+      throw new \InvalidArgumentException('Cannot hard-delete a project without an ID');
+    }
+
+    // Delete zip file
+    $this->file_repository->deleteProjectZipFileIfExists($projectId);
+
+    // Delete extracted files
+    try {
+      $this->file_repository->deleteProjectExtractFiles($projectId);
+    } catch (\Exception $e) {
+      $this->logger->warning('hardDeleteProject: could not delete extract files for project {id}: {error}', [
+        'id' => $projectId,
+        'error' => $e->getMessage(),
+      ]);
+    }
+
+    // Delete screenshots and thumbnails
+    $this->screenshot_repository->deleteScreenshot($projectId);
+    $this->screenshot_repository->deleteThumbnail($projectId);
+
+    // Remove from database (Doctrine cascades handle relations)
+    $this->entity_manager->remove($project);
+    $this->entity_manager->flush();
+  }
+
   private function getPopularProjects(?string $flavor, int $limit, int $offset, string $max_version): array
   {
     return $this->project_repository->getProjects($flavor, $max_version, $limit, $offset, 'popularity');

--- a/src/Storage/StorageLifecycleService.php
+++ b/src/Storage/StorageLifecycleService.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Storage;
+
+use App\DB\Entity\Project\Program;
+use App\DB\Entity\Project\Special\ExampleProgram;
+use App\DB\Entity\Project\Special\FeaturedProgram;
+use App\DB\Entity\User\User;
+use App\Project\CatrobatFile\ProjectFileRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+class StorageLifecycleService
+{
+  private const int BATCH_SIZE = 100;
+
+  public const int PROTECTED_DAYS = -1;
+  public const int ACTIVE_DAYS = 365;
+  public const int STANDARD_DAYS = 90;
+  public const int SHORT_DAYS = 30;
+
+  public const float DISK_WARN_THRESHOLD = 0.70;
+  public const float DISK_PRESSURE_THRESHOLD = 0.85;
+  public const float DISK_CRITICAL_THRESHOLD = 0.95;
+
+  private const int ACTIVE_DOWNLOAD_MINIMUM = 10;
+  private const int USER_ACTIVE_DAYS = 180;
+
+  public function __construct(
+    private readonly EntityManagerInterface $entity_manager,
+    private readonly ProjectFileRepository $file_repository,
+    private readonly ScreenshotRepository $screenshot_repository,
+    private readonly LoggerInterface $logger,
+  ) {
+  }
+
+  /**
+   * Determines which retention tier a project belongs to.
+   *
+   * @return int days until deletion (-1 = protected/never)
+   */
+  public function getRetentionDays(Program $project): int
+  {
+    if ($this->isProtected($project)) {
+      return self::PROTECTED_DAYS;
+    }
+
+    if ($this->isActive($project)) {
+      return self::ACTIVE_DAYS;
+    }
+
+    if ($this->isStandard($project)) {
+      return self::STANDARD_DAYS;
+    }
+
+    return self::SHORT_DAYS;
+  }
+
+  /**
+   * Protected: featured, example, or admin-approved projects. Never deleted.
+   */
+  public function isProtected(Program $project): bool
+  {
+    if ($project->getApproved()) {
+      return true;
+    }
+
+    $projectId = $project->getId();
+    if (null === $projectId) {
+      return false;
+    }
+
+    $featured = $this->entity_manager->createQueryBuilder()
+      ->select('COUNT(f.id)')
+      ->from(FeaturedProgram::class, 'f')
+      ->where('f.program = :project')
+      ->setParameter('project', $project)
+      ->getQuery()
+      ->getSingleScalarResult()
+    ;
+
+    if ((int) $featured > 0) {
+      return true;
+    }
+
+    $example = $this->entity_manager->createQueryBuilder()
+      ->select('COUNT(e.id)')
+      ->from(ExampleProgram::class, 'e')
+      ->where('e.program = :project')
+      ->setParameter('project', $project)
+      ->getQuery()
+      ->getSingleScalarResult()
+    ;
+
+    return (int) $example > 0;
+  }
+
+  /**
+   * Active: >= 10 downloads OR owner logged in within 180 days.
+   */
+  public function isActive(Program $project): bool
+  {
+    if ($project->getDownloads() >= self::ACTIVE_DOWNLOAD_MINIMUM) {
+      return true;
+    }
+
+    $user = $project->getUser();
+    if (null === $user) {
+      return false;
+    }
+
+    $lastLogin = $user->getLastLogin();
+    if (null === $lastLogin) {
+      return false;
+    }
+
+    $cutoff = new \DateTime('-'.self::USER_ACTIVE_DAYS.' days');
+
+    return $lastLogin >= $cutoff;
+  }
+
+  /**
+   * Standard: visible project by a verified user.
+   */
+  public function isStandard(Program $project): bool
+  {
+    if (!$project->getVisible()) {
+      return false;
+    }
+
+    if ($project->getAutoHidden()) {
+      return false;
+    }
+
+    $user = $project->getUser();
+    if (null === $user) {
+      return false;
+    }
+
+    return $user->isVerified();
+  }
+
+  /**
+   * Returns the current disk usage ratio for the storage partition (0.0 to 1.0).
+   */
+  public function getDiskUsageRatio(string $path): float
+  {
+    $total = @disk_total_space($path);
+    $free = @disk_free_space($path);
+
+    if (false === $total || false === $free || 0.0 === $total) {
+      return 0.0;
+    }
+
+    return 1.0 - ($free / $total);
+  }
+
+  /**
+   * Applies disk pressure multiplier to retention days.
+   */
+  public function applyDiskPressure(int $retention_days, float $disk_ratio): int
+  {
+    if (self::PROTECTED_DAYS === $retention_days) {
+      return self::PROTECTED_DAYS;
+    }
+
+    if ($disk_ratio >= self::DISK_CRITICAL_THRESHOLD) {
+      return (int) ceil($retention_days / 4);
+    }
+
+    if ($disk_ratio >= self::DISK_PRESSURE_THRESHOLD) {
+      return (int) ceil($retention_days / 2);
+    }
+
+    return $retention_days;
+  }
+
+  /**
+   * Returns true if uploads should be paused due to critical disk pressure.
+   */
+  public function shouldPauseUploads(float $disk_ratio): bool
+  {
+    return $disk_ratio >= self::DISK_CRITICAL_THRESHOLD;
+  }
+
+  /**
+   * Finds and deletes expired projects in batches.
+   *
+   * @return array{checked: int, deleted: int, errors: int}
+   */
+  public function deleteExpiredProjects(bool $dry_run = false, string $storage_path = ''): array
+  {
+    $disk_ratio = '' !== $storage_path ? $this->getDiskUsageRatio($storage_path) : 0.0;
+
+    if ($disk_ratio >= self::DISK_WARN_THRESHOLD) {
+      $this->logger->warning('Storage lifecycle: disk usage at {ratio}%', [
+        'ratio' => round($disk_ratio * 100.0, 1),
+      ]);
+    }
+
+    $checked = 0;
+    $deleted = 0;
+    $errors = 0;
+    $offset = 0;
+    $now = new \DateTime();
+
+    while (true) {
+      $projects = $this->entity_manager->createQueryBuilder()
+        ->select('p')
+        ->from(Program::class, 'p')
+        ->leftJoin('p.user', 'u')
+        ->orderBy('p.uploaded_at', 'ASC')
+        ->setFirstResult($offset)
+        ->setMaxResults(self::BATCH_SIZE)
+        ->getQuery()
+        ->getResult()
+      ;
+
+      if ([] === $projects) {
+        break;
+      }
+
+      /** @var Program $project */
+      foreach ($projects as $project) {
+        ++$checked;
+
+        $retention_days = $this->getRetentionDays($project);
+        $retention_days = $this->applyDiskPressure($retention_days, $disk_ratio);
+
+        if (self::PROTECTED_DAYS === $retention_days) {
+          continue;
+        }
+
+        $expiry = (clone $project->getUploadedAt())->modify('+'.$retention_days.' days');
+
+        if ($expiry >= $now) {
+          continue;
+        }
+
+        $projectId = $project->getId() ?? 'unknown';
+        $projectName = $project->getName();
+
+        if ($dry_run) {
+          $this->logger->info('Storage lifecycle [DRY-RUN]: would delete project {id} "{name}" (tier: {days}d, uploaded: {uploaded})', [
+            'id' => $projectId,
+            'name' => $projectName,
+            'days' => $retention_days,
+            'uploaded' => $project->getUploadedAt()->format('Y-m-d'),
+          ]);
+          ++$deleted;
+
+          continue;
+        }
+
+        try {
+          $this->hardDeleteProject($project);
+          ++$deleted;
+          $this->logger->info('Storage lifecycle: deleted project {id} "{name}"', [
+            'id' => $projectId,
+            'name' => $projectName,
+          ]);
+        } catch (\Throwable $e) {
+          ++$errors;
+          $this->logger->error('Storage lifecycle: failed to delete project {id}: {error}', [
+            'id' => $projectId,
+            'error' => $e->getMessage(),
+          ]);
+        }
+      }
+
+      $offset += self::BATCH_SIZE;
+      $this->entity_manager->clear();
+    }
+
+    return ['checked' => $checked, 'deleted' => $deleted, 'errors' => $errors];
+  }
+
+  /**
+   * Permanently deletes a project: files, screenshots, thumbnails, and database record.
+   * Doctrine cascade handles related entities (comments, notifications, likes, etc.).
+   */
+  public function hardDeleteProject(Program $project): void
+  {
+    $projectId = $project->getId();
+    if (null === $projectId) {
+      throw new \InvalidArgumentException('Cannot hard-delete a project without an ID');
+    }
+
+    // Delete zip file
+    $this->file_repository->deleteProjectZipFileIfExists($projectId);
+
+    // Delete extracted files
+    try {
+      $this->file_repository->deleteProjectExtractFiles($projectId);
+    } catch (\Exception $e) {
+      $this->logger->warning('Storage lifecycle: could not delete extract files for project {id}: {error}', [
+        'id' => $projectId,
+        'error' => $e->getMessage(),
+      ]);
+    }
+
+    // Delete screenshots and thumbnails
+    $this->screenshot_repository->deleteScreenshot($projectId);
+    $this->screenshot_repository->deleteThumbnail($projectId);
+
+    // Remove from database (Doctrine cascades handle relations)
+    $this->entity_manager->remove($project);
+    $this->entity_manager->flush();
+  }
+}

--- a/src/System/Commands/DBUpdater/CronJobCommand.php
+++ b/src/System/Commands/DBUpdater/CronJobCommand.php
@@ -134,6 +134,15 @@ class CronJobCommand extends Command
       $output
     );
 
+    // Storage lifecycle: delete expired projects
+    $this->runCronJob(
+      'Delete expired projects based on retention rules',
+      ['bin/console', 'catrobat:storage:lifecycle'],
+      ['timeout' => self::ONE_DAY_IN_SECONDS],
+      '1 day',
+      $output
+    );
+
     return 0;
   }
 

--- a/src/System/Commands/Storage/StorageLifecycleCommand.php
+++ b/src/System/Commands/Storage/StorageLifecycleCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\System\Commands\Storage;
+
+use App\Storage\StorageLifecycleService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+#[AsCommand(name: 'catrobat:storage:lifecycle', description: 'Delete expired projects based on retention tier rules and disk pressure.')]
+class StorageLifecycleCommand extends Command
+{
+  public function __construct(
+    private readonly StorageLifecycleService $lifecycle_service,
+    #[Autowire('%catrobat.file.storage.dir%')]
+    private readonly string $storage_dir,
+  ) {
+    parent::__construct();
+  }
+
+  #[\Override]
+  protected function configure(): void
+  {
+    $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show what would be deleted without actually deleting');
+  }
+
+  #[\Override]
+  protected function execute(InputInterface $input, OutputInterface $output): int
+  {
+    $io = new SymfonyStyle($input, $output);
+    $dry_run = (bool) $input->getOption('dry-run');
+
+    $io->title('Storage Lifecycle Manager');
+
+    if ($dry_run) {
+      $io->note('DRY-RUN mode: no projects will be deleted.');
+    }
+
+    $disk_ratio = $this->lifecycle_service->getDiskUsageRatio($this->storage_dir);
+    $io->text(sprintf('Current disk usage: %.1f%%', $disk_ratio * 100.0));
+
+    if ($this->lifecycle_service->shouldPauseUploads($disk_ratio)) {
+      $io->warning('CRITICAL: Disk usage above 95% -- uploads should be paused!');
+    }
+
+    $result = $this->lifecycle_service->deleteExpiredProjects($dry_run, $this->storage_dir);
+
+    $action = $dry_run ? 'would delete' : 'deleted';
+
+    $io->success(sprintf(
+      'Done. Checked %d projects: %s %d, %d errors.',
+      $result['checked'],
+      $action,
+      $result['deleted'],
+      $result['errors'],
+    ));
+
+    return Command::SUCCESS;
+  }
+}

--- a/tests/BehatFeatures/web/admin/db_updater/admin_cron_jobs.feature
+++ b/tests/BehatFeatures/web/admin/db_updater/admin_cron_jobs.feature
@@ -36,7 +36,7 @@ Feature: The admin cron jobs view provides a detailed list about all cron jobs a
     Then I should see "Cron jobs finished successfully"
     When I am on "/admin/system/cron-job/list"
     And I wait for the page to be loaded
-    And there should be "10" cron jobs in the database
+    And there should be "11" cron jobs in the database
 
   Scenario: Cron jobs can be reset
     Given I log in as "Admin"

--- a/tests/PhpUnit/Storage/StorageLifecycleServiceTest.php
+++ b/tests/PhpUnit/Storage/StorageLifecycleServiceTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Storage;
+
+use App\DB\Entity\Project\Program;
+use App\DB\Entity\User\User;
+use App\Project\CatrobatFile\ProjectFileRepository;
+use App\Storage\ScreenshotRepository;
+use App\Storage\StorageLifecycleService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * @internal
+ *
+ * @covers \App\Storage\StorageLifecycleService
+ */
+class StorageLifecycleServiceTest extends TestCase
+{
+  private StorageLifecycleService $service;
+
+  #[\Override]
+  protected function setUp(): void
+  {
+    $this->service = $this->buildServiceWithCounts(0, 0);
+  }
+
+  public function testProtectedTierForApprovedProject(): void
+  {
+    $project = $this->createProjectStub(approved: true);
+
+    self::assertSame(StorageLifecycleService::PROTECTED_DAYS, $this->service->getRetentionDays($project));
+    self::assertTrue($this->service->isProtected($project));
+  }
+
+  public function testProtectedTierForFeaturedProject(): void
+  {
+    $service = $this->buildServiceWithCounts(1, 0);
+
+    $project = $this->createProjectStub(approved: false);
+
+    self::assertTrue($service->isProtected($project));
+    self::assertSame(StorageLifecycleService::PROTECTED_DAYS, $service->getRetentionDays($project));
+  }
+
+  public function testProtectedTierForExampleProject(): void
+  {
+    $service = $this->buildServiceWithCounts(0, 1);
+
+    $project = $this->createProjectStub(approved: false);
+
+    self::assertTrue($service->isProtected($project));
+    self::assertSame(StorageLifecycleService::PROTECTED_DAYS, $service->getRetentionDays($project));
+  }
+
+  public function testActiveTierHighDownloads(): void
+  {
+    $project = $this->createProjectStub(downloads: 50, visible: true);
+
+    self::assertTrue($this->service->isActive($project));
+    self::assertSame(StorageLifecycleService::ACTIVE_DAYS, $this->service->getRetentionDays($project));
+  }
+
+  public function testActiveTierRecentUserLogin(): void
+  {
+    $user = $this->createStub(User::class);
+    $user->method('getLastLogin')->willReturn(new \DateTime('-30 days'));
+    $user->method('isVerified')->willReturn(true);
+
+    $project = $this->createProjectStub(downloads: 0, visible: true, user: $user);
+
+    self::assertTrue($this->service->isActive($project));
+    self::assertSame(StorageLifecycleService::ACTIVE_DAYS, $this->service->getRetentionDays($project));
+  }
+
+  public function testStandardTierVisibleVerifiedUser(): void
+  {
+    $user = $this->createStub(User::class);
+    $user->method('getLastLogin')->willReturn(new \DateTime('-200 days'));
+    $user->method('isVerified')->willReturn(true);
+
+    $project = $this->createProjectStub(downloads: 5, visible: true, autoHidden: false, user: $user);
+
+    self::assertTrue($this->service->isStandard($project));
+    self::assertSame(StorageLifecycleService::STANDARD_DAYS, $this->service->getRetentionDays($project));
+  }
+
+  public function testShortTierZeroDownloadsInactiveUser(): void
+  {
+    $user = $this->createStub(User::class);
+    $user->method('getLastLogin')->willReturn(new \DateTime('-365 days'));
+    $user->method('isVerified')->willReturn(false);
+
+    $project = $this->createProjectStub(downloads: 0, visible: true, autoHidden: false, user: $user);
+
+    self::assertFalse($this->service->isActive($project));
+    self::assertFalse($this->service->isStandard($project));
+    self::assertSame(StorageLifecycleService::SHORT_DAYS, $this->service->getRetentionDays($project));
+  }
+
+  public function testShortTierForHiddenProject(): void
+  {
+    $user = $this->createStub(User::class);
+    $user->method('getLastLogin')->willReturn(new \DateTime('-200 days'));
+    $user->method('isVerified')->willReturn(true);
+
+    $project = $this->createProjectStub(downloads: 5, visible: false, user: $user);
+
+    self::assertFalse($this->service->isStandard($project));
+    self::assertSame(StorageLifecycleService::SHORT_DAYS, $this->service->getRetentionDays($project));
+  }
+
+  public function testShortTierForAutoHiddenProject(): void
+  {
+    $user = $this->createStub(User::class);
+    $user->method('getLastLogin')->willReturn(new \DateTime('-200 days'));
+    $user->method('isVerified')->willReturn(true);
+
+    $project = $this->createProjectStub(downloads: 5, visible: true, autoHidden: true, user: $user);
+
+    self::assertFalse($this->service->isStandard($project));
+    self::assertSame(StorageLifecycleService::SHORT_DAYS, $this->service->getRetentionDays($project));
+  }
+
+  public function testShortTierForUnverifiedUser(): void
+  {
+    $user = $this->createStub(User::class);
+    $user->method('getLastLogin')->willReturn(new \DateTime('-200 days'));
+    $user->method('isVerified')->willReturn(false);
+
+    $project = $this->createProjectStub(downloads: 5, visible: true, autoHidden: false, user: $user);
+
+    self::assertFalse($this->service->isStandard($project));
+    self::assertSame(StorageLifecycleService::SHORT_DAYS, $this->service->getRetentionDays($project));
+  }
+
+  public function testDiskPressureHalvesRetention(): void
+  {
+    $result = $this->service->applyDiskPressure(90, 0.87);
+    self::assertSame(45, $result);
+  }
+
+  public function testDiskCriticalQuartersRetention(): void
+  {
+    $result = $this->service->applyDiskPressure(90, 0.96);
+    self::assertSame(23, $result);
+  }
+
+  public function testDiskPressureDoesNotAffectProtected(): void
+  {
+    $result = $this->service->applyDiskPressure(StorageLifecycleService::PROTECTED_DAYS, 0.99);
+    self::assertSame(StorageLifecycleService::PROTECTED_DAYS, $result);
+  }
+
+  public function testNormalDiskDoesNotChangeRetention(): void
+  {
+    $result = $this->service->applyDiskPressure(90, 0.50);
+    self::assertSame(90, $result);
+  }
+
+  public function testShouldPauseUploadsAtCritical(): void
+  {
+    self::assertTrue($this->service->shouldPauseUploads(0.96));
+    self::assertFalse($this->service->shouldPauseUploads(0.94));
+    self::assertFalse($this->service->shouldPauseUploads(0.50));
+  }
+
+  private function createProjectStub(
+    bool $approved = false,
+    int $downloads = 0,
+    bool $visible = true,
+    bool $autoHidden = false,
+    ?User $user = null,
+  ): Program {
+    if (null === $user) {
+      $user = $this->createStub(User::class);
+      $user->method('getLastLogin')->willReturn(null);
+      $user->method('isVerified')->willReturn(false);
+    }
+
+    $project = $this->createStub(Program::class);
+    $project->method('getId')->willReturn('test-project-id');
+    $project->method('getApproved')->willReturn($approved);
+    $project->method('getDownloads')->willReturn($downloads);
+    $project->method('getVisible')->willReturn($visible);
+    $project->method('getAutoHidden')->willReturn($autoHidden);
+    $project->method('getUser')->willReturn($user);
+    $project->method('getUploadedAt')->willReturn(new \DateTime('-400 days'));
+    $project->method('getName')->willReturn('Test Project');
+
+    return $project;
+  }
+
+  private function buildServiceWithCounts(int $featured, int $example): StorageLifecycleService
+  {
+    $query = $this->createStub(Query::class);
+
+    $callCount = 0;
+    $query->method('getSingleScalarResult')
+      ->willReturnCallback(function () use (&$callCount, $featured, $example): int {
+        return 0 === $callCount++ % 2 ? $featured : $example;
+      })
+    ;
+
+    $qb = $this->createStub(QueryBuilder::class);
+    $qb->method('select')->willReturnSelf();
+    $qb->method('from')->willReturnSelf();
+    $qb->method('where')->willReturnSelf();
+    $qb->method('setParameter')->willReturnSelf();
+    $qb->method('getQuery')->willReturn($query);
+
+    $em = $this->createStub(EntityManagerInterface::class);
+    $em->method('createQueryBuilder')->willReturn($qb);
+
+    return new StorageLifecycleService(
+      $em,
+      $this->createStub(ProjectFileRepository::class),
+      $this->createStub(ScreenshotRepository::class),
+      new NullLogger(),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Implements tiered retention rules for automatic project cleanup: Protected (never delete featured/example/approved), Active (365 days for popular or recently-active-user projects), Standard (90 days for visible/verified), Short (30 days for inactive/hidden/unverified)
- Adds disk pressure escalation: warn at 70%, halve retention at 85%, quarter retention + signal upload pause at 95%
- Adds `hardDeleteProject()` to `ProjectManager` for permanent file + DB removal with Doctrine cascade
- New console command `catrobat:storage:lifecycle` with `--dry-run` support, registered in `CronJobCommand` for daily execution

## Test plan
- [x] PHPUnit tests for all 4 retention tiers (protected, active, standard, short)
- [x] PHPUnit tests for disk pressure multipliers (normal, halve, quarter, protected-immune)
- [x] PHPUnit tests for upload pause threshold
- [ ] Manual: `bin/console catrobat:storage:lifecycle --dry-run` in dev environment
- [ ] Verify featured/example/approved projects are never selected for deletion
- [ ] Verify Doctrine cascade correctly removes related entities on hard delete

Closes #6498

🤖 Generated with [Claude Code](https://claude.com/claude-code)