### PR TITLE
fix: avoid featured banner 404s when image file is missing

### DIFF
--- a/src/Admin/FeaturedBannerAdmin.php
+++ b/src/Admin/FeaturedBannerAdmin.php
@@ -57,6 +57,10 @@ class FeaturedBannerAdmin extends AbstractAdmin
       return '/images/default/screenshot.png';
     }
 
+    if (!$this->featured_image_repository->exists($id, $image_type, true)) {
+      return '/images/default/screenshot.png';
+    }
+
     return '/'.$this->featured_image_repository->getWebPath($id, $image_type, true);
   }
 

--- a/src/Api/Services/Utility/UtilityResponseManager.php
+++ b/src/Api/Services/Utility/UtilityResponseManager.php
@@ -48,7 +48,11 @@ class UtilityResponseManager extends AbstractResponseManager
   {
     $image_type = $banner->getImageType();
     $id = $banner->getId();
-    if ('' !== $image_type && null !== $id) {
+    if (
+      '' !== $image_type
+      && null !== $id
+      && $this->image_repository->exists($id, $image_type, true)
+    ) {
       return '/'.$this->image_repository->getWebPath($id, $image_type, true);
     }
 

--- a/src/Storage/ImageRepository.php
+++ b/src/Storage/ImageRepository.php
@@ -107,6 +107,13 @@ class ImageRepository
     return $this->urlHelper->getAbsoluteUrl('/').$this->getWebPath($id, $extension, $featured);
   }
 
+  public function exists(int|string $id, string $extension, bool $featured): bool
+  {
+    $dir = $featured ? $this->featured_dir : $this->example_dir;
+
+    return is_file($dir.$this->generateFileNameFromId($id, $extension, $featured));
+  }
+
   public function getImagick(): \Imagick
   {
     if (null == $this->imagick) {


### PR DESCRIPTION
## Root cause
Featured banner image URLs are generated from `featured_<banner-id>.<ext>`. After the UUID migration, banner IDs changed, but existing files still use old names, so API returns URLs that 404.

## Fix
- add `ImageRepository::exists(...)`
- in `UtilityResponseManager`, only return the banner file URL if the file exists
- otherwise fall back to existing type-based/default image resolution
- in Sonata admin preview, also fall back to default image when file is missing

## Result
Index/API no longer serves broken featured image URLs for missing files.

## Validation
- `php -l src/Storage/ImageRepository.php`
- `php -l src/Api/Services/Utility/UtilityResponseManager.php`
- `php -l src/Admin/FeaturedBannerAdmin.php`
