### PR TITLE
Remove deprecated Google+ token fields from User entity

### DIFF
--- a/migrations/2026/Version20260402120000.php
+++ b/migrations/2026/Version20260402120000.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260402120000 extends AbstractMigration
+{
+  #[\Override]
+  public function getDescription(): string
+  {
+    return 'Remove deprecated Google+ token fields (gplus_id_token, gplus_refresh_token) from fos_user';
+  }
+
+  #[\Override]
+  public function up(Schema $schema): void
+  {
+    $this->addSql('ALTER TABLE fos_user DROP COLUMN gplus_id_token, DROP COLUMN gplus_refresh_token');
+  }
+
+  #[\Override]
+  public function down(Schema $schema): void
+  {
+    $this->addSql('ALTER TABLE fos_user ADD gplus_id_token VARCHAR(5000) DEFAULT NULL, ADD gplus_refresh_token VARCHAR(300) DEFAULT NULL');
+  }
+}

--- a/src/DB/Entity/User/User.php
+++ b/src/DB/Entity/User/User.php
@@ -165,18 +165,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \String
   #[ORM\Column(type: Types::TEXT, nullable: true)]
   protected ?string $apple_access_token = null;
 
-  /**
-   * @deprecated
-   */
-  #[ORM\Column(type: Types::STRING, length: 5000, nullable: true)]
-  protected ?string $gplus_id_token = null;
-
-  /**
-   * @deprecated
-   */
-  #[ORM\Column(type: Types::STRING, length: 300, nullable: true)]
-  protected ?string $gplus_refresh_token = null;
-
   #[ORM\Column(type: Types::INTEGER, unique: true, nullable: true)]
   protected ?int $scratch_user_id = null;
 
@@ -280,26 +268,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \String
   public function getAppleId(): ?string
   {
     return $this->apple_id;
-  }
-
-  public function setGplusIdToken(?string $gplus_id_token): void
-  {
-    $this->gplus_id_token = $gplus_id_token;
-  }
-
-  public function getGplusIdToken(): ?string
-  {
-    return $this->gplus_id_token;
-  }
-
-  public function setGplusRefreshToken(?string $gplus_refresh_token): void
-  {
-    $this->gplus_refresh_token = $gplus_refresh_token;
-  }
-
-  public function getGplusRefreshToken(): ?string
-  {
-    return $this->gplus_refresh_token;
   }
 
   public function getId(): ?string


### PR DESCRIPTION
## Summary
- Remove deprecated `gplus_id_token` and `gplus_refresh_token` properties, getters, and setters from the `User` entity
- Add Doctrine migration to drop the corresponding database columns from `fos_user`

Closes #6514

## Verification
Grep confirmed these fields are not referenced anywhere in the codebase (no controllers, services, security config, or OAuth logic uses them). They were already marked `@deprecated` and are remnants of the discontinued Google+ API, unrelated to current Google OAuth authentication.

## Test plan
- [ ] CI static analysis (php-cs-fixer, phpstan, psalm) passes
- [ ] Migration runs successfully against dev database
- [ ] Existing authentication and OAuth flows unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)