### PR TITLE
Fix: Show private (invite-only) studios in listings and search

### DIFF
--- a/src/Api/Services/Studio/StudioApiLoader.php
+++ b/src/Api/Services/Studio/StudioApiLoader.php
@@ -57,7 +57,6 @@ class StudioApiLoader extends AbstractApiLoader
       ->from(Studio::class, 's')
       ->where('s.auto_hidden = false')
       ->andWhere('s.is_enabled = true')
-      ->andWhere('s.is_public = true')
       ->orderBy('s.created_on', 'DESC')
       ->addOrderBy('s.id', 'DESC')
       ->setMaxResults($limit + 1)

--- a/src/Studio/StudioSearchService.php
+++ b/src/Studio/StudioSearchService.php
@@ -55,7 +55,6 @@ class StudioSearchService
 
     $bool_query = new BoolQuery();
 
-    $bool_query->addMust(new Terms('is_public', [true]));
     $bool_query->addMust(new Terms('is_enabled', [true]));
     $bool_query->addMust(new Terms('auto_hidden', [false]));
 

--- a/tests/BehatFeatures/api/studio/GET_studio/list_studios.feature
+++ b/tests/BehatFeatures/api/studio/GET_studio/list_studios.feature
@@ -17,7 +17,7 @@ Feature: List studios
       | 2  | Admin | Studio2     | admin |
       | 3  | Admin | Studio3     | admin |
 
-  Scenario: List all public studios
+  Scenario: List all studios including private (invite-only)
     When I GET "/api/studio"
     Then the response status code should be "200"
     And the client response should contain "Studio1"
@@ -29,18 +29,18 @@ Feature: List studios
     Then the response status code should be "200"
     And the client response should contain "has_more"
 
-  Scenario: Private studios are not included in public list
+  Scenario: Private (invite-only) studios are included in public list
     When I GET "/api/studio?limit=50"
     Then the response status code should be "200"
     And the client response should contain "Studio1"
     And the client response should contain "Studio2"
-    And the client response should not contain "Studio3"
+    And the client response should contain "Studio3"
 
-  Scenario: Authenticated user also only sees public studios in list
+  Scenario: Authenticated user also sees private (invite-only) studios in list
     Given I use a valid JWT Bearer token for "User1"
     When I GET "/api/studio?limit=50"
     Then the response status code should be "200"
-    And the client response should not contain "Studio3"
+    And the client response should contain "Studio3"
 
   Scenario: Invalid cursor returns 400
     When I GET "/api/studio?cursor=invalid!!"


### PR DESCRIPTION
## Summary

- Remove `is_public = true` filter from the studio listing API endpoint (`GET /api/studio`) so private studios appear on the `/studios` page and in the index page studio slider
- Remove `is_public` filter from Elasticsearch studio search queries so private studios appear in search results
- Update Behat tests to expect private studios in listing results

## Context

For studios, `is_public` controls whether anyone can freely join -- it does **not** mean the studio should be hidden. This is different from projects, where "private" means hidden from view.

- **Public studio**: anyone can join
- **Private studio**: joining requires an invitation (but the studio is still visible to everyone)

The previous behavior incorrectly hid private studios from the listing page, index page slider, and search results. The detail page access control for private studios (requiring membership to view internal content) remains unchanged.

### Terminology suggestion

Consider renaming the `is_public` toggle label in the UI from "Private" to "Invite-only" or "Closed" to avoid confusion with project visibility. The current "Private" label implies the studio is hidden, which is not the intended behavior.

## Files changed

- `src/Api/Services/Studio/StudioApiLoader.php` -- removed `is_public` filter from `loadStudiosPage()`
- `src/Studio/StudioSearchService.php` -- removed `is_public` filter from Elasticsearch search query
- `tests/BehatFeatures/api/studio/GET_studio/list_studios.feature` -- updated assertions to expect private studios in results

## Test plan

- [ ] Verify `GET /api/studio` returns both public and private studios
- [ ] Verify search results include private studios
- [ ] Verify private studio detail page still requires membership to view internal content (comments, projects, members)
- [ ] Verify the index page studio slider shows private studios
- [ ] Run `api-studio` Behat suite
- [ ] Run `api-search` Behat suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)