### PR TITLE
Fix deploy permissions: use ACL mode for www-data write access

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -29,6 +29,8 @@ set('slack_success_color', '#4BB543');
 // Symfony environment
 set('symfony_env', 'prod');
 set('writable_recursive', true);
+set('http_user', 'www-data');
+set('writable_mode', 'acl');
 
 // Shared directories
 set('shared_dirs', [


### PR DESCRIPTION
## Summary
- Deployer's default writable mode doesn't grant `www-data` write access to shared directories like `public/resources/`
- This caused upload failures on production: `extractTo()` failed, screenshot saving failed with `WriteBlob Failed`, etc.
- Set `writable_mode: acl` and `http_user: www-data` so Deployer uses `setfacl` (already in sudoers with NOPASSWD) to grant proper permissions on each deploy

## Context
After a fresh deploy, directories under `public/resources/` (shared symlink) are owned by `deploy:deploy` with `755`. PHP-FPM runs as `www-data` and can't write to them. ACL mode adds `www-data` write permission via `setfacl` without changing ownership.

## Test plan
- [ ] Deploy to staging/production and verify `getfacl /var/www/share/shared/public/resources/extract/` shows `www-data` has write access
- [ ] Upload a project after deploy — should succeed without manual `chown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)