### PR TITLE
Fix XSS in Project.js createLinks() via innerHTML

### DIFF
--- a/assets/Project/Project.js
+++ b/assets/Project/Project.js
@@ -26,11 +26,33 @@ export const Project = function (config) {
   // -------------------------- FileHelper
 
   function createLinks() {
+    const urlPattern = /(https?|ftp):\/\/[\w?=&./+\-;#~%]+/g
     document.querySelectorAll('#description').forEach((element) => {
-      element.innerHTML = element.innerHTML.replace(
-        /((http|https|ftp):\/\/[\w?=&./+\-;#~%]+(?![\w\s?&./;#~%"=-]*>))/g,
-        '<a href="$1" target="_blank">$1</a> ',
-      )
+      const text = element.textContent
+      const fragment = document.createDocumentFragment()
+      let lastIndex = 0
+      let match
+
+      while ((match = urlPattern.exec(text)) !== null) {
+        if (match.index > lastIndex) {
+          fragment.appendChild(document.createTextNode(text.slice(lastIndex, match.index)))
+        }
+        const url = match[0]
+        const a = document.createElement('a')
+        a.setAttribute('href', /^(https?|ftp):\/\//i.test(url) ? url : '#')
+        a.target = '_blank'
+        a.textContent = url
+        fragment.appendChild(a)
+        fragment.appendChild(document.createTextNode(' '))
+        lastIndex = urlPattern.lastIndex
+      }
+
+      if (lastIndex < text.length) {
+        fragment.appendChild(document.createTextNode(text.slice(lastIndex)))
+      }
+
+      element.textContent = ''
+      element.appendChild(fragment)
     })
   }
 

--- a/assets/Project/Project.js
+++ b/assets/Project/Project.js
@@ -39,8 +39,16 @@ export const Project = function (config) {
         }
         const url = match[0]
         const a = document.createElement('a')
-        a.setAttribute('href', /^(https?|ftp):\/\//i.test(url) ? url : '#')
+        try {
+          const parsed = new URL(url)
+          if (['http:', 'https:', 'ftp:'].includes(parsed.protocol)) {
+            a.href = parsed.href
+          }
+        } catch {
+          // invalid URL — leave href empty so link is inert
+        }
         a.target = '_blank'
+        a.rel = 'noopener noreferrer'
         a.textContent = url
         fragment.appendChild(a)
         fragment.appendChild(document.createTextNode(' '))


### PR DESCRIPTION
## Summary
- Fixed XSS vulnerability in `createLinks()` (`assets/Project/Project.js`) where `innerHTML` with regex replacement allowed script injection through crafted project descriptions
- Replaced unsafe `innerHTML` replacement with safe DOM API: reads text via `textContent`, builds anchor elements with `document.createElement('a')`, and assembles output using `DocumentFragment`
- Preserves existing behavior: URLs (http, https, ftp) in project descriptions are still converted to clickable links

## Test plan
- [ ] Verify project descriptions with URLs still render as clickable links
- [ ] Verify project descriptions with `<script>` tags or HTML are safely escaped
- [ ] Run `web-project-details` Behat suite

Closes #6510

🤖 Generated with [Claude Code](https://claude.com/claude-code)