### PR TITLE
Increase ClamAV StreamMaxLength to fix broken pipe on large uploads

### DIFF
--- a/docker/clamav/clamd.conf
+++ b/docker/clamav/clamd.conf
@@ -1,0 +1,15 @@
+# ClamAV daemon configuration for Catroweb
+# Catrobat project uploads can be up to 100 MB, so ClamAV limits
+# must accommodate the maximum allowed upload size.
+
+TCPSocket 3310
+TCPAddr 0.0.0.0
+
+# Maximum file size for INSTREAM scanning (must exceed upload_max_filesize)
+StreamMaxLength 200M
+
+# Maximum file size for on-disk scanning
+MaxFileSize 200M
+
+# Maximum scan size (sum of all extracted/decompressed data)
+MaxScanSize 400M

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -162,6 +162,7 @@ services:
       - '3310:3310'
     volumes:
       - clamav-data:/var/lib/clamav
+      - ./clamav/clamd.conf:/etc/clamav/clamd.conf:ro
     restart: unless-stopped
 
   # --- NSFW content safety scanning:

--- a/docs/operations/Malware-Scanning.md
+++ b/docs/operations/Malware-Scanning.md
@@ -104,6 +104,11 @@ Edit `/etc/clamav/clamd.conf`:
 # Enable TCP socket on localhost only
 TCPSocket 3310
 TCPAddr 127.0.0.1
+
+# Must exceed the maximum upload size (256 MB in production nginx/PHP config)
+StreamMaxLength 300M
+MaxFileSize 300M
+MaxScanSize 600M
 ```
 
 Remove or comment out `LocalSocket` if you only want TCP (the default Ubuntu config uses a Unix socket).

--- a/src/Security/Malware/MalwareScanner.php
+++ b/src/Security/Malware/MalwareScanner.php
@@ -126,8 +126,9 @@ class MalwareScanner
 
         // Send chunk length as 4-byte big-endian unsigned int, then the data
         $length = strlen($chunk);
-        fwrite($socket, pack('N', $length));
-        fwrite($socket, $chunk);
+        if (false === @fwrite($socket, pack('N', $length)) || false === @fwrite($socket, $chunk)) {
+          throw new \RuntimeException('Broken pipe: ClamAV closed the connection (file may exceed StreamMaxLength)');
+        }
       }
     } finally {
       fclose($handle);


### PR DESCRIPTION
## Summary
- ClamAV's default `StreamMaxLength` is 25 MB, but uploads can be up to 100 MB (Docker) / 256 MB (production). Files exceeding the limit cause clamd to close the socket mid-stream, producing dozens of broken pipe PHP notices per request.
- Adds `docker/clamav/clamd.conf` with `StreamMaxLength 200M` mounted into the dev container
- Documents the required limits (`StreamMaxLength 300M`) in the production setup guide
- Fixes `MalwareScanner` to detect `fwrite` failures early and throw one clear error instead of spamming broken pipe notices

## Production action required
After deploying, edit `/etc/clamav/clamd.conf` on the server to add:
```
StreamMaxLength 300M
MaxFileSize 300M
MaxScanSize 600M
```
Then: `sudo systemctl restart clamav-daemon`

## Test plan
- [ ] `docker compose -f docker/docker-compose.dev.yaml restart clamav` picks up the new config
- [ ] Upload a project >25 MB — should scan successfully instead of broken pipe
- [ ] `bin/phpunit --filter MalwareScannerTest` passes
- [ ] Verify production clamd.conf has the new limits after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)