### PR TITLE
Implement real keyset cursor pagination (replace offset bridges)

### DIFF
--- a/assets/MediaLibrary/OverviewPage.js
+++ b/assets/MediaLibrary/OverviewPage.js
@@ -176,8 +176,18 @@ if (overviewContainer) {
         chevrons.appendChild(leftChevron)
         chevrons.appendChild(rightChevron)
 
+        // Compute initial keyset cursor from the last preview asset
+        const lastPreview =
+          category.preview_assets.length > 0
+            ? category.preview_assets[category.preview_assets.length - 1]
+            : null
+        const initialCursor =
+          lastPreview && lastPreview.created_at && lastPreview.id
+            ? btoa(`${lastPreview.created_at}|${lastPreview.id}`)
+            : null
+
         const state = {
-          offset: category.preview_assets.length,
+          nextCursor: initialCursor,
           total: category.assets_count,
           isLoading: false,
           hasMore: category.assets_count > category.preview_assets.length,
@@ -402,8 +412,9 @@ if (overviewContainer) {
     const url = new URL(mediaAssetsApi, window.location.origin)
     url.searchParams.set('category_id', categoryId)
     url.searchParams.set('limit', assetsPerCategory)
-    // The media assets API uses base64-encoded offset as cursor
-    url.searchParams.set('cursor', btoa(String(state.offset)))
+    if (state.nextCursor) {
+      url.searchParams.set('cursor', state.nextCursor)
+    }
     if (searchQuery) {
       url.searchParams.set('search', searchQuery)
     }
@@ -411,16 +422,12 @@ if (overviewContainer) {
     fetch(url.toString())
       .then((response) => response.json())
       .then((data) => {
-        const assets = data.data || data.assets || []
+        const assets = data.data || []
         assets.forEach((asset) => {
           assetsGrid.appendChild(buildAssetCard(asset))
         })
-        state.offset += assets.length
-        if (data.has_more !== undefined) {
-          state.hasMore = data.has_more
-        } else if (assets.length < assetsPerCategory || state.offset >= state.total) {
-          state.hasMore = false
-        }
+        state.nextCursor = data.next_cursor || null
+        state.hasMore = data.has_more ?? false
 
         const wrapper = assetsGrid.closest('.media-assets-wrapper')
         const leftChevron = wrapper?.querySelector('.media-assets-chevron--left')

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,3 +22,6 @@ parameters:
   ignoreErrors:
     - identifier: missingType.generics
     - identifier: missingType.iterableValue
+    -
+      message: '#Call to method .+ of internal class Tests\\PhpUnit\\Api\\KeysetCursorTraitTest#'
+      path: src/Api/Traits/KeysetCursorTrait.php

--- a/src/Api/MediaLibraryApi.php
+++ b/src/Api/MediaLibraryApi.php
@@ -7,6 +7,7 @@ namespace App\Api;
 use App\Api\Services\Base\AbstractApiController;
 use App\Api\Services\MediaLibrary\MediaLibraryApiFacade;
 use App\Api\Traits\CursorPaginationTrait;
+use App\Api\Traits\KeysetCursorTrait;
 use App\DB\Entity\Flavor;
 use App\DB\Entity\MediaLibrary\MediaFileType as DbMediaFileType;
 use App\DB\Entity\User\User;
@@ -27,6 +28,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiInterface
 {
   use CursorPaginationTrait;
+  use KeysetCursorTrait;
   use RateLimitTrait;
 
   public function __construct(
@@ -66,9 +68,13 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
     }
 
     if (null !== $search) {
+      // Search uses in-memory filtering with array_slice — must stay offset-based
       $categories = $this->facade->getLoader()->getAllCategories();
     } else {
-      $categories = $this->facade->getLoader()->getCategories($limit, $cursor);
+      $cursor_data = $this->decodeIntKeysetCursor($cursor);
+      $categories = $this->facade->getLoader()->getCategoriesKeyset(
+        $limit, $cursor_data['value'] ?? null, $cursor_data['id'] ?? null
+      );
     }
 
     $responseCode = Response::HTTP_OK;
@@ -95,6 +101,13 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
     int &$responseCode,
     array &$responseHeaders,
   ): ?MediaCategoriesListResponse {
+    $cursor_data = $this->decodeIntKeysetCursor($cursor);
+    if (null === $cursor_data && null !== $cursor && '' !== $cursor) {
+      $responseCode = Response::HTTP_BAD_REQUEST;
+
+      return null;
+    }
+
     $locale = $this->facade->getResponseManager()->sanitizeLocale($accept_language);
     $cache_id = sprintf('mediaCategoriesGet_%s_%d_%s', $locale, $limit, $cursor ?? '');
 
@@ -106,12 +119,15 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
       return $cached['response'];
     }
 
-    $categories = $this->facade->getLoader()->getCategories($limit, $cursor);
+    $categories = $this->facade->getLoader()->getCategoriesKeyset(
+      $limit, $cursor_data['value'] ?? null, $cursor_data['id'] ?? null
+    );
 
     $responseCode = Response::HTTP_OK;
-    $response = $this->facade->getResponseManager()->createCategoriesResponse($categories, $limit, $cursor);
+    $response = $this->facade->getResponseManager()->createCategoriesKeysetResponse($categories, $limit);
     $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
     $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
+    $this->facade->getResponseManager()->cacheResponse($cache_id, $responseCode, $responseHeaders, $response);
 
     return $response;
   }
@@ -165,11 +181,20 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
       return null;
     }
 
-    $current_offset = $this->decodeCursorToOffset($cursor);
-    $assets = $this->facade->getLoader()->getAssetsPaginated($limit, $cursor, $id, null, null, null, 'created_at', 'DESC');
+    $cursor_data = $this->decodeKeysetCursor($cursor);
+    if (null === $cursor_data && null !== $cursor && '' !== $cursor) {
+      $responseCode = Response::HTTP_BAD_REQUEST;
+
+      return null;
+    }
+
+    $assets = $this->facade->getLoader()->getAssetsPaginatedKeyset(
+      $limit, $id, null, null, null, 'created_at', 'DESC',
+      $cursor_data['value'] ?? null, $cursor_data['id'] ?? null
+    );
 
     $responseCode = Response::HTTP_OK;
-    $response = $this->facade->getResponseManager()->createCategoryDetailResponse($category, $assets, $limit, $current_offset);
+    $response = $this->facade->getResponseManager()->createCategoryDetailKeysetResponse($category, $assets, $limit);
     $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
     $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
 
@@ -270,21 +295,27 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
 
     $db_file_type = $file_type ? $this->convertToDbFileType($file_type) : null;
 
-    $current_offset = $this->decodeCursorToOffset($cursor);
+    $cursor_data = $this->decodeKeysetCursor($cursor);
+    if (null === $cursor_data && null !== $cursor && '' !== $cursor) {
+      $responseCode = Response::HTTP_BAD_REQUEST;
 
-    $assets = $this->facade->getLoader()->getAssetsPaginated(
+      return null;
+    }
+
+    $assets = $this->facade->getLoader()->getAssetsPaginatedKeyset(
       $limit,
-      $cursor,
       $category_id,
       $db_file_type,
       $flavor,
       $search,
       $sort_by,
-      $sort_order
+      $sort_order,
+      $cursor_data['value'] ?? null,
+      $cursor_data['id'] ?? null
     );
 
     $responseCode = Response::HTTP_OK;
-    $response = $this->facade->getResponseManager()->createAssetsResponse($assets, $limit, $current_offset);
+    $response = $this->facade->getResponseManager()->createAssetsKeysetResponse($assets, $limit, $sort_by);
     $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
     $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
 

--- a/src/Api/ProjectsApi.php
+++ b/src/Api/ProjectsApi.php
@@ -10,6 +10,7 @@ use App\Api\Services\Projects\ProjectsApiFacade;
 use App\Api\Services\Reactions\ReactionsApiFacade;
 use App\Api\Services\Reactions\ReactionsApiProcessor;
 use App\Api\Traits\CursorPaginationTrait;
+use App\Api\Traits\KeysetCursorTrait;
 use App\DB\Entity\Project\Program;
 use App\DB\Entity\Project\ProgramDownloads;
 use App\Project\AddProjectRequest;
@@ -37,6 +38,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
 {
   use CursorPaginationTrait;
+  use KeysetCursorTrait;
   use RateLimitTrait;
 
   public function __construct(
@@ -121,11 +123,20 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
   #[\Override]
   public function projectsFeaturedGet(string $platform, string $max_version, int $limit, ?string $cursor, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): FeaturedProjectsListResponse
   {
-    $offset = $this->decodeCursorToOffset($cursor);
-    $featured_projects = $this->facade->getLoader()->getFeaturedProjects($flavor, $limit + 1, $offset, $platform, $max_version);
+    $cursor_data = $this->decodeIntKeysetCursor($cursor);
+    if (null === $cursor_data && null !== $cursor && '' !== $cursor) {
+      $responseCode = Response::HTTP_BAD_REQUEST;
+
+      return new FeaturedProjectsListResponse(['data' => [], 'next_cursor' => null, 'has_more' => false]);
+    }
+
+    $featured_projects = $this->facade->getLoader()->getFeaturedProjectsKeyset(
+      $flavor, $limit + 1, $platform, $max_version,
+      $cursor_data['value'] ?? null, isset($cursor_data['id']) ? (int) $cursor_data['id'] : null
+    );
 
     $responseCode = Response::HTTP_OK;
-    $response = $this->facade->getResponseManager()->createFeaturedProjectsListResponse($featured_projects, $limit, $attributes, $offset);
+    $response = $this->facade->getResponseManager()->createFeaturedProjectsKeysetResponse($featured_projects, $limit, $attributes);
     $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
     $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
 
@@ -140,12 +151,21 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
   public function projectsGet(string $accept_language, ?string $category, string $max_version, int $limit, ?string $cursor, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): ProjectsListResponse
   {
     $category = $category ?? 'recent';
-    $offset = $this->decodeCursorToOffset($cursor);
-    $locale = $this->facade->getResponseManager()->sanitizeLocale($accept_language);
-    $cache_id = sprintf('projectsGet_%s_%s_%s_%s_%d_%d', $category, $locale, $flavor, $max_version, $limit, $offset);
 
-    // Don't cache 'recent' category as it changes frequently
-    if ('recent' === $category) {
+    // Categories that must stay offset-based (Elasticsearch, random, or no stable sort)
+    if (in_array($category, ['random', 'example', 'scratch', 'trending', 'popular'], true)) {
+      $offset = $this->decodeCursorToOffset($cursor);
+      $locale = $this->facade->getResponseManager()->sanitizeLocale($accept_language);
+      $cache_id = sprintf('projectsGet_%s_%s_%s_%s_%d_%d', $category, $locale, $flavor, $max_version, $limit, $offset);
+
+      $cached = $this->facade->getResponseManager()->getCachedResponse($cache_id);
+      if (null !== $cached) {
+        $responseCode = $cached['response_code'];
+        $responseHeaders = $cached['response_headers'];
+
+        return $cached['response'];
+      }
+
       $user = $this->facade->getAuthenticationManager()->getAuthenticatedUser();
       $projects = $this->facade->getLoader()->getProjectsFromCategory($category, $max_version, $limit + 1, $offset, $flavor, $user);
 
@@ -153,26 +173,70 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
       $response = $this->facade->getResponseManager()->createProjectsListResponse($projects, $limit, $attributes, $offset);
       $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
       $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
+      $this->facade->getResponseManager()->cacheResponse($cache_id, $responseCode, $responseHeaders, $response);
 
       return $response;
     }
 
-    $cached = $this->facade->getResponseManager()->getCachedResponse($cache_id);
-    if (null !== $cached) {
-      $responseCode = $cached['response_code'];
-      $responseHeaders = $cached['response_headers'];
+    // Keyset cursor pagination for recent, most_viewed, most_downloaded
+    $sort_by = match ($category) {
+      'most_viewed' => 'views',
+      'most_downloaded' => 'downloads',
+      default => 'uploaded_at',
+    };
 
-      return $cached['response'];
+    $cursor_date = null;
+    $cursor_value = null;
+    $cursor_id = null;
+
+    if (null !== $cursor && '' !== $cursor) {
+      if ('uploaded_at' === $sort_by) {
+        $cursor_data = $this->decodeDateKeysetCursor($cursor);
+        if (null === $cursor_data) {
+          $responseCode = Response::HTTP_BAD_REQUEST;
+
+          return new ProjectsListResponse(['data' => [], 'next_cursor' => null, 'has_more' => false]);
+        }
+        $cursor_date = $cursor_data['date'];
+        $cursor_id = $cursor_data['id'];
+      } else {
+        $cursor_data = $this->decodeIntKeysetCursor($cursor);
+        if (null === $cursor_data) {
+          $responseCode = Response::HTTP_BAD_REQUEST;
+
+          return new ProjectsListResponse(['data' => [], 'next_cursor' => null, 'has_more' => false]);
+        }
+        $cursor_value = $cursor_data['value'];
+        $cursor_id = $cursor_data['id'];
+      }
     }
 
-    $user = $this->facade->getAuthenticationManager()->getAuthenticatedUser();
-    $projects = $this->facade->getLoader()->getProjectsFromCategory($category, $max_version, $limit + 1, $offset, $flavor, $user);
+    // Cache most_viewed/most_downloaded but not recent (changes too frequently)
+    if ('recent' !== $category) {
+      $locale = $this->facade->getResponseManager()->sanitizeLocale($accept_language);
+      $cache_id = sprintf('projectsGet_%s_%s_%s_%s_%d_%s', $category, $locale, $flavor, $max_version, $limit, $cursor ?? '');
+
+      $cached = $this->facade->getResponseManager()->getCachedResponse($cache_id);
+      if (null !== $cached) {
+        $responseCode = $cached['response_code'];
+        $responseHeaders = $cached['response_headers'];
+
+        return $cached['response'];
+      }
+    }
+
+    $projects = $this->facade->getLoader()->getProjectsKeyset(
+      $category, $max_version, $limit + 1, $flavor, $cursor_date, $cursor_value, $cursor_id
+    );
 
     $responseCode = Response::HTTP_OK;
-    $response = $this->facade->getResponseManager()->createProjectsListResponse($projects, $limit, $attributes, $offset);
+    $response = $this->facade->getResponseManager()->createProjectsKeysetResponse($projects, $limit, $sort_by, $attributes);
     $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
     $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
-    $this->facade->getResponseManager()->cacheResponse($cache_id, $responseCode, $responseHeaders, $response);
+
+    if ('recent' !== $category && isset($cache_id)) {
+      $this->facade->getResponseManager()->cacheResponse($cache_id, $responseCode, $responseHeaders, $response);
+    }
 
     return $response;
   }
@@ -180,7 +244,6 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
   #[\Override]
   public function projectsIdRecommendationsGet(string $id, string $category, string $accept_language, string $max_version, int $limit, ?string $cursor, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): ?ProjectsListResponse
   {
-    $offset = $this->decodeCursorToOffset($cursor);
     $project = $this->facade->getLoader()->findProjectByID($id, true);
     if (is_null($project)) {
       $responseCode = Response::HTTP_NOT_FOUND;
@@ -188,12 +251,25 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
       return null;
     }
 
-    $recommended_projects = $this->facade->getLoader()->getRecommendedProjects(
-      $id, $category, $max_version, $limit + 1, $offset, $flavor, $this->facade->getAuthenticationManager()->getAuthenticatedUser()
+    $cursor_date = null;
+    $cursor_id = null;
+    if (null !== $cursor && '' !== $cursor) {
+      $cursor_data = $this->decodeDateKeysetCursor($cursor);
+      if (null === $cursor_data) {
+        $responseCode = Response::HTTP_BAD_REQUEST;
+
+        return new ProjectsListResponse(['data' => [], 'next_cursor' => null, 'has_more' => false]);
+      }
+      $cursor_date = $cursor_data['date'];
+      $cursor_id = $cursor_data['id'];
+    }
+
+    $recommended_projects = $this->facade->getLoader()->getRecommendedProjectsKeyset(
+      $id, $category, $max_version, $limit + 1, $flavor, $cursor_date, $cursor_id
     );
 
     $responseCode = Response::HTTP_OK;
-    $response = $this->facade->getResponseManager()->createProjectsListResponse($recommended_projects, $limit, $attributes, $offset);
+    $response = $this->facade->getResponseManager()->createProjectsKeysetResponse($recommended_projects, $limit, 'uploaded_at', $attributes);
     $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
     $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
 
@@ -279,7 +355,7 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
   #[\Override]
   public function projectsSearchGet(string $query, string $max_version, int $limit, ?string $cursor, string $attributes, string $flavor, int &$responseCode, array &$responseHeaders): ProjectsListResponse
   {
-    // Elasticsearch: offset-based pagination (cursor decoded to offset)
+    // Elasticsearch only supports offset-based pagination (from/size), not keyset cursors
     $offset = $this->decodeCursorToOffset($cursor);
     $projects = $this->facade->getLoader()->searchProjects($query, $limit + 1, $offset, $max_version, $flavor);
 
@@ -368,11 +444,23 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
       return null;
     }
 
-    $offset = $this->decodeCursorToOffset($cursor);
-    $user_projects = $this->facade->getLoader()->getUserProjects($user_id, $limit + 1, $offset, $flavor, $max_version);
+    $cursor_date = null;
+    $cursor_id = null;
+    if (null !== $cursor && '' !== $cursor) {
+      $cursor_data = $this->decodeDateKeysetCursor($cursor);
+      if (null === $cursor_data) {
+        $responseCode = Response::HTTP_BAD_REQUEST;
+
+        return new ProjectsListResponse(['data' => [], 'next_cursor' => null, 'has_more' => false]);
+      }
+      $cursor_date = $cursor_data['date'];
+      $cursor_id = $cursor_data['id'];
+    }
+
+    $user_projects = $this->facade->getLoader()->getUserProjectsKeyset($user_id, $limit + 1, $flavor, $max_version, $cursor_date, $cursor_id);
 
     $responseCode = Response::HTTP_OK;
-    $response = $this->facade->getResponseManager()->createProjectsListResponse($user_projects, $limit, $attributes, $offset);
+    $response = $this->facade->getResponseManager()->createProjectsKeysetResponse($user_projects, $limit, 'uploaded_at', $attributes);
     $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
     $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
 
@@ -388,11 +476,23 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
       return null;
     }
 
-    $offset = $this->decodeCursorToOffset($cursor);
-    $projects = $this->facade->getLoader()->getUserPublicProjects($id, $limit + 1, $offset, $flavor, $max_version);
+    $cursor_date = null;
+    $cursor_id = null;
+    if (null !== $cursor && '' !== $cursor) {
+      $cursor_data = $this->decodeDateKeysetCursor($cursor);
+      if (null === $cursor_data) {
+        $responseCode = Response::HTTP_BAD_REQUEST;
+
+        return new ProjectsListResponse(['data' => [], 'next_cursor' => null, 'has_more' => false]);
+      }
+      $cursor_date = $cursor_data['date'];
+      $cursor_id = $cursor_data['id'];
+    }
+
+    $projects = $this->facade->getLoader()->getUserPublicProjectsKeyset($id, $limit + 1, $flavor, $max_version, $cursor_date, $cursor_id);
 
     $responseCode = Response::HTTP_OK;
-    $response = $this->facade->getResponseManager()->createProjectsListResponse($projects, $limit, $attributes, $offset);
+    $response = $this->facade->getResponseManager()->createProjectsKeysetResponse($projects, $limit, 'uploaded_at', $attributes);
     $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
     $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
 

--- a/src/Api/SearchApi.php
+++ b/src/Api/SearchApi.php
@@ -31,6 +31,7 @@ class SearchApi extends AbstractApiController implements SearchApiInterface
   #[\Override]
   public function searchGet(string $query, string $type, int $limit, ?string $cursor, int &$responseCode, array &$responseHeaders): array|SearchResponse
   {
+    // Elasticsearch only supports offset-based pagination (from/size), not keyset cursors
     $offset = $this->decodeCursorToOffset($cursor);
     $ip = $this->request_stack->getCurrentRequest()?->getClientIp() ?? 'unknown';
     if (null === $this->checkIpRateLimit($ip, $this->searchBurstLimiter)) {

--- a/src/Api/Services/MediaLibrary/MediaLibraryApiLoader.php
+++ b/src/Api/Services/MediaLibrary/MediaLibraryApiLoader.php
@@ -37,6 +37,43 @@ class MediaLibraryApiLoader extends AbstractApiLoader
     return $this->category_repository->findPaginated($limit + 1, $offset);
   }
 
+  /**
+   * @return array<MediaCategory>
+   */
+  public function getCategoriesKeyset(int $limit, ?int $cursor_priority = null, ?string $cursor_id = null): array
+  {
+    return $this->category_repository->findPaginatedKeyset($limit + 1, $cursor_priority, $cursor_id);
+  }
+
+  /**
+   * @return array<MediaAsset>
+   */
+  public function getAssetsPaginatedKeyset(
+    int $limit,
+    ?string $category_id,
+    ?MediaFileType $file_type,
+    ?string $flavor,
+    ?string $search,
+    string $sort_by,
+    string $sort_order,
+    ?string $cursor_sort_value = null,
+    ?string $cursor_id = null,
+  ): array {
+    $category = $category_id ? $this->category_repository->find($category_id) : null;
+
+    return $this->asset_repository->findPaginatedKeyset(
+      $limit + 1,
+      $category,
+      $file_type,
+      $flavor,
+      $search,
+      $sort_by,
+      $sort_order,
+      $cursor_sort_value,
+      $cursor_id,
+    );
+  }
+
   public function getAllCategories(): array
   {
     return $this->category_repository->findAll();

--- a/src/Api/Services/MediaLibrary/MediaLibraryResponseManager.php
+++ b/src/Api/Services/MediaLibrary/MediaLibraryResponseManager.php
@@ -279,8 +279,6 @@ class MediaLibraryResponseManager extends AbstractResponseManager
       $search = null;
     }
 
-    $current_offset = $this->decodeCursorToOffset($cursor);
-
     if (null === $search) {
       $has_more = count($categories) > $limit;
       if ($has_more) {
@@ -320,6 +318,8 @@ class MediaLibraryResponseManager extends AbstractResponseManager
         $categories
       );
     } else {
+      // Search uses in-memory filtering — must stay offset-based
+      $current_offset = $this->decodeCursorToOffset($cursor);
       $category_previews = [];
       foreach ($categories as $category) {
         $translated_name = $this->trans($category->getName());
@@ -369,9 +369,17 @@ class MediaLibraryResponseManager extends AbstractResponseManager
       }
     }
 
-    $next_cursor = ($has_more && [] !== $category_previews)
-      ? $this->encodeCursorFromOffset($current_offset, count($category_previews))
-      : null;
+    $next_cursor = null;
+    if ($has_more && [] !== $category_previews) {
+      if (null === $search && [] !== $categories) {
+        /** @var MediaCategory $last_cat */
+        $last_cat = end($categories);
+        $next_cursor = $this->encodeIntKeysetCursor($last_cat->getPriority(), $last_cat->getId());
+      } else {
+        // Search path uses in-memory filtering — must stay offset-based
+        $next_cursor = $this->encodeCursorFromOffset($current_offset, count($category_previews));
+      }
+    }
 
     return new \OpenAPI\Server\Model\MediaLibraryResponse([
       'data' => $category_previews,

--- a/src/Api/Services/MediaLibrary/MediaLibraryResponseManager.php
+++ b/src/Api/Services/MediaLibrary/MediaLibraryResponseManager.php
@@ -279,6 +279,7 @@ class MediaLibraryResponseManager extends AbstractResponseManager
       $search = null;
     }
 
+    $current_offset = 0;
     if (null === $search) {
       $has_more = count($categories) > $limit;
       if ($has_more) {

--- a/src/Api/Services/MediaLibrary/MediaLibraryResponseManager.php
+++ b/src/Api/Services/MediaLibrary/MediaLibraryResponseManager.php
@@ -323,7 +323,8 @@ class MediaLibraryResponseManager extends AbstractResponseManager
       $category_previews = [];
       foreach ($categories as $category) {
         $translated_name = $this->trans($category->getName());
-        $translated_description = $category->getDescription() ? $this->trans($category->getDescription()) : '';
+        $description = $category->getDescription();
+        $translated_description = null !== $description ? $this->trans($description) : '';
         $search_lower = strtolower($search);
         $name_match = str_contains(strtolower($translated_name), $search_lower);
         $desc_match = '' !== $translated_description && str_contains(strtolower($translated_description), $search_lower);

--- a/src/Api/Services/MediaLibrary/MediaLibraryResponseManager.php
+++ b/src/Api/Services/MediaLibrary/MediaLibraryResponseManager.php
@@ -6,6 +6,7 @@ namespace App\Api\Services\MediaLibrary;
 
 use App\Api\Services\Base\AbstractResponseManager;
 use App\Api\Traits\CursorPaginationTrait;
+use App\Api\Traits\KeysetCursorTrait;
 use App\DB\Entity\MediaLibrary\MediaAsset;
 use App\DB\Entity\MediaLibrary\MediaCategory;
 use App\DB\Entity\User\User;
@@ -22,6 +23,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class MediaLibraryResponseManager extends AbstractResponseManager
 {
   use CursorPaginationTrait;
+  use KeysetCursorTrait;
 
   public function __construct(
     TranslatorInterface $translator,
@@ -66,6 +68,106 @@ class MediaLibraryResponseManager extends AbstractResponseManager
       'name' => $this->trans($category->getName()),
       'description' => $category->getDescription() ? $this->trans($category->getDescription()) : null,
       'priority' => $category->getPriority(),
+    ]);
+  }
+
+  /**
+   * Keyset cursor response for categories ordered by priority ASC, id ASC.
+   */
+  public function createCategoriesKeysetResponse(array $categories, int $limit): MediaCategoriesListResponse
+  {
+    $has_more = count($categories) > $limit;
+    if ($has_more) {
+      array_pop($categories);
+    }
+
+    $category_responses = array_map(
+      $this->createCategoryResponse(...),
+      $categories
+    );
+
+    $next_cursor = null;
+    if ($has_more && [] !== $categories) {
+      /** @var MediaCategory $last */
+      $last = end($categories);
+      $next_cursor = $this->encodeIntKeysetCursor($last->getPriority(), $last->getId());
+    }
+
+    return new MediaCategoriesListResponse([
+      'data' => $category_responses,
+      'next_cursor' => $next_cursor,
+      'has_more' => $has_more,
+    ]);
+  }
+
+  /**
+   * Keyset cursor response for assets.
+   */
+  public function createAssetsKeysetResponse(array $assets, int $limit, string $sort_by): MediaAssetsListResponse
+  {
+    $has_more = count($assets) > $limit;
+    if ($has_more) {
+      array_pop($assets);
+    }
+
+    $asset_responses = array_map(
+      fn (MediaAsset $asset): MediaAssetResponse => $this->createAssetResponse($asset),
+      $assets
+    );
+
+    $next_cursor = null;
+    if ($has_more && [] !== $assets) {
+      /** @var MediaAsset $last */
+      $last = end($assets);
+      $sort_value = match ($sort_by) {
+        'name' => $last->getName(),
+        'downloads' => (string) $last->getDownloads(),
+        'updated_at' => $last->getUpdatedAt()?->format('Y-m-d\TH:i:s.uP') ?? '',
+        default => $last->getCreatedAt()?->format('Y-m-d\TH:i:s.uP') ?? '',
+      };
+      $next_cursor = $this->encodeKeysetCursor($sort_value, $last->getId());
+    }
+
+    return new MediaAssetsListResponse([
+      'data' => $asset_responses,
+      'next_cursor' => $next_cursor,
+      'has_more' => $has_more,
+    ]);
+  }
+
+  /**
+   * Keyset cursor response for category detail (assets within a category).
+   */
+  public function createCategoryDetailKeysetResponse(MediaCategory $category, array $assets, int $limit): MediaCategoryDetailResponse
+  {
+    $has_more = count($assets) > $limit;
+    if ($has_more) {
+      array_pop($assets);
+    }
+
+    $asset_responses = array_map(
+      fn (MediaAsset $asset): MediaAssetResponse => $this->createAssetResponse($asset),
+      $assets
+    );
+
+    $next_cursor = null;
+    if ($has_more && [] !== $assets) {
+      /** @var MediaAsset $last */
+      $last = end($assets);
+      $sort_value = $last->getCreatedAt()?->format('Y-m-d\TH:i:s.uP') ?? '';
+      $next_cursor = $this->encodeKeysetCursor($sort_value, $last->getId());
+    }
+
+    return new MediaCategoryDetailResponse([
+      'id' => $category->getId(),
+      'name' => $this->trans($category->getName()),
+      'description' => $category->getDescription() ? $this->trans($category->getDescription()) : null,
+      'priority' => $category->getPriority(),
+      'created_at' => $category->getCreatedAt(),
+      'updated_at' => $category->getUpdatedAt(),
+      'data' => $asset_responses,
+      'next_cursor' => $next_cursor,
+      'has_more' => $has_more,
     ]);
   }
 

--- a/src/Api/Services/Projects/ProjectsApiLoader.php
+++ b/src/Api/Services/Projects/ProjectsApiLoader.php
@@ -121,6 +121,78 @@ class ProjectsApiLoader extends AbstractApiLoader
     return $this->project_manager->getPublicUserProjects($user_id, $limit, $offset, $flavor, $max_version);
   }
 
+  /**
+   * @return array<Program>
+   */
+  public function getProjectsKeyset(string $category, string $max_version, int $limit, string $flavor, ?\DateTimeInterface $cursor_date = null, ?int $cursor_value = null, ?string $cursor_id = null, ?User $user = null): array
+  {
+    $order_by = match ($category) {
+      'most_viewed' => 'views',
+      'most_downloaded' => 'downloads',
+      default => 'uploaded_at',
+    };
+
+    return $this->filterNotSafeForMinors(
+      $this->project_manager->getProjectsKeyset($order_by, $flavor, $max_version, $limit, $cursor_date, $cursor_value, $cursor_id)
+    );
+  }
+
+  /**
+   * @return array<Program>
+   */
+  public function getFeaturedProjectsKeyset(?string $flavor, int $limit, string $platform, string $max_version, ?int $cursor_priority = null, ?int $cursor_id = null): array
+  {
+    return $this->featured_repository->getFeaturedProgramsKeyset($flavor, $limit, $platform, $max_version, $cursor_priority, $cursor_id);
+  }
+
+  /**
+   * @return array<Program>
+   */
+  public function getUserProjectsKeyset(string $user_id, int $limit, string $flavor, string $max_version, ?\DateTimeInterface $cursor_date = null, ?string $cursor_id = null): array
+  {
+    return $this->filterNotSafeForMinors(
+      $this->project_manager->getUserProjectsKeyset($user_id, $flavor, $max_version, $limit, $cursor_date, $cursor_id)
+    );
+  }
+
+  /**
+   * @return array<Program>
+   */
+  public function getUserPublicProjectsKeyset(string $user_id, int $limit, string $flavor, string $max_version, ?\DateTimeInterface $cursor_date = null, ?string $cursor_id = null): array
+  {
+    return $this->filterNotSafeForMinors(
+      $this->project_manager->getPublicUserProjectsKeyset($user_id, $flavor, $max_version, $limit, $cursor_date, $cursor_id)
+    );
+  }
+
+  /**
+   * @return array<Program>
+   */
+  public function getRecommendedProjectsKeyset(string $project_id, string $category, string $max_version, int $limit, string $flavor, ?\DateTimeInterface $cursor_date = null, ?string $cursor_id = null): array
+  {
+    if ('more_from_user' !== $category) {
+      return [];
+    }
+
+    $project = $this->findProjectByID($project_id, true);
+    if (null === $project) {
+      return [];
+    }
+
+    /** @var Program $base_project */
+    $base_project = $project->isExample() ? $project->getProgram() : $project;
+    $user_id = $base_project->getUser()?->getId();
+    if (null === $user_id) {
+      return [];
+    }
+
+    return $this->filterNotSafeForMinors(
+      $this->project_manager->getMoreProjectsFromUserKeyset(
+        $user_id, $project_id, $flavor, $max_version, $limit, $cursor_date, $cursor_id
+      )
+    );
+  }
+
   public function getClientIp(): ?string
   {
     return $this->request_stack->getCurrentRequest()->getClientIp();

--- a/src/Api/Services/Projects/ProjectsResponseManager.php
+++ b/src/Api/Services/Projects/ProjectsResponseManager.php
@@ -8,6 +8,7 @@ use App\Api\Exceptions\ApiErrorResponse;
 use App\Api\Services\Base\AbstractResponseManager;
 use App\Api\Services\Base\TranslatorAwareTrait;
 use App\Api\Traits\CursorPaginationTrait;
+use App\Api\Traits\KeysetCursorTrait;
 use App\DB\Entity\Project\Extension;
 use App\DB\Entity\Project\Program;
 use App\DB\Entity\Project\ProjectCodeStatistics;
@@ -39,6 +40,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class ProjectsResponseManager extends AbstractResponseManager
 {
   use CursorPaginationTrait;
+  use KeysetCursorTrait;
   use TranslatorAwareTrait;
 
   public function __construct(
@@ -229,6 +231,72 @@ class ProjectsResponseManager extends AbstractResponseManager
     $next_cursor = ($has_more && [] !== $data) ? $this->encodeCursorFromOffset($offset, count($data)) : null;
 
     return new ProjectsListResponse([
+      'data' => $data,
+      'next_cursor' => $next_cursor,
+      'has_more' => $has_more,
+    ]);
+  }
+
+  /**
+   * Create a paginated projects list response using keyset cursor from actual project data.
+   *
+   * @param string $sort_by The sort column: 'uploaded_at', 'views', or 'downloads'
+   */
+  public function createProjectsKeysetResponse(array $projects, int $limit, string $sort_by, ?string $attributes = null): ProjectsListResponse
+  {
+    $has_more = count($projects) > $limit;
+    if ($has_more) {
+      array_pop($projects);
+    }
+
+    $data = [];
+    foreach ($projects as $project) {
+      $data[] = $this->createProjectDataResponse($project, $attributes);
+    }
+
+    $next_cursor = null;
+    if ($has_more && [] !== $data) {
+      /** @var Program $last */
+      $last = end($projects);
+      $last_id = (string) $last->getId();
+      $next_cursor = match ($sort_by) {
+        'views' => $this->encodeIntKeysetCursor($last->getViews(), $last_id),
+        'downloads' => $this->encodeIntKeysetCursor($last->getDownloads(), $last_id),
+        default => $this->encodeDateKeysetCursor($last->getUploadedAt(), $last_id),
+      };
+    }
+
+    return new ProjectsListResponse([
+      'data' => $data,
+      'next_cursor' => $next_cursor,
+      'has_more' => $has_more,
+    ]);
+  }
+
+  /**
+   * Create a paginated featured projects list response using keyset cursor.
+   */
+  public function createFeaturedProjectsKeysetResponse(array $featured_projects, int $limit, ?string $attributes = null): FeaturedProjectsListResponse
+  {
+    $has_more = count($featured_projects) > $limit;
+    if ($has_more) {
+      array_pop($featured_projects);
+    }
+
+    $data = [];
+    /** @var FeaturedProgram $featured_project */
+    foreach ($featured_projects as $featured_project) {
+      $data[] = $this->createFeaturedProjectResponse($featured_project, $attributes);
+    }
+
+    $next_cursor = null;
+    if ($has_more && [] !== $data) {
+      /** @var FeaturedProgram $last */
+      $last = end($featured_projects);
+      $next_cursor = $this->encodeIntKeysetCursor($last->getPriority(), (string) $last->getId());
+    }
+
+    return new FeaturedProjectsListResponse([
       'data' => $data,
       'next_cursor' => $next_cursor,
       'has_more' => $has_more,

--- a/src/Api/Services/User/UserApiLoader.php
+++ b/src/Api/Services/User/UserApiLoader.php
@@ -7,11 +7,14 @@ namespace App\Api\Services\User;
 use App\Api\Services\Base\AbstractApiLoader;
 use App\DB\Entity\User\User;
 use App\User\UserManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 class UserApiLoader extends AbstractApiLoader
 {
-  public function __construct(private readonly UserManager $user_manager)
-  {
+  public function __construct(
+    private readonly UserManager $user_manager,
+    private readonly EntityManagerInterface $entity_manager,
+  ) {
   }
 
   public function findUserByID(string $id): ?User
@@ -65,5 +68,32 @@ class UserApiLoader extends AbstractApiLoader
     }
 
     return $this->user_manager->searchCount($query);
+  }
+
+  /**
+   * Keyset cursor query for all users ordered by createdAt DESC, id DESC.
+   *
+   * @return User[]
+   */
+  public function getAllUsersKeyset(int $limit, ?\DateTimeInterface $cursor_date = null, ?string $cursor_id = null): array
+  {
+    $qb = $this->entity_manager->createQueryBuilder()
+      ->select('u')
+      ->from(User::class, 'u')
+      ->orderBy('u.createdAt', 'DESC')
+      ->addOrderBy('u.id', 'DESC')
+      ->setMaxResults($limit)
+    ;
+
+    if (null !== $cursor_date && null !== $cursor_id) {
+      $qb->andWhere(
+        '(u.createdAt < :cursor_date) OR (u.createdAt = :cursor_date AND u.id < :cursor_id)'
+      )
+        ->setParameter('cursor_date', $cursor_date)
+        ->setParameter('cursor_id', $cursor_id)
+      ;
+    }
+
+    return $qb->getQuery()->getResult();
   }
 }

--- a/src/Api/Services/Utility/UtilityApiLoader.php
+++ b/src/Api/Services/Utility/UtilityApiLoader.php
@@ -27,6 +27,14 @@ class UtilityApiLoader extends AbstractApiLoader
     return $this->featured_banner_repository->findActiveBanners($limit, $offset);
   }
 
+  /**
+   * @return FeaturedBanner[]
+   */
+  public function getActiveBannersKeyset(int $limit, ?int $cursor_priority = null, ?string $cursor_id = null): array
+  {
+    return $this->featured_banner_repository->findActiveBannersKeyset($limit, $cursor_priority, $cursor_id);
+  }
+
   public function getSurvey(array $criteria): ?Survey
   {
     $survey_repo = $this->entity_manager->getRepository(Survey::class);

--- a/src/Api/Traits/KeysetCursorTrait.php
+++ b/src/Api/Traits/KeysetCursorTrait.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Api\Traits;
+
+trait KeysetCursorTrait
+{
+  /**
+   * Decode a keyset cursor of format: base64("value|id").
+   *
+   * @return array{value: string, id: string}|null null if cursor is empty/invalid
+   */
+  protected function decodeKeysetCursor(?string $cursor): ?array
+  {
+    if (null === $cursor || '' === $cursor) {
+      return null;
+    }
+
+    $decoded = base64_decode($cursor, true);
+    if (false === $decoded) {
+      return null;
+    }
+
+    $parts = explode('|', $decoded, 2);
+    if (2 !== count($parts) || '' === $parts[0] || '' === $parts[1]) {
+      return null;
+    }
+
+    return ['value' => $parts[0], 'id' => $parts[1]];
+  }
+
+  /**
+   * Encode a keyset cursor from a sort value and an ID.
+   */
+  protected function encodeKeysetCursor(string $value, string $id): string
+  {
+    return base64_encode($value.'|'.$id);
+  }
+
+  /**
+   * Decode a keyset cursor where the value is a datetime string.
+   *
+   * @return array{date: \DateTimeImmutable, id: string}|null
+   */
+  protected function decodeDateKeysetCursor(?string $cursor): ?array
+  {
+    $data = $this->decodeKeysetCursor($cursor);
+    if (null === $data) {
+      return null;
+    }
+
+    $date = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', $data['value']);
+    if (false === $date) {
+      $date = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:sP', $data['value']);
+    }
+
+    if (false === $date) {
+      return null;
+    }
+
+    return ['date' => $date, 'id' => $data['id']];
+  }
+
+  /**
+   * Encode a keyset cursor from a datetime and ID.
+   */
+  protected function encodeDateKeysetCursor(\DateTimeInterface $date, string $id): string
+  {
+    $utc = \DateTimeImmutable::createFromInterface($date)->setTimezone(new \DateTimeZone('UTC'));
+
+    return $this->encodeKeysetCursor($utc->format('Y-m-d\TH:i:s.uP'), $id);
+  }
+
+  /**
+   * Decode a keyset cursor where the value is an integer.
+   *
+   * @return array{value: int, id: string}|null
+   */
+  protected function decodeIntKeysetCursor(?string $cursor): ?array
+  {
+    $data = $this->decodeKeysetCursor($cursor);
+    if (null === $data) {
+      return null;
+    }
+
+    if (!ctype_digit($data['value']) && !str_starts_with($data['value'], '-')) {
+      return null;
+    }
+
+    return ['value' => (int) $data['value'], 'id' => $data['id']];
+  }
+
+  /**
+   * Encode a keyset cursor from an integer value and ID.
+   */
+  protected function encodeIntKeysetCursor(int $value, string $id): string
+  {
+    return $this->encodeKeysetCursor((string) $value, $id);
+  }
+}

--- a/src/Api/UsersApi.php
+++ b/src/Api/UsersApi.php
@@ -10,6 +10,7 @@ use App\Api\Services\Studio\StudioApiLoader;
 use App\Api\Services\Studio\StudioResponseManager;
 use App\Api\Services\User\UserApiFacade;
 use App\Api\Traits\CursorPaginationTrait;
+use App\Api\Traits\KeysetCursorTrait;
 use App\DB\Entity\Project\ProgramLike;
 use App\DB\Entity\User\Comment\UserComment;
 use App\DB\Entity\User\User;
@@ -34,6 +35,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 class UsersApi extends AbstractApiController implements UsersApiInterface
 {
   use CursorPaginationTrait;
+  use KeysetCursorTrait;
   use RateLimitTrait;
 
   private const int MAX_LIMIT = 50;
@@ -264,6 +266,7 @@ class UsersApi extends AbstractApiController implements UsersApiInterface
   #[\Override]
   public function usersSearchGet(string $query, int $limit, ?string $cursor, string $attributes, int &$responseCode, array &$responseHeaders): array|object|null
   {
+    // Elasticsearch only supports offset-based pagination (from/size), not keyset cursors
     $limit = min(max($limit, 1), self::MAX_LIMIT);
     $offset = $this->decodeCursorToOffset($cursor);
 
@@ -324,16 +327,53 @@ class UsersApi extends AbstractApiController implements UsersApiInterface
   public function usersGet(?string $query, int $limit, ?string $cursor, int &$responseCode, array &$responseHeaders): array|object|null
   {
     $limit = min(max($limit, 1), self::MAX_LIMIT);
-    $offset = $this->decodeCursorToOffset($cursor);
 
-    $users = $this->facade->getLoader()->getAllUsers($query, $limit + 1, $offset);
+    // With search query: Elasticsearch only supports offset-based pagination
+    if (null !== $query && '' !== trim($query)) {
+      $offset = $this->decodeCursorToOffset($cursor);
+      $users = $this->facade->getLoader()->getAllUsers($query, $limit + 1, $offset);
+
+      $has_more = count($users) > $limit;
+      if ($has_more) {
+        array_pop($users);
+      }
+
+      $next_cursor = $has_more ? base64_encode((string) ($offset + $limit)) : null;
+
+      $responseCode = Response::HTTP_OK;
+      $response = $this->facade->getResponseManager()->createUsersListResponse($users, $has_more, $next_cursor, 'ALL');
+      $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
+      $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
+
+      return $response;
+    }
+
+    // No query: real keyset cursor pagination ordered by createdAt DESC
+    $cursor_date = null;
+    $cursor_id = null;
+    if (null !== $cursor && '' !== $cursor) {
+      $cursor_data = $this->decodeDateKeysetCursor($cursor);
+      if (null === $cursor_data) {
+        $responseCode = Response::HTTP_BAD_REQUEST;
+
+        return null;
+      }
+      $cursor_date = $cursor_data['date'];
+      $cursor_id = $cursor_data['id'];
+    }
+
+    $users = $this->facade->getLoader()->getAllUsersKeyset($limit + 1, $cursor_date, $cursor_id);
 
     $has_more = count($users) > $limit;
     if ($has_more) {
       array_pop($users);
     }
 
-    $next_cursor = $has_more ? base64_encode((string) ($offset + $limit)) : null;
+    $next_cursor = null;
+    if ($has_more && [] !== $users) {
+      $last = end($users);
+      $next_cursor = $this->encodeDateKeysetCursor($last->getCreatedAt(), $last->getId());
+    }
 
     $responseCode = Response::HTTP_OK;
     $response = $this->facade->getResponseManager()->createUsersListResponse($users, $has_more, $next_cursor, 'ALL');

--- a/src/Api/UsersApi.php
+++ b/src/Api/UsersApi.php
@@ -372,7 +372,11 @@ class UsersApi extends AbstractApiController implements UsersApiInterface
     $next_cursor = null;
     if ($has_more && [] !== $users) {
       $last = end($users);
-      $next_cursor = $this->encodeDateKeysetCursor($last->getCreatedAt(), $last->getId());
+      $created_at = $last->getCreatedAt();
+      $last_id = $last->getId();
+      if (null !== $created_at && null !== $last_id) {
+        $next_cursor = $this->encodeDateKeysetCursor($created_at, $last_id);
+      }
     }
 
     $responseCode = Response::HTTP_OK;

--- a/src/Api/UtilityApi.php
+++ b/src/Api/UtilityApi.php
@@ -7,6 +7,7 @@ namespace App\Api;
 use App\Api\Services\Base\AbstractApiController;
 use App\Api\Services\Utility\UtilityApiFacade;
 use App\Api\Traits\CursorPaginationTrait;
+use App\Api\Traits\KeysetCursorTrait;
 use Doctrine\DBAL\Connection;
 use OpenAPI\Server\Api\UtilityApiInterface;
 use OpenAPI\Server\Model\FeaturedBannersListResponse;
@@ -17,6 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 class UtilityApi extends AbstractApiController implements UtilityApiInterface
 {
   use CursorPaginationTrait;
+  use KeysetCursorTrait;
 
   public function __construct(
     private readonly UtilityApiFacade $facade,
@@ -28,9 +30,22 @@ class UtilityApi extends AbstractApiController implements UtilityApiInterface
   public function featuredBannersGet(int $limit, ?string $cursor, int &$responseCode, array &$responseHeaders): FeaturedBannersListResponse
   {
     $limit = min(max($limit, 1), 50);
-    $offset = $this->decodeCursorToOffset($cursor);
 
-    $banners = $this->facade->getLoader()->getActiveBanners($limit + 1, $offset);
+    $cursor_data = $this->decodeIntKeysetCursor($cursor);
+    if (null === $cursor_data && null !== $cursor && '' !== $cursor) {
+      $responseCode = Response::HTTP_BAD_REQUEST;
+
+      $response = new FeaturedBannersListResponse();
+      $response->setData([]);
+      $response->setNextCursor(null);
+      $response->setHasMore(false);
+
+      return $response;
+    }
+
+    $banners = $this->facade->getLoader()->getActiveBannersKeyset(
+      $limit + 1, $cursor_data['value'] ?? null, $cursor_data['id'] ?? null
+    );
 
     $has_more = count($banners) > $limit;
     if ($has_more) {
@@ -42,9 +57,11 @@ class UtilityApi extends AbstractApiController implements UtilityApiInterface
       $banners,
     );
 
-    $next_cursor = ($has_more && [] !== $banner_responses)
-      ? $this->encodeCursorFromOffset($offset, count($banner_responses))
-      : null;
+    $next_cursor = null;
+    if ($has_more && [] !== $banners) {
+      $last = end($banners);
+      $next_cursor = $this->encodeIntKeysetCursor($last->getPriority(), $last->getId());
+    }
 
     $responseCode = Response::HTTP_OK;
 

--- a/src/Api/UtilityApi.php
+++ b/src/Api/UtilityApi.php
@@ -60,7 +60,10 @@ class UtilityApi extends AbstractApiController implements UtilityApiInterface
     $next_cursor = null;
     if ($has_more && [] !== $banners) {
       $last = end($banners);
-      $next_cursor = $this->encodeIntKeysetCursor($last->getPriority(), $last->getId());
+      $last_id = $last->getId();
+      if (null !== $last_id) {
+        $next_cursor = $this->encodeIntKeysetCursor($last->getPriority(), $last_id);
+      }
     }
 
     $responseCode = Response::HTTP_OK;

--- a/src/DB/EntityRepository/FeaturedBannerRepository.php
+++ b/src/DB/EntityRepository/FeaturedBannerRepository.php
@@ -36,4 +36,31 @@ class FeaturedBannerRepository extends ServiceEntityRepository
       ->getResult()
     ;
   }
+
+  /**
+   * Keyset cursor query for active banners ordered by priority DESC, id DESC.
+   *
+   * @return FeaturedBanner[]
+   */
+  public function findActiveBannersKeyset(int $limit, ?int $cursor_priority = null, ?string $cursor_id = null): array
+  {
+    $qb = $this->createQueryBuilder('fb')
+      ->select('fb')
+      ->where('fb.active = true')
+      ->orderBy('fb.priority', 'DESC')
+      ->addOrderBy('fb.id', 'DESC')
+      ->setMaxResults($limit)
+    ;
+
+    if (null !== $cursor_priority && null !== $cursor_id) {
+      $qb->andWhere(
+        '(fb.priority < :cursor_priority) OR (fb.priority = :cursor_priority AND fb.id < :cursor_id)'
+      )
+        ->setParameter('cursor_priority', $cursor_priority)
+        ->setParameter('cursor_id', $cursor_id)
+      ;
+    }
+
+    return $qb->getQuery()->getResult();
+  }
 }

--- a/src/DB/EntityRepository/MediaLibrary/MediaAssetRepository.php
+++ b/src/DB/EntityRepository/MediaLibrary/MediaAssetRepository.php
@@ -88,6 +88,52 @@ class MediaAssetRepository extends ServiceEntityRepository
     return $qb->getQuery()->getResult();
   }
 
+  /**
+   * Keyset cursor query for assets with configurable sort.
+   *
+   * @return array<MediaAsset>
+   */
+  public function findPaginatedKeyset(
+    int $limit,
+    ?MediaCategory $category = null,
+    ?MediaFileType $fileType = null,
+    ?string $flavor = null,
+    ?string $search = null,
+    string $sortBy = 'created_at',
+    string $sortOrder = 'DESC',
+    ?string $cursor_sort_value = null,
+    ?string $cursor_id = null,
+  ): array {
+    $qb = $this->createBaseQueryBuilder($category, $fileType, $flavor, $search);
+
+    $allowedSortFields = ['name', 'created_at', 'downloads', 'updated_at'];
+    if (!in_array($sortBy, $allowedSortFields, true)) {
+      $sortBy = 'created_at';
+    }
+    $sortOrder = 'ASC' === strtoupper($sortOrder) ? 'ASC' : 'DESC';
+    $cmp = 'DESC' === $sortOrder ? '<' : '>';
+    $idOrder = 'DESC' === $sortOrder ? 'DESC' : 'ASC';
+
+    $qb->orderBy('a.'.$sortBy, $sortOrder)
+      ->addOrderBy('a.id', $idOrder)
+      ->setMaxResults($limit)
+    ;
+
+    if (null !== $cursor_sort_value && null !== $cursor_id) {
+      $qb->andWhere(
+        sprintf(
+          '(a.%s %s :cursor_sort_value) OR (a.%s = :cursor_sort_value AND a.id %s :cursor_id)',
+          $sortBy, $cmp, $sortBy, $cmp
+        )
+      )
+        ->setParameter('cursor_sort_value', $cursor_sort_value)
+        ->setParameter('cursor_id', $cursor_id)
+      ;
+    }
+
+    return $qb->getQuery()->getResult();
+  }
+
   public function countAll(
     ?MediaCategory $category = null,
     ?MediaFileType $fileType = null,

--- a/src/DB/EntityRepository/MediaLibrary/MediaCategoryRepository.php
+++ b/src/DB/EntityRepository/MediaLibrary/MediaCategoryRepository.php
@@ -42,6 +42,31 @@ class MediaCategoryRepository extends ServiceEntityRepository
     return $qb->getQuery()->getResult();
   }
 
+  /**
+   * Keyset cursor query for categories ordered by priority ASC, id ASC.
+   *
+   * @return array<MediaCategory>
+   */
+  public function findPaginatedKeyset(int $limit, ?int $cursor_priority = null, ?string $cursor_id = null): array
+  {
+    $qb = $this->createQueryBuilder('c')
+      ->orderBy('c.priority', 'ASC')
+      ->addOrderBy('c.id', 'ASC')
+      ->setMaxResults($limit)
+    ;
+
+    if (null !== $cursor_priority && null !== $cursor_id) {
+      $qb->andWhere(
+        '(c.priority > :cursor_priority) OR (c.priority = :cursor_priority AND c.id > :cursor_id)'
+      )
+        ->setParameter('cursor_priority', $cursor_priority)
+        ->setParameter('cursor_id', $cursor_id)
+      ;
+    }
+
+    return $qb->getQuery()->getResult();
+  }
+
   public function countAll(): int
   {
     $qb = $this->createQueryBuilder('c')

--- a/src/DB/EntityRepository/Project/ProgramRepository.php
+++ b/src/DB/EntityRepository/Project/ProgramRepository.php
@@ -283,6 +283,95 @@ class ProgramRepository extends ServiceEntityRepository
   }
 
   // -------------------------------------------------------------------------------------------------------------------
+  //  Keyset Cursor Pagination
+  //
+
+  /**
+   * @return Program[]
+   */
+  public function getProjectsKeyset(?string $flavor, string $max_version, int $limit, string $order_by, ?\DateTimeInterface $cursor_date = null, ?int $cursor_value = null, ?string $cursor_id = null): array
+  {
+    $qb = $this->createQueryAllBuilder();
+    $qb = $this->excludeUnavailableAndPrivateProjects($qb, $flavor, $max_version);
+
+    $sort_field = match ($order_by) {
+      'views' => 'e.views',
+      'downloads' => 'e.downloads',
+      default => 'e.uploaded_at',
+    };
+
+    $qb->orderBy($sort_field, 'DESC')->addOrderBy('e.id', 'DESC');
+    $cursor_value_param = 'uploaded_at' === $order_by ? $cursor_date : $cursor_value;
+    $this->applyKeysetCursor($qb, $sort_field, $cursor_value_param, $cursor_id);
+    $qb->setMaxResults($limit);
+
+    return $qb->getQuery()->getResult();
+  }
+
+  /**
+   * @return Program[]
+   */
+  public function getPublicUserProjectsKeyset(string $user_id, ?string $flavor, string $max_version, int $limit, ?\DateTimeInterface $cursor_date = null, ?string $cursor_id = null): array
+  {
+    $qb = $this->createQueryAllBuilder();
+    $qb = $this->excludeUnavailableAndPrivateProjects($qb, $flavor, $max_version);
+    $qb->orderBy('e.uploaded_at', 'DESC')->addOrderBy('e.id', 'DESC');
+    $qb->andWhere($qb->expr()->eq('e.user', ':user_id'))->setParameter('user_id', $user_id);
+    $this->applyKeysetCursor($qb, 'e.uploaded_at', $cursor_date, $cursor_id);
+    $qb->setMaxResults($limit);
+
+    return $qb->getQuery()->getResult();
+  }
+
+  /**
+   * @return Program[]
+   */
+  public function getUserProjectsKeyset(string $user_id, ?string $flavor, string $max_version, int $limit, ?\DateTimeInterface $cursor_date = null, ?string $cursor_id = null): array
+  {
+    $qb = $this->createQueryAllBuilder();
+    $qb = $this->excludeUnavailableProjects($qb, $flavor, $max_version);
+    $qb->orderBy('e.uploaded_at', 'DESC')->addOrderBy('e.id', 'DESC');
+    $qb->andWhere($qb->expr()->eq('e.user', ':user_id'))->setParameter('user_id', $user_id);
+    $this->applyKeysetCursor($qb, 'e.uploaded_at', $cursor_date, $cursor_id);
+    $qb->setMaxResults($limit);
+
+    return $qb->getQuery()->getResult();
+  }
+
+  /**
+   * @return Program[]
+   */
+  public function getMoreProjectsFromUserKeyset(string $user_id, string $exclude_project_id, ?string $flavor, string $max_version, int $limit, ?\DateTimeInterface $cursor_date = null, ?string $cursor_id = null): array
+  {
+    $qb = $this->createQueryAllBuilder();
+    $qb = $this->excludeUnavailableAndPrivateProjects($qb, $flavor, $max_version);
+    $qb->orderBy('e.uploaded_at', 'DESC')->addOrderBy('e.id', 'DESC');
+    $qb->andWhere($qb->expr()->eq('e.user', ':user_id'))->setParameter('user_id', $user_id);
+    $qb->andWhere($qb->expr()->neq('e.id', ':project_id'))->setParameter('project_id', $exclude_project_id);
+    $this->applyKeysetCursor($qb, 'e.uploaded_at', $cursor_date, $cursor_id);
+    $qb->setMaxResults($limit);
+
+    return $qb->getQuery()->getResult();
+  }
+
+  /**
+   * Applies a keyset cursor WHERE clause for DESC ordering with id DESC tiebreaker.
+   */
+  private function applyKeysetCursor(QueryBuilder $qb, string $field, mixed $cursor_value, ?string $cursor_id): void
+  {
+    if (null === $cursor_value || null === $cursor_id) {
+      return;
+    }
+
+    $qb->andWhere(
+      sprintf('(%s < :cursor_value) OR (%s = :cursor_value AND e.id < :cursor_id)', $field, $field)
+    )
+      ->setParameter('cursor_value', $cursor_value)
+      ->setParameter('cursor_id', $cursor_id)
+    ;
+  }
+
+  // -------------------------------------------------------------------------------------------------------------------
   //  Remix System
   //
 

--- a/src/DB/EntityRepository/Project/Special/FeaturedRepository.php
+++ b/src/DB/EntityRepository/Project/Special/FeaturedRepository.php
@@ -125,6 +125,35 @@ class FeaturedRepository extends ServiceEntityRepository
     ;
   }
 
+  /**
+   * Keyset cursor query for featured programs ordered by priority DESC, id DESC.
+   */
+  public function getFeaturedProgramsKeyset(?string $flavor, int $limit, ?string $platform = null, ?string $max_version = null, ?int $cursor_priority = null, ?int $cursor_id = null): array
+  {
+    $qb = $this->createQueryBuilder('e');
+    $qb->select('e')->addSelect('program')
+      ->where('e.active = true')
+    ;
+    $qb->leftJoin('e.program', 'program');
+    $qb->orderBy('e.priority', 'DESC')->addOrderBy('e.id', 'DESC');
+    $qb = $this->addMaxVersionCondition($qb, $max_version);
+    $qb = $this->addFeaturedExampleFlavorCondition($qb, $flavor);
+    $qb = $this->addPlatformCondition($qb, $platform);
+
+    if (null !== $cursor_priority && null !== $cursor_id) {
+      $qb->andWhere(
+        '(e.priority < :cursor_priority) OR (e.priority = :cursor_priority AND e.id < :cursor_id)'
+      )
+        ->setParameter('cursor_priority', $cursor_priority)
+        ->setParameter('cursor_id', $cursor_id)
+      ;
+    }
+
+    $qb->setMaxResults($limit);
+
+    return $qb->getQuery()->getResult();
+  }
+
   public function isFeatured(Program $program): bool
   {
     $qb = $this->createQueryBuilder('e');

--- a/src/Project/ProjectManager.php
+++ b/src/Project/ProjectManager.php
@@ -531,6 +531,40 @@ class ProjectManager
     return $this->project_repository->getPublicUserProjects($user_id, $flavor, $max_version, $limit, $offset);
   }
 
+  /**
+   * Keyset cursor query for projects ordered by a given column.
+   *
+   * @return Program[]
+   */
+  public function getProjectsKeyset(string $order_by, ?string $flavor, string $max_version, int $limit, ?\DateTimeInterface $cursor_date = null, ?int $cursor_value = null, ?string $cursor_id = null): array
+  {
+    return $this->project_repository->getProjectsKeyset($flavor, $max_version, $limit, $order_by, $cursor_date, $cursor_value, $cursor_id);
+  }
+
+  /**
+   * @return Program[]
+   */
+  public function getPublicUserProjectsKeyset(string $user_id, ?string $flavor, string $max_version, int $limit, ?\DateTimeInterface $cursor_date = null, ?string $cursor_id = null): array
+  {
+    return $this->project_repository->getPublicUserProjectsKeyset($user_id, $flavor, $max_version, $limit, $cursor_date, $cursor_id);
+  }
+
+  /**
+   * @return Program[]
+   */
+  public function getUserProjectsKeyset(string $user_id, ?string $flavor, string $max_version, int $limit, ?\DateTimeInterface $cursor_date = null, ?string $cursor_id = null): array
+  {
+    return $this->project_repository->getUserProjectsKeyset($user_id, $flavor, $max_version, $limit, $cursor_date, $cursor_id);
+  }
+
+  /**
+   * @return Program[]
+   */
+  public function getMoreProjectsFromUserKeyset(string $user_id, string $exclude_project_id, ?string $flavor, string $max_version, int $limit, ?\DateTimeInterface $cursor_date = null, ?string $cursor_id = null): array
+  {
+    return $this->project_repository->getMoreProjectsFromUserKeyset($user_id, $exclude_project_id, $flavor, $max_version, $limit, $cursor_date, $cursor_id);
+  }
+
   public function countPublicUserProjects(string $user_id, ?string $flavor = null, string $max_version = ''): int
   {
     return $this->project_repository->countPublicUserProjects($user_id, $flavor, $max_version);

--- a/tests/BehatFeatures/api/projects/GET_projects/most_downloaded_category.feature
+++ b/tests/BehatFeatures/api/projects/GET_projects/most_downloaded_category.feature
@@ -28,8 +28,8 @@ Feature: Get most downloaded projects
       | project 3 |
       | project 4 |
       | project 6 |
-      | project 1 |
       | project 5 |
+      | project 1 |
       | project 2 |
 
   Scenario: Get most download projects in german and limit = 1
@@ -58,7 +58,7 @@ Feature: Get most downloaded projects
     Then the response should contain projects in the following order:
       | Name      |
       | project 6 |
-      | project 1 |
+      | project 5 |
 
   Scenario: Get most download projects in french with max_version = 0.982
     And I have a request header "HTTP_ACCEPT" with value "application/json"

--- a/tests/BehatFeatures/api/projects/GET_projects/recent_category.feature
+++ b/tests/BehatFeatures/api/projects/GET_projects/recent_category.feature
@@ -66,7 +66,7 @@ Feature: Get recent projects
           "filesize": 1.3369998931884766
         }
       ],
-      "next_cursor": "MQ==",
+      "next_cursor": "MjAxNC0wOC0wNVQxMjowMDowMC4wMDAwMDArMDA6MDB8NQ==",
       "has_more": true
     }
     """

--- a/tests/BehatFeatures/api/projects/GET_projects_featured/featured_projects.feature
+++ b/tests/BehatFeatures/api/projects/GET_projects_featured/featured_projects.feature
@@ -68,8 +68,8 @@ Feature: Featured Projects
       | project 12 |
       | project 10 |
       | project 5  |
-      | project 15 |
       | project 2  |
+      | project 15 |
       | project 6  |
       | project 1  |
 
@@ -88,7 +88,7 @@ Feature: Featured Projects
     Then the response should contain featured projects in the following order:
       | Name       |
       | project 5  |
-      | project 15 |
+      | project 2  |
 
   Scenario: Get featured projects for android platform
     Given I have a request header "HTTP_ACCEPT" with value "application/json"
@@ -158,7 +158,7 @@ Feature: Featured Projects
           "author": "Catrobat"
         }
       ],
-      "next_cursor": "Mg==",
+      "next_cursor": "Nnw0",
       "has_more": true
     }
     """

--- a/tests/BehatFeatures/api/projects/GET_projects_user_id/public_user_projects.feature
+++ b/tests/BehatFeatures/api/projects/GET_projects_user_id/public_user_projects.feature
@@ -29,29 +29,29 @@ Feature: User public projects
     Then the response should have the default projects model structure
     Then the response should contain projects in the following order:
       | Name       |
-      | project 1  |
-      | project 10 |
-      | project 3  |
-      | project 6  |
-      | project 7  |
       | project 9  |
+      | project 7  |
+      | project 6  |
+      | project 3  |
+      | project 10 |
+      | project 1  |
 
   Scenario: Cursor pagination - page 1 then page 2 via cursor
     And I have a request header "HTTP_ACCEPT" with value "application/json"
     And I request "GET" "/api/projects/user/user-1/?limit=2"
     Then the response status code should be "200"
     Then the response should contain projects in the following order:
-      | Name       |
-      | project 1  |
-      | project 10 |
+      | Name      |
+      | project 9 |
+      | project 7 |
     And the client response should contain "has_more"
     And I save the next_cursor from the response
     When I request page 2 with the saved cursor at "/api/projects/user/user-1/?limit=2"
     Then the response status code should be "200"
     Then the response should contain projects in the following order:
       | Name      |
-      | project 3 |
       | project 6 |
+      | project 3 |
 
   Scenario: Get user public projects for user-2 with limit = 2
     And I have a request header "HTTP_ACCEPT" with value "application/json"

--- a/tests/PhpUnit/Api/KeysetCursorTraitTest.php
+++ b/tests/PhpUnit/Api/KeysetCursorTraitTest.php
@@ -8,9 +8,9 @@ use App\Api\Traits\KeysetCursorTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @internal
- *
  * @coversDefaultClass \App\Api\Traits\KeysetCursorTrait
+ *
+ * @internal
  */
 class KeysetCursorTraitTest extends TestCase
 {
@@ -59,6 +59,7 @@ class KeysetCursorTraitTest extends TestCase
   {
     $cursor = $this->encodeKeysetCursor('value123', 'id456');
     $decoded = $this->decodeKeysetCursor($cursor);
+    $this->assertNotNull($decoded);
     $this->assertSame('value123', $decoded['value']);
     $this->assertSame('id456', $decoded['id']);
   }
@@ -131,6 +132,7 @@ class KeysetCursorTraitTest extends TestCase
     // Test that pipe in ID is handled correctly (only first pipe splits)
     $cursor = base64_encode('value|id|with|pipes');
     $result = $this->decodeKeysetCursor($cursor);
+    $this->assertNotNull($result);
     $this->assertSame('value', $result['value']);
     $this->assertSame('id|with|pipes', $result['id']);
   }

--- a/tests/PhpUnit/Api/KeysetCursorTraitTest.php
+++ b/tests/PhpUnit/Api/KeysetCursorTraitTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnit\Api;
+
+use App\Api\Traits\KeysetCursorTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversDefaultClass \App\Api\Traits\KeysetCursorTrait
+ */
+class KeysetCursorTraitTest extends TestCase
+{
+  use KeysetCursorTrait;
+
+  public function testDecodeKeysetCursorNull(): void
+  {
+    $this->assertNull($this->decodeKeysetCursor(null));
+  }
+
+  public function testDecodeKeysetCursorEmpty(): void
+  {
+    $this->assertNull($this->decodeKeysetCursor(''));
+  }
+
+  public function testDecodeKeysetCursorInvalidBase64(): void
+  {
+    $this->assertNull($this->decodeKeysetCursor('!!!'));
+  }
+
+  public function testDecodeKeysetCursorMissingPipe(): void
+  {
+    $this->assertNull($this->decodeKeysetCursor(base64_encode('nopipe')));
+  }
+
+  public function testDecodeKeysetCursorEmptyParts(): void
+  {
+    $this->assertNull($this->decodeKeysetCursor(base64_encode('|id')));
+    $this->assertNull($this->decodeKeysetCursor(base64_encode('value|')));
+  }
+
+  public function testDecodeKeysetCursorValid(): void
+  {
+    $cursor = base64_encode('somevalue|abc123');
+    $result = $this->decodeKeysetCursor($cursor);
+    $this->assertSame(['value' => 'somevalue', 'id' => 'abc123'], $result);
+  }
+
+  public function testEncodeKeysetCursor(): void
+  {
+    $cursor = $this->encodeKeysetCursor('myval', 'myid');
+    $this->assertSame(base64_encode('myval|myid'), $cursor);
+  }
+
+  public function testEncodeDecodeRoundtrip(): void
+  {
+    $cursor = $this->encodeKeysetCursor('value123', 'id456');
+    $decoded = $this->decodeKeysetCursor($cursor);
+    $this->assertSame('value123', $decoded['value']);
+    $this->assertSame('id456', $decoded['id']);
+  }
+
+  public function testDecodeDateKeysetCursorNull(): void
+  {
+    $this->assertNull($this->decodeDateKeysetCursor(null));
+  }
+
+  public function testDecodeDateKeysetCursorInvalid(): void
+  {
+    $this->assertNull($this->decodeDateKeysetCursor(base64_encode('notadate|id')));
+  }
+
+  public function testDecodeDateKeysetCursorValid(): void
+  {
+    $date = new \DateTimeImmutable('2024-06-15T10:30:00.000000+00:00');
+    $cursor = $this->encodeDateKeysetCursor($date, 'proj-123');
+    $result = $this->decodeDateKeysetCursor($cursor);
+
+    $this->assertNotNull($result);
+    $this->assertSame('proj-123', $result['id']);
+    $this->assertSame('2024-06-15', $result['date']->format('Y-m-d'));
+    $this->assertSame('10:30:00', $result['date']->format('H:i:s'));
+  }
+
+  public function testDecodeDateKeysetCursorWithTimezone(): void
+  {
+    $date = new \DateTimeImmutable('2024-06-15T12:30:00', new \DateTimeZone('Europe/Berlin'));
+    $cursor = $this->encodeDateKeysetCursor($date, 'id-1');
+    $result = $this->decodeDateKeysetCursor($cursor);
+
+    $this->assertNotNull($result);
+    // Should be converted to UTC
+    $this->assertSame('10:30:00', $result['date']->format('H:i:s'));
+  }
+
+  public function testDecodeIntKeysetCursorNull(): void
+  {
+    $this->assertNull($this->decodeIntKeysetCursor(null));
+  }
+
+  public function testDecodeIntKeysetCursorInvalidValue(): void
+  {
+    $this->assertNull($this->decodeIntKeysetCursor(base64_encode('notanint|id')));
+  }
+
+  public function testDecodeIntKeysetCursorValid(): void
+  {
+    $cursor = $this->encodeIntKeysetCursor(42, 'feat-5');
+    $result = $this->decodeIntKeysetCursor($cursor);
+
+    $this->assertNotNull($result);
+    $this->assertSame(42, $result['value']);
+    $this->assertSame('feat-5', $result['id']);
+  }
+
+  public function testDecodeIntKeysetCursorZero(): void
+  {
+    $cursor = $this->encodeIntKeysetCursor(0, 'id-0');
+    $result = $this->decodeIntKeysetCursor($cursor);
+
+    $this->assertNotNull($result);
+    $this->assertSame(0, $result['value']);
+    $this->assertSame('id-0', $result['id']);
+  }
+
+  public function testDecodeKeysetCursorPreservesSpecialChars(): void
+  {
+    // Test that pipe in ID is handled correctly (only first pipe splits)
+    $cursor = base64_encode('value|id|with|pipes');
+    $result = $this->decodeKeysetCursor($cursor);
+    $this->assertSame('value', $result['value']);
+    $this->assertSame('id|with|pipes', $result['id']);
+  }
+}


### PR DESCRIPTION
## Summary
- Replace offset-based cursor pagination with real keyset (seek) queries across all non-Elasticsearch collection endpoints
- New `KeysetCursorTrait` provides shared encode/decode helpers for date|id, int|id, and generic value|id cursor formats
- Keyset queries use compound `WHERE (sort_col < :val) OR (sort_col = :val AND id < :cursor_id)` eliminating O(n) offset skipping
- Elasticsearch and random/unstable-sort endpoints remain offset-based with documenting comments

### Endpoints migrated
| Endpoint | Sort Order | Cursor Format |
|----------|-----------|---------------|
| `projectsGet` (recent) | `uploaded_at DESC` | `date\|id` |
| `projectsGet` (most_viewed) | `views DESC` | `int\|id` |
| `projectsGet` (most_downloaded) | `downloads DESC` | `int\|id` |
| `projectsFeaturedGet` | `priority DESC` | `int\|id` |
| `projectsUserGet` | `uploaded_at DESC` | `date\|id` |
| `projectsUserIdGet` | `uploaded_at DESC` | `date\|id` |
| `projectsIdRecommendationsGet` | `uploaded_at DESC` | `date\|id` |
| `featuredBannersGet` | `priority DESC` | `int\|id` |
| `usersGet` (no query) | `createdAt DESC` | `date\|id` |
| `mediaCategoriesGet` | `priority ASC` | `int\|id` |
| `mediaCategoriesIdGet` | `created_at DESC` | `value\|id` |
| `mediaAssetsGet` | configurable | `value\|id` |
| `mediaLibraryGet` (non-search) | `priority ASC` | `int\|id` |

## Test plan
- [x] PHPUnit: 17 tests for KeysetCursorTrait encode/decode edge cases
- [x] Behat: Updated existing pagination tests for new sort orders (id DESC tiebreaker instead of name ASC)
- [x] Behat: Cursor pagination page-2 tests verify keyset cursors work end-to-end
- [ ] CI: Full test suite (some Behat tests may need sort-order adjustments)

Closes #6634

🤖 Generated with [Claude Code](https://claude.com/claude-code)