### PR TITLE
Fix comment text overflow breaking layout

### DIFF
--- a/assets/Project/ProjectPage.scss
+++ b/assets/Project/ProjectPage.scss
@@ -605,6 +605,7 @@ table td:nth-child(1) {
     color: light-dark(#4a5568, #cbd5e0);
     line-height: 1.5;
     font-size: 0.95rem;
+    overflow-wrap: anywhere;
 
     p {
       margin-bottom: 0;

--- a/assets/Studio/Studio.scss
+++ b/assets/Studio/Studio.scss
@@ -376,6 +376,7 @@
       color: light-dark(#4a5568, #cbd5e0);
       line-height: 1.5;
       font-size: 0.95rem;
+      overflow-wrap: anywhere;
 
       p {
         margin-bottom: 0;


### PR DESCRIPTION
## Summary
Long unbroken strings (URLs, repeated characters) in comments overflow their container and break the page layout. Adds `overflow-wrap: anywhere` to `.comment-text` in both project detail and studio comment styles.

Example: https://share.catrob.at/pocketcode/project/comment/127

## Test plan
- [ ] View a comment with a long unbroken string — text wraps instead of overflowing
- [ ] Normal comments still render correctly
- [ ] Studio comments also wrap properly
- [ ] `yarn run test-css` (Stylelint) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)