### PR TITLE
Fix cron job list per-page dropdown triggering reset error

### DIFF
--- a/src/Admin/System/CronJobs/CronJobsAdminController.php
+++ b/src/Admin/System/CronJobs/CronJobsAdminController.php
@@ -32,7 +32,7 @@ class CronJobsAdminController extends CRUDController
   public function listAction(Request $request): Response
   {
     return $this->render('Admin/SystemManagement/DbUpdater/CronJobs.html.twig', [
-      'action' => 'reset_cron_job',
+      'action' => 'list',
       'triggerCronJobsUrl' => $this->admin->generateUrl('trigger_cron_jobs'),
     ]);
   }


### PR DESCRIPTION
## Summary
- Fixed the admin cron job list page (`/admin/system/cron-job/list`) where changing the "per page" dropdown incorrectly showed "Resetting cron job failed" instead of changing the page size.
- **Root cause**: `CronJobsAdminController::listAction()` passed `'action' => 'reset_cron_job'` to the template context. Sonata Admin's per-page `<select>` uses the `action` variable to generate navigation URLs via `admin.generateUrl(action, ...)`. This caused per-page changes to navigate to the `reset_cron_job` route (without a valid cron job ID), triggering the error flash message.
- **Fix**: Changed `'action' => 'reset_cron_job'` to `'action' => 'list'` so the per-page dropdown correctly generates URLs pointing back to the list route.

## Test plan
- [ ] Navigate to `/admin/system/cron-job/list`
- [ ] Change the "per page" dropdown value
- [ ] Verify the page reloads with the correct number of items per page (no error message)
- [ ] Verify the "Reset cron job" action buttons on individual rows still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)