### PR TITLE
Project retention indicators, notifications, and JWT auth fix

### DIFF
--- a/assets/Components/RetentionTooltip.js
+++ b/assets/Components/RetentionTooltip.js
@@ -1,0 +1,25 @@
+/**
+ * Aligns retention tooltips based on the icon's horizontal position.
+ * If the icon is in the right half of the viewport, the tooltip
+ * anchors to the right; otherwise it anchors to the left.
+ */
+document.addEventListener(
+  'pointerenter',
+  (e) => {
+    if (!(e.target instanceof Element)) return
+
+    const wrap = e.target.closest('.retention-info-wrap')
+    if (!wrap) return
+
+    const tooltip = wrap.querySelector('.retention-tooltip')
+    if (!tooltip) return
+
+    const rect = wrap.getBoundingClientRect()
+    if (rect.left > window.innerWidth / 2) {
+      tooltip.classList.add('align-right')
+    } else {
+      tooltip.classList.remove('align-right')
+    }
+  },
+  true,
+)

--- a/assets/Index/WelcomeSection.scss
+++ b/assets/Index/WelcomeSection.scss
@@ -1,4 +1,5 @@
 #welcome-section {
+  padding-top: 2rem;
   margin-bottom: 2.5rem;
 
   .video-container {

--- a/assets/Project/OwnProjectList.js
+++ b/assets/Project/OwnProjectList.js
@@ -6,6 +6,7 @@ import ProjectApi from '../Api/ProjectApi'
 import { showSnackbar, SnackbarDuration } from '../Layout/Snackbar'
 import { escapeHtml, escapeAttr } from '../Components/HtmlEscape'
 import { shareOrCopy } from '../Components/ClipboardHelper'
+import '../Components/RetentionTooltip'
 
 require('./OwnProjectList.scss')
 
@@ -14,7 +15,7 @@ export class OwnProjectList {
     this.container = container
     this.projectsContainer = container.getElementsByClassName('projects-container')[0]
     const attributes =
-      'attributes=id,project_url,screenshot_small,screenshot_large,name,downloads,views,reactions,comments,private,not_for_kids'
+      'attributes=id,project_url,screenshot_small,screenshot_large,name,downloads,views,reactions,comments,private,not_for_kids,retention_days,retention_expiry'
     this.baseUrl = baseUrl
     this.apiUrl = apiUrl.includes('?') ? apiUrl + '&' + attributes : apiUrl + '?' + attributes
     this.projectsLoaded = 0
@@ -37,6 +38,15 @@ export class OwnProjectList {
       markNotForKids: ds.transMarkNotForKids || 'Mark not for kids',
       markSafeForKids: ds.transMarkSafeForKids || 'Mark safe for kids',
       delete: ds.transDelete || 'Delete project',
+      retentionProtected: ds.transRetentionProtected || 'Protected',
+      retentionDay: ds.transRetentionDay || '1 day left',
+      retentionDays: ds.transRetentionDays || '%days% days left',
+      retentionTooltip:
+        ds.transRetentionTooltip ||
+        'Projects are automatically removed after a period of inactivity. Get more downloads or log in regularly to extend retention.',
+      retentionTooltipProtected:
+        ds.transRetentionTooltipProtected ||
+        'This project is protected and will not be automatically deleted.',
     }
   }
 
@@ -105,13 +115,12 @@ export class OwnProjectList {
           self.projectsData[project.id] = project
           const projectElement = self._generate(project)
           self.projectsContainer.appendChild(projectElement)
-          projectElement.addEventListener(
-            'click',
-            function () {
+          const projectLink = projectElement.querySelector('a[href]')
+          if (projectLink) {
+            projectLink.addEventListener('click', function () {
               self._addLoadingSpinner(projectElement)
-            },
-            false,
-          )
+            })
+          }
         })
         self.container.classList.remove('loading')
 
@@ -174,6 +183,11 @@ export class OwnProjectList {
     const visibilityText = data.private
       ? this.projectInfoConfiguration.visibilityPrivateText
       : this.projectInfoConfiguration.visibilityPublicText
+
+    let retentionHtml = ''
+    if (data.retention_days !== undefined) {
+      retentionHtml = this._buildRetentionBadge(data.retention_days, data.retention_expiry)
+    }
 
     const transVisibility = data.private
       ? escapeHtml(this.translations.setPublic)
@@ -255,6 +269,7 @@ export class OwnProjectList {
       escapeHtml(visibilityText) +
       '</span>' +
       '</div>' +
+      retentionHtml +
       '</div>' +
       '<div class="projects-list-item--actions">' +
       '<button class="btn projects-list-item--menu-btn own-project-list__project__action" data-project-id="' +
@@ -509,5 +524,72 @@ export class OwnProjectList {
     if (spinner) {
       fromElement.removeChild(spinner)
     }
+  }
+
+  _buildRetentionBadge(retentionDays, retentionExpiry) {
+    const tooltip = escapeAttr(
+      retentionDays === -1
+        ? this.translations.retentionTooltipProtected ||
+            'This project is protected and will not be automatically deleted.'
+        : this.translations.retentionTooltip ||
+            'Projects are automatically removed after a period of inactivity. Get more downloads or log in regularly to extend retention.',
+    )
+
+    const infoBtn =
+      '<span class="retention-info-wrap" onclick="event.preventDefault();event.stopPropagation()">' +
+      '<span class="material-icons retention-info-icon">info_outline</span>' +
+      '<span class="retention-tooltip">' +
+      tooltip +
+      '</span>' +
+      '</span>'
+
+    if (retentionDays === -1) {
+      return (
+        '<div class="own-project-list__project__details__retention own-project-list__project__details__retention--protected">' +
+        '<span class="material-icons">verified</span>' +
+        '<span>' +
+        escapeHtml(this.translations.retentionProtected || 'Protected') +
+        '</span>' +
+        infoBtn +
+        '</div>'
+      )
+    }
+
+    let daysLeft = 0
+    if (retentionExpiry) {
+      daysLeft = Math.max(0, Math.ceil((new Date(retentionExpiry) - Date.now()) / 86400000))
+    }
+
+    let icon = 'schedule'
+    let cssModifier = ''
+    if (daysLeft <= 7) {
+      icon = 'warning'
+      cssModifier = ' own-project-list__project__details__retention--critical'
+    } else if (daysLeft <= 30) {
+      icon = 'hourglass_bottom'
+      cssModifier = ' own-project-list__project__details__retention--warning'
+    }
+
+    const label =
+      daysLeft === 1
+        ? this.translations.retentionDay || '1 day left'
+        : (this.translations.retentionDays || '%days% days left').replace(
+            '%days%',
+            String(daysLeft),
+          )
+
+    return (
+      '<div class="own-project-list__project__details__retention' +
+      cssModifier +
+      '">' +
+      '<span class="material-icons">' +
+      icon +
+      '</span>' +
+      '<span>' +
+      escapeHtml(label) +
+      '</span>' +
+      infoBtn +
+      '</div>'
+    )
   }
 }

--- a/assets/Project/OwnProjectList.scss
+++ b/assets/Project/OwnProjectList.scss
@@ -2,6 +2,7 @@
 @import '../Layout/Variables';
 @import '../Layout/Mixins';
 @import '~bootstrap/scss/mixins';
+@import 'RetentionTooltip';
 
 $max-project-thumb-size: 160px;
 $container-padding: 1rem;
@@ -112,6 +113,47 @@ $container-padding: 1rem;
           margin-top: 1px;
           margin-left: 2px;
           letter-spacing: 0.5px;
+        }
+      }
+
+      &__retention {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.2rem;
+        font-size: 0.7rem;
+        color: $text-muted;
+        margin-top: 0.2rem;
+
+        > .material-icons {
+          font-size: 0.85rem;
+        }
+
+        .retention-info-icon {
+          font-size: 12px !important;
+        }
+
+        &--protected {
+          color: light-dark(#2e7d32, #66bb6a);
+
+          .material-icons {
+            color: light-dark(#2e7d32, #66bb6a);
+          }
+        }
+
+        &--warning {
+          color: light-dark(#e65100, #ff9800);
+
+          .material-icons {
+            color: light-dark(#e65100, #ff9800);
+          }
+        }
+
+        &--critical {
+          color: light-dark(#c62828, #ef5350);
+
+          .material-icons {
+            color: light-dark(#c62828, #ef5350);
+          }
         }
       }
     }

--- a/assets/Project/ProjectList.js
+++ b/assets/Project/ProjectList.js
@@ -1,6 +1,7 @@
 import { showDefaultTopBarTitle, showCustomTopBarTitle } from '../Layout/TopBar'
 import { escapeHtml, escapeAttr } from '../Components/HtmlEscape'
 import { shareOrCopy } from '../Components/ClipboardHelper'
+import '../Components/RetentionTooltip'
 
 require('./ProjectList.scss')
 
@@ -60,7 +61,7 @@ export class ProjectList {
 
   formatApiUrl(apiUrl) {
     let attributes =
-      'id,name,project_url,screenshot_small,screenshot_large,not_for_kids,uploaded_string,'
+      'id,name,project_url,screenshot_small,screenshot_large,not_for_kids,uploaded_string,retention_days,retention_expiry,'
 
     if (this.propertyToShow && !attributes.includes(`,${this.propertyToShow},`)) {
       attributes += this.propertyToShow
@@ -147,6 +148,18 @@ export class ProjectList {
     }
     projectElement.appendChild(propDiv)
 
+    if (data.retention_days !== undefined) {
+      const retDiv = document.createElement('div')
+      retDiv.innerHTML = this._buildRetentionMeta(
+        data.retention_days,
+        data.retention_expiry,
+        this.container.dataset,
+      )
+      if (retDiv.firstChild) {
+        projectElement.appendChild(retDiv.firstChild)
+      }
+    }
+
     return projectElement
   }
 
@@ -173,9 +186,12 @@ export class ProjectList {
     if (uploadedString) {
       meta +=
         '<span class="projects-meta__item">' +
-        '<i class="material-icons">schedule</i>' +
+        '<i class="material-icons">calendar_today</i>' +
         uploadedString +
         '</span>'
+    }
+    if (data.retention_days !== undefined) {
+      meta += this._buildRetentionMeta(data.retention_days, data.retention_expiry, ds)
     }
 
     // Common menu items
@@ -465,7 +481,7 @@ export class ProjectList {
     const icons = {
       views: 'visibility',
       downloads: 'get_app',
-      uploaded: 'schedule',
+      uploaded: 'calendar_today',
       author: 'person',
     }
 
@@ -608,5 +624,64 @@ export class ProjectList {
     this.container.classList.remove('vertical')
     this.$body.classList.remove('overflow-hidden')
     return false
+  }
+
+  _buildRetentionMeta(retentionDays, retentionExpiry, ds) {
+    const tooltip = escapeAttr(
+      retentionDays === -1
+        ? ds.transRetentionTooltipProtected ||
+            'This project is protected and will not be automatically deleted.'
+        : ds.transRetentionTooltip ||
+            'Projects are automatically removed after a period of inactivity. Get more downloads or log in regularly to extend retention.',
+    )
+    const infoBtn =
+      '<span class="retention-info-wrap" onclick="event.preventDefault();event.stopPropagation()">' +
+      '<span class="material-icons retention-info-icon">info_outline</span>' +
+      '<span class="retention-tooltip">' +
+      tooltip +
+      '</span>' +
+      '</span>'
+
+    if (retentionDays === -1) {
+      return (
+        '<span class="projects-meta__item projects-meta__item--retention projects-meta__item--protected">' +
+        '<i class="material-icons">verified</i>' +
+        escapeHtml(ds.transRetentionProtected || 'Protected') +
+        infoBtn +
+        '</span>'
+      )
+    }
+
+    let daysLeft = 0
+    if (retentionExpiry) {
+      daysLeft = Math.max(0, Math.ceil((new Date(retentionExpiry) - Date.now()) / 86400000))
+    }
+
+    let icon = 'schedule'
+    let cssModifier = ''
+    if (daysLeft <= 7) {
+      icon = 'warning'
+      cssModifier = ' projects-meta__item--critical'
+    } else if (daysLeft <= 30) {
+      icon = 'hourglass_bottom'
+      cssModifier = ' projects-meta__item--warning'
+    }
+
+    const label =
+      daysLeft === 1
+        ? ds.transRetentionDay || '1 day left'
+        : (ds.transRetentionDays || '%days% days left').replace('%days%', String(daysLeft))
+
+    return (
+      '<span class="projects-meta__item projects-meta__item--retention' +
+      cssModifier +
+      '">' +
+      '<i class="material-icons">' +
+      icon +
+      '</i>' +
+      escapeHtml(label) +
+      infoBtn +
+      '</span>'
+    )
   }
 }

--- a/assets/Project/ProjectList.scss
+++ b/assets/Project/ProjectList.scss
@@ -2,6 +2,7 @@
 @import '../Layout/Variables';
 @import '../Layout/Mixins';
 @import '~bootstrap/scss/mixins';
+@import 'RetentionTooltip';
 
 $max-project-thumb-size: 160px;
 $container-padding: 1rem;
@@ -385,6 +386,31 @@ $container-padding: 1rem;
 
   .material-icons {
     font-size: 0.85rem;
+  }
+
+  &--retention {
+    font-size: 0.6rem;
+    color: light-dark(#bbb, #666);
+
+    .material-icons {
+      font-size: 0.65rem;
+    }
+
+    .retention-info-icon {
+      font-size: 10px !important;
+    }
+  }
+
+  &--protected {
+    color: light-dark(#8cb88e, #7dab7f);
+  }
+
+  &--warning {
+    color: light-dark(#c9a070, #c9975a);
+  }
+
+  &--critical {
+    color: light-dark(#c08080, #c97070);
   }
 }
 

--- a/assets/Project/_RetentionTooltip.scss
+++ b/assets/Project/_RetentionTooltip.scss
@@ -1,0 +1,55 @@
+// Shared retention tooltip styles (imported by ProjectList.scss and OwnProjectList.scss)
+
+.retention-info-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  margin-left: 2px;
+  vertical-align: middle;
+}
+
+.retention-info-icon {
+  font-size: 13px !important;
+  color: light-dark(#9e9e9e, #757575);
+  opacity: 0.7;
+  transition: opacity 0.15s;
+
+  .retention-info-wrap:hover &,
+  .retention-info-wrap:focus-within & {
+    opacity: 1;
+    color: light-dark(#616161, #bdbdbd);
+  }
+}
+
+.retention-tooltip {
+  display: none;
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  width: max-content;
+  max-width: min(250px, calc(100vw - 2rem));
+  padding: 0.65rem 0.85rem;
+  background: light-dark(#fff, #1e1e30);
+  border-radius: 10px;
+  box-shadow:
+    0 4px 20px light-dark(rgb(0 0 0 / 14%), rgb(0 0 0 / 45%)),
+    0 0 0 1px light-dark(rgb(0 0 0 / 5%), rgb(255 255 255 / 8%));
+  font-size: 0.78rem;
+  line-height: 1.55;
+  color: light-dark(#444, #ddd);
+  z-index: 1080;
+  pointer-events: none;
+  white-space: normal;
+  overflow-wrap: break-word;
+
+  &.align-right {
+    left: auto;
+    right: 0;
+  }
+
+  .retention-info-wrap:hover &,
+  .retention-info-wrap:focus-within & {
+    display: block;
+  }
+}

--- a/assets/Search/SearchPage.js
+++ b/assets/Search/SearchPage.js
@@ -138,7 +138,7 @@ function renderProjects(section, projects, theme, trans) {
       url,
       project.screenshot_small || '/images/default/screenshot.png',
       project.name || '',
-      'schedule',
+      'calendar_today',
       project.uploaded_string || '',
     )
     items.appendChild(card)

--- a/assets/Security/TokenExpirationHandler.js
+++ b/assets/Security/TokenExpirationHandler.js
@@ -1,69 +1,37 @@
-import { jwtDecode } from 'jwt-decode'
-import { deleteCookie, getCookie, setCookie } from './CookieHelper'
-
+/**
+ * Keeps the BEARER JWT cookie alive by periodically pinging the server.
+ *
+ * Since both BEARER and REFRESH_TOKEN are HttpOnly, JS cannot read or
+ * refresh them directly. Instead, we make a lightweight request every
+ * 45 minutes. The server-side RefreshBearerCookieOnKernelRequestEventListener
+ * detects the expired BEARER, validates the REFRESH_TOKEN, and sets a
+ * fresh BEARER cookie in the response.
+ *
+ * The JWT_TTL is 3600 seconds (1 hour), so pinging every 45 minutes
+ * ensures the token is refreshed before it expires.
+ */
 export class TokenExpirationHandler {
   constructor() {
-    const routingDataset = document.getElementById('js-api-routing').dataset
-    this.baseUrl = routingDataset.baseUrl
-    this.indexPath = routingDataset.index
-    this.authenticationRefreshPath = routingDataset.authenticationRefresh
-    this.checkBearerTokenExpiration()
-    this.interval = this.setScopedInterval(this.checkBearerTokenExpiration, 60000, this)
+    const routingDataset = document.getElementById('js-api-routing')?.dataset
+    if (!routingDataset) return
+
+    this.baseUrl = routingDataset.baseUrl || ''
+
+    // Ping every 45 minutes (JWT_TTL is 3600s = 60min)
+    this.interval = setInterval(() => this.pingServer(), 45 * 60 * 1000)
   }
 
-  checkBearerTokenExpiration() {
-    const refreshToken = getCookie('REFRESH_TOKEN')
-    if (!refreshToken) {
+  pingServer() {
+    // A simple HEAD request to the notifications count endpoint.
+    // It's lightweight (no body), authenticated (sends cookies),
+    // and triggers the server-side BEARER refresh if needed.
+    fetch(this.baseUrl + '/api/notifications/count', {
+      method: 'GET',
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
+    }).catch(() => {
+      // If the ping fails (e.g., no network), stop retrying
       clearInterval(this.interval)
-      return
-    }
-
-    const bearerToken = getCookie('BEARER')
-    if (bearerToken && jwtDecode) {
-      const decodedToken = jwtDecode(bearerToken)
-      if (decodedToken && decodedToken.exp) {
-        const now = Date.now().valueOf() / 1000
-        if (decodedToken.exp < now || decodedToken.exp < now + 60) {
-          this.refreshToken()
-        }
-      }
-    } else if (getCookie('REFRESH_TOKEN')) {
-      this.refreshToken()
-    }
-  }
-
-  refreshToken() {
-    fetch(this.authenticationRefreshPath, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ refresh_token: getCookie('REFRESH_TOKEN') }),
     })
-      .then((response) => {
-        if (response.status === 200) {
-          return response.json()
-        }
-      })
-      .then((data) => {
-        setCookie('BEARER', data.token, 'Tue, 19 Jan 2038 00:00:01 GMT', this.baseUrl + '/')
-        setCookie(
-          'REFRESH_TOKEN',
-          data.refresh_token,
-          'Tue, 19 Jan 2038 00:00:01 GMT',
-          this.baseUrl + '/',
-        )
-      })
-      .catch(() => {
-        deleteCookie('BEARER', this.baseUrl + '/')
-        deleteCookie('REFRESH_TOKEN', this.baseUrl + '/')
-      })
-  }
-
-  setScopedInterval(func, millis, scope) {
-    return setInterval(function () {
-      func.apply(scope)
-    }, millis)
   }
 }

--- a/assets/User/NotificationsPage.js
+++ b/assets/User/NotificationsPage.js
@@ -36,6 +36,12 @@ const TAB_CONFIG = [
     type: 'studio',
     prefix: 'studio-notification-',
   },
+  {
+    chipId: 'project-notif',
+    paneId: 'project-notifications',
+    type: 'project',
+    prefix: 'project-notification-',
+  },
 ]
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -245,6 +251,8 @@ class UserNotifications {
     if (fetched.type === 'follow' && fetched.project) return 'program'
     if (fetched.type === 'moderation' && fetched.project) return 'program'
     if (fetched.type === 'studio') return 'studio'
+    if (fetched.type === 'project' && fetched.project) return 'program'
+    if (fetched.type === 'project') return 'other'
     return fetched.type
   }
 

--- a/assets/controllers/project/browse_controller.js
+++ b/assets/controllers/project/browse_controller.js
@@ -2,6 +2,7 @@ import { Controller } from '@hotwired/stimulus'
 import { escapeHtml, escapeAttr } from '../../Components/HtmlEscape'
 import { shareOrCopy } from '../../Components/ClipboardHelper'
 import AcceptLanguage from '../../Api/AcceptLanguage'
+import '../../Components/RetentionTooltip'
 
 export default class extends Controller {
   static values = {
@@ -59,7 +60,7 @@ export default class extends Controller {
     const url =
       this.apiBaseUrlValue +
       '/projects/user' +
-      '?limit=50&attributes=id,name,project_url,screenshot_small,downloads,uploaded_string'
+      '?limit=50&attributes=id,name,project_url,screenshot_small,downloads,uploaded_string,retention_days,retention_expiry'
 
     try {
       const response = await fetch(url, {
@@ -93,7 +94,8 @@ export default class extends Controller {
     const params = new URLSearchParams({
       category: 'random',
       limit: '20',
-      attributes: 'id,name,author,screenshot_small,downloads,views,uploaded_string',
+      attributes:
+        'id,name,author,screenshot_small,downloads,views,uploaded_string,retention_days,retention_expiry',
     })
     if (this.exploreCursor) {
       params.set('offset', this.exploreCursor)
@@ -204,9 +206,13 @@ export default class extends Controller {
     if (uploadedString) {
       meta +=
         '<span class="projects-meta__item">' +
-        '<i class="material-icons">schedule</i>' +
+        '<i class="material-icons">calendar_today</i>' +
         uploadedString +
         '</span>'
+    }
+
+    if (project.retention_days !== undefined) {
+      meta += this._buildRetentionMeta(project.retention_days, project.retention_expiry)
     }
 
     if (!isOwned && author) {
@@ -456,5 +462,65 @@ export default class extends Controller {
     if (this.hasLoadMoreTarget) {
       this.loadMoreTarget.style.display = this.hasMoreExplore ? '' : 'none'
     }
+  }
+
+  _buildRetentionMeta(retentionDays, retentionExpiry) {
+    const ds = this.element.dataset
+    const tooltip = escapeAttr(
+      retentionDays === -1
+        ? ds.transRetentionTooltipProtected ||
+            'This project is protected and will not be automatically deleted.'
+        : ds.transRetentionTooltip ||
+            'Projects are automatically removed after a period of inactivity.',
+    )
+    const infoBtn =
+      '<span class="retention-info-wrap" onclick="event.preventDefault();event.stopPropagation()">' +
+      '<span class="material-icons retention-info-icon">info_outline</span>' +
+      '<span class="retention-tooltip">' +
+      tooltip +
+      '</span>' +
+      '</span>'
+
+    if (retentionDays === -1) {
+      return (
+        '<span class="projects-meta__item projects-meta__item--retention projects-meta__item--protected">' +
+        '<i class="material-icons">verified</i>' +
+        escapeHtml(ds.transRetentionProtected || 'Protected') +
+        infoBtn +
+        '</span>'
+      )
+    }
+
+    let daysLeft = 0
+    if (retentionExpiry) {
+      daysLeft = Math.max(0, Math.ceil((new Date(retentionExpiry) - Date.now()) / 86400000))
+    }
+
+    let icon = 'schedule'
+    let cssModifier = ''
+    if (daysLeft <= 7) {
+      icon = 'warning'
+      cssModifier = ' projects-meta__item--critical'
+    } else if (daysLeft <= 30) {
+      icon = 'hourglass_bottom'
+      cssModifier = ' projects-meta__item--warning'
+    }
+
+    const label =
+      daysLeft === 1
+        ? ds.transRetentionDay || '1 day left'
+        : (ds.transRetentionDays || '%days% days left').replace('%days%', String(daysLeft))
+
+    return (
+      '<span class="projects-meta__item projects-meta__item--retention' +
+      cssModifier +
+      '">' +
+      '<i class="material-icons">' +
+      icon +
+      '</i>' +
+      escapeHtml(label) +
+      infoBtn +
+      '</span>'
+    )
   }
 }

--- a/migrations/2026/Version20260406160000.php
+++ b/migrations/2026/Version20260406160000.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260406160000 extends AbstractMigration
+{
+  #[\Override]
+  public function getDescription(): string
+  {
+    return 'Add storage_protected flag to program table for retention whitelisting';
+  }
+
+  #[\Override]
+  public function up(Schema $schema): void
+  {
+    $this->addSql('ALTER TABLE program ADD storage_protected TINYINT(1) DEFAULT 0 NOT NULL');
+  }
+
+  #[\Override]
+  public function down(Schema $schema): void
+  {
+    $this->addSql('ALTER TABLE program DROP storage_protected');
+  }
+}

--- a/src/Admin/Projects/ProjectsAdmin.php
+++ b/src/Admin/Projects/ProjectsAdmin.php
@@ -88,6 +88,7 @@ class ProjectsAdmin extends AbstractAdmin
       ->add('flavor')
       ->add('visible', null, ['required' => false])
       ->add('approved', null, ['required' => false])
+      ->add('storage_protected', null, ['required' => false, 'label' => 'Storage Protected'])
     ;
   }
 
@@ -157,6 +158,7 @@ class ProjectsAdmin extends AbstractAdmin
       ->add('private', null, ['editable' => false, 'sortable' => false])
       ->add('approved', null, ['editable' => true, 'sortable' => false])
       ->add('visible', null, ['editable' => true, 'sortable' => false])
+      ->add('storage_protected', null, ['editable' => true, 'sortable' => false, 'label' => 'Protected'])
       ->add('not_for_kids', 'choice', [
         'editable' => true,
         'sortable' => false,

--- a/src/Api/OpenAPI/Server/Controller/AuthenticationController.php
+++ b/src/Api/OpenAPI/Server/Controller/AuthenticationController.php
@@ -31,6 +31,9 @@ namespace OpenAPI\Server\Controller;
 
 use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;
 use OpenAPI\Server\Api\AuthenticationApiInterface;
+use OpenAPI\Server\Model\LoginRequest;
+use OpenAPI\Server\Model\OAuthLoginRequest;
+use OpenAPI\Server\Model\RefreshRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -212,7 +215,7 @@ class AuthenticationController extends Controller
     // Deserialize the input values that needs it
     try {
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $o_auth_login_request = $this->deserialize($o_auth_login_request, \OpenAPI\Server\Model\OAuthLoginRequest::class, $inputFormat);
+      $o_auth_login_request = $this->deserialize($o_auth_login_request, OAuthLoginRequest::class, $inputFormat);
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -220,7 +223,7 @@ class AuthenticationController extends Controller
     // Validate the input values
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\OAuthLoginRequest::class);
+    $asserts[] = new Assert\Type(OAuthLoginRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($o_auth_login_request, $asserts);
     if ($response instanceof Response) {
@@ -303,7 +306,7 @@ class AuthenticationController extends Controller
     // Deserialize the input values that needs it
     try {
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $login_request = $this->deserialize($login_request, \OpenAPI\Server\Model\LoginRequest::class, $inputFormat);
+      $login_request = $this->deserialize($login_request, LoginRequest::class, $inputFormat);
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -311,7 +314,7 @@ class AuthenticationController extends Controller
     // Validate the input values
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\LoginRequest::class);
+    $asserts[] = new Assert\Type(LoginRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($login_request, $asserts);
     if ($response instanceof Response) {
@@ -395,7 +398,7 @@ class AuthenticationController extends Controller
     // Deserialize the input values that needs it
     try {
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $refresh_request = $this->deserialize($refresh_request, \OpenAPI\Server\Model\RefreshRequest::class, $inputFormat);
+      $refresh_request = $this->deserialize($refresh_request, RefreshRequest::class, $inputFormat);
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -403,7 +406,7 @@ class AuthenticationController extends Controller
     // Validate the input values
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\RefreshRequest::class);
+    $asserts[] = new Assert\Type(RefreshRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($refresh_request, $asserts);
     if ($response instanceof Response) {

--- a/src/Api/OpenAPI/Server/Controller/CommentsController.php
+++ b/src/Api/OpenAPI/Server/Controller/CommentsController.php
@@ -31,6 +31,7 @@ namespace OpenAPI\Server\Controller;
 
 use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;
 use OpenAPI\Server\Api\CommentsApiInterface;
+use OpenAPI\Server\Model\CommentCreateRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -471,7 +472,7 @@ class CommentsController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $comment_create_request = $this->deserialize($comment_create_request, \OpenAPI\Server\Model\CommentCreateRequest::class, $inputFormat);
+      $comment_create_request = $this->deserialize($comment_create_request, CommentCreateRequest::class, $inputFormat);
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -488,7 +489,7 @@ class CommentsController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\CommentCreateRequest::class);
+    $asserts[] = new Assert\Type(CommentCreateRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($comment_create_request, $asserts);
     if ($response instanceof Response) {

--- a/src/Api/OpenAPI/Server/Controller/MediaLibraryController.php
+++ b/src/Api/OpenAPI/Server/Controller/MediaLibraryController.php
@@ -31,6 +31,8 @@ namespace OpenAPI\Server\Controller;
 
 use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;
 use OpenAPI\Server\Api\MediaLibraryApiInterface;
+use OpenAPI\Server\Model\MediaAssetUpdateRequest;
+use OpenAPI\Server\Model\MediaCategoryRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -403,7 +405,7 @@ class MediaLibraryController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $media_asset_update_request = $this->deserialize($media_asset_update_request, \OpenAPI\Server\Model\MediaAssetUpdateRequest::class, $inputFormat);
+      $media_asset_update_request = $this->deserialize($media_asset_update_request, MediaAssetUpdateRequest::class, $inputFormat);
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -420,7 +422,7 @@ class MediaLibraryController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\MediaAssetUpdateRequest::class);
+    $asserts[] = new Assert\Type(MediaAssetUpdateRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($media_asset_update_request, $asserts);
     if ($response instanceof Response) {
@@ -943,7 +945,7 @@ class MediaLibraryController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $media_category_request = $this->deserialize($media_category_request, \OpenAPI\Server\Model\MediaCategoryRequest::class, $inputFormat);
+      $media_category_request = $this->deserialize($media_category_request, MediaCategoryRequest::class, $inputFormat);
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -960,7 +962,7 @@ class MediaLibraryController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\MediaCategoryRequest::class);
+    $asserts[] = new Assert\Type(MediaCategoryRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($media_category_request, $asserts);
     if ($response instanceof Response) {
@@ -1054,7 +1056,7 @@ class MediaLibraryController extends Controller
     // Deserialize the input values that needs it
     try {
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $media_category_request = $this->deserialize($media_category_request, \OpenAPI\Server\Model\MediaCategoryRequest::class, $inputFormat);
+      $media_category_request = $this->deserialize($media_category_request, MediaCategoryRequest::class, $inputFormat);
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -1063,7 +1065,7 @@ class MediaLibraryController extends Controller
     // Validate the input values
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\MediaCategoryRequest::class);
+    $asserts[] = new Assert\Type(MediaCategoryRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($media_category_request, $asserts);
     if ($response instanceof Response) {

--- a/src/Api/OpenAPI/Server/Controller/ModerationController.php
+++ b/src/Api/OpenAPI/Server/Controller/ModerationController.php
@@ -31,6 +31,10 @@ namespace OpenAPI\Server\Controller;
 
 use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;
 use OpenAPI\Server\Api\ModerationApiInterface;
+use OpenAPI\Server\Model\ContentAppealRequest;
+use OpenAPI\Server\Model\ContentReportRequest;
+use OpenAPI\Server\Model\ResolveAppealRequest;
+use OpenAPI\Server\Model\ResolveReportRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -79,7 +83,7 @@ class ModerationController extends Controller
     try {
       $id = $this->deserialize($id, 'int', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $content_appeal_request = $this->deserialize($content_appeal_request, \OpenAPI\Server\Model\ContentAppealRequest::class, $inputFormat);
+      $content_appeal_request = $this->deserialize($content_appeal_request, ContentAppealRequest::class, $inputFormat);
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -94,7 +98,7 @@ class ModerationController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\ContentAppealRequest::class);
+    $asserts[] = new Assert\Type(ContentAppealRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($content_appeal_request, $asserts);
     if ($response instanceof Response) {
@@ -171,7 +175,7 @@ class ModerationController extends Controller
     try {
       $id = $this->deserialize($id, 'int', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $content_report_request = $this->deserialize($content_report_request, \OpenAPI\Server\Model\ContentReportRequest::class, $inputFormat);
+      $content_report_request = $this->deserialize($content_report_request, ContentReportRequest::class, $inputFormat);
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -186,7 +190,7 @@ class ModerationController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\ContentReportRequest::class);
+    $asserts[] = new Assert\Type(ContentReportRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($content_report_request, $asserts);
     if ($response instanceof Response) {
@@ -351,7 +355,7 @@ class ModerationController extends Controller
     try {
       $id = $this->deserialize($id, 'int', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $resolve_appeal_request = $this->deserialize($resolve_appeal_request, \OpenAPI\Server\Model\ResolveAppealRequest::class, $inputFormat);
+      $resolve_appeal_request = $this->deserialize($resolve_appeal_request, ResolveAppealRequest::class, $inputFormat);
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -366,7 +370,7 @@ class ModerationController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\ResolveAppealRequest::class);
+    $asserts[] = new Assert\Type(ResolveAppealRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($resolve_appeal_request, $asserts);
     if ($response instanceof Response) {
@@ -529,7 +533,7 @@ class ModerationController extends Controller
     try {
       $id = $this->deserialize($id, 'int', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $resolve_report_request = $this->deserialize($resolve_report_request, \OpenAPI\Server\Model\ResolveReportRequest::class, $inputFormat);
+      $resolve_report_request = $this->deserialize($resolve_report_request, ResolveReportRequest::class, $inputFormat);
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -544,7 +548,7 @@ class ModerationController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\ResolveReportRequest::class);
+    $asserts[] = new Assert\Type(ResolveReportRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($resolve_report_request, $asserts);
     if ($response instanceof Response) {
@@ -619,7 +623,7 @@ class ModerationController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $content_appeal_request = $this->deserialize($content_appeal_request, \OpenAPI\Server\Model\ContentAppealRequest::class, $inputFormat);
+      $content_appeal_request = $this->deserialize($content_appeal_request, ContentAppealRequest::class, $inputFormat);
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -635,7 +639,7 @@ class ModerationController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\ContentAppealRequest::class);
+    $asserts[] = new Assert\Type(ContentAppealRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($content_appeal_request, $asserts);
     if ($response instanceof Response) {
@@ -712,7 +716,7 @@ class ModerationController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $content_report_request = $this->deserialize($content_report_request, \OpenAPI\Server\Model\ContentReportRequest::class, $inputFormat);
+      $content_report_request = $this->deserialize($content_report_request, ContentReportRequest::class, $inputFormat);
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -728,7 +732,7 @@ class ModerationController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\ContentReportRequest::class);
+    $asserts[] = new Assert\Type(ContentReportRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($content_report_request, $asserts);
     if ($response instanceof Response) {
@@ -805,7 +809,7 @@ class ModerationController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $content_appeal_request = $this->deserialize($content_appeal_request, \OpenAPI\Server\Model\ContentAppealRequest::class, $inputFormat);
+      $content_appeal_request = $this->deserialize($content_appeal_request, ContentAppealRequest::class, $inputFormat);
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -821,7 +825,7 @@ class ModerationController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\ContentAppealRequest::class);
+    $asserts[] = new Assert\Type(ContentAppealRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($content_appeal_request, $asserts);
     if ($response instanceof Response) {
@@ -898,7 +902,7 @@ class ModerationController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $content_report_request = $this->deserialize($content_report_request, \OpenAPI\Server\Model\ContentReportRequest::class, $inputFormat);
+      $content_report_request = $this->deserialize($content_report_request, ContentReportRequest::class, $inputFormat);
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -914,7 +918,7 @@ class ModerationController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\ContentReportRequest::class);
+    $asserts[] = new Assert\Type(ContentReportRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($content_report_request, $asserts);
     if ($response instanceof Response) {
@@ -991,7 +995,7 @@ class ModerationController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $content_appeal_request = $this->deserialize($content_appeal_request, \OpenAPI\Server\Model\ContentAppealRequest::class, $inputFormat);
+      $content_appeal_request = $this->deserialize($content_appeal_request, ContentAppealRequest::class, $inputFormat);
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -1007,7 +1011,7 @@ class ModerationController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\ContentAppealRequest::class);
+    $asserts[] = new Assert\Type(ContentAppealRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($content_appeal_request, $asserts);
     if ($response instanceof Response) {
@@ -1084,7 +1088,7 @@ class ModerationController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $content_report_request = $this->deserialize($content_report_request, \OpenAPI\Server\Model\ContentReportRequest::class, $inputFormat);
+      $content_report_request = $this->deserialize($content_report_request, ContentReportRequest::class, $inputFormat);
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -1100,7 +1104,7 @@ class ModerationController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\ContentReportRequest::class);
+    $asserts[] = new Assert\Type(ContentReportRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($content_report_request, $asserts);
     if ($response instanceof Response) {

--- a/src/Api/OpenAPI/Server/Controller/NotificationsController.php
+++ b/src/Api/OpenAPI/Server/Controller/NotificationsController.php
@@ -256,7 +256,7 @@ class NotificationsController extends Controller
       return $response;
     }
     $asserts = [];
-    $asserts[] = new Assert\Choice(['all', 'reaction', 'follow', 'comment', 'remix', 'studio']);
+    $asserts[] = new Assert\Choice(['all', 'reaction', 'follow', 'comment', 'remix', 'studio', 'project']);
     $asserts[] = new Assert\Type('string');
     $response = $this->validate($type, $asserts);
     if ($response instanceof Response) {

--- a/src/Api/OpenAPI/Server/Controller/ProjectsController.php
+++ b/src/Api/OpenAPI/Server/Controller/ProjectsController.php
@@ -31,6 +31,8 @@ namespace OpenAPI\Server\Controller;
 
 use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;
 use OpenAPI\Server\Api\ProjectsApiInterface;
+use OpenAPI\Server\Model\ReactionRequest;
+use OpenAPI\Server\Model\UpdateProjectRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -464,7 +466,7 @@ class ProjectsController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $update_project_request = $this->deserialize($update_project_request, \OpenAPI\Server\Model\UpdateProjectRequest::class, $inputFormat);
+      $update_project_request = $this->deserialize($update_project_request, UpdateProjectRequest::class, $inputFormat);
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -481,7 +483,7 @@ class ProjectsController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\UpdateProjectRequest::class);
+    $asserts[] = new Assert\Type(UpdateProjectRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($update_project_request, $asserts);
     if ($response instanceof Response) {
@@ -667,7 +669,7 @@ class ProjectsController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $reaction_request = $this->deserialize($reaction_request, \OpenAPI\Server\Model\ReactionRequest::class, $inputFormat);
+      $reaction_request = $this->deserialize($reaction_request, ReactionRequest::class, $inputFormat);
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -684,7 +686,7 @@ class ProjectsController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\ReactionRequest::class);
+    $asserts[] = new Assert\Type(ReactionRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($reaction_request, $asserts);
     if ($response instanceof Response) {

--- a/src/Api/OpenAPI/Server/Controller/StudioController.php
+++ b/src/Api/OpenAPI/Server/Controller/StudioController.php
@@ -31,6 +31,8 @@ namespace OpenAPI\Server\Controller;
 
 use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;
 use OpenAPI\Server\Api\StudioApiInterface;
+use OpenAPI\Server\Model\StudioAddProjectRequest;
+use OpenAPI\Server\Model\StudioCommentCreateRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -475,7 +477,7 @@ class StudioController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $studio_comment_create_request = $this->deserialize($studio_comment_create_request, \OpenAPI\Server\Model\StudioCommentCreateRequest::class, $inputFormat);
+      $studio_comment_create_request = $this->deserialize($studio_comment_create_request, StudioCommentCreateRequest::class, $inputFormat);
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -492,7 +494,7 @@ class StudioController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\StudioCommentCreateRequest::class);
+    $asserts[] = new Assert\Type(StudioCommentCreateRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($studio_comment_create_request, $asserts);
     if ($response instanceof Response) {
@@ -1414,7 +1416,7 @@ class StudioController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $studio_add_project_request = $this->deserialize($studio_add_project_request, \OpenAPI\Server\Model\StudioAddProjectRequest::class, $inputFormat);
+      $studio_add_project_request = $this->deserialize($studio_add_project_request, StudioAddProjectRequest::class, $inputFormat);
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -1431,7 +1433,7 @@ class StudioController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\StudioAddProjectRequest::class);
+    $asserts[] = new Assert\Type(StudioAddProjectRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($studio_add_project_request, $asserts);
     if ($response instanceof Response) {

--- a/src/Api/OpenAPI/Server/Controller/UserController.php
+++ b/src/Api/OpenAPI/Server/Controller/UserController.php
@@ -31,6 +31,9 @@ namespace OpenAPI\Server\Controller;
 
 use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;
 use OpenAPI\Server\Api\UserApiInterface;
+use OpenAPI\Server\Model\RegisterRequest;
+use OpenAPI\Server\Model\ResetPasswordRequest;
+use OpenAPI\Server\Model\UpdateUserRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -440,7 +443,7 @@ class UserController extends Controller
     // Deserialize the input values that needs it
     try {
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $register_request = $this->deserialize($register_request, \OpenAPI\Server\Model\RegisterRequest::class, $inputFormat);
+      $register_request = $this->deserialize($register_request, RegisterRequest::class, $inputFormat);
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -449,7 +452,7 @@ class UserController extends Controller
     // Validate the input values
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\RegisterRequest::class);
+    $asserts[] = new Assert\Type(RegisterRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($register_request, $asserts);
     if ($response instanceof Response) {
@@ -538,7 +541,7 @@ class UserController extends Controller
     // Deserialize the input values that needs it
     try {
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $update_user_request = $this->deserialize($update_user_request, \OpenAPI\Server\Model\UpdateUserRequest::class, $inputFormat);
+      $update_user_request = $this->deserialize($update_user_request, UpdateUserRequest::class, $inputFormat);
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -547,7 +550,7 @@ class UserController extends Controller
     // Validate the input values
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\UpdateUserRequest::class);
+    $asserts[] = new Assert\Type(UpdateUserRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($update_user_request, $asserts);
     if ($response instanceof Response) {
@@ -634,7 +637,7 @@ class UserController extends Controller
     // Deserialize the input values that needs it
     try {
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $reset_password_request = $this->deserialize($reset_password_request, \OpenAPI\Server\Model\ResetPasswordRequest::class, $inputFormat);
+      $reset_password_request = $this->deserialize($reset_password_request, ResetPasswordRequest::class, $inputFormat);
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -643,7 +646,7 @@ class UserController extends Controller
     // Validate the input values
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\ResetPasswordRequest::class);
+    $asserts[] = new Assert\Type(ResetPasswordRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($reset_password_request, $asserts);
     if ($response instanceof Response) {

--- a/src/Api/OpenAPI/Server/Model/NotificationResponse.php
+++ b/src/Api/OpenAPI/Server/Model/NotificationResponse.php
@@ -57,7 +57,7 @@ class NotificationResponse
    *
    * @SerializedName("type")
    *
-   * @Assert\Choice({ "reaction", "follow", "comment", "remix", "moderation", "other" })
+   * @Assert\Choice({ "reaction", "follow", "comment", "remix", "moderation", "studio", "project", "other" })
    *
    * @Assert\Type("string")
    *

--- a/src/Api/OpenAPI/Server/Model/NotificationsCountResponse.php
+++ b/src/Api/OpenAPI/Server/Model/NotificationsCountResponse.php
@@ -87,6 +87,33 @@ class NotificationsCountResponse
   protected ?int $remix = null;
 
   /**
+   * @SerializedName("moderation")
+   *
+   * @Assert\Type("int")
+   *
+   * @Type("int")
+   */
+  protected ?int $moderation = null;
+
+  /**
+   * @SerializedName("studio")
+   *
+   * @Assert\Type("int")
+   *
+   * @Type("int")
+   */
+  protected ?int $studio = null;
+
+  /**
+   * @SerializedName("project")
+   *
+   * @Assert\Type("int")
+   *
+   * @Type("int")
+   */
+  protected ?int $project = null;
+
+  /**
    * Constructor.
    *
    * @param array|null $data Associated array of property values initializing the model
@@ -99,6 +126,9 @@ class NotificationsCountResponse
       $this->follower = array_key_exists('follower', $data) ? $data['follower'] : $this->follower;
       $this->comment = array_key_exists('comment', $data) ? $data['comment'] : $this->comment;
       $this->remix = array_key_exists('remix', $data) ? $data['remix'] : $this->remix;
+      $this->moderation = array_key_exists('moderation', $data) ? $data['moderation'] : $this->moderation;
+      $this->studio = array_key_exists('studio', $data) ? $data['studio'] : $this->studio;
+      $this->project = array_key_exists('project', $data) ? $data['project'] : $this->project;
     }
   }
 
@@ -198,6 +228,66 @@ class NotificationsCountResponse
   public function setRemix(?int $remix = null): self
   {
     $this->remix = $remix;
+
+    return $this;
+  }
+
+  /**
+   * Gets moderation.
+   */
+  public function getModeration(): ?int
+  {
+    return $this->moderation;
+  }
+
+  /**
+   * Sets moderation.
+   *
+   * @return $this
+   */
+  public function setModeration(?int $moderation = null): self
+  {
+    $this->moderation = $moderation;
+
+    return $this;
+  }
+
+  /**
+   * Gets studio.
+   */
+  public function getStudio(): ?int
+  {
+    return $this->studio;
+  }
+
+  /**
+   * Sets studio.
+   *
+   * @return $this
+   */
+  public function setStudio(?int $studio = null): self
+  {
+    $this->studio = $studio;
+
+    return $this;
+  }
+
+  /**
+   * Gets project.
+   */
+  public function getProject(): ?int
+  {
+    return $this->project;
+  }
+
+  /**
+   * Sets project.
+   *
+   * @return $this
+   */
+  public function setProject(?int $project = null): self
+  {
+    $this->project = $project;
 
     return $this;
   }

--- a/src/Api/OpenAPI/Server/Model/ProjectResponse.php
+++ b/src/Api/OpenAPI/Server/Model/ProjectResponse.php
@@ -305,6 +305,28 @@ class ProjectResponse
   protected ?int $not_for_kids = null;
 
   /**
+   * Days until automatic deletion (-1 &#x3D; protected/never). Only returned when explicitly requested via attributes parameter.
+   *
+   * @SerializedName("retention_days")
+   *
+   * @Assert\Type("int")
+   *
+   * @Type("int")
+   */
+  protected ?int $retention_days = null;
+
+  /**
+   * ISO 8601 date when the project will be auto-deleted. Null for protected projects. Only returned when explicitly requested.
+   *
+   * @SerializedName("retention_expiry")
+   *
+   * @Assert\Type("\DateTime"))
+   *
+   * @Type("DateTime")
+   */
+  protected ?\DateTime $retention_expiry = null;
+
+  /**
    * Constructor.
    *
    * @param array|null $data Associated array of property values initializing the model
@@ -336,6 +358,8 @@ class ProjectResponse
       $this->download_url = array_key_exists('download_url', $data) ? $data['download_url'] : $this->download_url;
       $this->filesize = array_key_exists('filesize', $data) ? $data['filesize'] : $this->filesize;
       $this->not_for_kids = array_key_exists('not_for_kids', $data) ? $data['not_for_kids'] : $this->not_for_kids;
+      $this->retention_days = array_key_exists('retention_days', $data) ? $data['retention_days'] : $this->retention_days;
+      $this->retention_expiry = array_key_exists('retention_expiry', $data) ? $data['retention_expiry'] : $this->retention_expiry;
     }
   }
 
@@ -859,6 +883,50 @@ class ProjectResponse
   public function setNotForKids(?int $not_for_kids = null): self
   {
     $this->not_for_kids = $not_for_kids;
+
+    return $this;
+  }
+
+  /**
+   * Gets retention_days.
+   */
+  public function getRetentionDays(): ?int
+  {
+    return $this->retention_days;
+  }
+
+  /**
+   * Sets retention_days.
+   *
+   * @param int|null $retention_days Days until automatic deletion (-1 = protected/never). Only returned when explicitly requested via attributes parameter.
+   *
+   * @return $this
+   */
+  public function setRetentionDays(?int $retention_days = null): self
+  {
+    $this->retention_days = $retention_days;
+
+    return $this;
+  }
+
+  /**
+   * Gets retention_expiry.
+   */
+  public function getRetentionExpiry(): ?\DateTime
+  {
+    return $this->retention_expiry;
+  }
+
+  /**
+   * Sets retention_expiry.
+   *
+   * @param \DateTime|null $retention_expiry ISO 8601 date when the project will be auto-deleted. Null for protected projects. Only returned when explicitly requested.
+   *
+   * @return $this
+   */
+  public function setRetentionExpiry(?\DateTime $retention_expiry = null): self
+  {
+    $this->retention_expiry = $retention_expiry;
 
     return $this;
   }

--- a/src/Api/OpenAPI/Server/Resources/config/routing.yaml
+++ b/src/Api/OpenAPI/Server/Resources/config/routing.yaml
@@ -572,7 +572,7 @@ open_api_server_studio_studioidmembersget:
     id: '^[a-zA-Z0-9\\-]+$'
 
 open_api_server_studio_studioidmembersuseridbanpost:
-  path: /studio/{id}/members/{userId}/ban
+  path: /studio/{id}/members/{user_id}/ban
   methods: [POST]
   defaults:
     _controller: open_api_server.controller.studio::studioIdMembersUserIdBanPostAction
@@ -581,7 +581,7 @@ open_api_server_studio_studioidmembersuseridbanpost:
     user_id: '[a-z0-9]+'
 
 open_api_server_studio_studioidmembersuseridpromotepost:
-  path: /studio/{id}/members/{userId}/promote
+  path: /studio/{id}/members/{user_id}/promote
   methods: [POST]
   defaults:
     _controller: open_api_server.controller.studio::studioIdMembersUserIdPromotePostAction

--- a/src/Api/OpenAPI/Server/Resources/config/routing.yaml
+++ b/src/Api/OpenAPI/Server/Resources/config/routing.yaml
@@ -572,7 +572,7 @@ open_api_server_studio_studioidmembersget:
     id: '^[a-zA-Z0-9\\-]+$'
 
 open_api_server_studio_studioidmembersuseridbanpost:
-  path: /studio/{id}/members/{user_id}/ban
+  path: /studio/{id}/members/{userId}/ban
   methods: [POST]
   defaults:
     _controller: open_api_server.controller.studio::studioIdMembersUserIdBanPostAction
@@ -581,7 +581,7 @@ open_api_server_studio_studioidmembersuseridbanpost:
     user_id: '[a-z0-9]+'
 
 open_api_server_studio_studioidmembersuseridpromotepost:
-  path: /studio/{id}/members/{user_id}/promote
+  path: /studio/{id}/members/{userId}/promote
   methods: [POST]
   defaults:
     _controller: open_api_server.controller.studio::studioIdMembersUserIdPromotePostAction

--- a/src/Api/OpenAPI/specification.yaml
+++ b/src/Api/OpenAPI/specification.yaml
@@ -3216,6 +3216,7 @@ components:
           - 'comment'
           - 'remix'
           - 'studio'
+          - 'project'
         default: 'all'
 
     ##
@@ -4339,6 +4340,17 @@ components:
           type: integer
           example: 0
           description: 'Indicates whether a project is suitable for kids or not (0 = safe for kids, 1 = not safe for kids, 2 = not safe for kids set by moderator)'
+        retention_days:
+          type: integer
+          example: 365
+          nullable: true
+          description: 'Days until automatic deletion (-1 = protected/never). Only returned when explicitly requested via attributes parameter.'
+        retention_expiry:
+          type: string
+          format: date-time
+          nullable: true
+          example: '2027-04-06T12:00:00+00:00'
+          description: 'ISO 8601 date when the project will be auto-deleted. Null for protected projects. Only returned when explicitly requested.'
 
     ExtensionsResponse:
       type: array
@@ -4403,6 +4415,15 @@ components:
         remix:
           type: integer
           example: 3
+        moderation:
+          type: integer
+          example: 0
+        studio:
+          type: integer
+          example: 0
+        project:
+          type: integer
+          example: 0
 
     NotificationListResponse:
       type: object
@@ -4435,6 +4456,8 @@ components:
             - 'comment'
             - 'remix'
             - 'moderation'
+            - 'studio'
+            - 'project'
             - 'other'
           description: 'Notification Type'
         seen:

--- a/src/Api/Services/Notifications/NotificationsResponseManager.php
+++ b/src/Api/Services/Notifications/NotificationsResponseManager.php
@@ -11,6 +11,8 @@ use App\DB\Entity\User\Notifications\FollowNotification;
 use App\DB\Entity\User\Notifications\LikeNotification;
 use App\DB\Entity\User\Notifications\ModerationNotification;
 use App\DB\Entity\User\Notifications\NewProgramNotification;
+use App\DB\Entity\User\Notifications\ProjectDeletedNotification;
+use App\DB\Entity\User\Notifications\ProjectExpiringNotification;
 use App\DB\Entity\User\Notifications\RemixNotification;
 use App\DB\Entity\User\Notifications\StudioCommentNotification;
 use App\DB\Entity\User\Notifications\StudioProjectNotification;
@@ -215,6 +217,32 @@ class NotificationsResponseManager extends AbstractResponseManager
           '%user_link%' => '%user_link%',
           '%program_link%' => '%program_link%',
           '%studio_name%' => $notification->getStudio()?->getName() ?? '',
+        ]),
+      ]);
+    }
+
+    if ($notification instanceof ProjectExpiringNotification) {
+      return new NotificationResponse([
+        'id' => $notification->getId(),
+        'type' => 'project',
+        'seen' => $notification->getSeen(),
+        'project' => $notification->getProgram()?->getId(),
+        'project_name' => $notification->getProgram()?->getName(),
+        'message' => $this->trans('catro-notifications.project-expiring.message', [
+          '%program_link%' => '%program_link%',
+          '%days%' => (string) ($notification->getExpiryDays() ?? 0),
+        ]),
+      ]);
+    }
+
+    if ($notification instanceof ProjectDeletedNotification) {
+      return new NotificationResponse([
+        'id' => $notification->getId(),
+        'type' => 'project',
+        'seen' => $notification->getSeen(),
+        'project_name' => $notification->getProjectName(),
+        'message' => $this->trans('catro-notifications.project-deleted.message', [
+          '%project_name%' => $notification->getProjectName() ?? '',
         ]),
       ]);
     }

--- a/src/Api/Services/Projects/ProjectsResponseManager.php
+++ b/src/Api/Services/Projects/ProjectsResponseManager.php
@@ -9,12 +9,15 @@ use App\Api\Services\Base\TranslatorAwareTrait;
 use App\DB\Entity\Project\Extension;
 use App\DB\Entity\Project\Program;
 use App\DB\Entity\Project\ProjectCodeStatistics;
+use App\DB\Entity\Project\Special\ExampleProgram;
 use App\DB\Entity\Project\Special\FeaturedProgram;
 use App\DB\Entity\Project\Special\SpecialProgram;
 use App\DB\Entity\Project\Tag;
 use App\Project\ProjectManager;
 use App\Storage\ImageRepository;
+use App\Storage\StorageLifecycleService;
 use App\Utils\ElapsedTimeStringFormatter;
+use Doctrine\ORM\EntityManagerInterface;
 use OpenAPI\Server\Model\CodeStatisticsResponse;
 use OpenAPI\Server\Model\FeaturedProjectResponse;
 use OpenAPI\Server\Model\ProjectResponse;
@@ -42,6 +45,7 @@ class ProjectsResponseManager extends AbstractResponseManager
     SerializerInterface $serializer,
     private readonly ProjectManager $project_manager,
     \Psr\Cache\CacheItemPoolInterface $cache,
+    private readonly EntityManagerInterface $entity_manager,
   ) {
     parent::__construct($translator, $serializer, $cache);
   }
@@ -180,6 +184,21 @@ class ProjectsResponseManager extends AbstractResponseManager
       $data['not_for_kids'] = $project->getNotForKids();
     }
 
+    if (in_array('retention_days', $attributes_list, true) || in_array('retention_expiry', $attributes_list, true)) {
+      $retention_days = $this->computeRetentionDays($extraced_project);
+      if (in_array('retention_days', $attributes_list, true)) {
+        $data['retention_days'] = $retention_days;
+      }
+      if (in_array('retention_expiry', $attributes_list, true)) {
+        if (StorageLifecycleService::PROTECTED_DAYS === $retention_days) {
+          $data['retention_expiry'] = null;
+        } else {
+          $uploaded = $extraced_project->getUploadedAt();
+          $data['retention_expiry'] = \DateTime::createFromInterface($uploaded)->modify("+{$retention_days} days");
+        }
+      }
+    }
+
     return new ProjectResponse($data);
   }
 
@@ -191,6 +210,58 @@ class ProjectsResponseManager extends AbstractResponseManager
     }
 
     return $response;
+  }
+
+  private function computeRetentionDays(Program $project): int
+  {
+    if ($project->isStorageProtected()) {
+      return StorageLifecycleService::PROTECTED_DAYS;
+    }
+
+    $projectId = $project->getId();
+    if (null !== $projectId) {
+      $featured = (int) $this->entity_manager->createQueryBuilder()
+        ->select('COUNT(f.id)')
+        ->from(FeaturedProgram::class, 'f')
+        ->where('f.program = :project')
+        ->setParameter('project', $project)
+        ->getQuery()
+        ->getSingleScalarResult()
+      ;
+      if ($featured > 0) {
+        return StorageLifecycleService::PROTECTED_DAYS;
+      }
+
+      $example = (int) $this->entity_manager->createQueryBuilder()
+        ->select('COUNT(e.id)')
+        ->from(ExampleProgram::class, 'e')
+        ->where('e.program = :project')
+        ->setParameter('project', $project)
+        ->getQuery()
+        ->getSingleScalarResult()
+      ;
+      if ($example > 0) {
+        return StorageLifecycleService::PROTECTED_DAYS;
+      }
+    }
+
+    if ($project->getDownloads() >= 10) {
+      return StorageLifecycleService::ACTIVE_DAYS;
+    }
+
+    $user = $project->getUser();
+    if (null !== $user) {
+      $lastLogin = $user->getLastLogin();
+      if (null !== $lastLogin && $lastLogin > new \DateTime('-180 days')) {
+        return StorageLifecycleService::ACTIVE_DAYS;
+      }
+    }
+
+    if ($project->isVisible() && !$project->getAutoHidden() && null !== $user && $user->isVerified()) {
+      return StorageLifecycleService::STANDARD_DAYS;
+    }
+
+    return StorageLifecycleService::SHORT_DAYS;
   }
 
   public function createFeaturedProjectResponse(FeaturedProgram $featured_project, ?string $attributes = null): FeaturedProjectResponse

--- a/src/Application/Controller/Project/ProjectController.php
+++ b/src/Application/Controller/Project/ProjectController.php
@@ -15,6 +15,7 @@ use App\Project\Event\CheckScratchProjectEvent;
 use App\Project\ProjectManager;
 use App\Project\ProjectStatisticsService;
 use App\Storage\ScreenshotRepository;
+use App\Storage\StorageLifecycleService;
 use App\Translation\TranslationDelegate;
 use App\Utils\ElapsedTimeStringFormatter;
 use Doctrine\ORM\NonUniqueResultException;
@@ -43,6 +44,7 @@ class ProjectController extends AbstractController
     private readonly ProjectCustomTranslationRepository $projectCustomTranslationRepository,
     private readonly ContentVisibilityManager $content_visibility_manager,
     private readonly ProjectStatisticsService $project_statistics_service,
+    private readonly StorageLifecycleService $storage_lifecycle,
   ) {
   }
 
@@ -111,6 +113,10 @@ class ProjectController extends AbstractController
       'age' => $this->elapsed_time->format($project->getUploadedAt()->getTimestamp()),
       'filesize_mb' => sprintf('%.2f', $project->getFilesize() / 1_048_576),
       'total_downloads' => $project->getDownloads(),
+      'retention_days' => $this->storage_lifecycle->getRetentionDays($project),
+      'retention_expiry' => StorageLifecycleService::PROTECTED_DAYS === $this->storage_lifecycle->getRetentionDays($project)
+        ? null
+        : (clone $project->getUploadedAt())->modify('+'.$this->storage_lifecycle->getRetentionDays($project).' days'),
     ]);
   }
 

--- a/src/DB/Entity/Project/Program.php
+++ b/src/DB/Entity/Project/Program.php
@@ -225,6 +225,9 @@ class Program implements \Stringable
   protected ?User $approved_by_user = null;
 
   #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
+  protected bool $storage_protected = false;
+
+  #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
   protected bool $debug_build = false;
 
   #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
@@ -584,6 +587,16 @@ class Program implements \Stringable
   public function getApproved(): bool
   {
     return $this->approved;
+  }
+
+  public function isStorageProtected(): bool
+  {
+    return $this->storage_protected;
+  }
+
+  public function setStorageProtected(bool $storage_protected): void
+  {
+    $this->storage_protected = $storage_protected;
   }
 
   public function isVisible(): bool

--- a/src/DB/Entity/User/Notifications/CatroNotification.php
+++ b/src/DB/Entity/User/Notifications/CatroNotification.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: NotificationRepository::class)]
 #[ORM\InheritanceType('SINGLE_TABLE')]
 #[ORM\DiscriminatorColumn(name: 'notification_type', type: 'string')]
-#[ORM\DiscriminatorMap(['default' => 'CatroNotification', 'comment' => 'CommentNotification', 'like' => 'LikeNotification', 'follow' => 'FollowNotification', 'follow_project' => 'NewProgramNotification', 'broadcast_notification' => 'BroadcastNotification', 'remix_notification' => 'RemixNotification', 'moderation' => 'ModerationNotification', 'studio_comment' => 'StudioCommentNotification', 'studio_project' => 'StudioProjectNotification'])]
+#[ORM\DiscriminatorMap(['default' => 'CatroNotification', 'comment' => 'CommentNotification', 'like' => 'LikeNotification', 'follow' => 'FollowNotification', 'follow_project' => 'NewProgramNotification', 'broadcast_notification' => 'BroadcastNotification', 'remix_notification' => 'RemixNotification', 'moderation' => 'ModerationNotification', 'studio_comment' => 'StudioCommentNotification', 'studio_project' => 'StudioProjectNotification', 'project_expiring' => 'ProjectExpiringNotification', 'project_deleted' => 'ProjectDeletedNotification'])]
 class CatroNotification
 {
   #[ORM\Column(name: 'id', type: Types::INTEGER)]

--- a/src/DB/Entity/User/Notifications/ProjectDeletedNotification.php
+++ b/src/DB/Entity/User/Notifications/ProjectDeletedNotification.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DB\Entity\User\Notifications;
+
+use App\DB\Entity\User\User;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class ProjectDeletedNotification extends CatroNotification
+{
+  public function __construct(
+    User $user,
+    #[ORM\Column(name: 'deleted_project_name', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $project_name = null,
+  ) {
+    parent::__construct($user, '', '', 'project_deleted');
+  }
+
+  public function getProjectName(): ?string
+  {
+    return $this->project_name;
+  }
+}

--- a/src/DB/Entity/User/Notifications/ProjectExpiringNotification.php
+++ b/src/DB/Entity/User/Notifications/ProjectExpiringNotification.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DB\Entity\User\Notifications;
+
+use App\DB\Entity\Project\Program;
+use App\DB\Entity\User\User;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class ProjectExpiringNotification extends CatroNotification
+{
+  public function __construct(
+    User $user,
+    #[ORM\JoinColumn(name: 'program_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    #[ORM\ManyToOne(targetEntity: Program::class)]
+    private ?Program $program = null,
+    #[ORM\Column(name: 'expiry_days', type: Types::INTEGER, nullable: true)]
+    private ?int $expiry_days = null,
+  ) {
+    parent::__construct($user, '', '', 'project_expiring');
+  }
+
+  public function getProgram(): ?Program
+  {
+    return $this->program;
+  }
+
+  public function getExpiryDays(): ?int
+  {
+    return $this->expiry_days;
+  }
+}

--- a/src/DB/EntityRepository/User/Notification/NotificationRepository.php
+++ b/src/DB/EntityRepository/User/Notification/NotificationRepository.php
@@ -11,6 +11,8 @@ use App\DB\Entity\User\Notifications\FollowNotification;
 use App\DB\Entity\User\Notifications\LikeNotification;
 use App\DB\Entity\User\Notifications\ModerationNotification;
 use App\DB\Entity\User\Notifications\NewProgramNotification;
+use App\DB\Entity\User\Notifications\ProjectDeletedNotification;
+use App\DB\Entity\User\Notifications\ProjectExpiringNotification;
 use App\DB\Entity\User\Notifications\RemixNotification;
 use App\DB\Entity\User\Notifications\StudioCommentNotification;
 use App\DB\Entity\User\Notifications\StudioProjectNotification;
@@ -155,7 +157,7 @@ class NotificationRepository extends ServiceEntityRepository
   }
 
   /**
-   * @return array{total: int, like: int, follower: int, comment: int, remix: int, moderation: int, studio: int}
+   * @return array{total: int, like: int, follower: int, comment: int, remix: int, moderation: int, studio: int, project: int}
    */
   public function getUnseenCounts(User $user): array
   {
@@ -170,7 +172,8 @@ class NotificationRepository extends ServiceEntityRepository
         SUM(CASE WHEN notification_type = 'comment' THEN 1 ELSE 0 END) AS comment,
         SUM(CASE WHEN notification_type = 'remix_notification' THEN 1 ELSE 0 END) AS remix,
         SUM(CASE WHEN notification_type = 'moderation' THEN 1 ELSE 0 END) AS moderation,
-        SUM(CASE WHEN notification_type IN ('studio_comment', 'studio_project') THEN 1 ELSE 0 END) AS studio
+        SUM(CASE WHEN notification_type IN ('studio_comment', 'studio_project') THEN 1 ELSE 0 END) AS studio,
+        SUM(CASE WHEN notification_type IN ('comment', 'project_expiring', 'project_deleted') THEN 1 ELSE 0 END) AS project
       FROM %s
       WHERE user = :user_id AND seen = 0
       SQL;
@@ -178,7 +181,7 @@ class NotificationRepository extends ServiceEntityRepository
     $row = $conn->fetchAssociative(sprintf($sql, $tableName), ['user_id' => $user->getId()]);
 
     if (false === $row) {
-      return ['total' => 0, 'like' => 0, 'follower' => 0, 'comment' => 0, 'remix' => 0, 'moderation' => 0, 'studio' => 0];
+      return ['total' => 0, 'like' => 0, 'follower' => 0, 'comment' => 0, 'remix' => 0, 'moderation' => 0, 'studio' => 0, 'project' => 0];
     }
 
     return [
@@ -189,6 +192,7 @@ class NotificationRepository extends ServiceEntityRepository
       'remix' => (int) $row['remix'],
       'moderation' => (int) $row['moderation'],
       'studio' => (int) $row['studio'],
+      'project' => (int) $row['project'],
     ];
   }
 
@@ -201,6 +205,7 @@ class NotificationRepository extends ServiceEntityRepository
       'remix' => $qb->andWhere('n INSTANCE OF '.RemixNotification::class),
       'moderation' => $qb->andWhere('n INSTANCE OF '.ModerationNotification::class),
       'studio' => $qb->andWhere('(n INSTANCE OF '.StudioCommentNotification::class.' OR n INSTANCE OF '.StudioProjectNotification::class.')'),
+      'project' => $qb->andWhere('(n INSTANCE OF '.CommentNotification::class.' OR n INSTANCE OF '.ProjectExpiringNotification::class.' OR n INSTANCE OF '.ProjectDeletedNotification::class.')'),
       default => null,
     };
   }

--- a/src/Security/Authentication/CookieService.php
+++ b/src/Security/Authentication/CookieService.php
@@ -51,7 +51,7 @@ readonly class CookieService
       $this->isSecureCookie(),
       true,
       false,
-      Cookie::SAMESITE_STRICT
+      Cookie::SAMESITE_LAX
     );
   }
 
@@ -112,6 +112,6 @@ readonly class CookieService
    */
   private function getSameSite(string $cookie): string
   {
-    return 'REFRESH_TOKEN' === $cookie ? Cookie::SAMESITE_STRICT : Cookie::SAMESITE_LAX;
+    return Cookie::SAMESITE_LAX;
   }
 }

--- a/src/Storage/StorageLifecycleService.php
+++ b/src/Storage/StorageLifecycleService.php
@@ -7,6 +7,8 @@ namespace App\Storage;
 use App\DB\Entity\Project\Program;
 use App\DB\Entity\Project\Special\ExampleProgram;
 use App\DB\Entity\Project\Special\FeaturedProgram;
+use App\DB\Entity\User\Notifications\ProjectDeletedNotification;
+use App\DB\Entity\User\Notifications\ProjectExpiringNotification;
 use App\DB\Entity\User\User;
 use App\Project\CatrobatFile\ProjectFileRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -63,7 +65,7 @@ class StorageLifecycleService
    */
   public function isProtected(Program $project): bool
   {
-    if ($project->getApproved()) {
+    if ($project->isStorageProtected()) {
       return true;
     }
 
@@ -255,6 +257,12 @@ class StorageLifecycleService
         }
 
         try {
+          $user = $project->getUser();
+          if ($user instanceof User) {
+            $notification = new ProjectDeletedNotification($user, $projectName);
+            $this->entity_manager->persist($notification);
+            $this->entity_manager->flush();
+          }
           $this->hardDeleteProject($project);
           ++$deleted;
           $this->logger->info('Storage lifecycle: deleted project {id} "{name}"', [
@@ -308,5 +316,83 @@ class StorageLifecycleService
     // Remove from database (Doctrine cascades handle relations)
     $this->entity_manager->remove($project);
     $this->entity_manager->flush();
+  }
+
+  /**
+   * Sends expiry warning notifications for projects that will be deleted within the given threshold.
+   *
+   * @return array{warned: int}
+   */
+  public function sendExpiryWarnings(int $warning_days = 7, string $storage_path = ''): array
+  {
+    $disk_ratio = '' !== $storage_path ? $this->getDiskUsageRatio($storage_path) : 0.0;
+    $now = new \DateTime();
+    $warned = 0;
+    $offset = 0;
+
+    while (true) {
+      $projects = $this->entity_manager->createQueryBuilder()
+        ->select('p')
+        ->from(Program::class, 'p')
+        ->leftJoin('p.user', 'u')
+        ->orderBy('p.uploaded_at', 'ASC')
+        ->setFirstResult($offset)
+        ->setMaxResults(self::BATCH_SIZE)
+        ->getQuery()
+        ->getResult()
+      ;
+
+      if ([] === $projects) {
+        break;
+      }
+
+      /** @var Program $project */
+      foreach ($projects as $project) {
+        $retention_days = $this->getRetentionDays($project);
+        $retention_days = $this->applyDiskPressure($retention_days, $disk_ratio);
+
+        if (self::PROTECTED_DAYS === $retention_days) {
+          continue;
+        }
+
+        $expiry = (clone $project->getUploadedAt())->modify('+'.$retention_days.' days');
+        $days_left = (int) $now->diff($expiry)->format('%r%a');
+
+        if ($days_left <= 0 || $days_left > $warning_days) {
+          continue;
+        }
+
+        $user = $project->getUser();
+        if (!$user instanceof User) {
+          continue;
+        }
+
+        // Check if we already sent a warning for this project recently
+        $existing = $this->entity_manager->createQueryBuilder()
+          ->select('COUNT(n.id)')
+          ->from(ProjectExpiringNotification::class, 'n')
+          ->where('n.user = :user')
+          ->andWhere('n.program = :project')
+          ->setParameter('user', $user)
+          ->setParameter('project', $project)
+          ->getQuery()
+          ->getSingleScalarResult()
+        ;
+
+        if ((int) $existing > 0) {
+          continue;
+        }
+
+        $notification = new ProjectExpiringNotification($user, $project, $days_left);
+        $this->entity_manager->persist($notification);
+        ++$warned;
+      }
+
+      $this->entity_manager->flush();
+      $offset += self::BATCH_SIZE;
+      $this->entity_manager->clear();
+    }
+
+    return ['warned' => $warned];
   }
 }

--- a/src/System/Testing/Behat/Context/CatrowebBrowserContext.php
+++ b/src/System/Testing/Behat/Context/CatrowebBrowserContext.php
@@ -655,10 +655,10 @@ class CatrowebBrowserContext extends BrowserContext
   {
     $page = $this->getSession()->getPage();
     $this->assertSession()->elementExists('xpath',
-      '//div[1]/div/section[2]/div[2]/div/div/div[1]/table/tbody/tr['.$project_number.']/td[12]/div/a');
+      '//div[1]/div/section[2]/div[2]/div/div/div[1]/table/tbody/tr['.$project_number.']/td[13]/div/a');
 
     $page
-      ->find('xpath', '//div[1]/div/section[2]/div[2]/div/div/div[1]/table/tbody/tr['.$project_number.']/td[12]/div/a')
+      ->find('xpath', '//div[1]/div/section[2]/div[2]/div/div/div[1]/table/tbody/tr['.$project_number.']/td[13]/div/a')
       ->click()
     ;
   }

--- a/src/System/Testing/DataFixtures/ProjectDataFixtures.php
+++ b/src/System/Testing/DataFixtures/ProjectDataFixtures.php
@@ -92,6 +92,7 @@ class ProjectDataFixtures
     $project->setVisible(!isset($config['visible']) || 'true' === $config['visible']);
     $project->setUploadLanguage($config['upload_language'] ?? 'en');
     $project->setApproved(isset($config['approved']) && 'true' === $config['approved']);
+    $project->setStorageProtected(isset($config['storage_protected']) && 'true' === $config['storage_protected']);
     $project->setRemixRoot(!isset($config['remix_root']) || 'true' === $config['remix_root']);
     $project->setPrivate(isset($config['private']) && 'true' === $config['private']);
     $project->setDebugBuild(isset($config['debug']) && 'true' === $config['debug']);

--- a/templates/Project/ProjectPage.html.twig
+++ b/templates/Project/ProjectPage.html.twig
@@ -102,13 +102,48 @@
       </a>
 
       <div class="">
-        <i class="material-icons mt-2">query_builder</i>
+        <i class="material-icons mt-2">calendar_today</i>
         <span class="icon-text ms-2 align-bottom mt-2" id="project-age">{{ age }}</span>
       </div>
 
       <div class="">
         <i class="material-icons mt-2">description</i>
         <span class="icon-text ms-2 align-bottom mt-2" id="project-filesize">{{ filesize_mb }} MB</span>
+      </div>
+
+      {% set retention_tooltip = retention_days == -1
+        ? 'project.retention.tooltip_protected'|trans({}, 'catroweb')|default('This project is protected and will not be automatically deleted.')
+        : 'project.retention.tooltip'|trans({}, 'catroweb')|default('Projects are automatically removed after a period of inactivity. Get more downloads or log in regularly to extend retention.')
+      %}
+      <div class="mt-2 d-flex align-items-center gap-1">
+        {% if retention_days == -1 %}
+          <span class="badge bg-success-subtle text-success">
+            <i class="material-icons" style="font-size: 14px; vertical-align: middle;">verified</i>
+            {{ 'project.retention.protected'|trans({}, 'catroweb')|default('Protected') }}
+          </span>
+        {% elseif retention_expiry %}
+          {% set days_left = max(0, ((retention_expiry.timestamp - 'now'|date('U')) / 86400)|round(0, 'ceil')) %}
+          {% if days_left <= 7 %}
+            <span class="badge bg-danger-subtle text-danger">
+              <i class="material-icons" style="font-size: 14px; vertical-align: middle;">warning</i>
+              {{ 'project.retention.days_left'|trans({'%days%': days_left}, 'catroweb')|default(days_left ~ ' days left') }}
+            </span>
+          {% elseif days_left <= 30 %}
+            <span class="badge bg-warning-subtle text-warning">
+              <i class="material-icons" style="font-size: 14px; vertical-align: middle;">hourglass_bottom</i>
+              {{ 'project.retention.days_left'|trans({'%days%': days_left}, 'catroweb')|default(days_left ~ ' days left') }}
+            </span>
+          {% else %}
+            <span class="badge bg-secondary-subtle text-secondary">
+              <i class="material-icons" style="font-size: 14px; vertical-align: middle;">schedule</i>
+              {{ 'project.retention.days_left'|trans({'%days%': days_left}, 'catroweb')|default(days_left ~ ' days left') }}
+            </span>
+          {% endif %}
+        {% endif %}
+        <span class="retention-info-wrap">
+          <span class="material-icons retention-info-icon">info_outline</span>
+          <span class="retention-tooltip">{{ retention_tooltip }}</span>
+        </span>
       </div>
 
       <div id="not-for-kids-indicator" class="{{ not project.getNotForKids() ? 'd-none' : '' }}">

--- a/templates/Project/ProjectsBrowse.html.twig
+++ b/templates/Project/ProjectsBrowse.html.twig
@@ -41,6 +41,11 @@
     data-trans-report-suspended="{{ 'report.suspended'|trans({}, 'catroweb')|default('Account suspended')|e('html_attr') }}"
     data-trans-report-rate-limited="{{ 'report.rateLimited'|trans({}, 'catroweb')|default('Too many reports')|e('html_attr') }}"
     data-trans-report-placeholder="{{ 'report.placeholder'|trans({}, 'catroweb')|default('Please describe the issue...')|e('html_attr') }}"
+    data-trans-retention-protected="{{ 'project.retention.protected'|trans({}, 'catroweb')|default('Protected')|e('html_attr') }}"
+    data-trans-retention-day="{{ 'project.retention.day_left'|trans({}, 'catroweb')|default('1 day left')|e('html_attr') }}"
+    data-trans-retention-days="{{ 'project.retention.days_left'|trans({'%days%': '%days%'}, 'catroweb')|default('%days% days left')|e('html_attr') }}"
+    data-trans-retention-tooltip="{{ 'project.retention.tooltip'|trans({}, 'catroweb')|default('Projects are automatically removed after a period of inactivity. Get more downloads or log in regularly to extend retention.')|e('html_attr') }}"
+    data-trans-retention-tooltip-protected="{{ 'project.retention.tooltip_protected'|trans({}, 'catroweb')|default('This project is protected and will not be automatically deleted.')|e('html_attr') }}"
     data-login-url="{{ path('login') }}"
   >
     {% if is_logged_in %}

--- a/templates/User/Notification/NotificationsPage.html.twig
+++ b/templates/User/Notification/NotificationsPage.html.twig
@@ -45,6 +45,12 @@
         title: '' ~ 'catro-notifications.tab.studio'|trans({}, 'catroweb'),
         controls: 'studio-notifications',
       },
+      {
+        id: 'project-notif',
+        icon: 'code',
+        title: '' ~ 'catro-notifications.tab.project'|trans({}, 'catroweb'),
+        controls: 'project-notifications',
+      },
     ],
   }) }}
 
@@ -79,6 +85,11 @@
         id: 'studio-notifications',
         emptyID: 'no-notif-studio',
         emptyMessage: '' ~ 'catro-notifications.noStudios'|trans({}, 'catroweb'),
+      },
+      {
+        id: 'project-notifications',
+        emptyID: 'no-notif-project',
+        emptyMessage: '' ~ 'catro-notifications.noProjects'|trans({}, 'catroweb'),
       },
     ] %}
     <div id="{{ category.id }}" class="tab-pane fade {% if loop.first %} show active {% endif %}" role="tabpanel">

--- a/templates/User/Profile/MyProfilePage.html.twig
+++ b/templates/User/Profile/MyProfilePage.html.twig
@@ -153,6 +153,11 @@
            data-trans-mark-not-for-kids="{{ 'MarkNotForKids'|trans({}, 'catroweb') }}"
            data-trans-mark-safe-for-kids="{{ 'MarkSafeForKids'|trans({}, 'catroweb') }}"
            data-trans-delete="{{ 'project.deleteAction'|trans({}, 'catroweb') }}"
+           data-trans-retention-protected="{{ 'project.retention.protected'|trans({}, 'catroweb')|default('Protected') }}"
+           data-trans-retention-day="{{ 'project.retention.day_left'|trans({}, 'catroweb')|default('1 day left') }}"
+           data-trans-retention-days="{{ 'project.retention.days_left'|trans({'%days%': '%days%'}, 'catroweb')|default('%days% days left') }}"
+           data-trans-retention-tooltip="{{ 'project.retention.tooltip'|trans({}, 'catroweb')|default('Projects are automatically removed after a period of inactivity. Get more downloads or log in regularly to extend retention.') }}"
+           data-trans-retention-tooltip-protected="{{ 'project.retention.tooltip_protected'|trans({}, 'catroweb')|default('This project is protected and will not be automatically deleted.') }}"
            class="own-project-list loading">
         <div class="container">
           <div class="lazyload projects-spinner-container">

--- a/templates/User/Profile/ProfilePage.html.twig
+++ b/templates/User/Profile/ProfilePage.html.twig
@@ -157,6 +157,11 @@
            data-trans-report-suspended="{{ 'report.suspended'|trans({}, 'catroweb')|default('Account suspended')|e('html_attr') }}"
            data-trans-report-rate-limited="{{ 'report.rateLimited'|trans({}, 'catroweb')|default('Too many reports')|e('html_attr') }}"
            data-trans-report-placeholder="{{ 'report.placeholder'|trans({}, 'catroweb')|default('Please describe the issue...')|e('html_attr') }}"
+           data-trans-retention-protected="{{ 'project.retention.protected'|trans({}, 'catroweb')|default('Protected')|e('html_attr') }}"
+           data-trans-retention-day="{{ 'project.retention.day_left'|trans({}, 'catroweb')|default('1 day left')|e('html_attr') }}"
+           data-trans-retention-days="{{ 'project.retention.days_left'|trans({'%days%': '%days%'}, 'catroweb')|default('%days% days left')|e('html_attr') }}"
+           data-trans-retention-tooltip="{{ 'project.retention.tooltip'|trans({}, 'catroweb')|default('Projects are automatically removed after a period of inactivity. Get more downloads or log in regularly to extend retention.')|e('html_attr') }}"
+           data-trans-retention-tooltip-protected="{{ 'project.retention.tooltip_protected'|trans({}, 'catroweb')|default('This project is protected and will not be automatically deleted.')|e('html_attr') }}"
            class="project-list loading project-list--full">
         <div class="container">
           <div class="lazyload projects-spinner-container">

--- a/tests/BehatFeatures/api/projects/GET_projects_user/project_retention.feature
+++ b/tests/BehatFeatures/api/projects/GET_projects_user/project_retention.feature
@@ -1,0 +1,30 @@
+@api @projects
+Feature: Project retention information in API responses
+
+  Background:
+    Given there are users:
+      | id | name     | password |
+      | 1  | Catrobat | 123456   |
+    And there are projects:
+      | id | name              | owned by | downloads | storage_protected |
+      | 1  | Protected Project | Catrobat | 0         | true              |
+      | 2  | Popular Project   | Catrobat | 50        |                   |
+      | 3  | Normal Project    | Catrobat | 0         |                   |
+
+  Scenario: Retention attributes are returned when requested
+    Given I use a valid JWT Bearer token for "Catrobat"
+    And I request "GET" "/api/projects/user?attributes=id,name,retention_days,retention_expiry"
+    Then the response status code should be "200"
+    And the client response should contain "retention_days"
+    And the client response should contain "retention_expiry"
+
+  Scenario: Storage-protected project has retention_days -1
+    Given I use a valid JWT Bearer token for "Catrobat"
+    And I request "GET" "/api/projects/user?attributes=id,name,retention_days"
+    Then the response status code should be "200"
+    And the client response should contain "retention_days"
+
+  Scenario: Retention attributes are not returned by default
+    Given I use a valid JWT Bearer token for "Catrobat"
+    And I request "GET" "/api/projects/user?attributes=id,name"
+    Then the response status code should be "200"

--- a/tests/BehatFeatures/web/admin/projects_overview.feature
+++ b/tests/BehatFeatures/web/admin/projects_overview.feature
@@ -24,12 +24,12 @@ Feature: Admin all projects
     And I am on "/admin/project/list"
     And I wait for the page to be loaded
     Then I should see the table with all projects in the following order:
-      | Uploaded At           | Name      | User  | Flavor     | Views | Downloads | private | Approved | Visible | not_for_kids  | Action |
-      | April 22, 2019 13:00  | program 5 | Karim | pocketcode | 15    | 111       | no      | no       | no      | Safe for kids | Show   |
-      | April 6, 2019 13:02   | program 3 | Pauli | arduino    | 122   | 234       | no      | no       | no      | Safe for kids | Show   |
-      | April 2, 2019 13:10   | program 4 | Pauli | pocketcode | 12    | 222       | no      | no       | no      | Safe for kids | Show   |
-      | April 2, 2019 13:00   | program 2 | Karim | luna       | 921   | 123       | no      | no       | yes     | Safe for kids | Show   |
-      | January 1, 2019 12:00 | program 1 | Karim | pocketcode | 120   | 3         | no      | no       | yes     | Safe for kids | Show   |
+      | Uploaded At           | Name      | User  | Flavor     | Views | Downloads | private | Approved | Visible | Protected | not_for_kids  | Action |
+      | April 22, 2019 13:00  | program 5 | Karim | pocketcode | 15    | 111       | no      | no       | no      | no        | Safe for kids | Show   |
+      | April 6, 2019 13:02   | program 3 | Pauli | arduino    | 122   | 234       | no      | no       | no      | no        | Safe for kids | Show   |
+      | April 2, 2019 13:10   | program 4 | Pauli | pocketcode | 12    | 222       | no      | no       | no      | no        | Safe for kids | Show   |
+      | April 2, 2019 13:00   | program 2 | Karim | luna       | 921   | 123       | no      | no       | yes     | no        | Safe for kids | Show   |
+      | January 1, 2019 12:00 | program 1 | Karim | pocketcode | 120   | 3         | no      | no       | yes     | no        | Safe for kids | Show   |
 
 
   Scenario: List all projects sorted by views ascending
@@ -39,12 +39,12 @@ Feature: Admin all projects
     And I click on the column with the name "Views"
     And I wait for the page to be loaded
     Then I should see the table with all projects in the following order:
-      | Uploaded At           | Name      | User  | Flavor     | Views | Downloads | private | Approved | Visible | not_for_kids  | Action |
-      | April 2, 2019 13:10   | program 4 | Pauli | pocketcode | 12    | 222       | no      | no       | no      | Safe for kids | Show   |
-      | April 22, 2019 13:00  | program 5 | Karim | pocketcode | 15    | 111       | no      | no       | no      | Safe for kids | Show   |
-      | January 1, 2019 12:00 | program 1 | Karim | pocketcode | 120   | 3         | no      | no       | yes     | Safe for kids | Show   |
-      | April 6, 2019 13:02   | program 3 | Pauli | arduino    | 122   | 234       | no      | no       | no      | Safe for kids | Show   |
-      | April 2, 2019 13:00   | program 2 | Karim | luna       | 921   | 123       | no      | no       | yes     | Safe for kids | Show   |
+      | Uploaded At           | Name      | User  | Flavor     | Views | Downloads | private | Approved | Visible | Protected | not_for_kids  | Action |
+      | April 2, 2019 13:10   | program 4 | Pauli | pocketcode | 12    | 222       | no      | no       | no      | no        | Safe for kids | Show   |
+      | April 22, 2019 13:00  | program 5 | Karim | pocketcode | 15    | 111       | no      | no       | no      | no        | Safe for kids | Show   |
+      | January 1, 2019 12:00 | program 1 | Karim | pocketcode | 120   | 3         | no      | no       | yes     | no        | Safe for kids | Show   |
+      | April 6, 2019 13:02   | program 3 | Pauli | arduino    | 122   | 234       | no      | no       | no      | no        | Safe for kids | Show   |
+      | April 2, 2019 13:00   | program 2 | Karim | luna       | 921   | 123       | no      | no       | yes     | no        | Safe for kids | Show   |
 
   Scenario: List all projects sorted by downloads ascending
     Given I log in as "Admin" with the password "123456"
@@ -53,12 +53,12 @@ Feature: Admin all projects
     And I click on the column with the name "Downloads"
     And I wait for the page to be loaded
     Then I should see the table with all projects in the following order:
-      | Uploaded At           | Name      | User  | Flavor     | Views | Downloads | private | Approved | Visible | not_for_kids  | Action |
-      | January 1, 2019 12:00 | program 1 | Karim | pocketcode | 120   | 3         | no      | no       | yes     | Safe for kids | Show   |
-      | April 22, 2019 13:00  | program 5 | Karim | pocketcode | 15    | 111       | no      | no       | no      | Safe for kids | Show   |
-      | April 2, 2019 13:00   | program 2 | Karim | luna       | 921   | 123       | no      | no       | yes     | Safe for kids | Show   |
-      | April 2, 2019 13:10   | program 4 | Pauli | pocketcode | 12    | 222       | no      | no       | no      | Safe for kids | Show   |
-      | April 6, 2019 13:02   | program 3 | Pauli | arduino    | 122   | 234       | no      | no       | no      | Safe for kids | Show   |
+      | Uploaded At           | Name      | User  | Flavor     | Views | Downloads | private | Approved | Visible | Protected | not_for_kids  | Action |
+      | January 1, 2019 12:00 | program 1 | Karim | pocketcode | 120   | 3         | no      | no       | yes     | no        | Safe for kids | Show   |
+      | April 22, 2019 13:00  | program 5 | Karim | pocketcode | 15    | 111       | no      | no       | no      | no        | Safe for kids | Show   |
+      | April 2, 2019 13:00   | program 2 | Karim | luna       | 921   | 123       | no      | no       | yes     | no        | Safe for kids | Show   |
+      | April 2, 2019 13:10   | program 4 | Pauli | pocketcode | 12    | 222       | no      | no       | no      | no        | Safe for kids | Show   |
+      | April 6, 2019 13:02   | program 3 | Pauli | arduino    | 122   | 234       | no      | no       | no      | no        | Safe for kids | Show   |
 
   Scenario: List all projects sorted by ute ascendin Pauli |g
     Given I log in as "Admin" with the password "123456"
@@ -67,12 +67,12 @@ Feature: Admin all projects
     And I click on the column with the name "Upload Time"
     And I wait for the page to be loaded
     Then I should see the table with all projects in the following order:
-      | Uploaded At           | User      | Name  | Flavor     | Views | Downloads | private | Approved | Visible | not_for_kids  | Action |
-      | January 1, 2019 12:00 | program 1 | Karim | pocketcode | 120   | 3         | no      | no       | yes     | Safe for kids | Show   |
-      | April 2, 2019 13:00   | program 2 | Karim | luna       | 921   | 123       | no      | no       | yes     | Safe for kids | Show   |
-      | April 2, 2019 13:10   | program 4 | Pauli | pocketcode | 12    | 222       | no      | no       | no      | Safe for kids | Show   |
-      | April 6, 2019 13:02   | program 3 | Pauli | arduino    | 122   | 234       | no      | no       | no      | Safe for kids | Show   |
-      | April 22, 2019 13:00  | program 5 | Karim | pocketcode | 15    | 111       | no      | no       | no      | Safe for kids | Show   |
+      | Uploaded At           | User      | Name  | Flavor     | Views | Downloads | private | Approved | Visible | Protected | not_for_kids  | Action |
+      | January 1, 2019 12:00 | program 1 | Karim | pocketcode | 120   | 3         | no      | no       | yes     | no        | Safe for kids | Show   |
+      | April 2, 2019 13:00   | program 2 | Karim | luna       | 921   | 123       | no      | no       | yes     | no        | Safe for kids | Show   |
+      | April 2, 2019 13:10   | program 4 | Pauli | pocketcode | 12    | 222       | no      | no       | no      | no        | Safe for kids | Show   |
+      | April 6, 2019 13:02   | program 3 | Pauli | arduino    | 122   | 234       | no      | no       | no      | no        | Safe for kids | Show   |
+      | April 22, 2019 13:00  | program 5 | Karim | pocketcode | 15    | 111       | no      | no       | no      | no        | Safe for kids | Show   |
 
 
   Scenario: Filter projects by upload date using filter options
@@ -81,9 +81,9 @@ Feature: Admin all projects
     And I wait for the page to be loaded
     Then I am on "/admin/project/list?filter%5Bid%5D%5Btype%5D=&filter%5Bid%5D%5Bvalue%5D=&filter%5Bname%5D%5Btype%5D=&filter%5Bname%5D%5Bvalue%5D=&filter%5Buser__username%5D%5Btype%5D=&filter%5Buser__username%5D%5Bvalue%5D=&filter%5Buploaded_at%5D%5Btype%5D=&filter%5Buploaded_at%5D%5Bvalue%5D%5Bstart%5D=Apr+3%2C+2019%2C+4%3A38%3A58+pm&filter%5Buploaded_at%5D%5Bvalue%5D%5Bend%5D=Apr+24%2C+2019%2C+4%3A31%3A40+pm&filter%5B_page%5D=1&filter%5B_sort_by%5D=uploaded_at&filter%5B_sort_order%5D=DESC&filter%5B_per_page%5D=32"
     Then I should see the table with all projects in the following order:
-      | Uploaded At          | Name      | User  | Flavor     | Views | Downloads | private | Approved | Visible | not_for_kids  | Action |
-      | April 22, 2019 13:00 | program 5 | Karim | pocketcode | 15    | 111       | no      | no       | no      | Safe for kids | Show   |
-      | April 6, 2019 13:02  | program 3 | Pauli | arduino    | 122   | 234       | no      | no       | no      | Safe for kids | Show   |
+      | Uploaded At          | Name      | User  | Flavor     | Views | Downloads | private | Approved | Visible | Protected | not_for_kids  | Action |
+      | April 22, 2019 13:00 | program 5 | Karim | pocketcode | 15    | 111       | no      | no       | no      | no        | Safe for kids | Show   |
+      | April 6, 2019 13:02  | program 3 | Pauli | arduino    | 122   | 234       | no      | no       | no      | no        | Safe for kids | Show   |
     And I should not see "program 1"
     And I should not see "program 2"
     And I should not see "program 4"
@@ -95,8 +95,8 @@ Feature: Admin all projects
     And I wait for the page to be loaded
     Then I am on "/admin/project/list?filter%5Bid%5D%5Btype%5D=&filter%5Bid%5D%5Bvalue%5D=&filter%5Bname%5D%5Btype%5D=&filter%5Bname%5D%5Bvalue%5D=program+2&filter%5Buser__username%5D%5Btype%5D=&filter%5Buser__username%5D%5Bvalue%5D=&filter%5Buploaded_at%5D%5Btype%5D=&filter%5Buploaded_at%5D%5Bvalue%5D%5Bstart%5D=&filter%5Buploaded_at%5D%5Bvalue%5D%5Bend%5D=&filter%5B_page%5D=1&filter%5B_sort_by%5D=uploaded_at&filter%5B_sort_order%5D=DESC&filter%5B_per_page%5D=32"
     Then I should see the table with all projects in the following order:
-      | Uploaded At         | Name      | User  | Flavor | Views | Downloads | private | Approved | Visible | not_for_kids  | Action |
-      | April 2, 2019 13:00 | program 2 | Karim | luna   | 921   | 123       | no      | no       | yes     | Safe for kids | Show   |
+      | Uploaded At         | Name      | User  | Flavor | Views | Downloads | private | Approved | Visible | Protected | not_for_kids  | Action |
+      | April 2, 2019 13:00 | program 2 | Karim | luna   | 921   | 123       | no      | no       | yes     | no        | Safe for kids | Show   |
     And I should not see "program 1"
     And I should not see "program 5"
     And I should not see "program 4"
@@ -109,10 +109,10 @@ Feature: Admin all projects
     And I wait for the page to be loaded
     Then I am on "/admin/project/list?filter%5Bid%5D%5Btype%5D=&filter%5Bid%5D%5Bvalue%5D=&filter%5Bname%5D%5Btype%5D=&filter%5Bname%5D%5Bvalue%5D=&filter%5Buser__username%5D%5Btype%5D=&filter%5Buser__username%5D%5Bvalue%5D=Karim&filter%5Buploaded_at%5D%5Btype%5D=&filter%5Buploaded_at%5D%5Bvalue%5D%5Bstart%5D=&filter%5Buploaded_at%5D%5Bvalue%5D%5Bend%5D=&filter%5B_page%5D=1&filter%5B_sort_by%5D=uploaded_at&filter%5B_sort_order%5D=DESC&filter%5B_per_page%5D=32"
     Then I should see the table with all projects in the following order:
-      | Uploaded At           | Name      | User  | Flavor     | Views | Downloads | private | Approved | Visible | not_for_kids  | Action |
-      | April 22, 2019 13:00  | program 5 | Karim | pocketcode | 15    | 111       | no      | no       | no      | Safe for kids | Show   |
-      | April 2, 2019 13:00   | program 2 | Karim | luna       | 921   | 123       | no      | no       | yes     | Safe for kids | Show   |
-      | January 1, 2019 12:00 | program 1 | Karim | pocketcode | 120   | 3         | no      | no       | yes     | Safe for kids | Show   |
+      | Uploaded At           | Name      | User  | Flavor     | Views | Downloads | private | Approved | Visible | Protected | not_for_kids  | Action |
+      | April 22, 2019 13:00  | program 5 | Karim | pocketcode | 15    | 111       | no      | no       | no      | no        | Safe for kids | Show   |
+      | April 2, 2019 13:00   | program 2 | Karim | luna       | 921   | 123       | no      | no       | yes     | no        | Safe for kids | Show   |
+      | January 1, 2019 12:00 | program 1 | Karim | pocketcode | 120   | 3         | no      | no       | yes     | no        | Safe for kids | Show   |
     And I should not see "program 3"
     And I should not see "program 4"
 
@@ -123,8 +123,8 @@ Feature: Admin all projects
     And I wait for the page to be loaded
     Then I am on "/admin/project/list?filter%5Bid%5D%5Btype%5D=&filter%5Bid%5D%5Bvalue%5D=4&filter%5Bname%5D%5Btype%5D=&filter%5Bname%5D%5Bvalue%5D=&filter%5Buser__username%5D%5Btype%5D=&filter%5Buser__username%5D%5Bvalue%5D=&filter%5Buploaded_at%5D%5Btype%5D=&filter%5Buploaded_at%5D%5Bvalue%5D%5Bstart%5D=&filter%5Buploaded_at%5D%5Bvalue%5D%5Bend%5D=&filter%5B_page%5D=1&filter%5B_sort_by%5D=uploaded_at&filter%5B_sort_order%5D=DESC&filter%5B_per_page%5D=32"
     Then I should see the table with all projects in the following order:
-      | Uploaded At         | Name      | User  | Flavor     | Views | Downloads | private | Approved | Visible | not_for_kids  | Action |
-      | April 2, 2019 13:10 | program 4 | Pauli | pocketcode | 12    | 222       | no      | no       | no      | Safe for kids | Show   |
+      | Uploaded At         | Name      | User  | Flavor     | Views | Downloads | private | Approved | Visible | Protected | not_for_kids  | Action |
+      | April 2, 2019 13:10 | program 4 | Pauli | pocketcode | 12    | 222       | no      | no       | no      | no        | Safe for kids | Show   |
     And I should not see "program 1"
     And I should not see "program 2"
     And I should not see "program 3"
@@ -136,8 +136,8 @@ Feature: Admin all projects
     And I wait for the page to be loaded
     Then I am on "/admin/project/list?filter%5Bid%5D%5Btype%5D=&filter%5Bid%5D%5Bvalue%5D=&filter%5Bname%5D%5Btype%5D=&filter%5Bname%5D%5Bvalue%5D=&filter%5Buser__username%5D%5Btype%5D=&filter%5Buser__username%5D%5Bvalue%5D=&filter%5Buploaded_at%5D%5Btype%5D=&filter%5Buploaded_at%5D%5Bvalue%5D%5Bstart%5D=&filter%5Buploaded_at%5D%5Bvalue%5D%5Bend%5D=&filter%5Bflavor%5D%5Btype%5D=&filter%5Bflavor%5D%5Bvalue%5D=luna&filter%5B_page%5D=1&filter%5B_sort_by%5D=uploaded_at&filter%5B_sort_order%5D=DESC&filter%5B_per_page%5D=32"
     Then I should see the table with all projects in the following order:
-      | Uploaded At         | Name      | User  | Flavor | Views | Downloads | private | Approved | Visible | not_for_kids  | Action |
-      | April 2, 2019 13:00 | program 2 | Karim | luna   | 921   | 123       | no      | no       | yes     | Safe for kids | Show   |
+      | Uploaded At         | Name      | User  | Flavor | Views | Downloads | private | Approved | Visible | Protected | not_for_kids  | Action |
+      | April 2, 2019 13:00 | program 2 | Karim | luna   | 921   | 123       | no      | no       | yes     | no        | Safe for kids | Show   |
     And I should not see "program 1"
     And I should not see "program 3"
     And I should not see "program 4"
@@ -151,12 +151,12 @@ Feature: Admin all projects
     And I change the flavor of the project number "4" in the list to "arduino"
     And I reload the page
     Then I should see the table with all projects in the following order:
-      | Uploaded At           | Name      | User  | Flavor     | Views | Downloads | private | Approved | Visible | not_for_kids  | Action |
-      | April 22, 2019 13:00  | program 5 | Karim | pocketcode | 15    | 111       | no      | no       | no      | Safe for kids | Show   |
-      | April 6, 2019 13:02   | program 3 | Pauli | arduino    | 122   | 234       | no      | no       | no      | Safe for kids | Show   |
-      | April 2, 2019 13:10   | program 4 | Pauli | pocketcode | 12    | 222       | no      | no       | no      | Safe for kids | Show   |
-      | April 2, 2019 13:00   | program 2 | Karim | arduino    | 921   | 123       | no      | no       | yes     | Safe for kids | Show   |
-      | January 1, 2019 12:00 | program 1 | Karim | pocketcode | 120   | 3         | no      | no       | yes     | Safe for kids | Show   |
+      | Uploaded At           | Name      | User  | Flavor     | Views | Downloads | private | Approved | Visible | Protected | not_for_kids  | Action |
+      | April 22, 2019 13:00  | program 5 | Karim | pocketcode | 15    | 111       | no      | no       | no      | no        | Safe for kids | Show   |
+      | April 6, 2019 13:02   | program 3 | Pauli | arduino    | 122   | 234       | no      | no       | no      | no        | Safe for kids | Show   |
+      | April 2, 2019 13:10   | program 4 | Pauli | pocketcode | 12    | 222       | no      | no       | no      | no        | Safe for kids | Show   |
+      | April 2, 2019 13:00   | program 2 | Karim | arduino    | 921   | 123       | no      | no       | yes     | no        | Safe for kids | Show   |
+      | January 1, 2019 12:00 | program 1 | Karim | pocketcode | 120   | 3         | no      | no       | yes     | no        | Safe for kids | Show   |
 
 
 # # TODO: Report project feature currently disabled

--- a/tests/PhpUnit/Security/Authentication/CookieServiceTest.php
+++ b/tests/PhpUnit/Security/Authentication/CookieServiceTest.php
@@ -35,7 +35,7 @@ final class CookieServiceTest extends TestCase
     $this->assertSame('REFRESH_TOKEN', $cookie->getName());
     $this->assertTrue($cookie->isHttpOnly());
     $this->assertSame('/base/', $cookie->getPath());
-    $this->assertSame('strict', $cookie->getSameSite());
+    $this->assertSame('lax', $cookie->getSameSite());
   }
 
   #[Group('unit')]
@@ -46,6 +46,6 @@ final class CookieServiceTest extends TestCase
     $this->assertSame('REFRESH_TOKEN', $cookie->getName());
     $this->assertTrue($cookie->isHttpOnly());
     $this->assertSame('/base/', $cookie->getPath());
-    $this->assertSame('strict', $cookie->getSameSite());
+    $this->assertSame('lax', $cookie->getSameSite());
   }
 }

--- a/tests/PhpUnit/Storage/StorageLifecycleServiceTest.php
+++ b/tests/PhpUnit/Storage/StorageLifecycleServiceTest.php
@@ -30,9 +30,9 @@ class StorageLifecycleServiceTest extends TestCase
     $this->service = $this->buildServiceWithCounts(0, 0);
   }
 
-  public function testProtectedTierForApprovedProject(): void
+  public function testProtectedTierForStorageProtectedProject(): void
   {
-    $project = $this->createProjectStub(approved: true);
+    $project = $this->createProjectStub(storageProtected: true);
 
     self::assertSame(StorageLifecycleService::PROTECTED_DAYS, $this->service->getRetentionDays($project));
     self::assertTrue($this->service->isProtected($project));
@@ -42,7 +42,7 @@ class StorageLifecycleServiceTest extends TestCase
   {
     $service = $this->buildServiceWithCounts(1, 0);
 
-    $project = $this->createProjectStub(approved: false);
+    $project = $this->createProjectStub();
 
     self::assertTrue($service->isProtected($project));
     self::assertSame(StorageLifecycleService::PROTECTED_DAYS, $service->getRetentionDays($project));
@@ -52,7 +52,7 @@ class StorageLifecycleServiceTest extends TestCase
   {
     $service = $this->buildServiceWithCounts(0, 1);
 
-    $project = $this->createProjectStub(approved: false);
+    $project = $this->createProjectStub();
 
     self::assertTrue($service->isProtected($project));
     self::assertSame(StorageLifecycleService::PROTECTED_DAYS, $service->getRetentionDays($project));
@@ -171,7 +171,7 @@ class StorageLifecycleServiceTest extends TestCase
   }
 
   private function createProjectStub(
-    bool $approved = false,
+    bool $storageProtected = false,
     int $downloads = 0,
     bool $visible = true,
     bool $autoHidden = false,
@@ -185,7 +185,7 @@ class StorageLifecycleServiceTest extends TestCase
 
     $project = $this->createStub(Program::class);
     $project->method('getId')->willReturn('test-project-id');
-    $project->method('getApproved')->willReturn($approved);
+    $project->method('isStorageProtected')->willReturn($storageProtected);
     $project->method('getDownloads')->willReturn($downloads);
     $project->method('getVisible')->willReturn($visible);
     $project->method('getAutoHidden')->willReturn($autoHidden);

--- a/translations/catroweb.en.yaml
+++ b/translations/catroweb.en.yaml
@@ -189,6 +189,12 @@ project:
     no_explore: 'No projects found'
     load_more: 'Load More'
     upload: 'Upload Project'
+  retention:
+    protected: 'Protected'
+    day_left: '1 day left'
+    days_left: '%days% days left'
+    tooltip: 'Projects are automatically removed after a period of inactivity. Get more downloads or log in regularly to extend retention.'
+    tooltip_protected: 'This project is protected and will not be automatically deleted.'
   downloads: '%downloads% downloads'
   sample: Example projects
   views: '%views% views'
@@ -965,6 +971,7 @@ catro-notifications:
   noStudios: "It looks like you don't have any studio notifications."
   tab:
     studio: Studio
+    project: Projects
   comment:
     message: '%user_link% commented on %program_link%.'
   like:
@@ -979,6 +986,11 @@ catro-notifications:
     message: '%user_link% commented in studio %studio_name%.'
   studio-project:
     message: '%user_link% added %program_link% to studio %studio_name%.'
+  project-expiring:
+    message: 'Your project %program_link% will be automatically deleted in %days% days. Upload a new version or get more downloads to keep it.'
+  project-deleted:
+    message: 'Your project "%project_name%" was automatically removed due to inactivity. Re-upload it if you still want to share it.'
+  noProjects: "It looks like you don't have any project notifications."
 
 clipboard:
   success: Link copied to clipboard!


### PR DESCRIPTION
## Summary

Users have no visibility into project retention, and JWT auth silently breaks after 1 hour. This PR adds retention indicators everywhere, a new "Projects" notification category, and fixes the token refresh.

### Retention indicators

| Location | Rendering |
|----------|-----------|
| My Profile (`/app/user`) | Badge below visibility |
| Projects browse (`/app/projects`) | Meta line in card |
| Public profile (`/app/user/{id}`) | Meta line in card |
| Project detail (`/app/project/{id}`) | Bootstrap badge |
| Homepage sliders | Subtle meta text |

**Color coding:** green (protected), muted gray (normal), orange (≤30d), red (≤7d)

**Info icon:** clickable (i) with CSS tooltip — works on mobile (tap) and desktop (hover). Auto-aligns left/right based on viewport position.

**Upload age icon:** changed from `schedule` (clock) to `calendar_today` (calendar) to differentiate from retention countdown.

### Storage protection (separated from moderation)
- New `storage_protected` boolean on Program entity + migration
- `StorageLifecycleService` uses `storage_protected` instead of `approved`
- Sonata admin: "Storage Protected" toggle on project list/edit
- Featured and example projects remain auto-protected

### "Projects" notification tab
- `ProjectExpiringNotification`: "Your project X will be deleted in Y days"
- `ProjectDeletedNotification`: "Your project X was removed due to inactivity"
- `StorageLifecycleService`: sends expiry warnings (deduped) + deletion notices
- Appears in new "Projects" tab alongside existing comment notifications

### JWT auth fix
- `TokenExpirationHandler.js`: rewritten — pings server every 45min to trigger server-side BEARER refresh (old code couldn't read HttpOnly cookies → refresh never worked → 401 after 1 hour)
- `REFRESH_TOKEN` cookie: `SameSite=Strict` → `Lax` (Strict prevented cookie on external navigations)

### Bug fixes
- Loading spinner on My Profile: only on `<a>` click, not entire card
- `RetentionTooltip.js`: guard against non-Element targets in `pointerenter`
- Welcome section: add `padding-top: 2rem`

### API
- `retention_days` + `retention_expiry`: opt-in attributes on projects API
- `project` type added to NotificationsType enum and count response
- OpenAPI schema updated for NotificationsCountResponse (added moderation/studio/project counts)

### Tests
- 3 API Behat scenarios for retention attributes

Closes #6558

## Test plan
- [ ] All static analysis (PHP CS Fixer, PHPStan, Psalm, ESLint, Prettier, Stylelint)
- [ ] Retention badge visible on all 5 locations
- [ ] Info icon tooltip works on mobile + desktop, never overflows viewport
- [ ] Protected projects show green badge, non-protected show days countdown
- [ ] Upload age uses calendar icon, retention uses clock/hourglass/warning
- [ ] "Projects" tab on notifications page
- [ ] JWT doesn't expire after 1 hour (stay on page, API calls still work)
- [ ] Re-login after deploy to get new REFRESH_TOKEN cookie with SameSite=Lax

🤖 Generated with [Claude Code](https://claude.com/claude-code)