### PR TITLE
Fix project upload: handle zip with nested subdirectory

### DIFF
--- a/src/Project/CatrobatFile/CatrobatFileExtractor.php
+++ b/src/Project/CatrobatFile/CatrobatFileExtractor.php
@@ -75,7 +75,29 @@ class CatrobatFileExtractor
     $zip->extractTo($full_extract_dir);
     $zip->close();
 
+    // Some Catrobat apps wrap project files in a subdirectory. If code.xml is not at the
+    // root but exists inside a single subdirectory, promote that subdirectory to root.
+    if (!file_exists($full_extract_dir.'code.xml')) {
+      $entries = array_diff((array) scandir($full_extract_dir), ['.', '..']);
+      if (1 === count($entries)) {
+        $single_entry = reset($entries);
+        $nested_dir = $full_extract_dir.$single_entry.'/';
+        if (is_dir($nested_dir) && file_exists($nested_dir.'code.xml')) {
+          $this->promoteDirectoryContents($nested_dir, $full_extract_dir);
+        }
+      }
+    }
+
     return new ExtractedCatrobatFile($full_extract_dir, $full_extract_path, $temp_path);
+  }
+
+  private function promoteDirectoryContents(string $nested_dir, string $target_dir): void
+  {
+    $items = array_diff((array) scandir($nested_dir), ['.', '..']);
+    foreach ($items as $item) {
+      rename($nested_dir.$item, $target_dir.$item);
+    }
+    rmdir($nested_dir);
   }
 
   public function getExtractDir(): string

--- a/tests/PhpUnit/Project/CatrobatFile/CatrobatFileExtractorTest.php
+++ b/tests/PhpUnit/Project/CatrobatFile/CatrobatFileExtractorTest.php
@@ -64,7 +64,7 @@ class CatrobatFileExtractorTest extends TestCase
 
   private function createNestedCatrobatFile(): string
   {
-    $tmp_file = tempnam(sys_get_temp_dir(), 'catrobat_test_').'.catrobat';
+    $tmp_file = (string) tempnam(sys_get_temp_dir(), 'catrobat_test_').'.catrobat';
     $zip = new \ZipArchive();
     $zip->open($tmp_file, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
     $zip->addFromString('ProjectName/code.xml', '<program><header><programName>Test</programName><catrobatLanguageVersion>0.99</catrobatLanguageVersion><description></description><notesAndCredits></notesAndCredits><applicationVersion>1.0</applicationVersion><url></url><remixOf></remixOf><tags></tags></header><objectList></objectList></program>');

--- a/tests/PhpUnit/Project/CatrobatFile/CatrobatFileExtractorTest.php
+++ b/tests/PhpUnit/Project/CatrobatFile/CatrobatFileExtractorTest.php
@@ -50,4 +50,26 @@ class CatrobatFileExtractorTest extends TestCase
     $this->expectException(InvalidCatrobatFileException::class);
     $this->catrobat_file_extractor->extract($invalid_catrobat_file);
   }
+
+  /**
+   * @throws \Exception
+   */
+  public function testExtractsFileWithNestedDirectory(): void
+  {
+    $nested_catrobat_file = $this->createNestedCatrobatFile();
+    $extracted = $this->catrobat_file_extractor->extract(new File($nested_catrobat_file));
+    self::assertFileExists($extracted->getPath().'code.xml');
+    unlink($nested_catrobat_file);
+  }
+
+  private function createNestedCatrobatFile(): string
+  {
+    $tmp_file = tempnam(sys_get_temp_dir(), 'catrobat_test_').'.catrobat';
+    $zip = new \ZipArchive();
+    $zip->open($tmp_file, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+    $zip->addFromString('ProjectName/code.xml', '<program><header><programName>Test</programName><catrobatLanguageVersion>0.99</catrobatLanguageVersion><description></description><notesAndCredits></notesAndCredits><applicationVersion>1.0</applicationVersion><url></url><remixOf></remixOf><tags></tags></header><objectList></objectList></program>');
+    $zip->close();
+
+    return $tmp_file;
+  }
 }


### PR DESCRIPTION
## Summary
- **Critical production bug**: Project uploads fail with `errors.xml.missing` when the Catrobat app wraps project files inside a subdirectory within the zip archive
- After zip extraction, if `code.xml` is not at the root but exists inside a single subdirectory, the extractor now promotes that subdirectory's contents to root level
- Added unit test covering the nested directory case

## Test plan
- [x] PHPUnit tests pass (4/4 including new test)
- [x] PHPStan passes clean
- [x] PHP-CS-Fixer passes clean
- [ ] Deploy and verify project uploads work for affected users

🤖 Generated with [Claude Code](https://claude.com/claude-code)