### PR TITLE
Add missing cron jobs to dispatcher and fix featured image permissions

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -138,6 +138,12 @@ task('dump:env', function () {
   run('bin/console dotenv:dump prod');
 });
 
+// Fix ownership on shared resource directories so www-data (PHP-FPM) can write
+task('fix:resource_permissions', function () {
+  run('sudo chown -R www-data:www-data {{deploy_path}}/shared/public/resources/featured {{deploy_path}}/shared/public/resources/example');
+  run('sudo chmod -R 775 {{deploy_path}}/shared/public/resources/featured {{deploy_path}}/shared/public/resources/example');
+});
+
 // Smoke test: verify the health endpoint after deployment
 task('smoke_test', function () {
   $maxRetries = 5;
@@ -179,6 +185,7 @@ task('deploy', [
   'deploy:cache:clear',
   'database:migrate',
   'deploy:symlink',
+  'fix:resource_permissions',
   'restart:nginx',
   'restart:php-fpm',
   'update:flavors',

--- a/src/Storage/ImageRepository.php
+++ b/src/Storage/ImageRepository.php
@@ -60,7 +60,11 @@ class ImageRepository
 
     $dir = dirname($filename);
     if (!is_dir($dir)) {
-      mkdir($dir, 0777, true);
+      mkdir($dir, 0775, true);
+    }
+
+    if (!is_writable($dir)) {
+      throw new \RuntimeException(sprintf('Directory "%s" is not writable. Check file ownership and permissions.', $dir));
     }
 
     if (file_exists($filename)) {
@@ -68,7 +72,7 @@ class ImageRepository
     }
 
     $thumb->writeImage($filename);
-    chmod($filename, 0777);
+    chmod($filename, 0664);
     $thumb->destroy();
   }
 

--- a/src/System/Commands/DBUpdater/CronJobCommand.php
+++ b/src/System/Commands/DBUpdater/CronJobCommand.php
@@ -153,6 +153,70 @@ class CronJobCommand extends Command
       $output
     );
 
+    $this->runCronJob(
+      'Garbage collect orphaned assets',
+      ['bin/console', 'catrobat:gc-assets'],
+      ['timeout' => self::ONE_DAY_IN_SECONDS],
+      '1 week',
+      $output
+    );
+
+    // User maintenance
+
+    $this->runCronJob(
+      'Clean unverified user accounts',
+      ['bin/console', 'catrobat:clean:unverified-users'],
+      ['timeout' => self::ONE_HOUR_IN_SECONDS],
+      '1 day',
+      $output
+    );
+
+    // Ranking and popularity
+
+    $this->runCronJob(
+      'Update project popularity scores',
+      ['bin/console', 'catrobat:update:popularity'],
+      ['timeout' => self::ONE_HOUR_IN_SECONDS],
+      '6 hours',
+      $output
+    );
+
+    $this->runCronJob(
+      'Update user rankings',
+      ['bin/console', 'catrobat:update:userranking'],
+      ['timeout' => self::ONE_HOUR_IN_SECONDS],
+      '1 day',
+      $output
+    );
+
+    // Project integrity
+
+    $this->runCronJob(
+      'Detect broken projects',
+      ['bin/console', 'catrobat:workflow:detect_broken_projects'],
+      ['timeout' => self::ONE_DAY_IN_SECONDS],
+      '1 day',
+      $output
+    );
+
+    // Log maintenance
+
+    $this->runCronJob(
+      'Archive log files',
+      ['bin/console', 'catrobat:logs:archive'],
+      ['timeout' => self::ONE_HOUR_IN_SECONDS],
+      '1 day',
+      $output
+    );
+
+    $this->runCronJob(
+      'Clean old log files',
+      ['bin/console', 'catrobat:clean:logs'],
+      ['timeout' => self::ONE_HOUR_IN_SECONDS],
+      '1 week',
+      $output
+    );
+
     return 0;
   }
 

--- a/tests/BehatFeatures/web/admin/db_updater/admin_cron_jobs.feature
+++ b/tests/BehatFeatures/web/admin/db_updater/admin_cron_jobs.feature
@@ -14,16 +14,25 @@ Feature: The admin cron jobs view provides a detailed list about all cron jobs a
     Then I should see "Cron Jobs"
     And I should see the cron jobs table:
       | Name                                                         | State | Cron Interval | Start At | End At | Result Code |
+      | (Re-)Add project extensions                                  | idle  | 1 year        |          |        | 0           |
       | Add bronze_user UserAchievements                             | idle  | 1 year        |          |        | 0           |
       | Add diamond_user UserAchievements                            | idle  | 1 week        |          |        | 0           |
       | Add gold_user UserAchievements                               | idle  | 1 week        |          |        | 0           |
-      | Add perfect_profile UserAchievements                         | idle  | 1 week        |          |        | 0           |
+      | Add perfect_profile UserAchievements                         | idle  | 1 year        |          |        | 0           |
       | Add silver_user UserAchievements                             | idle  | 1 week        |          |        | 0           |
-      | Add verified_developer UserAchievements                      | idle  | 1 year        |          |        | 0           |
+      | Add verified_developer UserAchievements                      | idle  | 1 week        |          |        | 0           |
+      | Archive log files                                            | idle  | 1 day         |          |        | 0           |
       | Clean old extracted project files                            | idle  | 1 day         |          |        | 0           |
+      | Clean old log files                                          | idle  | 1 week        |          |        | 0           |
+      | Clean unverified user accounts                               | idle  | 1 day         |          |        | 0           |
+      | Delete expired projects based on retention rules             | idle  | 1 day         |          |        | 0           |
       | Delete old entries in machine translation table              | idle  | 1 month       |          |        | 0           |
+      | Detect broken projects                                       | idle  | 1 day         |          |        | 0           |
+      | Garbage collect orphaned assets                              | idle  | 1 week        |          |        | 0           |
       | Remove and add new projects to the random projects' category | idle  | 1 week        |          |        | 0           |
       | Retroactively unlock custom translation achievements         | idle  | 1 month       |          |        | 0           |
+      | Update project popularity scores                             | idle  | 6 hours       |          |        | 0           |
+      | Update user rankings                                         | idle  | 1 day         |          |        | 0           |
 
   Scenario: Cron jobs can be manually triggered
     Given I log in as "Admin"
@@ -37,7 +46,7 @@ Feature: The admin cron jobs view provides a detailed list about all cron jobs a
     Then I should see "Cron jobs finished successfully"
     When I am on "/admin/system/cron-job/list"
     And I wait for the page to be loaded
-    And there should be "12" cron jobs in the database
+    And there should be "19" cron jobs in the database
 
   Scenario: Cron jobs can be reset
     Given I log in as "Admin"


### PR DESCRIPTION
## Summary
- Register all periodic maintenance commands in `catrobat:cronjob` dispatcher so they're visible in the admin cron jobs overview: popularity scores, user rankings, broken project detection, asset GC, unverified user cleanup, log archival/cleanup
- Fix featured banner image upload (`ImagickException: WriteBlob Failed`) by adding a writable directory check with clear error message in `ImageRepository::save()`
- Add `fix:resource_permissions` deploy task to ensure `featured/` and `example/` dirs are owned by `www-data` after each deploy
- Update Behat test to expect all 19 cron jobs (was 10) and fix previously incorrect intervals for `perfect_profile` and `verified_developer`

## Test plan
- [ ] Verify `bin/console catrobat:cronjob` runs all jobs including new ones
- [ ] Verify admin cron jobs page at `/admin/system/cron-job/list` shows all 19 jobs
- [ ] Verify featured banner upload works in admin panel
- [ ] Run Behat suite: `docker exec app.catroweb bin/behat -f pretty -s web-admin tests/BehatFeatures/web/admin/db_updater/admin_cron_jobs.feature`

🤖 Generated with [Claude Code](https://claude.com/claude-code)