### PR TITLE
Fix deploy: use chmod instead of sudo for resource permissions

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -138,10 +138,9 @@ task('dump:env', function () {
   run('bin/console dotenv:dump prod');
 });
 
-// Fix ownership on shared resource directories so www-data (PHP-FPM) can write
+// Ensure shared resource directories are world-writable so www-data (PHP-FPM) can write images
 task('fix:resource_permissions', function () {
-  run('sudo chown -R www-data:www-data {{deploy_path}}/shared/public/resources/featured {{deploy_path}}/shared/public/resources/example');
-  run('sudo chmod -R 775 {{deploy_path}}/shared/public/resources/featured {{deploy_path}}/shared/public/resources/example');
+  run('chmod -R 777 {{deploy_path}}/shared/public/resources/featured {{deploy_path}}/shared/public/resources/example');
 });
 
 // Smoke test: verify the health endpoint after deployment


### PR DESCRIPTION
## Summary
- The `fix:resource_permissions` deploy task used `sudo chown` which fails because the `deploy` user has no passwordless sudo
- Replace with `chmod 777` which works since `deploy` owns the directories
- This broke the deployment pipeline in the last deploy (release 56)

## Test plan
- [ ] Trigger a deploy and verify `fix:resource_permissions` task passes
- [ ] Verify featured banner upload works after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)