### PR TITLE
Fix index page CLS: add featured banner skeleton, remove scratch

### DIFF
--- a/assets/Index/FeaturedBanner.js
+++ b/assets/Index/FeaturedBanner.js
@@ -20,6 +20,7 @@ export class FeaturedBanner {
         return r.json()
       })
       .then((items) => {
+        this.removeSkeleton()
         if (!Array.isArray(items) || items.length === 0) {
           this.container.style.display = 'none'
           return
@@ -41,6 +42,7 @@ export class FeaturedBanner {
       })
       .catch((error) => {
         console.error('Failed to load featured banners', error)
+        this.removeSkeleton()
         this.container.style.display = 'none'
       })
   }
@@ -127,5 +129,12 @@ export class FeaturedBanner {
 
     this.container.appendChild(carouselDiv)
     new Carousel(carouselDiv)
+  }
+
+  removeSkeleton() {
+    const skeleton = this.container.querySelector('.featured-slider__skeleton')
+    if (skeleton) {
+      skeleton.remove()
+    }
   }
 }

--- a/templates/Index/IndexPage.html.twig
+++ b/templates/Index/IndexPage.html.twig
@@ -22,7 +22,11 @@
        data-is-guest="{{ app.user ? '0' : '1' }}"
        data-is-webview="{{ isWebview() ? '1' : '0' }}"
        data-trans-featured="{{ 'project.featured'|trans({}, 'catroweb') }}"
-  ></div>
+  >
+    <div class="featured-slider__skeleton featured-banner">
+      <div style="aspect-ratio: 1024/400; background: light-dark(#f0f0f0, #1a1a2e);"></div>
+    </div>
+  </div>
 
   <div id="home-projects">
     {# array values: [api project_type, translation, property to show] #}
@@ -39,7 +43,6 @@
         ['example', 'example', 'author'],
         ['trending', 'trending', 'downloads'],
         ['_studios_', null, null],
-        ['scratch', 'scratchremixes', 'views'],
         ['popular', 'popular', 'author'],
       ] %}
     {% else %}
@@ -48,7 +51,6 @@
         ['trending', 'trending', 'downloads'],
         ['random', 'random', 'uploaded'],
         ['_studios_', null, null],
-        ['scratch', 'scratchremixes', 'views'],
         ['popular', 'popular', 'author'],
       ] %}
     {% endif %}

--- a/tests/BehatFeatures/web/general/homepage.feature
+++ b/tests/BehatFeatures/web/general/homepage.feature
@@ -49,16 +49,6 @@ Feature: Pocketcode homepage
       | 70058680          | 6                 |
       | 70058680          | 7                 |
 
-  Scenario: Scratch remixes project should be visible:
-    Given I am on homepage
-    And I wait for the page to be loaded
-    And I wait for AJAX to finish
-    Then I should see the featured slider
-    Then the element "#home-projects__scratch" should exist
-    And the "#home-projects__scratch" element should contain "project 6"
-    And the "#home-projects__scratch" element should contain "project 7"
-    And the "#home-projects__scratch" element should not contain "project 1"
-
   Scenario: Viewing the homepage at website root
     Given I am on homepage
     And I wait for the page to be loaded
@@ -66,7 +56,6 @@ Feature: Pocketcode homepage
     Then I should see the featured slider
     Then one of the ".project-list__title" elements should contain "Examples"
     Then one of the ".project-list__title" elements should contain "Trending projects"
-    Then one of the ".project-list__title" elements should contain "Scratch remixes"
     Then one of the ".project-list__title" elements should contain "Random projects"
     Then one of the ".project-list__title" elements should contain "Popular projects"
 


### PR DESCRIPTION
## Summary
- **Featured banner skeleton**: The `#featured-slider` div starts empty, then JS builds the carousel after an API fetch, causing a large CLS when the 1024x400 banner pops in. Added an inline skeleton placeholder with `aspect-ratio: 1024/400` so the space is reserved on initial render.
- **Remove scratch section**: Scratch projects are currently hidden, so removed the scratch remixes category from both logged-in and guest index page views.

## Test plan
- [ ] Load index page — banner area should have reserved space (no layout shift when carousel loads)
- [ ] Banner skeleton disappears when carousel renders or when no banners exist
- [ ] No "Scratch remixes" section on the index page
- [ ] `yarn run test-js` (ESLint) passes
- [ ] `yarn run test-asset` (Prettier) passes
- [ ] Behat `web-general` suite passes (scratch scenario removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)