### PR TITLE
ci: restore deploy task logs for deployment debugging

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -43,10 +43,14 @@ jobs:
         uses: ./.github/actions/setup-php-composer
 
       - name: Deploy Share
-        uses: deployphp/action@v1
+        # Pin to a commit that still streams full dep output in Actions logs.
+        # Newer deployphp/action@v1 revisions swallow task-level output and only
+        # print "Failed: dep deploy", which blocks root-cause debugging.
+        uses: deployphp/action@5d9b48b8ce6a81cfff681cbc330eb7944f102093
         with:
           private-key: ${{ secrets.DEPLOY_SHARE_SSH_KEY }}
           dep: deploy
+          verbosity: -vvv
         env:
           APP_NAME: Catroweb
           DEPLOY_GIT: https://github.com/Catrobat/Catroweb.git


### PR DESCRIPTION
## Summary
- pin `deployphp/action` to a commit that still streams Deployer task output in Actions logs
- set deploy verbosity to `-vvv` in the deployment workflow

## Why
Recent deployment failures only show `Failed: dep deploy` without task-level output, which blocks root-cause analysis. This restores actionable logs for the next run.

## Scope
- `.github/workflows/deployment.yaml` only
