### PR TITLE
Fix admin logs file switcher ignoring clicks

### DIFF
--- a/assets/Admin/SystemManagement/Logs.js
+++ b/assets/Admin/SystemManagement/Logs.js
@@ -92,7 +92,8 @@ function loadFileContent(file) {
   document.getElementById('inner-log-container').innerHTML = ''
   document.getElementById('currentFileName').textContent = file
 
-  fetch(`${window.location.href}?file=${file}&count=1000`)
+  const baseUrl = window.location.origin + window.location.pathname
+  fetch(`${baseUrl}?file=${encodeURIComponent(file)}&count=1000`)
     .then((response) => {
       if (!response.ok) {
         throw new Error('Network response was not ok')


### PR DESCRIPTION
## Summary
- Fixed the admin logs page (`/admin/logs/list`) where clicking a different log file in the file list did nothing
- Root cause: `loadFileContent()` used `window.location.href` to build the fetch URL, which includes existing query parameters. This produced malformed URLs like `?file=old.log?file=new.log&count=1000` where the second `?` made the new parameters invalid, so the controller kept returning the same file
- Fix: use `window.location.origin + window.location.pathname` to strip query params, and `encodeURIComponent()` for the filename

## Test plan
- [ ] Navigate to `/admin/logs/list` as an admin
- [ ] Click on different log files in the file list — each should load and display the selected file's content
- [ ] Verify filters (level, search) still work after switching files

🤖 Generated with [Claude Code](https://claude.com/claude-code)