### PR TITLE
Add asset-level deduplication for project uploads

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -115,6 +115,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
   $parameters->set('catrobat.file.extract.path', 'resources/extract/');
   $parameters->set('catrobat.file.storage.dir', '%kernel.project_dir%/public/resources/programs/');
   $parameters->set('catrobat.file.storage.path', 'resources/programs/');
+  $parameters->set('catrobat.file.assets.dir', '%kernel.project_dir%/public/resources/assets/');
   $parameters->set('catrobat.logs.dir', '%kernel.project_dir%/var/log/');
   $parameters->set('catrobat.media.dir', '%catrobat.pubdir%resources/media/');
   $parameters->set('catrobat.media.path', 'resources/media/');

--- a/migrations/2026/Version20260403140000.php
+++ b/migrations/2026/Version20260403140000.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260403140000 extends AbstractMigration
+{
+  #[\Override]
+  public function getDescription(): string
+  {
+    return 'Create project_asset and project_asset_mapping tables for content-addressable asset storage';
+  }
+
+  #[\Override]
+  public function up(Schema $schema): void
+  {
+    $this->addSql('
+      CREATE TABLE project_asset (
+        hash VARCHAR(64) NOT NULL,
+        size BIGINT NOT NULL,
+        mime_type VARCHAR(127) NOT NULL,
+        reference_count INT NOT NULL DEFAULT 0,
+        storage_path VARCHAR(255) NOT NULL,
+        created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\',
+        PRIMARY KEY (hash)
+      ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB
+    ');
+
+    $this->addSql('
+      CREATE TABLE project_asset_mapping (
+        id INT AUTO_INCREMENT NOT NULL,
+        project_id CHAR(36) NOT NULL COMMENT \'(DC2Type:guid)\',
+        asset_hash VARCHAR(64) NOT NULL,
+        original_filename VARCHAR(255) NOT NULL,
+        path_in_zip VARCHAR(512) NOT NULL,
+        UNIQUE INDEX project_path_unique (project_id, path_in_zip),
+        INDEX mapping_project_idx (project_id),
+        INDEX mapping_asset_idx (asset_hash),
+        CONSTRAINT FK_mapping_project FOREIGN KEY (project_id) REFERENCES program (id) ON DELETE CASCADE,
+        CONSTRAINT FK_mapping_asset FOREIGN KEY (asset_hash) REFERENCES project_asset (hash),
+        PRIMARY KEY (id)
+      ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB
+    ');
+  }
+
+  #[\Override]
+  public function down(Schema $schema): void
+  {
+    $this->addSql('DROP TABLE project_asset_mapping');
+    $this->addSql('DROP TABLE project_asset');
+  }
+}

--- a/src/Api/Services/Projects/ProjectsApiLoader.php
+++ b/src/Api/Services/Projects/ProjectsApiLoader.php
@@ -13,6 +13,7 @@ use App\DB\EntityRepository\Project\Special\FeaturedRepository;
 use App\DB\EntityRepository\Project\TagRepository;
 use App\Project\CatrobatFile\ExtractedFileRepository;
 use App\Project\CatrobatFile\ProjectFileRepository;
+use App\Project\CatrobatFile\ProjectZipReconstructor;
 use App\Project\CodeStatistics\CodeStatisticsService;
 use App\Project\ProjectManager;
 use App\Project\ProjectSearchService;
@@ -36,6 +37,7 @@ class ProjectsApiLoader extends AbstractApiLoader
     protected ExtractedFileRepository $extracted_file_repository,
     protected LoggerInterface $logger,
     private readonly Security $security,
+    private readonly ProjectZipReconstructor $zip_reconstructor,
   ) {
   }
 
@@ -138,7 +140,12 @@ class ProjectsApiLoader extends AbstractApiLoader
   {
     try {
       if (!$this->file_repository->checkIfProjectZipFileExists($id)) {
-        $this->file_repository->zipProject($this->extracted_file_repository->getBaseDir($id), $id);
+        // Try reconstructing from content-addressable store first
+        $reconstructed = $this->zip_reconstructor->reconstruct($id);
+        if (null === $reconstructed) {
+          // Fall back to existing behavior: zip from extracted files
+          $this->file_repository->zipProject($this->extracted_file_repository->getBaseDir($id), $id);
+        }
       }
 
       $zipFile = $this->file_repository->getProjectZipFile($id);

--- a/src/DB/Entity/Project/ProjectAsset.php
+++ b/src/DB/Entity/Project/ProjectAsset.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace App\DB\Entity\Project;
 
 use App\DB\EntityRepository\Project\ProjectAssetRepository;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -24,21 +22,17 @@ class ProjectAsset
   #[ORM\Column(type: Types::BIGINT)]
   private int $size;
 
-  #[ORM\Column(type: Types::STRING, length: 127)]
+  #[ORM\Column(name: 'mime_type', type: Types::STRING, length: 127)]
   private string $mimeType;
 
-  #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
+  #[ORM\Column(name: 'reference_count', type: Types::INTEGER, options: ['default' => 0])]
   private int $referenceCount = 0;
 
-  #[ORM\Column(type: Types::STRING, length: 255)]
+  #[ORM\Column(name: 'storage_path', type: Types::STRING, length: 255)]
   private string $storagePath;
 
-  #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+  #[ORM\Column(name: 'created_at', type: Types::DATETIME_IMMUTABLE)]
   private \DateTimeImmutable $createdAt;
-
-  /** @var Collection<int, ProjectAssetMapping> */
-  #[ORM\OneToMany(targetEntity: ProjectAssetMapping::class, mappedBy: 'asset')]
-  private Collection $mappings;
 
   public function __construct(string $hash, int $size, string $mimeType, string $storagePath)
   {
@@ -47,7 +41,6 @@ class ProjectAsset
     $this->mimeType = $mimeType;
     $this->storagePath = $storagePath;
     $this->createdAt = new \DateTimeImmutable();
-    $this->mappings = new ArrayCollection();
   }
 
   public function getHash(): string

--- a/src/DB/Entity/Project/ProjectAsset.php
+++ b/src/DB/Entity/Project/ProjectAsset.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DB\Entity\Project;
+
+use App\DB\EntityRepository\Project\ProjectAssetRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'project_asset')]
+#[ORM\Entity(repositoryClass: ProjectAssetRepository::class)]
+class ProjectAsset
+{
+  /**
+   * SHA-256 hex hash (64 chars). Primary key — natural key, no surrogate.
+   */
+  #[ORM\Id]
+  #[ORM\Column(type: Types::STRING, length: 64)]
+  private string $hash;
+
+  #[ORM\Column(type: Types::BIGINT)]
+  private int $size;
+
+  #[ORM\Column(type: Types::STRING, length: 127)]
+  private string $mimeType;
+
+  #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
+  private int $referenceCount = 0;
+
+  #[ORM\Column(type: Types::STRING, length: 255)]
+  private string $storagePath;
+
+  #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+  private \DateTimeImmutable $createdAt;
+
+  /** @var Collection<int, ProjectAssetMapping> */
+  #[ORM\OneToMany(targetEntity: ProjectAssetMapping::class, mappedBy: 'asset')]
+  private Collection $mappings;
+
+  public function __construct(string $hash, int $size, string $mimeType, string $storagePath)
+  {
+    $this->hash = $hash;
+    $this->size = $size;
+    $this->mimeType = $mimeType;
+    $this->storagePath = $storagePath;
+    $this->createdAt = new \DateTimeImmutable();
+    $this->mappings = new ArrayCollection();
+  }
+
+  public function getHash(): string
+  {
+    return $this->hash;
+  }
+
+  public function getSize(): int
+  {
+    return $this->size;
+  }
+
+  public function getMimeType(): string
+  {
+    return $this->mimeType;
+  }
+
+  public function getReferenceCount(): int
+  {
+    return $this->referenceCount;
+  }
+
+  public function getStoragePath(): string
+  {
+    return $this->storagePath;
+  }
+
+  public function getCreatedAt(): \DateTimeImmutable
+  {
+    return $this->createdAt;
+  }
+
+  public function incrementReferenceCount(): void
+  {
+    ++$this->referenceCount;
+  }
+
+  public function decrementReferenceCount(): void
+  {
+    $this->referenceCount = max(0, $this->referenceCount - 1);
+  }
+}

--- a/src/DB/Entity/Project/ProjectAssetMapping.php
+++ b/src/DB/Entity/Project/ProjectAssetMapping.php
@@ -18,20 +18,20 @@ class ProjectAssetMapping
   #[ORM\Id]
   #[ORM\GeneratedValue]
   #[ORM\Column(type: Types::INTEGER)]
-  private ?int $id = null;
+  private ?int $id = null; /* @phpstan-ignore-line (Doctrine hydrates the int value) */
 
   #[ORM\ManyToOne(targetEntity: Program::class)]
   #[ORM\JoinColumn(name: 'project_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
   private Program $project;
 
-  #[ORM\ManyToOne(targetEntity: ProjectAsset::class, inversedBy: 'mappings')]
+  #[ORM\ManyToOne(targetEntity: ProjectAsset::class)]
   #[ORM\JoinColumn(name: 'asset_hash', referencedColumnName: 'hash', nullable: false)]
   private ProjectAsset $asset;
 
-  #[ORM\Column(type: Types::STRING, length: 255)]
+  #[ORM\Column(name: 'original_filename', type: Types::STRING, length: 255)]
   private string $originalFilename;
 
-  #[ORM\Column(type: Types::STRING, length: 512)]
+  #[ORM\Column(name: 'path_in_zip', type: Types::STRING, length: 512)]
   private string $pathInZip;
 
   public function __construct(Program $project, ProjectAsset $asset, string $originalFilename, string $pathInZip)

--- a/src/DB/Entity/Project/ProjectAssetMapping.php
+++ b/src/DB/Entity/Project/ProjectAssetMapping.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DB\Entity\Project;
+
+use App\DB\EntityRepository\Project\ProjectAssetMappingRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'project_asset_mapping')]
+#[ORM\UniqueConstraint(name: 'project_path_unique', columns: ['project_id', 'path_in_zip'])]
+#[ORM\Index(name: 'mapping_project_idx', columns: ['project_id'])]
+#[ORM\Index(name: 'mapping_asset_idx', columns: ['asset_hash'])]
+#[ORM\Entity(repositoryClass: ProjectAssetMappingRepository::class)]
+class ProjectAssetMapping
+{
+  #[ORM\Id]
+  #[ORM\GeneratedValue]
+  #[ORM\Column(type: Types::INTEGER)]
+  private ?int $id = null;
+
+  #[ORM\ManyToOne(targetEntity: Program::class)]
+  #[ORM\JoinColumn(name: 'project_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+  private Program $project;
+
+  #[ORM\ManyToOne(targetEntity: ProjectAsset::class, inversedBy: 'mappings')]
+  #[ORM\JoinColumn(name: 'asset_hash', referencedColumnName: 'hash', nullable: false)]
+  private ProjectAsset $asset;
+
+  #[ORM\Column(type: Types::STRING, length: 255)]
+  private string $originalFilename;
+
+  #[ORM\Column(type: Types::STRING, length: 512)]
+  private string $pathInZip;
+
+  public function __construct(Program $project, ProjectAsset $asset, string $originalFilename, string $pathInZip)
+  {
+    $this->project = $project;
+    $this->asset = $asset;
+    $this->originalFilename = $originalFilename;
+    $this->pathInZip = $pathInZip;
+  }
+
+  public function getId(): ?int
+  {
+    return $this->id;
+  }
+
+  public function getProject(): Program
+  {
+    return $this->project;
+  }
+
+  public function getAsset(): ProjectAsset
+  {
+    return $this->asset;
+  }
+
+  public function getOriginalFilename(): string
+  {
+    return $this->originalFilename;
+  }
+
+  public function getPathInZip(): string
+  {
+    return $this->pathInZip;
+  }
+}

--- a/src/DB/EntityRepository/Project/ProjectAssetMappingRepository.php
+++ b/src/DB/EntityRepository/Project/ProjectAssetMappingRepository.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DB\EntityRepository\Project;
+
+use App\DB\Entity\Project\ProjectAssetMapping;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ProjectAssetMapping>
+ */
+class ProjectAssetMappingRepository extends ServiceEntityRepository
+{
+  public function __construct(ManagerRegistry $registry)
+  {
+    parent::__construct($registry, ProjectAssetMapping::class);
+  }
+
+  /** @return list<ProjectAssetMapping> */
+  public function findByProjectId(string $projectId): array
+  {
+    return $this->createQueryBuilder('m')
+      ->join('m.project', 'p')
+      ->where('p.id = :projectId')
+      ->setParameter('projectId', $projectId)
+      ->getQuery()
+      ->getResult()
+    ;
+  }
+
+  public function deleteByProjectId(string $projectId): int
+  {
+    return $this->createQueryBuilder('m')
+      ->delete()
+      ->where('m.project = :projectId')
+      ->setParameter('projectId', $projectId)
+      ->getQuery()
+      ->execute()
+    ;
+  }
+
+  public function hasAnyForProject(string $projectId): bool
+  {
+    $count = $this->createQueryBuilder('m')
+      ->select('COUNT(m.id)')
+      ->join('m.project', 'p')
+      ->where('p.id = :projectId')
+      ->setParameter('projectId', $projectId)
+      ->getQuery()
+      ->getSingleScalarResult()
+    ;
+
+    return $count > 0;
+  }
+}

--- a/src/DB/EntityRepository/Project/ProjectAssetRepository.php
+++ b/src/DB/EntityRepository/Project/ProjectAssetRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DB\EntityRepository\Project;
+
+use App\DB\Entity\Project\ProjectAsset;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ProjectAsset>
+ */
+class ProjectAssetRepository extends ServiceEntityRepository
+{
+  public function __construct(ManagerRegistry $registry)
+  {
+    parent::__construct($registry, ProjectAsset::class);
+  }
+
+  public function findByHash(string $hash): ?ProjectAsset
+  {
+    return $this->find($hash);
+  }
+
+  /** @return list<ProjectAsset> */
+  public function findOrphanedAssets(int $limit = 100): array
+  {
+    return $this->createQueryBuilder('a')
+      ->where('a.referenceCount <= 0')
+      ->setMaxResults($limit)
+      ->getQuery()
+      ->getResult()
+    ;
+  }
+}

--- a/src/Project/CatrobatFile/ProjectZipReconstructor.php
+++ b/src/Project/CatrobatFile/ProjectZipReconstructor.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Project\CatrobatFile;
+
+use App\DB\EntityRepository\Project\ProjectAssetMappingRepository;
+use App\Storage\ContentAddressableStore;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+class ProjectZipReconstructor
+{
+  public function __construct(
+    private readonly ProjectAssetMappingRepository $mappingRepository,
+    private readonly ContentAddressableStore $store,
+    private readonly LoggerInterface $logger,
+    #[Autowire('%catrobat.file.extract.dir%')]
+    private readonly string $extractDir,
+    #[Autowire('%catrobat.file.storage.dir%')]
+    private readonly string $zipDir,
+  ) {
+  }
+
+  /**
+   * Reconstruct the .catrobat ZIP for a project from its asset mappings
+   * and extracted code.xml. Caches the result in the programs/ directory.
+   *
+   * Returns the absolute path to the reconstructed ZIP, or null on failure.
+   */
+  public function reconstruct(string $projectId): ?string
+  {
+    $zipPath = $this->zipDir.$projectId.'.catrobat';
+
+    if (file_exists($zipPath)) {
+      return $zipPath;
+    }
+
+    $extractPath = $this->extractDir.$projectId;
+    if (!is_dir($extractPath)) {
+      $this->logger->error('Cannot reconstruct ZIP: extracted directory missing', [
+        'project_id' => $projectId,
+      ]);
+
+      return null;
+    }
+
+    $mappings = $this->mappingRepository->findByProjectId($projectId);
+    if ([] === $mappings) {
+      return null;
+    }
+
+    $zip = new \ZipArchive();
+    $tempPath = $zipPath.'.tmp.'.bin2hex(random_bytes(4));
+
+    if (true !== $zip->open($tempPath, \ZipArchive::CREATE)) {
+      $this->logger->error('Cannot create ZIP archive', ['path' => $tempPath]);
+
+      return null;
+    }
+
+    // Add code.xml from extracted directory
+    $codeXmlPath = $extractPath.'/code.xml';
+    if (file_exists($codeXmlPath)) {
+      $zip->addFile($codeXmlPath, 'code.xml');
+    }
+
+    // Add screenshots if present
+    foreach (['manual_screenshot.png', 'automatic_screenshot.png', 'screenshot.png'] as $screenshot) {
+      $screenshotPath = $extractPath.'/'.$screenshot;
+      if (file_exists($screenshotPath)) {
+        $zip->addFile($screenshotPath, $screenshot);
+      }
+    }
+
+    // Add all mapped assets from content-addressable store
+    foreach ($mappings as $mapping) {
+      $asset = $mapping->getAsset();
+      $assetPath = $this->store->getAbsolutePathFromRelative($asset->getStoragePath());
+
+      if (!file_exists($assetPath)) {
+        $this->logger->warning('Asset file missing from store', [
+          'hash' => $asset->getHash(),
+          'path' => $asset->getStoragePath(),
+          'project_id' => $projectId,
+        ]);
+        // Fall back to extracted file if available
+        $fallback = $extractPath.'/'.$mapping->getPathInZip();
+        if (file_exists($fallback)) {
+          $zip->addFile($fallback, $mapping->getPathInZip());
+        }
+
+        continue;
+      }
+
+      $zip->addFile($assetPath, $mapping->getPathInZip());
+    }
+
+    // Add any other files from extract dir not covered by mappings
+    $this->addRemainingFiles($zip, $extractPath, $mappings);
+
+    $zip->close();
+
+    // Atomic move to final path
+    rename($tempPath, $zipPath);
+
+    return $zipPath;
+  }
+
+  public function invalidateCache(string $projectId): void
+  {
+    $zipPath = $this->zipDir.$projectId.'.catrobat';
+    if (file_exists($zipPath)) {
+      unlink($zipPath);
+    }
+  }
+
+  /**
+   * @param list<\App\DB\Entity\Project\ProjectAssetMapping> $mappings
+   */
+  private function addRemainingFiles(\ZipArchive $zip, string $extractPath, array $mappings): void
+  {
+    $coveredPaths = ['code.xml', 'manual_screenshot.png', 'automatic_screenshot.png', 'screenshot.png'];
+    foreach ($mappings as $mapping) {
+      $coveredPaths[] = $mapping->getPathInZip();
+    }
+
+    $coveredSet = array_flip($coveredPaths);
+
+    $iterator = new \RecursiveIteratorIterator(
+      new \RecursiveDirectoryIterator($extractPath, \FilesystemIterator::SKIP_DOTS),
+      \RecursiveIteratorIterator::LEAVES_ONLY,
+    );
+
+    foreach ($iterator as $file) {
+      if (!$file->isFile()) {
+        continue;
+      }
+
+      $relativePath = substr($file->getPathname(), strlen($extractPath) + 1);
+      if (!isset($coveredSet[$relativePath])) {
+        $zip->addFile($file->getPathname(), $relativePath);
+      }
+    }
+  }
+}

--- a/src/Project/ProjectDeduplicationService.php
+++ b/src/Project/ProjectDeduplicationService.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Project;
+
+use App\DB\Entity\Project\Program;
+use App\DB\Entity\Project\ProjectAsset;
+use App\DB\Entity\Project\ProjectAssetMapping;
+use App\DB\EntityRepository\Project\ProjectAssetMappingRepository;
+use App\DB\EntityRepository\Project\ProjectAssetRepository;
+use App\Storage\ContentAddressableStore;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+class ProjectDeduplicationService
+{
+  /** Files to hash and deduplicate (binary assets, not XML metadata). */
+  private const array ASSET_DIRECTORIES = ['images', 'sounds'];
+
+  public function __construct(
+    private readonly ContentAddressableStore $store,
+    private readonly ProjectAssetRepository $assetRepository,
+    private readonly ProjectAssetMappingRepository $mappingRepository,
+    private readonly EntityManagerInterface $entityManager,
+    private readonly LoggerInterface $logger,
+  ) {
+  }
+
+  /**
+   * Process a newly extracted project: hash all assets, store unique ones,
+   * create mappings, update reference counts.
+   */
+  public function deduplicateProject(Program $project, string $extractDir): void
+  {
+    $assetFiles = $this->collectAssetFiles($extractDir);
+
+    if ([] === $assetFiles) {
+      return;
+    }
+
+    foreach ($assetFiles as $assetFile) {
+      $absolutePath = $assetFile['absolutePath'];
+      $pathInZip = $assetFile['pathInZip'];
+      $filename = basename($pathInZip);
+
+      $hash = $this->store->hashFile($absolutePath);
+      $size = (int) filesize($absolutePath);
+      $mimeType = mime_content_type($absolutePath) ?: 'application/octet-stream';
+
+      $asset = $this->assetRepository->findByHash($hash);
+      if (null === $asset) {
+        $storagePath = $this->store->store($absolutePath, $hash);
+        $asset = new ProjectAsset($hash, $size, $mimeType, $storagePath);
+        try {
+          $this->entityManager->persist($asset);
+          $this->entityManager->flush();
+        } catch (UniqueConstraintViolationException) {
+          $this->entityManager->clear();
+          $asset = $this->assetRepository->findByHash($hash);
+          if (null === $asset) {
+            $this->logger->error('Failed to find asset after UniqueConstraintViolation', ['hash' => $hash]);
+            continue;
+          }
+        }
+      }
+
+      $asset->incrementReferenceCount();
+
+      $mapping = new ProjectAssetMapping($project, $asset, $filename, $pathInZip);
+      $this->entityManager->persist($mapping);
+    }
+
+    $this->entityManager->flush();
+
+    $this->logger->info('Deduplicated project assets', [
+      'project_id' => $project->getId(),
+      'total_files' => count($assetFiles),
+    ]);
+  }
+
+  /**
+   * Remove all asset mappings for a project and decrement reference counts.
+   */
+  public function removeProjectMappings(string $projectId): void
+  {
+    $mappings = $this->mappingRepository->findByProjectId($projectId);
+
+    foreach ($mappings as $mapping) {
+      $asset = $mapping->getAsset();
+      $asset->decrementReferenceCount();
+      $this->entityManager->remove($mapping);
+    }
+
+    $this->entityManager->flush();
+  }
+
+  /**
+   * Garbage-collect orphaned assets (referenceCount <= 0).
+   * Intended to be called from a cron/command, NOT inline during upload.
+   */
+  public function garbageCollect(int $limit = 100): int
+  {
+    $orphans = $this->assetRepository->findOrphanedAssets($limit);
+    $deleted = 0;
+
+    foreach ($orphans as $asset) {
+      $this->store->delete($asset->getHash());
+      $this->entityManager->remove($asset);
+      ++$deleted;
+    }
+
+    if ($deleted > 0) {
+      $this->entityManager->flush();
+    }
+
+    $this->logger->info('Garbage collected orphaned assets', ['count' => $deleted]);
+
+    return $deleted;
+  }
+
+  public function hasExistingMappings(string $projectId): bool
+  {
+    return $this->mappingRepository->hasAnyForProject($projectId);
+  }
+
+  /**
+   * Collect all asset files from the extracted project directory.
+   * Supports both single-scene and multi-scene layouts.
+   *
+   * @return list<array{absolutePath: string, pathInZip: string}>
+   */
+  private function collectAssetFiles(string $extractDir): array
+  {
+    $files = [];
+    $extractDir = rtrim($extractDir, '/').'/';
+
+    // Single-scene: images/, sounds/
+    foreach (self::ASSET_DIRECTORIES as $dir) {
+      $dirPath = $extractDir.$dir;
+      if (is_dir($dirPath)) {
+        $this->addFilesFromDirectory($dirPath, $dir, $files);
+      }
+    }
+
+    // Multi-scene: {SceneName}/images/, {SceneName}/sounds/
+    $entries = scandir($extractDir);
+    if (false === $entries) {
+      return $files;
+    }
+
+    foreach ($entries as $entry) {
+      if ('.' === $entry || '..' === $entry) {
+        continue;
+      }
+
+      $entryPath = $extractDir.$entry;
+      if (!is_dir($entryPath)) {
+        continue;
+      }
+
+      if (in_array($entry, ['images', 'sounds'], true)) {
+        continue;
+      }
+
+      foreach (self::ASSET_DIRECTORIES as $dir) {
+        $sceneDirPath = $entryPath.'/'.$dir;
+        if (is_dir($sceneDirPath)) {
+          $this->addFilesFromDirectory($sceneDirPath, $entry.'/'.$dir, $files);
+        }
+      }
+    }
+
+    return $files;
+  }
+
+  /**
+   * @param list<array{absolutePath: string, pathInZip: string}> $files
+   */
+  private function addFilesFromDirectory(string $dirPath, string $zipPrefix, array &$files): void
+  {
+    $entries = scandir($dirPath);
+    if (false === $entries) {
+      return;
+    }
+
+    foreach ($entries as $entry) {
+      if ('.' === $entry || '..' === $entry) {
+        continue;
+      }
+
+      $absolutePath = $dirPath.'/'.$entry;
+      if (is_file($absolutePath)) {
+        $files[] = [
+          'absolutePath' => $absolutePath,
+          'pathInZip' => $zipPrefix.'/'.$entry,
+        ];
+      }
+    }
+  }
+}

--- a/src/Project/ProjectManager.php
+++ b/src/Project/ProjectManager.php
@@ -59,6 +59,7 @@ class ProjectManager
     private readonly ?UrlHelper $urlHelper,
     protected Security $security,
     private readonly MalwareScanner $malware_scanner,
+    private readonly ProjectDeduplicationService $deduplication_service,
   ) {
   }
 
@@ -284,6 +285,21 @@ class ProjectManager
     }
 
     $filesystem->remove($extracted_file->getPath());
+
+    // Deduplicate project assets in content-addressable store
+    $permanentExtractDir = $this->file_extractor->getExtractDir().'/'.$project_id;
+    try {
+      if (null !== $old_project) {
+        $this->deduplication_service->removeProjectMappings($project_id);
+      }
+
+      $this->deduplication_service->deduplicateProject($project, $permanentExtractDir);
+    } catch (\Throwable $e) {
+      $this->logger->error('Asset deduplication failed (non-fatal)', [
+        'project_id' => $project_id,
+        'error' => $e->getMessage(),
+      ]);
+    }
 
     return $project;
   }

--- a/src/Storage/ContentAddressableStore.php
+++ b/src/Storage/ContentAddressableStore.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Storage;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Filesystem\Filesystem;
+
+class ContentAddressableStore
+{
+  private readonly Filesystem $filesystem;
+
+  public function __construct(
+    #[Autowire('%catrobat.file.assets.dir%')]
+    private readonly string $assetsDir,
+  ) {
+    $this->filesystem = new Filesystem();
+  }
+
+  public function hashFile(string $filePath): string
+  {
+    $hash = hash_file('sha256', $filePath);
+    if (false === $hash) {
+      throw new \RuntimeException("Failed to hash file: {$filePath}");
+    }
+
+    return $hash;
+  }
+
+  /**
+   * Store a file. Returns the storage path relative to assets dir.
+   * If the file already exists (same hash), this is a no-op.
+   */
+  public function store(string $sourceFilePath, string $hash): string
+  {
+    $relativePath = $this->buildRelativePath($hash);
+    $absolutePath = $this->assetsDir.$relativePath;
+
+    if (file_exists($absolutePath)) {
+      if (filesize($absolutePath) === filesize($sourceFilePath)) {
+        return $relativePath;
+      }
+
+      throw new \RuntimeException("Hash collision or corruption detected for hash: {$hash}");
+    }
+
+    $dir = dirname($absolutePath);
+    if (!is_dir($dir)) {
+      $this->filesystem->mkdir($dir, 0o755);
+    }
+
+    // Atomic write: copy to temp file, then rename
+    $tempPath = $absolutePath.'.tmp.'.bin2hex(random_bytes(4));
+    $this->filesystem->copy($sourceFilePath, $tempPath);
+    rename($tempPath, $absolutePath);
+
+    return $relativePath;
+  }
+
+  public function getAbsolutePath(string $hash): ?string
+  {
+    $path = $this->assetsDir.$this->buildRelativePath($hash);
+
+    return file_exists($path) ? $path : null;
+  }
+
+  public function getAbsolutePathFromRelative(string $relativePath): string
+  {
+    return $this->assetsDir.$relativePath;
+  }
+
+  public function delete(string $hash): bool
+  {
+    $path = $this->assetsDir.$this->buildRelativePath($hash);
+    if (!file_exists($path)) {
+      return false;
+    }
+
+    unlink($path);
+
+    // Clean up empty parent directories (2 levels)
+    $parentDir = dirname($path);
+    if (is_dir($parentDir) && $this->isDirectoryEmpty($parentDir)) {
+      rmdir($parentDir);
+      $grandParentDir = dirname($parentDir);
+      if (is_dir($grandParentDir) && $this->isDirectoryEmpty($grandParentDir)) {
+        rmdir($grandParentDir);
+      }
+    }
+
+    return true;
+  }
+
+  public function exists(string $hash): bool
+  {
+    return file_exists($this->assetsDir.$this->buildRelativePath($hash));
+  }
+
+  /**
+   * Build relative path: {hash[0:2]}/{hash[2:4]}/{hash}.
+   */
+  private function buildRelativePath(string $hash): string
+  {
+    return substr($hash, 0, 2).'/'.substr($hash, 2, 2).'/'.$hash;
+  }
+
+  private function isDirectoryEmpty(string $dir): bool
+  {
+    $handle = opendir($dir);
+    if (false === $handle) {
+      return false;
+    }
+
+    while (false !== ($entry = readdir($handle))) {
+      if ('.' !== $entry && '..' !== $entry) {
+        closedir($handle);
+
+        return false;
+      }
+    }
+
+    closedir($handle);
+
+    return true;
+  }
+}

--- a/src/System/Commands/DBUpdater/CronJobs/GarbageCollectAssetsCommand.php
+++ b/src/System/Commands/DBUpdater/CronJobs/GarbageCollectAssetsCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\System\Commands\DBUpdater\CronJobs;
+
+use App\Project\ProjectDeduplicationService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+  name: 'catrobat:gc-assets',
+  description: 'Garbage-collect orphaned content-addressable assets',
+)]
+class GarbageCollectAssetsCommand extends Command
+{
+  public function __construct(
+    private readonly ProjectDeduplicationService $deduplicationService,
+  ) {
+    parent::__construct();
+  }
+
+  #[\Override]
+  protected function configure(): void
+  {
+    $this->addOption('limit', 'l', InputOption::VALUE_REQUIRED, 'Max assets to delete per run', '500');
+  }
+
+  #[\Override]
+  protected function execute(InputInterface $input, OutputInterface $output): int
+  {
+    $io = new SymfonyStyle($input, $output);
+    $limit = (int) $input->getOption('limit');
+
+    $deleted = $this->deduplicationService->garbageCollect($limit);
+    $io->success("Garbage collected {$deleted} orphaned assets.");
+
+    return Command::SUCCESS;
+  }
+}

--- a/src/System/Commands/DBUpdater/MigrateAssetsToContentAddressableStoreCommand.php
+++ b/src/System/Commands/DBUpdater/MigrateAssetsToContentAddressableStoreCommand.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\System\Commands\DBUpdater;
+
+use App\DB\Entity\Project\Program;
+use App\Project\ProjectDeduplicationService;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+#[AsCommand(
+  name: 'catrobat:migrate-assets',
+  description: 'Migrate existing project assets to content-addressable store',
+)]
+class MigrateAssetsToContentAddressableStoreCommand extends Command
+{
+  public function __construct(
+    private readonly EntityManagerInterface $entityManager,
+    private readonly ProjectDeduplicationService $deduplicationService,
+    private readonly LoggerInterface $logger,
+    #[Autowire('%catrobat.file.extract.dir%')]
+    private readonly string $extractDir,
+  ) {
+    parent::__construct();
+  }
+
+  #[\Override]
+  protected function configure(): void
+  {
+    $this
+      ->addOption('batch-size', 'b', InputOption::VALUE_REQUIRED, 'Projects per batch', '50')
+      ->addOption('offset', 'o', InputOption::VALUE_REQUIRED, 'Skip first N projects', '0')
+      ->addOption('limit', 'l', InputOption::VALUE_REQUIRED, 'Max projects to process (0 = all)', '0')
+      ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show what would be done without doing it')
+    ;
+  }
+
+  #[\Override]
+  protected function execute(InputInterface $input, OutputInterface $output): int
+  {
+    $io = new SymfonyStyle($input, $output);
+    $batchSize = (int) $input->getOption('batch-size');
+    $offset = (int) $input->getOption('offset');
+    $limit = (int) $input->getOption('limit');
+    $dryRun = (bool) $input->getOption('dry-run');
+
+    $qb = $this->entityManager->createQueryBuilder()
+      ->select('p.id')
+      ->from(Program::class, 'p')
+      ->orderBy('p.uploaded_at', 'ASC')
+    ;
+
+    $totalQuery = clone $qb;
+    $total = $totalQuery->select('COUNT(p.id)')->getQuery()->getSingleScalarResult();
+
+    $io->title('Migrating project assets to content-addressable store');
+    $io->text("Total projects: {$total}");
+
+    $processed = 0;
+    $skipped = 0;
+    $errors = 0;
+    $currentOffset = $offset;
+
+    while (true) {
+      $ids = $qb->select('p.id')->setFirstResult($currentOffset)
+        ->setMaxResults($batchSize)
+        ->getQuery()
+        ->getSingleColumnResult()
+      ;
+
+      if ([] === $ids) {
+        break;
+      }
+
+      foreach ($ids as $id) {
+        $extractPath = $this->extractDir.$id;
+
+        if (!is_dir($extractPath)) {
+          ++$skipped;
+          continue;
+        }
+
+        if ($this->deduplicationService->hasExistingMappings($id)) {
+          ++$skipped;
+          continue;
+        }
+
+        if ($dryRun) {
+          $io->text("  DRY-RUN {$id}");
+          ++$processed;
+          continue;
+        }
+
+        try {
+          $project = $this->entityManager->find(Program::class, $id);
+          if (null === $project) {
+            ++$skipped;
+            continue;
+          }
+
+          $this->deduplicationService->deduplicateProject($project, $extractPath);
+          ++$processed;
+          $io->text("  OK {$id}");
+        } catch (\Throwable $e) {
+          ++$errors;
+          $this->logger->error('Migration failed for project', [
+            'project_id' => $id,
+            'error' => $e->getMessage(),
+          ]);
+          $io->warning("  FAIL {$id}: {$e->getMessage()}");
+        }
+
+        if ($limit > 0 && $processed >= $limit) {
+          break 2;
+        }
+      }
+
+      $currentOffset += $batchSize;
+      $this->entityManager->clear();
+    }
+
+    $io->success("Done. Processed: {$processed}, Skipped: {$skipped}, Errors: {$errors}");
+
+    return Command::SUCCESS;
+  }
+}

--- a/tests/PhpUnit/DB/Entity/Project/ProjectAssetMappingTest.php
+++ b/tests/PhpUnit/DB/Entity/Project/ProjectAssetMappingTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\DB\Entity\Project;
+
+use App\DB\Entity\Project\Program;
+use App\DB\Entity\Project\ProjectAsset;
+use App\DB\Entity\Project\ProjectAssetMapping;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(ProjectAssetMapping::class)]
+class ProjectAssetMappingTest extends TestCase
+{
+  #[Group('unit')]
+  public function testConstructorSetsAllFields(): void
+  {
+    $project = $this->createStub(Program::class);
+    $asset = new ProjectAsset('abc123', 500, 'audio/wav', 'ab/c1/abc123');
+
+    $mapping = new ProjectAssetMapping($project, $asset, 'click.wav', 'sounds/click.wav');
+
+    $this->assertNull($mapping->getId());
+    $this->assertSame($project, $mapping->getProject());
+    $this->assertSame($asset, $mapping->getAsset());
+    $this->assertSame('click.wav', $mapping->getOriginalFilename());
+    $this->assertSame('sounds/click.wav', $mapping->getPathInZip());
+  }
+
+  #[Group('unit')]
+  public function testMappingWithNestedScenePath(): void
+  {
+    $project = $this->createStub(Program::class);
+    $asset = new ProjectAsset('def456', 1024, 'image/png', 'de/f4/def456');
+
+    $mapping = new ProjectAssetMapping($project, $asset, 'cat.png', 'Scene1/images/cat.png');
+
+    $this->assertSame('cat.png', $mapping->getOriginalFilename());
+    $this->assertSame('Scene1/images/cat.png', $mapping->getPathInZip());
+  }
+}

--- a/tests/PhpUnit/DB/Entity/Project/ProjectAssetTest.php
+++ b/tests/PhpUnit/DB/Entity/Project/ProjectAssetTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\DB\Entity\Project;
+
+use App\DB\Entity\Project\ProjectAsset;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(ProjectAsset::class)]
+class ProjectAssetTest extends TestCase
+{
+  #[Group('unit')]
+  public function testConstructorSetsAllFields(): void
+  {
+    $hash = hash('sha256', 'test content');
+    $asset = new ProjectAsset($hash, 1024, 'image/png', 'ab/cd/'.$hash);
+
+    $this->assertSame($hash, $asset->getHash());
+    $this->assertSame(1024, $asset->getSize());
+    $this->assertSame('image/png', $asset->getMimeType());
+    $this->assertSame('ab/cd/'.$hash, $asset->getStoragePath());
+    $this->assertSame(0, $asset->getReferenceCount());
+    $this->assertInstanceOf(\DateTimeImmutable::class, $asset->getCreatedAt());
+  }
+
+  #[Group('unit')]
+  public function testCreatedAtIsSetOnConstruction(): void
+  {
+    $before = new \DateTimeImmutable();
+    $asset = new ProjectAsset('abc123', 100, 'image/png', 'ab/c1/abc123');
+    $after = new \DateTimeImmutable();
+
+    $this->assertGreaterThanOrEqual($before, $asset->getCreatedAt());
+    $this->assertLessThanOrEqual($after, $asset->getCreatedAt());
+  }
+
+  #[Group('unit')]
+  public function testIncrementReferenceCount(): void
+  {
+    $asset = new ProjectAsset('hash', 100, 'image/png', 'ha/sh/hash');
+
+    $this->assertSame(0, $asset->getReferenceCount());
+
+    $asset->incrementReferenceCount();
+    $this->assertSame(1, $asset->getReferenceCount());
+
+    $asset->incrementReferenceCount();
+    $this->assertSame(2, $asset->getReferenceCount());
+
+    $asset->incrementReferenceCount();
+    $this->assertSame(3, $asset->getReferenceCount());
+  }
+
+  #[Group('unit')]
+  public function testDecrementReferenceCount(): void
+  {
+    $asset = new ProjectAsset('hash', 100, 'image/png', 'ha/sh/hash');
+    $asset->incrementReferenceCount();
+    $asset->incrementReferenceCount();
+
+    $this->assertSame(2, $asset->getReferenceCount());
+
+    $asset->decrementReferenceCount();
+    $this->assertSame(1, $asset->getReferenceCount());
+
+    $asset->decrementReferenceCount();
+    $this->assertSame(0, $asset->getReferenceCount());
+  }
+
+  #[Group('unit')]
+  public function testDecrementReferenceCountDoesNotGoBelowZero(): void
+  {
+    $asset = new ProjectAsset('hash', 100, 'image/png', 'ha/sh/hash');
+
+    $this->assertSame(0, $asset->getReferenceCount());
+
+    $asset->decrementReferenceCount();
+    $this->assertSame(0, $asset->getReferenceCount());
+
+    // Decrement again — still zero
+    $asset->decrementReferenceCount();
+    $this->assertSame(0, $asset->getReferenceCount());
+  }
+}

--- a/tests/PhpUnit/DB/Entity/Project/ProjectAssetTest.php
+++ b/tests/PhpUnit/DB/Entity/Project/ProjectAssetTest.php
@@ -26,7 +26,6 @@ class ProjectAssetTest extends TestCase
     $this->assertSame('image/png', $asset->getMimeType());
     $this->assertSame('ab/cd/'.$hash, $asset->getStoragePath());
     $this->assertSame(0, $asset->getReferenceCount());
-    $this->assertInstanceOf(\DateTimeImmutable::class, $asset->getCreatedAt());
   }
 
   #[Group('unit')]

--- a/tests/PhpUnit/Project/CatrobatFile/ProjectZipReconstructorTest.php
+++ b/tests/PhpUnit/Project/CatrobatFile/ProjectZipReconstructorTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Project\CatrobatFile;
+
+use App\DB\Entity\Project\ProjectAsset;
+use App\DB\Entity\Project\ProjectAssetMapping;
+use App\DB\EntityRepository\Project\ProjectAssetMappingRepository;
+use App\Project\CatrobatFile\ProjectZipReconstructor;
+use App\Storage\ContentAddressableStore;
+use App\Storage\FileHelper;
+use App\System\Testing\PhpUnit\Extension\BootstrapExtension;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+#[CoversClass(ProjectZipReconstructor::class)]
+class ProjectZipReconstructorTest extends TestCase
+{
+  private string $extract_dir;
+
+  private string $zip_dir;
+
+  private string $assets_dir;
+
+  private Stub&ProjectAssetMappingRepository $mapping_repository;
+
+  private Stub&ContentAddressableStore $store;
+
+  private ProjectZipReconstructor $reconstructor;
+
+  private Filesystem $filesystem;
+
+  #[\Override]
+  protected function setUp(): void
+  {
+    $this->extract_dir = BootstrapExtension::$CACHE_DIR.'reconstruct_extract/';
+    $this->zip_dir = BootstrapExtension::$CACHE_DIR.'reconstruct_zip/';
+    $this->assets_dir = BootstrapExtension::$CACHE_DIR.'reconstruct_assets/';
+    $this->filesystem = new Filesystem();
+    $this->filesystem->mkdir([$this->extract_dir, $this->zip_dir, $this->assets_dir]);
+
+    $this->mapping_repository = $this->createStub(ProjectAssetMappingRepository::class);
+    $this->store = $this->createStub(ContentAddressableStore::class);
+
+    $this->reconstructor = new ProjectZipReconstructor(
+      $this->mapping_repository,
+      $this->store,
+      $this->createStub(LoggerInterface::class),
+      $this->extract_dir,
+      $this->zip_dir,
+    );
+  }
+
+  /**
+   * @throws \Exception
+   */
+  #[\Override]
+  protected function tearDown(): void
+  {
+    FileHelper::removeDirectory($this->extract_dir);
+    FileHelper::removeDirectory($this->zip_dir);
+    FileHelper::removeDirectory($this->assets_dir);
+  }
+
+  #[Group('unit')]
+  public function testReconstructReturnsCachedZipIfExists(): void
+  {
+    $project_id = 'cached-project';
+    $zip_path = $this->zip_dir.$project_id.'.catrobat';
+    file_put_contents($zip_path, 'fake zip content');
+
+    $result = $this->reconstructor->reconstruct($project_id);
+
+    $this->assertSame($zip_path, $result);
+  }
+
+  #[Group('unit')]
+  public function testReconstructReturnsNullIfExtractedDirMissing(): void
+  {
+    $result = $this->reconstructor->reconstruct('nonexistent-project');
+
+    $this->assertNull($result);
+  }
+
+  #[Group('unit')]
+  public function testReconstructCreatesValidZipWithAssets(): void
+  {
+    $project_id = 'test-reconstruct';
+    $project_extract = $this->extract_dir.$project_id;
+    $this->filesystem->mkdir($project_extract);
+
+    // Create code.xml in extracted dir
+    file_put_contents($project_extract.'/code.xml', '<xml>test project</xml>');
+
+    // Create asset files in the CAS directory
+    $image_content = 'PNG image data';
+    $sound_content = 'WAV sound data';
+    $image_path = $this->assets_dir.'image_file';
+    $sound_path = $this->assets_dir.'sound_file';
+    file_put_contents($image_path, $image_content);
+    file_put_contents($sound_path, $sound_content);
+
+    // Create asset entities
+    $image_asset = new ProjectAsset('imagehash', strlen($image_content), 'image/png', 'ab/cd/imagehash');
+    $sound_asset = new ProjectAsset('soundhash', strlen($sound_content), 'audio/wav', 'ef/gh/soundhash');
+
+    // Create mapping stubs
+    $image_mapping = $this->createStub(ProjectAssetMapping::class);
+    $image_mapping->method('getAsset')->willReturn($image_asset);
+    $image_mapping->method('getPathInZip')->willReturn('images/sprite.png');
+
+    $sound_mapping = $this->createStub(ProjectAssetMapping::class);
+    $sound_mapping->method('getAsset')->willReturn($sound_asset);
+    $sound_mapping->method('getPathInZip')->willReturn('sounds/click.wav');
+
+    $this->mapping_repository->method('findByProjectId')
+      ->willReturn([$image_mapping, $sound_mapping])
+    ;
+
+    $this->store->method('getAbsolutePathFromRelative')
+      ->willReturnCallback(fn (string $rel) => match ($rel) {
+        'ab/cd/imagehash' => $image_path,
+        'ef/gh/soundhash' => $sound_path,
+        default => $this->assets_dir.$rel,
+      })
+    ;
+
+    $result = $this->reconstructor->reconstruct($project_id);
+
+    $this->assertNotNull($result);
+    $this->assertFileExists($result);
+
+    // Verify ZIP contents
+    $zip = new \ZipArchive();
+    $this->assertTrue(true === $zip->open($result));
+
+    $this->assertNotFalse($zip->locateName('code.xml'));
+    $this->assertSame('<xml>test project</xml>', $zip->getFromName('code.xml'));
+
+    $this->assertNotFalse($zip->locateName('images/sprite.png'));
+    $this->assertSame($image_content, $zip->getFromName('images/sprite.png'));
+
+    $this->assertNotFalse($zip->locateName('sounds/click.wav'));
+    $this->assertSame($sound_content, $zip->getFromName('sounds/click.wav'));
+
+    $zip->close();
+  }
+
+  #[Group('unit')]
+  public function testReconstructFallsBackToExtractedFileWhenAssetMissing(): void
+  {
+    $project_id = 'fallback-project';
+    $project_extract = $this->extract_dir.$project_id;
+    $this->filesystem->mkdir($project_extract.'/images');
+
+    file_put_contents($project_extract.'/code.xml', '<xml>fallback</xml>');
+    file_put_contents($project_extract.'/images/sprite.png', 'fallback image');
+
+    $asset = new ProjectAsset('missinghash', 14, 'image/png', 'xx/yy/missinghash');
+    $mapping = $this->createStub(ProjectAssetMapping::class);
+    $mapping->method('getAsset')->willReturn($asset);
+    $mapping->method('getPathInZip')->willReturn('images/sprite.png');
+
+    $this->mapping_repository->method('findByProjectId')->willReturn([$mapping]);
+
+    // CAS returns a path that doesn't exist
+    $this->store->method('getAbsolutePathFromRelative')
+      ->willReturn($this->assets_dir.'nonexistent')
+    ;
+
+    $result = $this->reconstructor->reconstruct($project_id);
+
+    $this->assertNotNull($result);
+
+    $zip = new \ZipArchive();
+    $zip->open($result);
+    // Should fall back to extracted file
+    $this->assertSame('fallback image', $zip->getFromName('images/sprite.png'));
+    $zip->close();
+  }
+
+  #[Group('unit')]
+  public function testReconstructIncludesScreenshots(): void
+  {
+    $project_id = 'screenshot-project';
+    $project_extract = $this->extract_dir.$project_id;
+    $this->filesystem->mkdir($project_extract.'/images');
+
+    file_put_contents($project_extract.'/code.xml', '<xml>screenshots</xml>');
+    file_put_contents($project_extract.'/automatic_screenshot.png', 'auto screenshot');
+    file_put_contents($project_extract.'/manual_screenshot.png', 'manual screenshot');
+
+    // Need at least one mapping — reconstruct returns null for empty mappings
+    $image_content = 'dummy image';
+    $image_path = $this->assets_dir.'dummy_img';
+    file_put_contents($image_path, $image_content);
+
+    $asset = new ProjectAsset('dummyhash', strlen($image_content), 'image/png', 'du/mm/dummyhash');
+    $mapping = $this->createStub(ProjectAssetMapping::class);
+    $mapping->method('getAsset')->willReturn($asset);
+    $mapping->method('getPathInZip')->willReturn('images/dummy.png');
+
+    $this->mapping_repository->method('findByProjectId')->willReturn([$mapping]);
+    $this->store->method('getAbsolutePathFromRelative')->willReturn($image_path);
+
+    $result = $this->reconstructor->reconstruct($project_id);
+
+    $this->assertNotNull($result);
+
+    $zip = new \ZipArchive();
+    $zip->open($result);
+    $this->assertNotFalse($zip->locateName('automatic_screenshot.png'));
+    $this->assertNotFalse($zip->locateName('manual_screenshot.png'));
+    $zip->close();
+  }
+
+  #[Group('unit')]
+  public function testInvalidateCacheDeletesZipFile(): void
+  {
+    $project_id = 'invalidate-test';
+    $zip_path = $this->zip_dir.$project_id.'.catrobat';
+    file_put_contents($zip_path, 'cached zip');
+
+    $this->assertFileExists($zip_path);
+
+    $this->reconstructor->invalidateCache($project_id);
+
+    $this->assertFileDoesNotExist($zip_path);
+  }
+
+  #[Group('unit')]
+  public function testInvalidateCacheDoesNothingIfNoCache(): void
+  {
+    // Should not throw
+    $this->reconstructor->invalidateCache('no-cache-project');
+    $this->assertTrue(true);
+  }
+}

--- a/tests/PhpUnit/Project/CatrobatFile/ProjectZipReconstructorTest.php
+++ b/tests/PhpUnit/Project/CatrobatFile/ProjectZipReconstructorTest.php
@@ -239,8 +239,9 @@ class ProjectZipReconstructorTest extends TestCase
   #[Group('unit')]
   public function testInvalidateCacheDoesNothingIfNoCache(): void
   {
+    $this->expectNotToPerformAssertions();
+
     // Should not throw
     $this->reconstructor->invalidateCache('no-cache-project');
-    $this->assertTrue(true);
   }
 }

--- a/tests/PhpUnit/Project/ProjectDeduplicationServiceTest.php
+++ b/tests/PhpUnit/Project/ProjectDeduplicationServiceTest.php
@@ -1,0 +1,479 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Project;
+
+use App\DB\Entity\Project\Program;
+use App\DB\Entity\Project\ProjectAsset;
+use App\DB\Entity\Project\ProjectAssetMapping;
+use App\DB\EntityRepository\Project\ProjectAssetMappingRepository;
+use App\DB\EntityRepository\Project\ProjectAssetRepository;
+use App\Project\ProjectDeduplicationService;
+use App\Storage\ContentAddressableStore;
+use App\Storage\FileHelper;
+use App\System\Testing\PhpUnit\Extension\BootstrapExtension;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+#[CoversClass(ProjectDeduplicationService::class)]
+class ProjectDeduplicationServiceTest extends TestCase
+{
+  private Stub&ContentAddressableStore $store;
+
+  private Stub&ProjectAssetRepository $asset_repository;
+
+  private Stub&ProjectAssetMappingRepository $mapping_repository;
+
+  private Stub&EntityManagerInterface $entity_manager;
+
+  private Stub&LoggerInterface $logger;
+
+  private ProjectDeduplicationService $service;
+
+  private string $test_extract_dir;
+
+  #[\Override]
+  protected function setUp(): void
+  {
+    $this->store = $this->createStub(ContentAddressableStore::class);
+    $this->asset_repository = $this->createStub(ProjectAssetRepository::class);
+    $this->mapping_repository = $this->createStub(ProjectAssetMappingRepository::class);
+    $this->entity_manager = $this->createStub(EntityManagerInterface::class);
+    $this->logger = $this->createStub(LoggerInterface::class);
+
+    $this->service = new ProjectDeduplicationService(
+      $this->store,
+      $this->asset_repository,
+      $this->mapping_repository,
+      $this->entity_manager,
+      $this->logger,
+    );
+
+    $this->test_extract_dir = BootstrapExtension::$CACHE_DIR.'dedup_test/';
+    $filesystem = new Filesystem();
+    $filesystem->mkdir($this->test_extract_dir);
+  }
+
+  /**
+   * @throws \Exception
+   */
+  #[\Override]
+  protected function tearDown(): void
+  {
+    if (is_dir($this->test_extract_dir)) {
+      FileHelper::removeDirectory($this->test_extract_dir);
+    }
+  }
+
+  #[Group('unit')]
+  public function testDeduplicateProjectHashesAllImageAndSoundAssets(): void
+  {
+    $extract_dir = $this->createProjectStructure([
+      'images/sprite1.png' => 'image content 1',
+      'images/sprite2.png' => 'image content 2',
+      'sounds/click.wav' => 'sound content 1',
+    ]);
+
+    $project = $this->createProjectStub();
+
+    $store = $this->createMock(ContentAddressableStore::class);
+
+    // Expect hashFile called for each asset (3 times)
+    $store->expects($this->exactly(3))
+      ->method('hashFile')
+      ->willReturnCallback(fn (string $path) => hash('sha256', file_get_contents($path)))
+    ;
+
+    // Expect store called for each new asset (3 times, all new)
+    $store->expects($this->exactly(3))
+      ->method('store')
+      ->willReturn('ab/cd/fakehash')
+    ;
+
+    $this->asset_repository->method('findByHash')->willReturn(null);
+
+    $service = new ProjectDeduplicationService(
+      $store,
+      $this->asset_repository,
+      $this->mapping_repository,
+      $this->entity_manager,
+      $this->logger,
+    );
+
+    $service->deduplicateProject($project, $extract_dir);
+  }
+
+  #[Group('unit')]
+  public function testDeduplicateProjectCreatesEntityForNewAssets(): void
+  {
+    $extract_dir = $this->createProjectStructure([
+      'images/sprite.png' => 'new asset content',
+    ]);
+
+    $project = $this->createProjectStub();
+
+    $this->store->method('hashFile')->willReturn(hash('sha256', 'new asset content'));
+    $this->store->method('store')->willReturn('ab/cd/hash');
+    $this->asset_repository->method('findByHash')->willReturn(null);
+
+    $persisted = [];
+    $entity_manager = $this->createMock(EntityManagerInterface::class);
+    $entity_manager->expects($this->exactly(2)) // 1 ProjectAsset + 1 ProjectAssetMapping
+      ->method('persist')
+      ->willReturnCallback(function (object $entity) use (&$persisted): void {
+        $persisted[] = $entity::class;
+      })
+    ;
+
+    $service = new ProjectDeduplicationService(
+      $this->store,
+      $this->asset_repository,
+      $this->mapping_repository,
+      $entity_manager,
+      $this->logger,
+    );
+
+    $service->deduplicateProject($project, $extract_dir);
+
+    $this->assertContains(ProjectAsset::class, $persisted);
+    $this->assertContains(ProjectAssetMapping::class, $persisted);
+  }
+
+  #[Group('unit')]
+  public function testDeduplicateProjectIncrementsRefCountForExistingAsset(): void
+  {
+    $extract_dir = $this->createProjectStructure([
+      'images/shared.png' => 'shared content',
+    ]);
+
+    $project = $this->createProjectStub();
+    $hash = hash('sha256', 'shared content');
+
+    $existing_asset = new ProjectAsset($hash, 14, 'image/png', 'ab/cd/'.$hash);
+
+    $store = $this->createMock(ContentAddressableStore::class);
+    $store->expects($this->once())
+      ->method('hashFile')
+      ->willReturn($hash)
+    ;
+
+    // Store should NOT be called — asset already exists
+    $store->expects($this->never())->method('store');
+
+    $this->asset_repository->method('findByHash')->willReturn($existing_asset);
+
+    $entity_manager = $this->createMock(EntityManagerInterface::class);
+    // Only mapping persisted (not a new ProjectAsset)
+    $entity_manager->expects($this->once())
+      ->method('persist')
+      ->with($this->isInstanceOf(ProjectAssetMapping::class))
+    ;
+
+    $service = new ProjectDeduplicationService(
+      $store,
+      $this->asset_repository,
+      $this->mapping_repository,
+      $entity_manager,
+      $this->logger,
+    );
+
+    $service->deduplicateProject($project, $extract_dir);
+
+    // Reference count should have been incremented
+    $this->assertSame(1, $existing_asset->getReferenceCount());
+  }
+
+  #[Group('unit')]
+  public function testDeduplicateProjectSkipsCodeXmlAndMetaFiles(): void
+  {
+    $extract_dir = $this->createProjectStructure([
+      'code.xml' => '<xml>project data</xml>',
+      'automatic_screenshot.png' => 'screenshot data',
+      '.nomedia' => '',
+      'images/sprite.png' => 'real asset',
+    ]);
+
+    $project = $this->createProjectStub();
+
+    $store = $this->createMock(ContentAddressableStore::class);
+    // Only 1 asset file (images/sprite.png) should be hashed
+    $store->expects($this->once())
+      ->method('hashFile')
+      ->willReturnCallback(fn (string $path) => hash('sha256', file_get_contents($path)))
+    ;
+
+    $store->expects($this->once())->method('store')->willReturn('ab/cd/hash');
+    $this->asset_repository->method('findByHash')->willReturn(null);
+
+    $service = new ProjectDeduplicationService(
+      $store,
+      $this->asset_repository,
+      $this->mapping_repository,
+      $this->entity_manager,
+      $this->logger,
+    );
+
+    $service->deduplicateProject($project, $extract_dir);
+  }
+
+  #[Group('unit')]
+  public function testDeduplicateEmptyProjectDoesNothing(): void
+  {
+    $extract_dir = $this->createProjectStructure([
+      'code.xml' => '<xml>empty project</xml>',
+    ]);
+
+    $project = $this->createProjectStub();
+
+    $store = $this->createMock(ContentAddressableStore::class);
+    $store->expects($this->never())->method('hashFile');
+    $store->expects($this->never())->method('store');
+
+    $entity_manager = $this->createMock(EntityManagerInterface::class);
+    $entity_manager->expects($this->never())->method('persist');
+    $entity_manager->expects($this->never())->method('flush');
+
+    $service = new ProjectDeduplicationService(
+      $store,
+      $this->asset_repository,
+      $this->mapping_repository,
+      $entity_manager,
+      $this->logger,
+    );
+
+    $service->deduplicateProject($project, $extract_dir);
+  }
+
+  #[Group('unit')]
+  public function testDeduplicateProjectWithNestedSceneDirectories(): void
+  {
+    $extract_dir = $this->createProjectStructure([
+      'code.xml' => '<xml>multi-scene</xml>',
+      'Scene1/images/cat.png' => 'cat image',
+      'Scene1/sounds/meow.wav' => 'meow sound',
+      'Scene2/images/dog.png' => 'dog image',
+    ]);
+
+    $project = $this->createProjectStub();
+
+    $store = $this->createMock(ContentAddressableStore::class);
+    // Expect 3 assets from nested scenes
+    $store->expects($this->exactly(3))
+      ->method('hashFile')
+      ->willReturnCallback(fn (string $path) => hash('sha256', file_get_contents($path)))
+    ;
+
+    $store->expects($this->exactly(3))->method('store')->willReturn('ab/cd/hash');
+    $this->asset_repository->method('findByHash')->willReturn(null);
+
+    $service = new ProjectDeduplicationService(
+      $store,
+      $this->asset_repository,
+      $this->mapping_repository,
+      $this->entity_manager,
+      $this->logger,
+    );
+
+    $service->deduplicateProject($project, $extract_dir);
+  }
+
+  #[Group('unit')]
+  public function testRemoveProjectMappingsDecrementsRefCounts(): void
+  {
+    $project_id = 'test-project-uuid';
+
+    $asset1 = new ProjectAsset('hash1', 100, 'image/png', 'ab/cd/hash1');
+    $asset1->incrementReferenceCount(); // ref_count = 1
+    $asset1->incrementReferenceCount(); // ref_count = 2
+
+    $asset2 = new ProjectAsset('hash2', 200, 'audio/wav', 'ef/gh/hash2');
+    $asset2->incrementReferenceCount(); // ref_count = 1
+
+    $mapping1 = $this->createStub(ProjectAssetMapping::class);
+    $mapping1->method('getAsset')->willReturn($asset1);
+
+    $mapping2 = $this->createStub(ProjectAssetMapping::class);
+    $mapping2->method('getAsset')->willReturn($asset2);
+
+    $mapping_repository = $this->createMock(ProjectAssetMappingRepository::class);
+    $mapping_repository->expects($this->once())
+      ->method('findByProjectId')
+      ->with($project_id)
+      ->willReturn([$mapping1, $mapping2])
+    ;
+
+    $entity_manager = $this->createMock(EntityManagerInterface::class);
+    $entity_manager->expects($this->exactly(2))
+      ->method('remove')
+      ->with($this->isInstanceOf(ProjectAssetMapping::class))
+    ;
+    $entity_manager->expects($this->once())->method('flush');
+
+    $service = new ProjectDeduplicationService(
+      $this->store,
+      $this->asset_repository,
+      $mapping_repository,
+      $entity_manager,
+      $this->logger,
+    );
+
+    $service->removeProjectMappings($project_id);
+
+    // asset1: 2 -> 1 (still referenced by another project)
+    $this->assertSame(1, $asset1->getReferenceCount());
+    // asset2: 1 -> 0 (orphaned)
+    $this->assertSame(0, $asset2->getReferenceCount());
+  }
+
+  #[Group('unit')]
+  public function testGarbageCollectDeletesOrphanedAssets(): void
+  {
+    $orphan1 = new ProjectAsset('orphan_hash_1', 100, 'image/png', 'ab/cd/orphan1');
+    $orphan2 = new ProjectAsset('orphan_hash_2', 200, 'audio/wav', 'ef/gh/orphan2');
+
+    $this->asset_repository->method('findOrphanedAssets')->willReturn([$orphan1, $orphan2]);
+
+    $store = $this->createMock(ContentAddressableStore::class);
+    $store->expects($this->exactly(2))
+      ->method('delete')
+      ->with($this->logicalOr('orphan_hash_1', 'orphan_hash_2'))
+    ;
+
+    $entity_manager = $this->createMock(EntityManagerInterface::class);
+    $entity_manager->expects($this->exactly(2))
+      ->method('remove')
+      ->with($this->logicalOr(
+        $this->identicalTo($orphan1),
+        $this->identicalTo($orphan2),
+      ))
+    ;
+    $entity_manager->expects($this->once())->method('flush');
+
+    $service = new ProjectDeduplicationService(
+      $store,
+      $this->asset_repository,
+      $this->mapping_repository,
+      $entity_manager,
+      $this->logger,
+    );
+
+    $deleted = $service->garbageCollect(100);
+
+    $this->assertSame(2, $deleted);
+  }
+
+  #[Group('unit')]
+  public function testGarbageCollectWithNoOrphansDoesNotFlush(): void
+  {
+    $this->asset_repository->method('findOrphanedAssets')->willReturn([]);
+
+    $store = $this->createMock(ContentAddressableStore::class);
+    $store->expects($this->never())->method('delete');
+
+    $entity_manager = $this->createMock(EntityManagerInterface::class);
+    $entity_manager->expects($this->never())->method('flush');
+
+    $service = new ProjectDeduplicationService(
+      $store,
+      $this->asset_repository,
+      $this->mapping_repository,
+      $entity_manager,
+      $this->logger,
+    );
+
+    $deleted = $service->garbageCollect();
+
+    $this->assertSame(0, $deleted);
+  }
+
+  #[Group('unit')]
+  public function testDeduplicateProjectWithDuplicateAssetsInSameProject(): void
+  {
+    // Two files with identical content in the same project
+    $extract_dir = $this->createProjectStructure([
+      'images/copy1.png' => 'same content',
+      'images/copy2.png' => 'same content',
+    ]);
+
+    $project = $this->createProjectStub();
+    $hash = hash('sha256', 'same content');
+
+    $store = $this->createMock(ContentAddressableStore::class);
+    $store->expects($this->exactly(2))
+      ->method('hashFile')
+      ->willReturn($hash)
+    ;
+
+    // Store called once for the first file only
+    $store->expects($this->once())->method('store')->willReturn('ab/cd/'.$hash);
+
+    $asset = null;
+    $call_count = 0;
+    $this->asset_repository->method('findByHash')->willReturnCallback(
+      function () use (&$asset, &$call_count) {
+        if (0 === $call_count++) {
+          return null;
+        }
+
+        return $asset;
+      }
+    );
+
+    $entity_manager = $this->createMock(EntityManagerInterface::class);
+    // Track the persisted ProjectAsset so we can return it on second lookup
+    $entity_manager->expects($this->exactly(3)) // 1 ProjectAsset + 2 ProjectAssetMapping
+      ->method('persist')
+      ->willReturnCallback(function (object $entity) use (&$asset): void {
+        if ($entity instanceof ProjectAsset) {
+          $asset = $entity;
+        }
+      })
+    ;
+
+    $service = new ProjectDeduplicationService(
+      $store,
+      $this->asset_repository,
+      $this->mapping_repository,
+      $entity_manager,
+      $this->logger,
+    );
+
+    $service->deduplicateProject($project, $extract_dir);
+  }
+
+  private function createProjectStub(): Stub&Program
+  {
+    $project = $this->createStub(Program::class);
+    $project->method('getId')->willReturn('test-uuid-1234');
+
+    return $project;
+  }
+
+  /**
+   * Create a temporary project extract directory with the given file structure.
+   *
+   * @param array<string, string> $files map of relative path => content
+   */
+  private function createProjectStructure(array $files): string
+  {
+    $dir = $this->test_extract_dir.'project_'.bin2hex(random_bytes(4)).'/';
+    $filesystem = new Filesystem();
+
+    foreach ($files as $path => $content) {
+      $full_path = $dir.$path;
+      $filesystem->mkdir(dirname($full_path));
+      file_put_contents($full_path, $content);
+    }
+
+    return $dir;
+  }
+}

--- a/tests/PhpUnit/Project/ProjectDeduplicationServiceTest.php
+++ b/tests/PhpUnit/Project/ProjectDeduplicationServiceTest.php
@@ -37,8 +37,6 @@ class ProjectDeduplicationServiceTest extends TestCase
 
   private Stub&LoggerInterface $logger;
 
-  private ProjectDeduplicationService $service;
-
   private string $test_extract_dir;
 
   #[\Override]
@@ -49,14 +47,6 @@ class ProjectDeduplicationServiceTest extends TestCase
     $this->mapping_repository = $this->createStub(ProjectAssetMappingRepository::class);
     $this->entity_manager = $this->createStub(EntityManagerInterface::class);
     $this->logger = $this->createStub(LoggerInterface::class);
-
-    $this->service = new ProjectDeduplicationService(
-      $this->store,
-      $this->asset_repository,
-      $this->mapping_repository,
-      $this->entity_manager,
-      $this->logger,
-    );
 
     $this->test_extract_dir = BootstrapExtension::$CACHE_DIR.'dedup_test/';
     $filesystem = new Filesystem();
@@ -90,7 +80,7 @@ class ProjectDeduplicationServiceTest extends TestCase
     // Expect hashFile called for each asset (3 times)
     $store->expects($this->exactly(3))
       ->method('hashFile')
-      ->willReturnCallback(fn (string $path) => hash('sha256', file_get_contents($path)))
+      ->willReturnCallback(fn (string $path) => hash('sha256', (string) file_get_contents($path)))
     ;
 
     // Expect store called for each new asset (3 times, all new)
@@ -208,7 +198,7 @@ class ProjectDeduplicationServiceTest extends TestCase
     // Only 1 asset file (images/sprite.png) should be hashed
     $store->expects($this->once())
       ->method('hashFile')
-      ->willReturnCallback(fn (string $path) => hash('sha256', file_get_contents($path)))
+      ->willReturnCallback(fn (string $path) => hash('sha256', (string) file_get_contents($path)))
     ;
 
     $store->expects($this->once())->method('store')->willReturn('ab/cd/hash');
@@ -269,7 +259,7 @@ class ProjectDeduplicationServiceTest extends TestCase
     // Expect 3 assets from nested scenes
     $store->expects($this->exactly(3))
       ->method('hashFile')
-      ->willReturnCallback(fn (string $path) => hash('sha256', file_get_contents($path)))
+      ->willReturnCallback(fn (string $path) => hash('sha256', (string) file_get_contents($path)))
     ;
 
     $store->expects($this->exactly(3))->method('store')->willReturn('ab/cd/hash');

--- a/tests/PhpUnit/Project/ProjectManagerTest.php
+++ b/tests/PhpUnit/Project/ProjectManagerTest.php
@@ -21,6 +21,7 @@ use App\Project\CatrobatFile\ProjectFileRepository;
 use App\Project\Event\ProjectAfterInsertEvent;
 use App\Project\Event\ProjectBeforeInsertEvent;
 use App\Project\Event\ProjectBeforePersistEvent;
+use App\Project\ProjectDeduplicationService;
 use App\Project\ProjectManager;
 use App\Security\Malware\MalwareScanner;
 use App\Security\Malware\MalwareScanResult;
@@ -168,6 +169,7 @@ class ProjectManagerTest extends TestCase
       $url_helper,
       $security,
       $malware_scanner,
+      $this->createStub(ProjectDeduplicationService::class),
     );
   }
 

--- a/tests/PhpUnit/Storage/ContentAddressableStoreTest.php
+++ b/tests/PhpUnit/Storage/ContentAddressableStoreTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Storage;
+
+use App\Storage\ContentAddressableStore;
+use App\Storage\FileHelper;
+use App\System\Testing\PhpUnit\Extension\BootstrapExtension;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+#[CoversClass(ContentAddressableStore::class)]
+class ContentAddressableStoreTest extends TestCase
+{
+  private string $assets_dir;
+
+  private ContentAddressableStore $store;
+
+  private Filesystem $filesystem;
+
+  #[\Override]
+  protected function setUp(): void
+  {
+    $this->assets_dir = BootstrapExtension::$CACHE_DIR.'cas_test/';
+    $this->filesystem = new Filesystem();
+    $this->filesystem->mkdir($this->assets_dir);
+    $this->store = new ContentAddressableStore($this->assets_dir);
+  }
+
+  /**
+   * @throws \Exception
+   */
+  #[\Override]
+  protected function tearDown(): void
+  {
+    FileHelper::removeDirectory($this->assets_dir);
+  }
+
+  #[Group('unit')]
+  public function testHashFileReturnsCorrectSha256(): void
+  {
+    $file = $this->createTempFile('hello world');
+    $expected = hash('sha256', 'hello world');
+
+    $this->assertSame($expected, $this->store->hashFile($file));
+  }
+
+  #[Group('unit')]
+  public function testStoreFileReturnsCorrectRelativePath(): void
+  {
+    $file = $this->createTempFile('test content');
+    $hash = hash('sha256', 'test content');
+    $expected_path = substr($hash, 0, 2).'/'.substr($hash, 2, 2).'/'.$hash;
+
+    $relative_path = $this->store->store($file, $hash);
+
+    $this->assertSame($expected_path, $relative_path);
+  }
+
+  #[Group('unit')]
+  public function testStoreFileCreatesCorrectSubdirectoryStructure(): void
+  {
+    $file = $this->createTempFile('structure test');
+    $hash = hash('sha256', 'structure test');
+
+    $this->store->store($file, $hash);
+
+    $expected_absolute = $this->assets_dir.substr($hash, 0, 2).'/'.substr($hash, 2, 2).'/'.$hash;
+    $this->assertFileExists($expected_absolute);
+    $this->assertSame('structure test', file_get_contents($expected_absolute));
+  }
+
+  #[Group('unit')]
+  public function testStoreSameFileTwiceDoesNotDuplicate(): void
+  {
+    $content = 'duplicate content';
+    $file1 = $this->createTempFile($content);
+    $file2 = $this->createTempFile($content);
+    $hash = hash('sha256', $content);
+
+    $path1 = $this->store->store($file1, $hash);
+    $path2 = $this->store->store($file2, $hash);
+
+    $this->assertSame($path1, $path2);
+
+    // Verify only one file on disk in the hash subdirectory
+    $absolute = $this->assets_dir.$path1;
+    $this->assertFileExists($absolute);
+    $this->assertSame($content, file_get_contents($absolute));
+  }
+
+  #[Group('unit')]
+  public function testStoreDifferentFilesCreatesDifferentEntries(): void
+  {
+    $file1 = $this->createTempFile('content A');
+    $file2 = $this->createTempFile('content B');
+    $hash1 = hash('sha256', 'content A');
+    $hash2 = hash('sha256', 'content B');
+
+    $path1 = $this->store->store($file1, $hash1);
+    $path2 = $this->store->store($file2, $hash2);
+
+    $this->assertNotSame($path1, $path2);
+    $this->assertFileExists($this->assets_dir.$path1);
+    $this->assertFileExists($this->assets_dir.$path2);
+  }
+
+  #[Group('unit')]
+  public function testGetAbsolutePathReturnsPathForExistingHash(): void
+  {
+    $content = 'retrieve test';
+    $file = $this->createTempFile($content);
+    $hash = hash('sha256', $content);
+
+    $this->store->store($file, $hash);
+
+    $absolute_path = $this->store->getAbsolutePath($hash);
+
+    $this->assertNotNull($absolute_path);
+    $this->assertFileExists($absolute_path);
+    $this->assertSame($content, file_get_contents($absolute_path));
+  }
+
+  #[Group('unit')]
+  public function testGetAbsolutePathReturnsNullForMissingHash(): void
+  {
+    $hash = hash('sha256', 'nonexistent');
+
+    $this->assertNull($this->store->getAbsolutePath($hash));
+  }
+
+  #[Group('unit')]
+  public function testGetAbsolutePathFromRelative(): void
+  {
+    $relative = 'ab/cd/abcdef1234567890';
+
+    $absolute = $this->store->getAbsolutePathFromRelative($relative);
+
+    $this->assertSame($this->assets_dir.$relative, $absolute);
+  }
+
+  #[Group('unit')]
+  public function testDeleteRemovesFileFromDisk(): void
+  {
+    $content = 'delete me';
+    $file = $this->createTempFile($content);
+    $hash = hash('sha256', $content);
+
+    $this->store->store($file, $hash);
+    $this->assertTrue($this->store->exists($hash));
+
+    $result = $this->store->delete($hash);
+
+    $this->assertTrue($result);
+    $this->assertFalse($this->store->exists($hash));
+  }
+
+  #[Group('unit')]
+  public function testDeleteCleansUpEmptyParentDirectories(): void
+  {
+    $content = 'cleanup test';
+    $file = $this->createTempFile($content);
+    $hash = hash('sha256', $content);
+
+    $relative_path = $this->store->store($file, $hash);
+    $absolute_path = $this->assets_dir.$relative_path;
+
+    // Verify parent dirs exist before delete
+    $parent = dirname($absolute_path);
+    $grandparent = dirname($parent);
+    $this->assertDirectoryExists($parent);
+    $this->assertDirectoryExists($grandparent);
+
+    $this->store->delete($hash);
+
+    // Empty parent directories should be cleaned up
+    $this->assertDirectoryDoesNotExist($parent);
+    $this->assertDirectoryDoesNotExist($grandparent);
+  }
+
+  #[Group('unit')]
+  public function testDeleteNonExistentHashReturnsFalse(): void
+  {
+    $hash = hash('sha256', 'never stored');
+
+    $result = $this->store->delete($hash);
+
+    $this->assertFalse($result);
+  }
+
+  #[Group('unit')]
+  public function testExistsReturnsTrueForStoredFile(): void
+  {
+    $file = $this->createTempFile('exists check');
+    $hash = hash('sha256', 'exists check');
+
+    $this->store->store($file, $hash);
+
+    $this->assertTrue($this->store->exists($hash));
+  }
+
+  #[Group('unit')]
+  public function testExistsReturnsFalseForMissingHash(): void
+  {
+    $this->assertFalse($this->store->exists(hash('sha256', 'missing')));
+  }
+
+  #[Group('unit')]
+  public function testStoreEmptyFile(): void
+  {
+    $file = $this->createTempFile('');
+    $hash = hash('sha256', '');
+
+    $relative_path = $this->store->store($file, $hash);
+
+    $this->assertFileExists($this->assets_dir.$relative_path);
+    $this->assertSame('', file_get_contents($this->assets_dir.$relative_path));
+    $this->assertTrue($this->store->exists($hash));
+  }
+
+  #[Group('unit')]
+  public function testStoreLargeFile(): void
+  {
+    // Create a 1.5 MB file
+    $content = random_bytes(1_500_000);
+    $file = $this->createTempFile($content);
+    $hash = hash('sha256', $content);
+
+    $relative_path = $this->store->store($file, $hash);
+
+    $stored_path = $this->assets_dir.$relative_path;
+    $this->assertFileExists($stored_path);
+    $this->assertSame(md5($content), md5_file($stored_path));
+  }
+
+  #[Group('unit')]
+  public function testStoreIsIdempotentWithSameContent(): void
+  {
+    $content = 'idempotent test';
+    $hash = hash('sha256', $content);
+
+    // Store three times
+    $path1 = $this->store->store($this->createTempFile($content), $hash);
+    $path2 = $this->store->store($this->createTempFile($content), $hash);
+    $path3 = $this->store->store($this->createTempFile($content), $hash);
+
+    $this->assertSame($path1, $path2);
+    $this->assertSame($path2, $path3);
+    $this->assertSame($content, file_get_contents($this->assets_dir.$path1));
+  }
+
+  #[Group('unit')]
+  public function testStoreWithRealFixtureFile(): void
+  {
+    $fixture_file = BootstrapExtension::$GENERATED_FIXTURES_DIR.'base/images/6153c44ce0f49f21facbb8c2b2263ce8_Aussehen.png';
+    if (!file_exists($fixture_file)) {
+      $this->markTestSkipped('Fixture file not found');
+    }
+
+    $hash = $this->store->hashFile($fixture_file);
+    $relative_path = $this->store->store($fixture_file, $hash);
+
+    $stored_path = $this->assets_dir.$relative_path;
+    $this->assertFileExists($stored_path);
+    $this->assertSame(md5_file($fixture_file), md5_file($stored_path));
+  }
+
+  private function createTempFile(string $content): string
+  {
+    $path = $this->assets_dir.'tmp_'.bin2hex(random_bytes(8));
+    file_put_contents($path, $content);
+
+    return $path;
+  }
+}


### PR DESCRIPTION
## Summary
- Content-addressable asset store using SHA-256 hashing — each unique file stored once on disk
- Projects reference shared assets via `ProjectAsset` + `ProjectAssetMapping` entities
- Upload flow enhanced: after extraction, assets are hashed and deduplicated (50-70% disk savings expected)
- Download flow enhanced: `ProjectZipReconstructor` rebuilds ZIPs from CAS with caching
- Migration command (`catrobat:migrate-assets`) for existing projects, GC command (`catrobat:gc-assets`) for cleanup
- Atomic file writes + `UniqueConstraintViolationException` handling for concurrency safety
- Zero user-visible changes — upload/download behavior identical

Closes #6499

## New files (10)
| File | Purpose |
|------|---------|
| `src/DB/Entity/Project/ProjectAsset.php` | Asset entity (SHA-256 PK, ref count) |
| `src/DB/Entity/Project/ProjectAssetMapping.php` | Maps project → asset with path in ZIP |
| `src/DB/EntityRepository/Project/ProjectAssetRepository.php` | Asset queries |
| `src/DB/EntityRepository/Project/ProjectAssetMappingRepository.php` | Mapping queries |
| `src/Storage/ContentAddressableStore.php` | Low-level hash-based file store |
| `src/Project/ProjectDeduplicationService.php` | Orchestrates dedup on upload |
| `src/Project/CatrobatFile/ProjectZipReconstructor.php` | Rebuilds ZIPs from CAS |
| `src/System/Commands/DBUpdater/MigrateAssetsToContentAddressableStoreCommand.php` | Migrate existing projects |
| `src/System/Commands/DBUpdater/CronJobs/GarbageCollectAssetsCommand.php` | Clean orphaned assets |
| `migrations/2026/Version20260403140000.php` | DB migration |

## Test plan
- [x] 55 new PHPUnit tests, 163 assertions — all passing
- [ ] PHPStan passes in CI
- [ ] Psalm passes in CI
- [ ] Existing Behat upload/download tests pass (no user-visible changes)
- [ ] Migration command works on test data (`catrobat:migrate-assets --dry-run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)