### PR TITLE
fix(studios): stop emitting Location header on 200 responses (live bug)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -181,6 +181,12 @@ Always use `--using-cache=no` on generated OpenAPI files. CI runs without cache 
 # Then rebuild Docker container if using Docker
 ```
 
+### Never set `Location` on a 2xx non-201 response
+
+PHP's CGI/FastCGI SAPI rewrites `200 OK + Location: ...` into `302 Found`, even though the framework set status 200. This silently breaks client-side `fetch()` that tries `response.json()` after following the redirect to an HTML page. Symfony's PHP built-in server (cli-server SAPI) doesn't do this rewrite, so dev works while prod is broken.
+
+Use `Content-Location` for descriptive metadata on 2xx non-201 responses. Keep `Location` only on `201 Created`.
+
 ### PHP-CS-Fixer: Multiple Files
 
 Run on each file separately: `bin/php-cs-fixer fix file1 && bin/php-cs-fixer fix file2`

--- a/src/Api/Services/Studio/StudioResponseManager.php
+++ b/src/Api/Services/Studio/StudioResponseManager.php
@@ -323,9 +323,23 @@ class StudioResponseManager extends AbstractResponseManager
     ;
   }
 
-  public function addStudioLocationToHeaders(array &$responseHeaders, Studio $studio): void
+  /**
+   * For 201 Created responses. Emits a `Location` header per HTTP semantics.
+   */
+  public function addStudioCreatedLocationToHeaders(array &$responseHeaders, Studio $studio): void
   {
     $responseHeaders['Location'] = $this->createStudioLocation($studio);
+  }
+
+  /**
+   * For 200 OK responses. Emits `Content-Location` (descriptive metadata)
+   * instead of `Location` — PHP's CGI/FastCGI SAPI rewrites a response with
+   * `200 + Location` into `302 Found`, which breaks client-side fetches that
+   * then follow the redirect to an HTML page and fail JSON parsing.
+   */
+  public function addStudioContentLocationToHeaders(array &$responseHeaders, Studio $studio): void
+  {
+    $responseHeaders['Content-Location'] = $this->createStudioLocation($studio);
   }
 
   protected function createStudioLocation(Studio $studio): string

--- a/src/Api/StudiosApi.php
+++ b/src/Api/StudiosApi.php
@@ -74,7 +74,7 @@ class StudiosApi extends AbstractApiController implements StudiosApiInterface
     $response = $this->facade->getResponseManager()->createStudioResponseWithUserContext($studio, $user);
     $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
     $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
-    $this->facade->getResponseManager()->addStudioLocationToHeaders($responseHeaders, $studio);
+    $this->facade->getResponseManager()->addStudioContentLocationToHeaders($responseHeaders, $studio);
 
     return $response;
   }
@@ -124,7 +124,7 @@ class StudiosApi extends AbstractApiController implements StudiosApiInterface
     $response = $this->facade->getResponseManager()->createStudioResponse($studio);
     $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
     $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
-    $this->facade->getResponseManager()->addStudioLocationToHeaders($responseHeaders, $studio);
+    $this->facade->getResponseManager()->addStudioCreatedLocationToHeaders($responseHeaders, $studio);
 
     return $response;
   }
@@ -176,7 +176,7 @@ class StudiosApi extends AbstractApiController implements StudiosApiInterface
     $response = $this->facade->getResponseManager()->createStudioResponse($studio);
     $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
     $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
-    $this->facade->getResponseManager()->addStudioLocationToHeaders($responseHeaders, $studio);
+    $this->facade->getResponseManager()->addStudioContentLocationToHeaders($responseHeaders, $studio);
 
     return $response;
   }


### PR DESCRIPTION
## Summary

Studio detail pages on **prod** show no member count, no activity count, and no join/leave button. Dev works fine. Reported live bug.

**Root cause:** `StudioResponseManager::addStudioLocationToHeaders()` adds a `Location` header to 2xx responses. PHP's CGI/FastCGI SAPI (used by php-fpm on prod) rewrites `200 OK + Location: ...` into `302 Found`, even though the controller sets status 200. Symfony's PHP built-in server (cli-server SAPI, used in dev) doesn't do this rewrite — hence dev looks fine.

`StudioDetailPage.js` fetches `/api/studios/{id}`, follows the 302 to `/app/studio/{id}` (an HTML page), `await response.json()` throws, the outer `catch` clears the skeletons without rendering anything — exactly the reported symptom.

Verified on prod:
```
$ curl -sD- https://share.catrob.at/api/studios/c662cd63-...
HTTP/2 302
location: https://share.catrob.at/app/studio/c662cd63-...
x-openapi-message: OK          ← controller set 200, SAPI rewrote to 302
```

Affected call sites:
- `StudiosApi::studiosIdGet` (200) — **broken**
- `StudiosApi::studiosIdPatch` (200, admin settings save) — **broken**
- `StudiosApi::studiosPost` (201) — fine (201 + Location is valid HTTP, no SAPI rewrite)

## Fix

Split `addStudioLocationToHeaders` into two helpers:

- `addStudioCreatedLocationToHeaders` → emits `Location` (for 201)
- `addStudioContentLocationToHeaders` → emits `Content-Location` (for 200)

`Content-Location` conveys the same "this is where the resource lives" metadata without triggering any SAPI redirect behavior.

Added a short gotcha note in `.claude/CLAUDE.md` so this doesn't get reintroduced elsewhere.

## Test plan
- [ ] Deploy to prod and reload a public studio page → header shows member/activity counts and join button
- [ ] Logged-in member → leave button appears; logged-in non-member → join button
- [ ] Admin saves studio settings via PATCH → save succeeds (response is 200, not 302)
- [ ] CI: `api-studio` Behat suite + PHPUnit
- [ ] CI: php-cs-fixer / phpstan / psalm

🤖 Generated with [Claude Code](https://claude.com/claude-code)