### PR TITLE
Fix project upload: check extractTo return value

### DIFF
--- a/src/Project/CatrobatFile/CatrobatFileExtractor.php
+++ b/src/Project/CatrobatFile/CatrobatFileExtractor.php
@@ -72,7 +72,11 @@ class CatrobatFileExtractor
       }
     }
 
-    $zip->extractTo($full_extract_dir);
+    if (!$zip->extractTo($full_extract_dir)) {
+      $zip->close();
+      throw new InvalidCatrobatFileException('errors.file.invalid', 505, 'Failed to extract archive');
+    }
+
     $zip->close();
 
     // Some Catrobat apps wrap project files in a subdirectory. If code.xml is not at the


### PR DESCRIPTION
## Summary
- `ZipArchive::extractTo()` can silently return `false` on failure (disk full, permissions, etc.) without throwing an exception
- The code was not checking the return value, so when extraction failed it continued to `scandir()` a non-existent directory, causing cascading errors (`scandir` warning + `errors.xml.missing`)
- This made **all project uploads fail** in production (confirmed in prod logs from 2026-04-07, affecting multiple users)
- Fix: check the return value and throw `InvalidCatrobatFileException` with a clear error message before proceeding

## Test plan
- [ ] Verify existing upload Behat tests still pass (`api-projects-write` suite)
- [ ] Confirm PHPStan and Psalm pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)