### PR TITLE
Fix studio detail top-bar title double escaping

### DIFF
--- a/templates/Layout/Header.html.twig
+++ b/templates/Layout/Header.html.twig
@@ -30,7 +30,7 @@
             {% else %}
             <span id="top-app-bar__title"
                class="mdc-top-app-bar__title">
-              {{ top_bar_page_title }}
+              {{ top_bar_page_title|raw }}
             </span>
             {% endif %}
 


### PR DESCRIPTION
## Summary
- fix double-escaped top-bar page titles by rendering the provided `top_bar_page_title` block value as already-escaped output
- resolves studio detail titles showing HTML entities like `&#039;` instead of apostrophes

## Testing
- php bin/console lint:twig templates/Layout/Header.html.twig
