### PR TITLE
Fix cron job reset crash on missing entity

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -32,11 +32,6 @@
       <code><![CDATA[getId]]></code>
     </PossiblyNullReference>
   </file>
-  <file src="src/Admin/System/CronJobs/CronJobsAdminController.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$cron_job]]></code>
-    </PossiblyNullArgument>
-  </file>
   <file src="src/Admin/System/DB_Updater/Controller/AchievementsAdminController.php">
     <PossiblyNullArgument>
       <code><![CDATA[$id]]></code>

--- a/src/Admin/System/CronJobs/CronJobsAdminController.php
+++ b/src/Admin/System/CronJobs/CronJobsAdminController.php
@@ -47,8 +47,10 @@ class CronJobsAdminController extends CRUDController
     }
 
     $cron_job = $this->cron_job_repository->findByName(strval($request->query->get('id')));
-    if (is_null($cron_job)) {
+    if (null === $cron_job) {
       $this->addFlash('sonata_flash_error', 'Resetting cron job failed');
+
+      return new RedirectResponse($this->admin->generateUrl('list'));
     }
 
     $this->entity_manager->remove($cron_job);


### PR DESCRIPTION
## Summary
- Fix TypeError in `CronJobsAdminController::resetCronJobAction()` when the cron job is not found
- The null check was missing a `return` statement, causing `EntityManager::remove(null)` to crash

## Test plan
- [x] PHPStan passes
- [x] PHP-CS-Fixer passes
- [ ] Verify resetting a non-existent cron job shows error flash instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)