### PR TITLE
Add admin studio management overview and dashboard stats

### DIFF
--- a/config/packages/sonata_admin.php
+++ b/config/packages/sonata_admin.php
@@ -72,6 +72,17 @@ return static function (ContainerConfigurator $containerConfigurator): void {
               'color' => 'bg-green',
             ],
           ],
+          [
+            'class' => 'col-lg-3 col-xs-6',
+            'position' => 'bottom',
+            'type' => 'sonata.admin.block.stats',
+            'settings' => [
+              'code' => 'admin.block.studios.overview',
+              'icon' => 'fas fa-object-group',
+              'text' => 'All studios',
+              'color' => 'bg-purple',
+            ],
+          ],
         ],
         'groups' => [
           'sonata.admin.group.featured_banners' => [
@@ -102,6 +113,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
               'admin.block.users.overview',
               'admin.block.users.consent_log',
               'admin.block.users.data_report',
+            ],
+          ],
+          'sonata.admin.group.studios' => [
+            'label' => 'Studios',
+            'translation_domain' => 'catroweb',
+            'icon' => '<i class="fa fa-object-group"></i>',
+            'items' => [
+              'admin.block.studios.overview',
             ],
           ],
           'sonata.admin.group.comments' => [

--- a/config/services.php
+++ b/config/services.php
@@ -22,6 +22,7 @@ use App\Admin\Statistics\Translation\Controller\CommentMachineTranslationAdminCo
 use App\Admin\Statistics\Translation\Controller\ProjectMachineTranslationAdminController;
 use App\Admin\Statistics\Translation\ProjectCustomTranslationAdmin;
 use App\Admin\Statistics\Translation\ProjectMachineTranslationAdmin;
+use App\Admin\Studios\StudioAdmin;
 use App\Admin\System\CronJobs\CronJobsAdmin;
 use App\Admin\System\CronJobs\CronJobsAdminController;
 use App\Admin\System\DB_Updater\AchievementsAdmin;
@@ -74,6 +75,7 @@ use App\DB\Entity\Project\Extension;
 use App\DB\Entity\Project\Program;
 use App\DB\Entity\Project\Special\ExampleProgram;
 use App\DB\Entity\Project\Tag;
+use App\DB\Entity\Studio\Studio;
 use App\DB\Entity\System\CronJob;
 use App\DB\Entity\System\FeatureFlag;
 use App\DB\Entity\System\MaintenanceInformation;
@@ -401,6 +403,21 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'code' => null,
         'model_class' => ConsentLog::class,
         'controller' => null,
+      ]
+    )
+  ;
+  $services->set('admin.block.studios.overview', StudioAdmin::class)
+    ->tag(
+      'sonata.admin',
+      [
+        'manager_type' => 'orm',
+        'model_class' => Studio::class,
+        'label' => 'Studio Overview',
+        'show_mosaic_button' => false,
+        'default' => true,
+        'code' => null,
+        'controller' => null,
+        'pager_type' => 'simple',
       ]
     )
   ;

--- a/src/Admin/Studios/StudioAdmin.php
+++ b/src/Admin/Studios/StudioAdmin.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Studios;
+
+use App\DB\Entity\Studio\Studio;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Route\RouteCollectionInterface;
+use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\DoctrineORMAdminBundle\Filter\DateTimeRangeFilter;
+use Sonata\Form\Type\DateTimeRangePickerType;
+
+/**
+ * @phpstan-extends AbstractAdmin<Studio>
+ */
+class StudioAdmin extends AbstractAdmin
+{
+  #[\Override]
+  protected function generateBaseRouteName(bool $isChildAdmin = false): string
+  {
+    return 'admin_studios';
+  }
+
+  #[\Override]
+  protected function generateBaseRoutePattern(bool $isChildAdmin = false): string
+  {
+    return 'studio';
+  }
+
+  #[\Override]
+  protected function configureDefaultSortValues(array &$sortValues): void
+  {
+    $sortValues[DatagridInterface::SORT_BY] = 'created_on';
+    $sortValues[DatagridInterface::SORT_ORDER] = 'DESC';
+  }
+
+  #[\Override]
+  protected function configureDatagridFilters(DatagridMapper $filter): void
+  {
+    $filter
+      ->add('id')
+      ->add('name')
+      ->add('is_public')
+      ->add('is_enabled')
+      ->add('allow_comments')
+      ->add('created_on', DateTimeRangeFilter::class, [
+        'field_type' => DateTimeRangePickerType::class,
+        'label' => 'Created On',
+      ])
+    ;
+  }
+
+  #[\Override]
+  protected function configureListFields(ListMapper $list): void
+  {
+    $list
+      ->addIdentifier('name')
+      ->add('id')
+      ->add('is_public', null, ['label' => 'Public'])
+      ->add('is_enabled', null, ['label' => 'Enabled'])
+      ->add('allow_comments', null, ['label' => 'Comments'])
+      ->add('created_on', null, ['label' => 'Created On'])
+      ->add(ListMapper::NAME_ACTIONS, null, [
+        'actions' => [
+          'show' => [],
+          'delete' => [],
+        ],
+      ])
+    ;
+  }
+
+  #[\Override]
+  protected function configureShowFields(ShowMapper $show): void
+  {
+    $show
+      ->add('name')
+      ->add('id')
+      ->add('description')
+      ->add('is_public', null, ['label' => 'Public'])
+      ->add('is_enabled', null, ['label' => 'Enabled'])
+      ->add('allow_comments', null, ['label' => 'Comments'])
+      ->add('auto_hidden', null, ['label' => 'Auto Hidden'])
+      ->add('created_on', null, ['label' => 'Created On'])
+      ->add('updated_on', null, ['label' => 'Updated On'])
+    ;
+  }
+
+  #[\Override]
+  protected function configureRoutes(RouteCollectionInterface $collection): void
+  {
+    $collection->remove('create')->remove('edit')->remove('export');
+  }
+}

--- a/tests/BehatFeatures/web/admin/studios_overview.feature
+++ b/tests/BehatFeatures/web/admin/studios_overview.feature
@@ -1,0 +1,31 @@
+@admin
+Feature: Admin studios overview
+
+  Background:
+    Given there are admins:
+      | id | name  | password | email                | approved |
+      | 1  | Edmin | 123456   | admin@pocketcode.org | true     |
+    And there are studios:
+      | id                                   | name       | description   | created_on          |
+      | 11111111-1111-4111-8111-111111111111 | Studio One | First Studio  | 2024-01-01 10:00:00 |
+      | 22222222-2222-4222-8222-222222222222 | Studio Two | Second Studio | 2024-01-02 10:00:00 |
+
+  Scenario: Admin can access studios overview
+    Given I log in as "Edmin" with the password "123456"
+    And I am on "/admin/studio/list"
+    And I wait for the page to be loaded
+    Then I should see "Studio One"
+    And I should see "Studio Two"
+
+  Scenario: Admin can open studio delete action
+    Given I log in as "Edmin" with the password "123456"
+    And I am on "/admin/studio/11111111-1111-4111-8111-111111111111/delete"
+    And I wait for the page to be loaded
+    Then I should see "Delete"
+    And I should see "Studio One"
+
+  Scenario: Dashboard shows studios stats tile
+    Given I log in as "Edmin" with the password "123456"
+    And I am on "/admin/dashboard"
+    And I wait for the page to be loaded
+    Then I should see "All studios"


### PR DESCRIPTION
## Summary
- add a new Sonata StudioAdmin overview (`/admin/studio/list`) with list, filters, show and delete actions
- register the studios admin block in DI/services and expose it in admin navigation groups
- add a dashboard stats card for studio count (`All studios`) similar to users/projects
- add admin Behat coverage for studio overview, delete action entrypoint, and dashboard tile visibility

## Verification
- `bin/phpstan analyse` ✅
- `bin/psalm --no-cache --show-info=false` ✅
- `bin/behat -s web-admin tests/BehatFeatures/web/admin/studios_overview.feature` ⚠️ fails locally in this environment because admin login session setup falls back to login page / JWT test auth key config mismatch (`JWTEncodeFailureException` in `var/log/test/test-2026-04-12.log`)
