### PR TITLE
Fix robots.txt redirect to use absolute path

### DIFF
--- a/src/Application/Controller/Base/RedirectController.php
+++ b/src/Application/Controller/Base/RedirectController.php
@@ -38,7 +38,7 @@ class RedirectController extends AbstractController
   #[Route(path: '/robots.txt', name: 'robots.txt', methods: ['GET'])]
   public function robotsTxt(): Response
   {
-    return $this->redirect('../../robots.txt', Response::HTTP_MOVED_PERMANENTLY);
+    return $this->redirect('/robots.txt', Response::HTTP_MOVED_PERMANENTLY);
     // The file is only hosted without flavors/themes!
   }
 


### PR DESCRIPTION
## Summary
- Changed `RedirectController::robotsTxt()` from relative redirect `../../robots.txt` to absolute `/robots.txt`
- The relative path doesn't resolve correctly and breaks depending on URL depth

Closes #6525

## Test plan
- [ ] Visit `/robots.txt` and verify it returns a 301 redirect to the static `robots.txt` file
- [ ] Verify the `Location` header uses an absolute path `/robots.txt`

## Server changes
No server configuration changes needed. The `public/robots.txt` file already exists and is served by the web server. This route only applies when the request reaches Symfony (e.g., themed URLs like `/{theme}/robots.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)