### PR TITLE
Add delete project action to project detail page menu

### DIFF
--- a/assets/Project/Project.js
+++ b/assets/Project/Project.js
@@ -2,7 +2,7 @@ import { Modal, Tab } from 'bootstrap'
 import Swal from 'sweetalert2'
 import { showSnackbar, SnackbarDuration } from '../Layout/Snackbar'
 import { redirect } from '../Components/RedirectButton'
-import { ApiFetch } from '../Api/ApiHelper'
+import { ApiFetch, ApiDeleteFetch } from '../Api/ApiHelper'
 import ProjectApi from '../Api/ProjectApi'
 
 export const Project = function (
@@ -831,6 +831,43 @@ document.addEventListener('DOMContentLoaded', function () {
           '#share-snackbar',
           newValue ? visItem.dataset.transSuccessPrivate : visItem.dataset.transSuccessPublic,
         )
+      })
+    })
+  }
+
+  const deleteItem = document.getElementById('top-app-bar__btn-delete-project')
+  if (deleteItem) {
+    deleteItem.addEventListener('click', function () {
+      const projectId = deleteItem.dataset.projectId
+      const baseUrl = document.querySelector('#js-api-routing').dataset.baseUrl
+
+      Swal.fire({
+        title: deleteItem.dataset.transConfirmTitle,
+        html: deleteItem.dataset.transConfirmText,
+        icon: 'warning',
+        showCancelButton: true,
+        allowOutsideClick: false,
+        customClass: {
+          confirmButton: 'btn btn-danger',
+          cancelButton: 'btn btn-outline-primary',
+        },
+        buttonsStyling: false,
+        confirmButtonText: deleteItem.dataset.transConfirmYes,
+        cancelButtonText: deleteItem.dataset.transCancel,
+      }).then((result) => {
+        if (!result.value) return
+
+        new ApiDeleteFetch(
+          baseUrl + '/api/project/' + projectId,
+          'Delete Project',
+          deleteItem.dataset.transError,
+          function () {
+            window.location.href = baseUrl + '/'
+          },
+          {
+            404: deleteItem.dataset.transNotFound,
+          },
+        ).run()
       })
     })
   }

--- a/templates/Layout/Header/ProjectOptions.html.twig
+++ b/templates/Layout/Header/ProjectOptions.html.twig
@@ -52,7 +52,7 @@
         class="mdc-deprecated-list-item"
         role="menuitem"
         data-project-id="{{ project.id }}"
-        data-trans-confirm-title="{{ 'reallyDeleteProgram'|trans({}, 'catroweb') }}"
+        data-trans-confirm-title="{{ 'profile.reallyDeleteProgram'|trans({}, 'catroweb') }}"
         data-trans-confirm-text="{{ 'project.deleteConfirmText'|trans({}, 'catroweb') }}"
         data-trans-confirm-yes="{{ 'project.deleteAction'|trans({}, 'catroweb') }}"
         data-trans-cancel="{{ 'cancel'|trans({}, 'catroweb') }}"

--- a/templates/Layout/Header/ProjectOptions.html.twig
+++ b/templates/Layout/Header/ProjectOptions.html.twig
@@ -52,7 +52,7 @@
         class="mdc-deprecated-list-item"
         role="menuitem"
         data-project-id="{{ project.id }}"
-        data-trans-confirm-title="{{ 'project.reallyDeleteProgram'|trans({}, 'catroweb') }}"
+        data-trans-confirm-title="{{ 'reallyDeleteProgram'|trans({}, 'catroweb') }}"
         data-trans-confirm-text="{{ 'project.deleteConfirmText'|trans({}, 'catroweb') }}"
         data-trans-confirm-yes="{{ 'project.deleteAction'|trans({}, 'catroweb') }}"
         data-trans-cancel="{{ 'cancel'|trans({}, 'catroweb') }}"

--- a/templates/Layout/Header/ProjectOptions.html.twig
+++ b/templates/Layout/Header/ProjectOptions.html.twig
@@ -48,6 +48,20 @@
         {{ project.notForKids ? 'MarkSafeForKids'|trans({}, 'catroweb') : 'MarkNotForKids'|trans({}, 'catroweb') }}
       </span>
     </li>
+    <li id="top-app-bar__btn-delete-project"
+        class="mdc-deprecated-list-item"
+        role="menuitem"
+        data-project-id="{{ project.id }}"
+        data-trans-confirm-title="{{ 'project.reallyDeleteProgram'|trans({}, 'catroweb') }}"
+        data-trans-confirm-text="{{ 'project.deleteConfirmText'|trans({}, 'catroweb') }}"
+        data-trans-confirm-yes="{{ 'project.deleteAction'|trans({}, 'catroweb') }}"
+        data-trans-cancel="{{ 'cancel'|trans({}, 'catroweb') }}"
+        data-trans-error="{{ 'somethingWentWrong'|trans({}, 'catroweb') }}"
+        data-trans-not-found="{{ 'project.deleteNotFoundError'|trans({}, 'catroweb') }}">
+      <span class="mdc-deprecated-list-item__ripple"></span>
+      <span class="mdc-deprecated-list-item__graphic material-icons" style="color: var(--bs-danger)">delete</span>
+      <span class="mdc-deprecated-list-item__text" style="color: var(--bs-danger)">{{ 'project.deleteAction'|trans({}, 'catroweb') }}</span>
+    </li>
   {% endif %}
 
   {% if not my_project|default(false) and not is_whitelisted|default(false) and not project.autoHidden %}

--- a/tests/BehatFeatures/web/project-details/project_delete.feature
+++ b/tests/BehatFeatures/web/project-details/project_delete.feature
@@ -1,0 +1,29 @@
+@web @project_page
+Feature: As a project owner I want to be able to delete my project from the project detail page
+
+  Background:
+    Given there are users:
+      | id | name     |
+      | 1  | Catrobat |
+      | 2  | User     |
+    And there are projects:
+      | id | name      | owned by |
+      | 1  | project 1 | Catrobat |
+      | 2  | project 2 | User     |
+
+  Scenario: Non-owner does not see delete button in options menu
+    Given I log in as "Catrobat"
+    And I am on "/app/project/2"
+    And I wait for the page to be loaded
+    Then the element "#top-app-bar__btn-delete-project" should not exist
+
+  Scenario: Guest does not see delete button in options menu
+    Given I am on "/app/project/1"
+    And I wait for the page to be loaded
+    Then the element "#top-app-bar__btn-delete-project" should not exist
+
+  Scenario: Owner sees delete button in options menu
+    Given I log in as "Catrobat"
+    And I am on "/app/project/1"
+    And I wait for the page to be loaded
+    Then the element "#top-app-bar__btn-delete-project" should exist

--- a/translations/catroweb.en.yaml
+++ b/translations/catroweb.en.yaml
@@ -149,6 +149,7 @@ project:
     There is no way to restore your actions!
     Yes, delete it!
     Cancel
+  deleteConfirmText: This action cannot be undone. Your project will be permanently deleted.
   deleteNotFoundError: The project to be deleted could not be found under your user.
   private: private
   public: public


### PR DESCRIPTION
## Summary
- Adds a "Delete project" menu item (red, with delete icon) to the project detail page's top menu for project owners
- Shows a SweetAlert2 confirmation dialog before deleting
- Calls `DELETE /api/project/{id}` and redirects to home on success
- Uses the same patterns as existing visibility/not-for-kids toggles

## Test plan
- [ ] View your own project → three-dot menu shows "Delete project" in red
- [ ] View someone else's project → no delete option shown
- [ ] Click delete → confirmation dialog appears
- [ ] Cancel → nothing happens
- [ ] Confirm → project deleted, redirected to home
- [ ] `yarn run test-js` (ESLint) passes
- [ ] `yarn run test-asset` (Prettier) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)