### PR TITLE
Fix broadcast notification loading all users into memory

### DIFF
--- a/assets/Admin/UserCommunication/BroadcastNotification.js
+++ b/assets/Admin/UserCommunication/BroadcastNotification.js
@@ -7,12 +7,14 @@ function broadcastNotification() {
 
       const message = document.querySelector('#msg').value
 
-      fetch(`send?Message=${encodeURIComponent(message)}`, {
-        method: 'GET',
+      fetch('send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ Message: message }),
       })
         .then((response) => response.text())
         .then((data) => {
-          if (data === 'OK') {
+          if (data.startsWith('OK')) {
             resultBox.classList.remove('error')
             resultBox.classList.add('success')
           } else {

--- a/src/Admin/UserCommunication/BroadcastNotification/BroadcastNotificationAdmin.php
+++ b/src/Admin/UserCommunication/BroadcastNotification/BroadcastNotificationAdmin.php
@@ -29,6 +29,6 @@ class BroadcastNotificationAdmin extends AbstractAdmin
   protected function configureRoutes(RouteCollectionInterface $collection): void
   {
     $collection->clearExcept(['list']);
-    $collection->add('send');
+    $collection->add('send', null, [], [], [], '', [], ['POST']);
   }
 }

--- a/src/Admin/UserCommunication/BroadcastNotification/BroadcastNotificationController.php
+++ b/src/Admin/UserCommunication/BroadcastNotification/BroadcastNotificationController.php
@@ -6,7 +6,6 @@ namespace App\Admin\UserCommunication\BroadcastNotification;
 
 use App\DB\Entity\User\Notifications\BroadcastNotification;
 use App\DB\Entity\User\User;
-use App\User\Notification\NotificationManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +19,6 @@ class BroadcastNotificationController extends CRUDController
   private const int BATCH_SIZE = 100;
 
   public function __construct(
-    protected NotificationManager $notification_manager,
     protected EntityManagerInterface $entity_manager,
   ) {
   }
@@ -38,12 +36,11 @@ class BroadcastNotificationController extends CRUDController
       return new Response('Message must not be empty', Response::HTTP_BAD_REQUEST);
     }
 
-    $title = '';
     $count = 0;
 
     $query = $this->entity_manager->createQuery('SELECT u FROM '.User::class.' u');
     foreach ($query->toIterable() as $user) {
-      $notification = new BroadcastNotification($user, $title, $message);
+      $notification = new BroadcastNotification($user, '', $message);
       $this->entity_manager->persist($notification);
       ++$count;
 

--- a/src/Admin/UserCommunication/BroadcastNotification/BroadcastNotificationController.php
+++ b/src/Admin/UserCommunication/BroadcastNotification/BroadcastNotificationController.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Admin\UserCommunication\BroadcastNotification;
 
 use App\DB\Entity\User\Notifications\BroadcastNotification;
+use App\DB\Entity\User\User;
 use App\User\Notification\NotificationManager;
-use App\User\UserManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,9 +17,11 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class BroadcastNotificationController extends CRUDController
 {
+  private const int BATCH_SIZE = 100;
+
   public function __construct(
     protected NotificationManager $notification_manager,
-    protected UserManager $user_manager,
+    protected EntityManagerInterface $entity_manager,
   ) {
   }
 
@@ -30,18 +33,31 @@ class BroadcastNotificationController extends CRUDController
 
   public function sendAction(Request $request): Response
   {
-    $message = (string) $request->query->get('Message');
-    $title = '';
-
-    $this->notification_manager->addNotifications($this->getNotifications($message, $title, $this->user_manager));
-
-    return new Response('OK');
-  }
-
-  private function getNotifications(string $message, string $title, UserManager $user_manager): \Generator
-  {
-    foreach ($user_manager->findAll() as $user) {
-      yield new BroadcastNotification($user, $title, $message);
+    $message = (string) $request->request->get('Message', '');
+    if ('' === $message) {
+      return new Response('Message must not be empty', Response::HTTP_BAD_REQUEST);
     }
+
+    $title = '';
+    $count = 0;
+
+    $query = $this->entity_manager->createQuery('SELECT u FROM '.User::class.' u');
+    foreach ($query->toIterable() as $user) {
+      $notification = new BroadcastNotification($user, $title, $message);
+      $this->entity_manager->persist($notification);
+      ++$count;
+
+      if (0 === $count % self::BATCH_SIZE) {
+        $this->entity_manager->flush();
+        $this->entity_manager->clear();
+      }
+    }
+
+    if (0 !== $count % self::BATCH_SIZE) {
+      $this->entity_manager->flush();
+      $this->entity_manager->clear();
+    }
+
+    return new Response('OK - '.$count.' notifications sent');
   }
 }


### PR DESCRIPTION
## Summary
- Use Doctrine `toIterable()` to stream users in batches of 100 instead of `findAll()` which hydrates every User entity at once
- Flush and clear entity manager every 100 notifications to bound memory usage
- Switch send action from GET to POST (avoids URL length limits and access log exposure)
- Add empty message validation

Closes #6518

## Test plan
- [ ] Verify broadcast notification page loads correctly in admin panel
- [ ] Send a test notification and confirm it arrives for users
- [ ] Verify empty message is rejected with error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)