### PR TITLE
Fix notifications API 500: add missing DB columns

### DIFF
--- a/migrations/2026/Version20260408200000.php
+++ b/migrations/2026/Version20260408200000.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260408200000 extends AbstractMigration
+{
+  #[\Override]
+  public function getDescription(): string
+  {
+    return 'Add missing columns for ProjectExpiringNotification and ProjectDeletedNotification entities';
+  }
+
+  #[\Override]
+  public function up(Schema $schema): void
+  {
+    $this->addSql('ALTER TABLE CatroNotification ADD expiry_days INT DEFAULT NULL, ADD deleted_project_name VARCHAR(255) DEFAULT NULL');
+  }
+
+  #[\Override]
+  public function down(Schema $schema): void
+  {
+    $this->addSql('ALTER TABLE CatroNotification DROP expiry_days, DROP deleted_project_name');
+  }
+}


### PR DESCRIPTION
## Summary
- The `GET /api/notifications` endpoint was returning a 500 Internal Server Error for users (e.g., "catrobat") because the `CatroNotification` table was missing the `expiry_days` and `deleted_project_name` columns
- These columns are required by the `ProjectExpiringNotification` and `ProjectDeletedNotification` entities, and Doctrine's Single Table Inheritance query selects all discriminator-mapped columns -- causing a SQL "Column not found" exception
- Adds a migration to create the two missing columns
- The fix has already been applied directly to the production database to resolve the live issue

## Root cause
The `ProjectExpiringNotification` entity declares `expiry_days` (ORM Column) and `ProjectDeletedNotification` declares `deleted_project_name` (ORM Column), but no migration was ever created to add these columns to the `CatroNotification` table. When Doctrine queries the base `CatroNotification` entity, it generates SQL that selects all columns from all STI subclasses, including the missing ones.

## Test plan
- [ ] Migration runs successfully: `bin/console doctrine:migrations:migrate`
- [ ] `GET /api/notifications?limit=20&type=all` returns 200 with valid data
- [ ] Existing Behat notification tests still pass: `docker exec app.catroweb bin/behat -f pretty -s api-notifications`

🤖 Generated with [Claude Code](https://claude.com/claude-code)