### PR TITLE
Fix #6627: unify profile/project image upload UX

### DIFF
--- a/assets/Components/ImageUploadHelper.js
+++ b/assets/Components/ImageUploadHelper.js
@@ -1,0 +1,37 @@
+import {
+  compressImageIfNeeded,
+  exceedsMaxSize,
+  isAllowedImageType,
+} from '../Studio/ImageCompressor'
+
+export const ImageUploadError = {
+  invalidType: 'invalid-type',
+  tooLarge: 'too-large',
+  processingFailed: 'processing-failed',
+}
+
+export async function prepareImageFileForUpload(file) {
+  if (!file || !isAllowedImageType(file)) {
+    return { ok: false, error: ImageUploadError.invalidType }
+  }
+
+  try {
+    const result = await compressImageIfNeeded(file)
+    if (exceedsMaxSize(result.file)) {
+      return { ok: false, error: ImageUploadError.tooLarge }
+    }
+
+    return { ok: true, file: result.file, wasCompressed: result.wasCompressed }
+  } catch {
+    return { ok: false, error: ImageUploadError.processingFailed }
+  }
+}
+
+export function readFileAsDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new window.FileReader()
+    reader.onerror = () => reject(new Error('Failed to read image file'))
+    reader.onload = (event) => resolve(event.currentTarget.result)
+    reader.readAsDataURL(file)
+  })
+}

--- a/assets/Project/ProjectPage.js
+++ b/assets/Project/ProjectPage.js
@@ -16,11 +16,11 @@ import { ProjectEditorNavigation } from './ProjectEditorNavigation'
 import { ProjectEditor } from './ProjectEditor'
 import { ProjectEditorTextField } from './ProjectEditorTextField'
 import { ProjectName } from './ProjectName'
-import ProjectApi from '../Api/ProjectApi'
 import { ProjectEditorTextFieldModel } from './ProjectEditorTextFieldModel'
 import { ProjectEditorModel } from './ProjectEditorModel'
-import MessageDialogs from '../Components/MessageDialogs'
 import { escapeAttr, escapeHtml } from '../Components/HtmlEscape'
+import { showSnackbar, SnackbarDuration } from '../Layout/Snackbar'
+import { prepareImageFileForUpload, readFileAsDataUrl } from '../Components/ImageUploadHelper'
 import './RemixGraphInline'
 
 require('./ProjectPage.scss')
@@ -658,38 +658,60 @@ function initComponents(data, earlyInits) {
 
 function initProjectScreenshotUpload() {
   const addChangeListenerToFileInput = function (input) {
-    input.onchange = () => {
-      document.getElementById('upload-image-spinner').classList.remove('d-none')
+    input.onchange = async () => {
+      const spinner = document.getElementById('upload-image-spinner')
+      spinner.classList.remove('d-none')
 
-      const reader = new window.FileReader()
-      reader.onerror = () => {
-        document.getElementById('upload-image-spinner').classList.add('d-none')
-        MessageDialogs.showErrorMessage(projectConfiguration.messages.screenshotInvalid)
+      const file = input.files?.[0]
+      const processed = await prepareImageFileForUpload(file)
+      if (!processed.ok) {
+        spinner.classList.add('d-none')
+        showSnackbar(
+          '#share-snackbar',
+          projectConfiguration.messages.screenshotInvalid,
+          SnackbarDuration.error,
+        )
+        return
       }
-      reader.onload = (event) => {
-        const image = event.currentTarget.result // base64 data url
-        const projectApi = new ProjectApi()
-        projectApi.updateProject(
-          projectElement.dataset.projectId,
-          { screenshot: image },
-          function () {
-            const imageElement = document.getElementById('project-thumbnail-big')
-            if (imageElement.src.includes('?')) {
-              imageElement.src += '&x=' + new Date().getTime()
-            } else {
-              imageElement.src += '?x=' + new Date().getTime()
-            }
-            document.querySelector('.text-img-upload-success').classList.remove('d-none')
-            setTimeout(function () {
-              document.querySelector('.text-img-upload-success').classList.add('d-none')
-            }, 3000)
-          },
-          function () {
-            document.getElementById('upload-image-spinner').classList.add('d-none')
+
+      try {
+        const image = await readFileAsDataUrl(processed.file)
+        const response = await window.fetch(
+          `${baseUrl}/api/projects/${encodeURIComponent(projectElement.dataset.projectId)}`,
+          {
+            method: 'PATCH',
+            credentials: 'same-origin',
+            headers: { 'Content-type': 'application/json' },
+            body: JSON.stringify({ screenshot: image }),
           },
         )
+
+        if (response.status !== 204) {
+          showSnackbar(
+            '#share-snackbar',
+            projectConfiguration.messages.screenshotInvalid,
+            SnackbarDuration.error,
+          )
+          return
+        }
+
+        const imageElement = document.getElementById('project-thumbnail-big')
+        if (imageElement) {
+          const cacheBuster = 'x=' + new Date().getTime()
+          const hasQuery = imageElement.src.includes('?')
+          imageElement.src = `${imageElement.src}${hasQuery ? '&' : '?'}${cacheBuster}`
+        }
+
+        showSnackbar('#share-snackbar', projectConfiguration.messages.imageUploadSuccess)
+      } catch {
+        showSnackbar(
+          '#share-snackbar',
+          projectConfiguration.messages.screenshotInvalid,
+          SnackbarDuration.error,
+        )
+      } finally {
+        spinner.classList.add('d-none')
       }
-      reader.readAsDataURL(input.files[0])
     }
   }
   const changeButton = document.getElementById('change-project-thumbnail-button')

--- a/assets/User/MyProfilePage.js
+++ b/assets/User/MyProfilePage.js
@@ -10,20 +10,19 @@ import { PasswordVisibilityToggle } from '../Components/PasswordVisibilityToggle
 import Swal from 'sweetalert2'
 import MessageDialogs from '../Components/MessageDialogs'
 import { ApiDeleteFetch, ApiFetch, ApiPatchFetch } from '../Api/ApiHelper'
+import { showSnackbar, SnackbarDuration } from '../Layout/Snackbar'
 import VerifyAccountHandler from './VerifyAccountHandler'
 import { escapeHtml } from '../Components/HtmlEscape'
 import { achievementBadgeHtml } from './AchievementBadge'
 import { ProjectList } from '../Project/ProjectList'
+import { prepareImageFileForUpload, readFileAsDataUrl } from '../Components/ImageUploadHelper'
 
 require('./Profile.scss')
 require('./Achievements.scss')
 require('../Project/ProjectsBrowse.scss')
 
 document.addEventListener('DOMContentLoaded', () => {
-  if (
-    window.location.search.includes('profileChangeSuccess') ||
-    window.location.search.includes('profilePictureChangeSuccess')
-  ) {
+  if (window.location.search.includes('profileChangeSuccess')) {
     window.history.replaceState(
       undefined,
       document.title,
@@ -78,6 +77,17 @@ class OwnProfile {
     this.initDeleteAccount()
   }
 
+  async updateProfilePicture(pictureDataUrl) {
+    const response = await window.fetch(this.baseUrl + '/api/users/me', {
+      method: 'PATCH',
+      credentials: 'same-origin',
+      headers: { 'Content-type': 'application/json' },
+      body: JSON.stringify({ picture: pictureDataUrl }),
+    })
+
+    return response.status === 204
+  }
+
   updateProfile(data, successCallback, finalCallback) {
     new ApiPatchFetch(
       this.baseUrl + '/api/users/me',
@@ -117,7 +127,7 @@ class OwnProfile {
 
   addProfilePictureChangeListenerToInput(input) {
     const self = this
-    input.addEventListener('change', () => {
+    input.addEventListener('change', async () => {
       let loadingSpinner
       if (this.avatarElement) {
         const loadingSpinnerTemplate = document.getElementById(
@@ -128,8 +138,8 @@ class OwnProfile {
           loadingSpinnerTemplate.children[0].className,
         )[0]
       }
-      const reader = new window.FileReader()
-      reader.onerror = () => {
+
+      const removeLoadingSpinner = () => {
         if (
           loadingSpinner &&
           self.avatarElement &&
@@ -138,28 +148,45 @@ class OwnProfile {
           this.avatarElement.removeChild(loadingSpinner)
           loadingSpinner = null
         }
-        MessageDialogs.showErrorMessage(myProfileConfiguration.messages.profilePictureInvalid)
       }
-      reader.onload = (event) => {
-        const image = event.currentTarget.result // base64 data url
-        self.updateProfile(
-          { picture: image },
-          function () {
-            window.location.search = 'profilePictureChangeSuccess'
-          },
-          function () {
-            if (
-              loadingSpinner &&
-              self.avatarElement &&
-              loadingSpinner.parentElement === self.avatarElement
-            ) {
-              self.avatarElement.removeChild(loadingSpinner)
-              loadingSpinner = null
-            }
-          },
+
+      const processed = await prepareImageFileForUpload(input.files?.[0])
+      if (!processed.ok) {
+        removeLoadingSpinner()
+        showSnackbar(
+          '#share-snackbar',
+          myProfileConfiguration.messages.profilePictureInvalid,
+          SnackbarDuration.error,
         )
+        return
       }
-      reader.readAsDataURL(input.files[0])
+
+      try {
+        const image = await readFileAsDataUrl(processed.file)
+        const wasSuccessful = await self.updateProfilePicture(image)
+        if (!wasSuccessful) {
+          showSnackbar(
+            '#share-snackbar',
+            myProfileConfiguration.messages.profilePictureInvalid,
+            SnackbarDuration.error,
+          )
+          return
+        }
+
+        const avatarImage = self.avatarElement?.querySelector('.profile__basic-info__avatar__img')
+        if (avatarImage) {
+          avatarImage.src = image
+        }
+        showSnackbar('#share-snackbar', myProfileConfiguration.messages.imageUploadSuccess)
+      } catch {
+        showSnackbar(
+          '#share-snackbar',
+          myProfileConfiguration.messages.profilePictureInvalid,
+          SnackbarDuration.error,
+        )
+      } finally {
+        removeLoadingSpinner()
+      }
     })
   }
 

--- a/templates/Project/ProjectPage.html.twig
+++ b/templates/Project/ProjectPage.html.twig
@@ -74,9 +74,6 @@
           <i class="material-icons text-start d-none" id="upload-image-spinner">
             {{ include('Components/LoadingSpinner.html.twig', {spinner_id: 'upload-image-pb', size: 'small'}, false) }}</i>
         </div>
-        <div class="d-none mt-2 error-message text-img-upload-success alert alert-success">
-          {{ 'success.imgUpload'|trans({}, 'catroweb') }}
-        </div>
       {% endif %}
     </div>
 
@@ -423,6 +420,7 @@
       forbidden: '{{ 'api.updateProject.forbidden'|trans({}, 'catroweb') }}',
       notFound: '{{ 'api.updateProject.notFound'|trans({}, 'catroweb') }}',
       screenshotInvalid: '{{ 'api.project.screenshotInvalid'|trans({}, 'catroweb') }}',
+      imageUploadSuccess: '{{ 'success.imgUpload'|trans({}, 'catroweb')|escape('js')|raw }}',
     }
   }
 </script>

--- a/templates/User/Profile/MyProfilePage.html.twig
+++ b/templates/User/Profile/MyProfilePage.html.twig
@@ -14,11 +14,6 @@
       {{ 'myprofile.profileChangeSuccess'|trans({}, 'catroweb') }}
     </div>
   {% endif %}
-  {% if queryParams.profilePictureChangeSuccess is defined %}
-    <div id="alert-profile-picture-change-success" class="alert alert-success">
-      {{ 'success.imgUpload'|trans({}, 'catroweb') }}
-    </div>
-  {% endif %}
   {% if app.user.profileHidden %}
     <div class="alert alert-danger d-flex align-items-center mb-3" role="alert">
       <i class="material-icons me-2">block</i>
@@ -303,6 +298,7 @@
         passwordsDontMatch: '{{ 'passwordsNoMatch'|trans({}, 'catroweb')|escape('js')|raw }}'
       },
       profilePictureInvalid: '{{ 'api.registerUser.pictureInvalid'|trans({}, 'catroweb')|escape('js')|raw }}',
+      imageUploadSuccess: '{{ 'success.imgUpload'|trans({}, 'catroweb')|escape('js')|raw }}',
       passwordChangedSuccessText:  '{{ 'myprofile.passwordUpdated'|trans({}, 'catroweb')|escape('js')|raw }}'
     }
   }

--- a/tests/BehatFeatures/web/achievements/achievement__perfect_profile.feature
+++ b/tests/BehatFeatures/web/achievements/achievement__perfect_profile.feature
@@ -14,8 +14,8 @@ Feature: Every user that changed his profile picture must have the perfect_profi
     And I wait for AJAX to finish
     Then I should see "Profile"
     When I attach the avatar "logo.png" to "own-profile-picture-upload-field"
-    And I wait for the page to be loaded
-    And I wait for the element "#alert-profile-picture-change-success" to be visible
+    And I wait for AJAX to finish
+    And I wait for the element "#share-snackbar-label" to contain "Your image was uploaded successfully!"
     When I am on "/app/achievements"
     And I wait for the page to be loaded
     Then the "#unlocked-achievements" element should contain "Initiative"
@@ -29,8 +29,8 @@ Feature: Every user that changed his profile picture must have the perfect_profi
     And I wait for AJAX to finish
     Then I should see "Profile"
     When I attach the avatar "logo.png" to "own-profile-picture-upload-field"
-    And I wait for the page to be loaded
-    And I wait for the element "#alert-profile-picture-change-success" to be visible
+    And I wait for AJAX to finish
+    And I wait for the element "#share-snackbar-label" to contain "Your image was uploaded successfully!"
     And I am on "/app/achievements"
     And I wait for the page to be loaded
     Then the "#unlocked-achievements" element should not contain "Initiative"

--- a/tests/BehatFeatures/web/profile/profile_image.feature
+++ b/tests/BehatFeatures/web/profile/profile_image.feature
@@ -15,14 +15,12 @@ Feature:
 
   Scenario: uploading avatar should work
     When I attach the avatar "logo.png" to "own-profile-picture-upload-field"
-    And I wait for the page to be loaded
-    And I wait for the element "#alert-profile-picture-change-success" to be visible
-    And I wait for the element "#alert-profile-picture-change-success" to contain "Your image was uploaded successfully!"
+    And I wait for AJAX to finish
+    And I wait for the element "#share-snackbar-label" to contain "Your image was uploaded successfully!"
     Then the avatar img tag should not have the "default" data url
 
   Scenario: upload corrupt image as profile picture
     When I attach the avatar "corrupt.jpg" to "own-profile-picture-upload-field"
-    And I wait for the page to be loaded
-    Then I wait for the element ".swal2-modal" to be visible
-    And I wait for the element ".swal2-html-container" to contain "Profile picture invalid or not supported"
+    And I wait for AJAX to finish
+    Then I wait for the element "#share-snackbar-label" to contain "Profile picture invalid or not supported"
     Then the avatar img tag should have the "default" data url

--- a/tests/BehatFeatures/web/project-details/project_image.feature
+++ b/tests/BehatFeatures/web/project-details/project_image.feature
@@ -47,13 +47,10 @@ Feature:
     And I wait for the element "#name" to contain "project 1"
     Then I should see "project 1"
     And I wait for the element "#change-project-thumbnail-button" to be visible
+    But the element ".text-img-upload-success" should not exist
     When I attach the avatar "logo.png" to "project-screenshot-upload-field"
-    And I wait for AJAX to finish
-    And I wait for the element ".text-img-upload-success" to be visible
-    Then I wait for the element ".text-img-upload-success" to contain "Your image was uploaded successfully!"
-    And I wait 3100 milliseconds
-    Then the element ".text-img-upload-success" should not be visible
+    Then I wait for the element "#upload-image-spinner" to appear and if so to disappear again
+    And I wait for the element "#share-snackbar-label" to contain "Your image was uploaded successfully!"
     When I attach the avatar "galaxy.jpg" to "project-screenshot-upload-field"
-    And I wait for AJAX to finish
-    And I wait for the element ".text-img-upload-success" to be visible
-    Then I wait for the element ".text-img-upload-success" to contain "Your image was uploaded successfully!"
+    Then I wait for the element "#upload-image-spinner" to appear and if so to disappear again
+    And I wait for the element "#share-snackbar-label" to contain "Your image was uploaded successfully!"


### PR DESCRIPTION
## Summary
- add shared client-side image preprocessing helper (type validation + resize/compression + max-size guard)
- use the shared upload preprocessing for both project screenshot upload and profile avatar upload
- remove inline success alert on the project page and stop profile page reload/query-parameter success flow
- keep image updates layout-stable by updating existing image elements in place
- switch upload feedback to snackbar (success and error) for both flows
- adapt Behat web scenarios that previously asserted inline/swal success paths

## Validation
- yarn run test-js
- yarn run test-asset
- yarn run test-twig
- bin/phpstan analyze
- attempted: bin/behat tests/BehatFeatures/web/project-details/project_image.feature tests/BehatFeatures/web/profile/profile_image.feature tests/BehatFeatures/web/achievements/achievement__perfect_profile.feature (hangs locally right after "No code coverage driver available"; no scenario output)

Closes #6627