### PR TITLE
Allow anonymous access to invite-only studio detail pages

### DIFF
--- a/src/Api/StudioApi.php
+++ b/src/Api/StudioApi.php
@@ -66,14 +66,6 @@ class StudioApi extends AbstractApiController implements StudioApiInterface
       return null;
     }
 
-    $user = $this->facade->getAuthenticationManager()->getAuthenticatedUser();
-    $studioUser = $this->facade->getLoader()->loadStudioUser($user, $studio);
-    if (!$studio->isIsPublic() && !$studioUser instanceof StudioUser) {
-      $responseCode = Response::HTTP_FORBIDDEN;
-
-      return null;
-    }
-
     $responseCode = Response::HTTP_OK;
     $response = $this->facade->getResponseManager()->createStudioResponse($studio);
     $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);

--- a/src/Application/Controller/Studio/StudioController.php
+++ b/src/Application/Controller/Studio/StudioController.php
@@ -66,11 +66,6 @@ class StudioController extends AbstractController
       }
     }
 
-    // Block anonymous users from viewing private studios
-    if (!$is_public && null === $user) {
-      throw $this->createNotFoundException();
-    }
-
     return $this->render('Studio/DetailsPage.html.twig', [
       'studio' => $studio,
       'user_role' => $user_role,

--- a/tests/BehatFeatures/api/studio/GET_studio_id/fetch_studio.feature
+++ b/tests/BehatFeatures/api/studio/GET_studio_id/fetch_studio.feature
@@ -1,5 +1,5 @@
 @api @studio
-Feature: Updating an existing studio
+Feature: Fetching studio details
 
   Background:
     Given there are users:
@@ -16,11 +16,11 @@ Feature: Updating an existing studio
       | id | user       | studio_id | role   |
       | 2  | Member     | 2         | member |
 
-  Scenario: Only Studio Members are allowed to get private studio details
+  Scenario: Non-existing studio returns 404
     And I request "GET" "/api/studio/not-exist"
     Then the response status code should be "404"
 
-  Scenario: public studios can be seen by everyone
+  Scenario: Public studios can be seen by everyone
     Given I request "GET" "/api/studio/1"
     Then the response status code should be "200"
     And I should get the json object:
@@ -37,16 +37,42 @@ Feature: Updating an existing studio
       }
     """
 
-  Scenario: With authentication private studios can not be read
+  Scenario: Invite-only studios can be seen by anonymous users
     And I request "GET" "/api/studio/2"
-    Then the response status code should be "403"
+    Then the response status code should be "200"
+    And I should get the json object:
+    """
+      {
+        "id": "2",
+        "name": "Private Studio",
+        "description": "nothing to see here..",
+        "is_public": false,
+        "enable_comments": true,
+        "image_path": "",
+        "members_count": 1,
+        "projects_count": 0
+      }
+    """
 
-  Scenario: Only Studio Members are allowed to get private studio details
+  Scenario: Invite-only studios can be seen by non-members
     Given I use a valid JWT Bearer token for "Non-member"
     And I request "GET" "/api/studio/2"
-    Then the response status code should be "403"
+    Then the response status code should be "200"
+    And I should get the json object:
+    """
+      {
+        "id": "2",
+        "name": "Private Studio",
+        "description": "nothing to see here..",
+        "is_public": false,
+        "enable_comments": true,
+        "image_path": "",
+        "members_count": 1,
+        "projects_count": 0
+      }
+    """
 
-  Scenario: Private studios can be seen by members
+  Scenario: Invite-only studios can be seen by members
     Given I use a valid JWT Bearer token for "Member"
     Given I request "GET" "/api/studio/2"
     Then the response status code should be "200"

--- a/tests/BehatFeatures/web/studio/studio-details__overview.feature
+++ b/tests/BehatFeatures/web/studio/studio-details__overview.feature
@@ -85,6 +85,14 @@ Feature: Every Studio should have an overview containing the most necessary info
     Then the ".member_count" element should contain "1"
     And the element ".studio-detail__header__details__join-button" should be visible
 
+  Scenario: Anonymous user can view invite-only studio detail page
+    Given I am on "/app/studio/2"
+    And I wait for the page to be loaded
+    And I wait for AJAX to finish
+    Then I should see "CatrobatStudio02"
+    And I should see "hasADescription"
+    And the element ".studio-detail__header__details__join-button" should be visible
+
   Scenario: User logged in and their request was declined form the admin of the private studio
     Given I log in as "Catrobat1"
     And I am on "/app/studio/2"

--- a/tests/PhpUnit/Api/StudioApiTest.php
+++ b/tests/PhpUnit/Api/StudioApiTest.php
@@ -107,7 +107,7 @@ final class StudioApiTest extends TestCase
   }
 
   #[Group('unit')]
-  public function testStudioIdGetPrivateNonMemberReturnsForbidden(): void
+  public function testStudioIdGetPrivateNonMemberReturnsOk(): void
   {
     $response_code = 200;
     $response_headers = [];
@@ -120,8 +120,8 @@ final class StudioApiTest extends TestCase
 
     $result = $this->api->studioIdGet('some-id', 'en', $response_code, $response_headers);
 
-    $this->assertSame(Response::HTTP_FORBIDDEN, $response_code);
-    $this->assertNull($result);
+    $this->assertSame(Response::HTTP_OK, $response_code);
+    $this->assertNotNull($result);
   }
 
   #[Group('unit')]


### PR DESCRIPTION
## Summary
- Removed the 404 block that prevented anonymous users from viewing invite-only (private) studio detail pages in `StudioController`
- Removed the 403 membership check from the `GET /api/studio/{id}` endpoint in `StudioApi` — the detail endpoint is now accessible to everyone regardless of membership status
- Internal actions (commenting, adding projects, joining) still require membership as before
- Updated API Behat tests to expect 200 instead of 403 for anonymous/non-member access to invite-only studios
- Added a web Behat test verifying anonymous users can view invite-only studio detail pages

## Test plan
- [ ] Verify `GET /api/studio/{id}` returns 200 for invite-only studios when called by anonymous users
- [ ] Verify `GET /api/studio/{id}` returns 200 for invite-only studios when called by non-members
- [ ] Verify the web detail page `/app/studio/{id}` loads for anonymous users on invite-only studios
- [ ] Verify write actions (POST comments, POST projects, etc.) still require membership on invite-only studios
- [ ] Run `api-studio` Behat suite
- [ ] Run `web-studio` Behat suite (if it exists) or the relevant web studio tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)