### PR TITLE
Add report action for studio comments (#6629)

### DIFF
--- a/assets/controllers/studio/comment_controller.js
+++ b/assets/controllers/studio/comment_controller.js
@@ -88,6 +88,26 @@ export default class extends Controller {
     const rawDate = comment.created_at || comment.timestamp
     const dateStr = rawDate ? new Date(rawDate).toLocaleString('en-GB') : ''
 
+    const isOwnComment = this.isLoggedInValue && comment.username === this.userNameValue
+    const isDeleted = comment.is_deleted
+    const userApproved = comment.user_approved
+    const showReport =
+      (this.userRoleValue === 'admin' || !this.isLoggedInValue || !isOwnComment) &&
+      !isDeleted &&
+      !userApproved &&
+      !this.isMinorValue
+
+    const reportBtn = showReport
+      ? `<a id="comment-report-button-${escapeAttr(String(comment.id))}"
+            class="comment-report-button"
+            data-action="click->studio--comment#reportComment"
+            data-comment-id="${escapeAttr(String(comment.id))}"
+            data-bs-toggle="tooltip"
+            title="${escapeAttr(this.element.dataset.transReport || 'Report')}">
+          <i class="material-icons">report</i>
+        </a>`
+      : ''
+
     const deleteBtn = canDelete
       ? `<a class="comment-delete-button"
             data-action="click->studio--comment#confirmDeleteComment"
@@ -129,6 +149,7 @@ export default class extends Controller {
           </div>
           <div class="comment-actions d-flex align-items-center gap-2">
             ${replyInfo}
+            ${reportBtn}
             ${deleteBtn}
           </div>
         </div>
@@ -230,6 +251,50 @@ export default class extends Controller {
         SnackbarDuration.error,
       )
     }
+  }
+
+  reportComment(event) {
+    const commentId =
+      event.currentTarget.dataset.commentId ||
+      event.target.closest('[data-comment-id]')?.dataset.commentId
+
+    if (!commentId) {
+      return
+    }
+
+    const apiUrl = `/api/comments/${encodeURIComponent(commentId)}/report`
+
+    import('../../Moderation/ReportDialog').then(({ showReportDialog }) =>
+      showReportDialog({
+        contentType: 'comment',
+        contentId: commentId,
+        apiUrl,
+        loginUrl: this.element.dataset.pathLoginUrl || '/app/login',
+        isLoggedIn: this.isLoggedInValue,
+        translations: {
+          title: this.element.dataset.transReportTitle || 'Report',
+          submit: this.element.dataset.transReportSubmit || 'Submit Report',
+          cancel: this.element.dataset.transReportCancel || 'Cancel',
+          success: this.element.dataset.transReportSuccess || 'Your report has been submitted.',
+          error:
+            this.element.dataset.transReportError || 'Oops, that did not work. Please try again!',
+          duplicate:
+            this.element.dataset.transReportDuplicate || "You've already reported this content.",
+          trustTooLow:
+            this.element.dataset.transReportTrustTooLow ||
+            'Your account is too new to file reports.',
+          unverified: this.element.dataset.transReportUnverified || 'Email verification required.',
+          suspended:
+            this.element.dataset.transReportSuspended || 'Your account has been suspended.',
+          rateLimited:
+            this.element.dataset.transReportRateLimited ||
+            "You're submitting reports too quickly. Please wait and try again.",
+          notePlaceholder:
+            this.element.dataset.transReportPlaceholder ||
+            'Please describe why you are reporting this...',
+        },
+      }),
+    )
   }
 
   async confirmDeleteComment(event) {

--- a/assets/controllers/studio/comment_controller.js
+++ b/assets/controllers/studio/comment_controller.js
@@ -89,13 +89,8 @@ export default class extends Controller {
     const dateStr = rawDate ? new Date(rawDate).toLocaleString('en-GB') : ''
 
     const isOwnComment = this.isLoggedInValue && comment.username === this.userNameValue
-    const isDeleted = comment.is_deleted
-    const userApproved = comment.user_approved
     const showReport =
-      (this.userRoleValue === 'admin' || !this.isLoggedInValue || !isOwnComment) &&
-      !isDeleted &&
-      !userApproved &&
-      !this.isMinorValue
+      !isOwnComment && !comment.is_deleted && !comment.user_approved && !this.isMinorValue
 
     const reportBtn = showReport
       ? `<a id="comment-report-button-${escapeAttr(String(comment.id))}"

--- a/src/Api/OpenAPI/Server/Model/StudioCommentResponse.php
+++ b/src/Api/OpenAPI/Server/Model/StudioCommentResponse.php
@@ -107,6 +107,17 @@ class StudioCommentResponse
   protected ?int $reply_count = null;
 
   /**
+   * Whether the comment author is an approved (whitelisted) user.
+   *
+   * @SerializedName("user_approved")
+   *
+   * @Assert\Type("bool")
+   *
+   * @Type("bool")
+   */
+  protected ?bool $user_approved = null;
+
+  /**
    * @SerializedName("created_at")
    *
    * @Assert\Type("\DateTime"))
@@ -130,6 +141,7 @@ class StudioCommentResponse
       $this->user_avatar = array_key_exists('user_avatar', $data) ? $data['user_avatar'] : $this->user_avatar;
       $this->parent_id = array_key_exists('parent_id', $data) ? $data['parent_id'] : $this->parent_id;
       $this->reply_count = array_key_exists('reply_count', $data) ? $data['reply_count'] : $this->reply_count;
+      $this->user_approved = array_key_exists('user_approved', $data) ? $data['user_approved'] : $this->user_approved;
       $this->created_at = array_key_exists('created_at', $data) ? $data['created_at'] : $this->created_at;
     }
   }
@@ -272,6 +284,28 @@ class StudioCommentResponse
   public function setReplyCount(?int $reply_count = null): self
   {
     $this->reply_count = $reply_count;
+
+    return $this;
+  }
+
+  /**
+   * Gets user_approved.
+   */
+  public function getUserApproved(): ?bool
+  {
+    return $this->user_approved;
+  }
+
+  /**
+   * Sets user_approved.
+   *
+   * @param bool|null $user_approved Whether the comment author is an approved (whitelisted) user
+   *
+   * @return $this
+   */
+  public function setUserApproved(?bool $user_approved = null): self
+  {
+    $this->user_approved = $user_approved;
 
     return $this;
   }

--- a/src/Api/OpenAPI/specification.yaml
+++ b/src/Api/OpenAPI/specification.yaml
@@ -4837,6 +4837,9 @@ components:
           nullable: true
         reply_count:
           type: integer
+        user_approved:
+          type: boolean
+          description: 'Whether the comment author is an approved (whitelisted) user'
         created_at:
           type: string
           format: date-time

--- a/src/Api/Services/Studio/StudioResponseManager.php
+++ b/src/Api/Services/Studio/StudioResponseManager.php
@@ -226,6 +226,7 @@ class StudioResponseManager extends AbstractResponseManager
       ->setUserAvatar($user?->getAvatar())
       ->setParentId($comment->getParentId())
       ->setReplyCount($this->studio_manager->countCommentReplies($comment->getId() ?? ''))
+      ->setUserApproved($user?->isApproved() ?? false)
       ->setCreatedAt($comment->getUploadDate())
     ;
   }

--- a/src/System/Testing/Behat/Context/DataFixturesContext.php
+++ b/src/System/Testing/Behat/Context/DataFixturesContext.php
@@ -1378,10 +1378,6 @@ class DataFixturesContext implements Context
     \assert(null !== $studioManager);
 
     foreach ($table->getHash() as $config) {
-      if (array_key_exists('id', $config)) {
-        MyUuidGenerator::setNextValue($config['id']);
-      }
-
       if (array_key_exists('studio_name', $config)) {
         $studio = $studioManager->findStudioByName($config['studio_name']);
       } else {
@@ -1390,8 +1386,21 @@ class DataFixturesContext implements Context
       /** @var User|null $user */
       $user = $this->getUserManager()->findUserByUsername($config['user']);
 
-      $studio_comment = $studioManager->addCommentToStudio($user, $studio, $config['comment']);
-      $this->getManager()->persist($studio_comment);
+      if (array_key_exists('id', $config)) {
+        // Create comment directly to ensure the forced ID is applied to the comment
+        // (addCommentToStudio creates an activity first, which would consume the UUID)
+        MyUuidGenerator::setNextValue($config['id']);
+        $comment = new UserComment();
+        $comment->setStudio($studio);
+        $comment->setText($config['comment']);
+        $comment->setUser($user);
+        $comment->setUploadDate(new \DateTime());
+        $comment->setUsername($user->getUsername());
+        $this->getManager()->persist($comment);
+      } else {
+        $studio_comment = $studioManager->addCommentToStudio($user, $studio, $config['comment']);
+        $this->getManager()->persist($studio_comment);
+      }
     }
 
     $this->getManager()->flush();

--- a/src/System/Testing/Behat/Context/DataFixturesContext.php
+++ b/src/System/Testing/Behat/Context/DataFixturesContext.php
@@ -1389,6 +1389,7 @@ class DataFixturesContext implements Context
       if (array_key_exists('id', $config)) {
         // Create comment directly to ensure the forced ID is applied to the comment
         // (addCommentToStudio creates an activity first, which would consume the UUID)
+        \assert(null !== $user);
         MyUuidGenerator::setNextValue($config['id']);
         $comment = new UserComment();
         $comment->setStudio($studio);

--- a/src/System/Testing/Behat/Context/DataFixturesContext.php
+++ b/src/System/Testing/Behat/Context/DataFixturesContext.php
@@ -1389,14 +1389,16 @@ class DataFixturesContext implements Context
       if (array_key_exists('id', $config)) {
         // Create comment directly to ensure the forced ID is applied to the comment
         // (addCommentToStudio creates an activity first, which would consume the UUID)
-        \assert(null !== $user);
+        if (!$user instanceof User) {
+          throw new \RuntimeException('User not found: '.$config['user']);
+        }
         MyUuidGenerator::setNextValue($config['id']);
         $comment = new UserComment();
         $comment->setStudio($studio);
         $comment->setText($config['comment']);
         $comment->setUser($user);
         $comment->setUploadDate(new \DateTime());
-        $comment->setUsername($user->getUsername());
+        $comment->setUsername($user->getUsername() ?? $config['user']);
         $this->getManager()->persist($comment);
       } else {
         $studio_comment = $studioManager->addCommentToStudio($user, $studio, $config['comment']);

--- a/templates/Studio/Details/CommentList.html.twig
+++ b/templates/Studio/Details/CommentList.html.twig
@@ -21,7 +21,7 @@
      data-trans-replies="{{ 'studio.details.comments.replies'|trans({}, 'catroweb')|default('replies') }}"
      data-trans-deleted-comment="{{ 'project.deletedComment'|trans({}, 'catroweb')|default('Deleted') }}"
      data-trans-report="{{ 'project.report'|trans({}, 'catroweb')|default('Report') }}"
-     data-trans-report-title="{{ 'moderation.report.title'|trans({}, 'catroweb')|default('Report') }}"
+     data-trans-report-title="{{ 'moderation.report.title'|trans({'%content_type%': 'comment'}, 'catroweb') }}"
      data-trans-report-submit="{{ 'moderation.report.submit'|trans({}, 'catroweb')|default('Submit Report') }}"
      data-trans-report-cancel="{{ 'cancel'|trans({}, 'catroweb')|default('Cancel') }}"
      data-trans-report-success="{{ 'moderation.report.success'|trans({}, 'catroweb')|default('Your report has been submitted.') }}"

--- a/templates/Studio/Details/CommentList.html.twig
+++ b/templates/Studio/Details/CommentList.html.twig
@@ -20,6 +20,19 @@
      data-trans-rate-limited="{{ 'moderation.studio.rate_limited'|trans({}, 'catroweb')|default('You are posting comments too quickly.') }}"
      data-trans-replies="{{ 'studio.details.comments.replies'|trans({}, 'catroweb')|default('replies') }}"
      data-trans-deleted-comment="{{ 'project.deletedComment'|trans({}, 'catroweb')|default('Deleted') }}"
+     data-trans-report="{{ 'project.report'|trans({}, 'catroweb')|default('Report') }}"
+     data-trans-report-title="{{ 'moderation.report.title'|trans({}, 'catroweb')|default('Report') }}"
+     data-trans-report-submit="{{ 'moderation.report.submit'|trans({}, 'catroweb')|default('Submit Report') }}"
+     data-trans-report-cancel="{{ 'cancel'|trans({}, 'catroweb')|default('Cancel') }}"
+     data-trans-report-success="{{ 'moderation.report.success'|trans({}, 'catroweb')|default('Your report has been submitted.') }}"
+     data-trans-report-error="{{ 'moderation.report.error'|trans({}, 'catroweb')|default('Oops, that did not work. Please try again!') }}"
+     data-trans-report-duplicate="{{ 'moderation.report.duplicate'|trans({}, 'catroweb')|default('You have already reported this content.') }}"
+     data-trans-report-trust-too-low="{{ 'moderation.report.trust_too_low'|trans({}, 'catroweb')|default('Your account is too new to file reports.') }}"
+     data-trans-report-unverified="{{ 'moderation.report.unverified'|trans({}, 'catroweb')|default('Email verification required.') }}"
+     data-trans-report-suspended="{{ 'moderation.report.suspended'|trans({}, 'catroweb')|default('Your account has been suspended.') }}"
+     data-trans-report-rate-limited="{{ 'moderation.report.rate_limited'|trans({}, 'catroweb')|default('You are submitting reports too quickly.') }}"
+     data-trans-report-placeholder="{{ 'moderation.report.placeholder'|trans({}, 'catroweb')|default('Please describe why you are reporting this...') }}"
+     data-path-login-url="{{ path('login', {theme: 'pocketcode'}) }}"
 >
   <div id="studio-comments" class="mt-3">
 

--- a/tests/BehatFeatures/api/studio/POST_studio_comment_report/report_studio_comment.feature
+++ b/tests/BehatFeatures/api/studio/POST_studio_comment_report/report_studio_comment.feature
@@ -1,0 +1,92 @@
+@api @studio
+Feature: Report a studio comment
+
+  Background:
+    Given there are users:
+      | id | name     | verified |
+      | 1  | Admin    | true     |
+      | 2  | Member   | true     |
+      | 3  | Reporter | true     |
+      | 4  | NewUser  | false    |
+    And the users are created at:
+      | name     | created_at          |
+      | Admin    | 2024-01-01 12:00:00 |
+      | Member   | 2024-01-01 12:00:00 |
+      | Reporter | 2024-01-01 12:00:00 |
+    And there are studios:
+      | id | name    | description | is_public |
+      | 1  | Studio1 | Test studio | true      |
+    And there are studio users:
+      | id | user     | studio_name | role   |
+      | 1  | Admin    | Studio1     | admin  |
+      | 2  | Member   | Studio1     | member |
+      | 3  | Reporter | Studio1     | member |
+    And there are studio comments:
+      | id                                   | user   | studio_name | comment            |
+      | 00000000-0000-0000-0000-000000000050 | Member | Studio1     | Inappropriate text |
+      | 00000000-0000-0000-0000-000000000051 | Admin  | Studio1     | Admin comment      |
+
+  Scenario: Report a studio comment (authenticated)
+    Given I use a valid JWT Bearer token for "Reporter"
+    And I have a request header "CONTENT_TYPE" with value "application/json"
+    And I have the following JSON request body:
+      """
+      {"category": "inappropriate"}
+      """
+    When I request "POST" "/api/comments/00000000-0000-0000-0000-000000000050/report"
+    Then the response status code should be "204"
+
+  Scenario: Report a studio comment requires authentication
+    When I request "POST" "/api/comments/00000000-0000-0000-0000-000000000050/report"
+    Then the response status code should be "401"
+
+  Scenario: Report own studio comment returns 403
+    Given I use a valid JWT Bearer token for "Member"
+    And I have a request header "CONTENT_TYPE" with value "application/json"
+    And I have the following JSON request body:
+      """
+      {"category": "inappropriate"}
+      """
+    When I request "POST" "/api/comments/00000000-0000-0000-0000-000000000050/report"
+    Then the response status code should be "403"
+
+  Scenario: Duplicate report on studio comment returns 409
+    Given I use a valid JWT Bearer token for "Reporter"
+    And I have a request header "CONTENT_TYPE" with value "application/json"
+    And I have the following JSON request body:
+      """
+      {"category": "inappropriate"}
+      """
+    When I request "POST" "/api/comments/00000000-0000-0000-0000-000000000050/report"
+    Then the response status code should be "204"
+    Given I have the following JSON request body:
+      """
+      {"category": "spam"}
+      """
+    When I request "POST" "/api/comments/00000000-0000-0000-0000-000000000050/report"
+    Then the response status code should be "409"
+
+  Scenario: Report studio comment with unverified email returns 403
+    Given I use a valid JWT Bearer token for "NewUser"
+    And I have a request header "CONTENT_TYPE" with value "application/json"
+    And I have the following JSON request body:
+      """
+      {"category": "inappropriate"}
+      """
+    When I request "POST" "/api/comments/00000000-0000-0000-0000-000000000050/report"
+    Then the response status code should be "403"
+
+  Scenario: Report non-existent studio comment returns 404
+    Given I use a valid JWT Bearer token for "Reporter"
+    And I have a request header "CONTENT_TYPE" with value "application/json"
+    And I have the following JSON request body:
+      """
+      {"category": "inappropriate"}
+      """
+    When I request "POST" "/api/comments/00000000-0000-0000-0000-000000009999/report"
+    Then the response status code should be "404"
+
+  Scenario: Studio comment response includes user_approved field
+    When I GET "/api/studios/1/comments"
+    Then the response status code should be "200"
+    And the client response should contain "user_approved"


### PR DESCRIPTION
## Summary
- Adds a report button to studio comments, matching project comment behaviour (fixes #6629)
- Reuses the existing `ReportDialog` and `POST /api/comments/{id}/report` endpoint — no new report endpoint needed since studio comments share the `UserComment` entity with project comments
- Keeps visibility rules consistent with project comments: hidden on own/deleted comments, for minors, and for approved (whitelisted) authors
- Lazy-loads `ReportDialog` to avoid bundling SweetAlert2 on the studio details page

## Changes
- **API**: Added `user_approved` to `StudioCommentResponse` so the frontend can hide the report button on whitelisted authors
- **Frontend**: Studio comment Stimulus controller now renders a report button and invokes `ReportDialog` via dynamic import
- **Template**: Added `data-trans-report-*` translation attributes on `CommentList.html.twig`
- **Test infra**: Fixed `there are studio comments` Behat fixture so forced UUIDs land on the comment rather than being consumed by the `StudioActivity` that `addCommentToStudio` creates first
- **Tests**: New `api-studio` Behat coverage for reporting (auth / own comment / duplicate / unverified / 404 / `user_approved` field)

## Test plan
- [x] `bin/behat -s api-studio tests/BehatFeatures/api/studio/POST_studio_comment_report/` — 7/7 scenarios pass
- [x] `bin/behat -s api-studio tests/BehatFeatures/api/studio/GET_studio_id_comments/` — 8/8 still pass
- [x] `bin/behat -s api-studio tests/BehatFeatures/api/studio/POST_studio_id_comments/` — 8/8 still pass
- [x] `yarn run test-js`, `yarn run test-asset`
- [x] `bin/php-cs-fixer`, `bin/phpstan`, `bin/psalm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)