### PR TITLE
perf: SSR first banner, lazy controllers, drop core-js, hash CSS

### DIFF
--- a/assets/Index/FeaturedBanner.js
+++ b/assets/Index/FeaturedBanner.js
@@ -140,9 +140,8 @@ export class FeaturedBanner {
   }
 
   removeSkeleton() {
-    const skeleton = this.container.querySelector('.featured-slider__skeleton')
-    if (skeleton) {
-      skeleton.remove()
-    }
+    this.container
+      .querySelectorAll('.featured-slider__skeleton, .featured-slider__ssr')
+      .forEach((el) => el.remove())
   }
 }

--- a/assets/controllers/project/browse_controller.js
+++ b/assets/controllers/project/browse_controller.js
@@ -6,6 +6,7 @@ import { getImageUrl } from '../../Layout/ImageVariants'
 import AcceptLanguage from '../../Api/AcceptLanguage'
 import '../../Components/RetentionTooltip'
 
+/* stimulusFetch: 'lazy' */
 export default class extends Controller {
   static values = {
     apiBaseUrl: String,

--- a/assets/controllers/security/parent-portal_controller.js
+++ b/assets/controllers/security/parent-portal_controller.js
@@ -3,6 +3,7 @@ import { showValidationMessage } from '../../Components/TextField'
 import { AjaxController } from '../ajax_controller'
 import { initCaptchaWidget } from '../../Security/CaptchaWidget'
 
+/* stimulusFetch: 'lazy' */
 export default class extends AjaxController {
   static values = {
     sendLinkPath: String,

--- a/assets/controllers/security/registration_controller.js
+++ b/assets/controllers/security/registration_controller.js
@@ -5,6 +5,7 @@ import { AjaxController } from '../ajax_controller'
 import { LoginTokenHandler } from '../../Security/LoginTokenHandler'
 import { initCaptchaWidget } from '../../Security/CaptchaWidget'
 
+/* stimulusFetch: 'lazy' */
 export default class extends AjaxController {
   static values = {
     baseUrl: String,

--- a/assets/controllers/security/reset-password_controller.js
+++ b/assets/controllers/security/reset-password_controller.js
@@ -4,6 +4,7 @@ import { showValidationMessage } from '../../Components/TextField'
 import { AjaxController } from '../ajax_controller'
 import { initCaptchaWidget } from '../../Security/CaptchaWidget'
 
+/* stimulusFetch: 'lazy' */
 export default class extends AjaxController {
   static values = {
     apiPath: String,

--- a/assets/controllers/studio/activity-list_controller.js
+++ b/assets/controllers/studio/activity-list_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import { escapeHtml } from '../../Components/HtmlEscape'
 
+/* stimulusFetch: 'lazy' */
 export default class extends Controller {
   static values = {
     activitiesUrl: String,

--- a/assets/controllers/studio/comment_controller.js
+++ b/assets/controllers/studio/comment_controller.js
@@ -4,6 +4,7 @@ import { getImageUrl } from '../../Layout/ImageVariants'
 import { showSnackbar, SnackbarDuration } from '../../Layout/Snackbar'
 import Swal from 'sweetalert2'
 
+/* stimulusFetch: 'lazy' */
 export default class extends Controller {
   static values = {
     studioId: String,

--- a/assets/controllers/studio/join-requests_controller.js
+++ b/assets/controllers/studio/join-requests_controller.js
@@ -3,6 +3,7 @@ import { showSnackbar, SnackbarDuration } from '../../Layout/Snackbar'
 import { escapeHtml, escapeAttr } from '../../Components/HtmlEscape'
 import { getImageUrl } from '../../Layout/ImageVariants'
 
+/* stimulusFetch: 'lazy' */
 export default class extends Controller {
   static values = {
     joinRequestsUrl: String,

--- a/assets/controllers/studio/member-list_controller.js
+++ b/assets/controllers/studio/member-list_controller.js
@@ -5,6 +5,7 @@ import { getImageUrl } from '../../Layout/ImageVariants'
 import { MDCMenu } from '@material/menu'
 import Swal from 'sweetalert2'
 
+/* stimulusFetch: 'lazy' */
 export default class extends Controller {
   static values = {
     membersUrl: String,

--- a/assets/controllers/studio/overview_controller.js
+++ b/assets/controllers/studio/overview_controller.js
@@ -5,6 +5,7 @@ import { getImageUrl } from '../../Layout/ImageVariants'
 import { showSnackbar, SnackbarDuration } from '../../Layout/Snackbar'
 import AcceptLanguage from '../../Api/AcceptLanguage'
 
+/* stimulusFetch: 'lazy' */
 export default class extends Controller {
   static values = {
     apiBaseUrl: String,

--- a/assets/controllers/studio/project-list_controller.js
+++ b/assets/controllers/studio/project-list_controller.js
@@ -5,6 +5,7 @@ import { shareOrCopy } from '../../Components/ClipboardHelper'
 import { getImageUrl } from '../../Layout/ImageVariants'
 import Swal from 'sweetalert2'
 
+/* stimulusFetch: 'lazy' */
 export default class extends Controller {
   static values = {
     studioId: String,

--- a/assets/controllers/user/own-project-list_controller.js
+++ b/assets/controllers/user/own-project-list_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import { OwnProjectList } from '../../Project/OwnProjectList'
 
+/* stimulusFetch: 'lazy' */
 export default class extends Controller {
   connect() {
     const baseUrl = this.element.dataset.baseUrl

--- a/babel.config.js
+++ b/babel.config.js
@@ -3,12 +3,9 @@ module.exports = {
     [
       '@babel/preset-env',
       {
-        useBuiltIns: 'usage', // Only includes the polyfills you need based on the usage
-        corejs: 3, // Use core-js version 3 for polyfilling
+        useBuiltIns: false,
       },
     ],
   ],
-  plugins: [
-    '@babel/plugin-proposal-class-properties', // Add the class properties plugin
-  ],
+  plugins: ['@babel/plugin-proposal-class-properties'],
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "auto-changelog": "^2.5.0",
     "autoprefixer": "^10.5.0",
     "browserslist": "^4.28.2",
-    "core-js": "^3.49.0",
     "dotenv": "^17.4.2",
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",

--- a/src/Application/Controller/Base/IndexController.php
+++ b/src/Application/Controller/Base/IndexController.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Application\Controller\Base;
 
+use App\Api\Services\Utility\UtilityResponseManager;
 use App\DB\Entity\System\MaintenanceInformation;
 use App\DB\Entity\User\User;
+use App\DB\EntityRepository\FeaturedBannerRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -19,6 +21,8 @@ class IndexController extends AbstractController
   public function __construct(
     private readonly EntityManagerInterface $entityManager,
     private readonly TranslatorInterface $translator,
+    private readonly FeaturedBannerRepository $featuredBannerRepository,
+    private readonly UtilityResponseManager $utilityResponseManager,
   ) {
   }
 
@@ -28,9 +32,31 @@ class IndexController extends AbstractController
     /** @var User|null $user */
     $user = $this->getUser();
 
+    $first_banner = $this->getFirstBannerData();
+
     return $this->render('Index/IndexPage.html.twig', [
       'is_first_oauth_login' => null !== $user && $user->isOauthUser() && !$user->isOauthPasswordCreated(),
+      'first_banner' => $first_banner,
     ]);
+  }
+
+  /**
+   * @return array{image_url: string, link_url: string|null, title: string}|null
+   */
+  private function getFirstBannerData(): ?array
+  {
+    $banners = $this->featuredBannerRepository->findActiveBannersKeyset(1);
+    if ([] === $banners) {
+      return null;
+    }
+
+    $response = $this->utilityResponseManager->createFeaturedBannerResponse($banners[0]);
+
+    return [
+      'image_url' => $response->getImageUrl() ?? '/images/default/screenshot-card@1x.webp',
+      'link_url' => $response->getLinkUrl(),
+      'title' => $response->getTitle() ?? '',
+    ];
   }
 
   #[Route(path: '/maintenance/list', name: 'maintenance_list', methods: ['GET'])]

--- a/templates/Index/IndexPage.html.twig
+++ b/templates/Index/IndexPage.html.twig
@@ -2,6 +2,9 @@
 
 {% block head %}
   {{ encore_entry_link_tags('index_page') }}
+  {% if first_banner is defined and first_banner %}
+    <link rel="preload" as="image" href="{{ first_banner.image_url }}" fetchpriority="high">
+  {% endif %}
 {% endblock %}
 
 {% block body %}
@@ -24,9 +27,31 @@
        data-is-webview="{{ isWebview() ? '1' : '0' }}"
        data-trans-featured="{{ 'project.featured'|trans({}, 'catroweb') }}"
   >
-    <div class="featured-slider__skeleton featured-banner mb-2" style="grid-area: 1/1;">
-      <div style="aspect-ratio: 1024/600; background: light-dark(#f0f0f0, #1a1a2e);"></div>
-    </div>
+    {% if first_banner is defined and first_banner %}
+      <div class="featured-slider__ssr featured-banner mb-2" style="grid-area: 1/1;">
+        {% if first_banner.link_url %}
+          <a href="{{ first_banner.link_url }}">
+            <img src="{{ first_banner.image_url }}"
+                 class="carousel-item__image d-block w-100"
+                 alt="{{ first_banner.title }}"
+                 width="1024" height="600"
+                 fetchpriority="high">
+          </a>
+        {% else %}
+          <div>
+            <img src="{{ first_banner.image_url }}"
+                 class="carousel-item__image d-block w-100"
+                 alt="{{ first_banner.title }}"
+                 width="1024" height="600"
+                 fetchpriority="high">
+          </div>
+        {% endif %}
+      </div>
+    {% else %}
+      <div class="featured-slider__skeleton featured-banner mb-2" style="grid-area: 1/1;">
+        <div style="aspect-ratio: 1024/600; background: light-dark(#f0f0f0, #1a1a2e);"></div>
+      </div>
+    {% endif %}
   </div>
 
   <div id="home-projects">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,9 +20,8 @@ Encore
   // public path used by the web server to access the output path
   .setPublicPath('/build')
 
-  // overwriting the css versioning until the transition to webpack is full done
   .configureFilenames({
-    css: 'css/[name].css', // -[contenthash] to be used once styles are only imported!
+    css: 'css/[name]-[contenthash].css',
     js: 'js/[name]-[chunkhash].js',
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3885,7 +3885,6 @@ __metadata:
     bootstrap: "npm:^5.3.8"
     browserslist: "npm:^4.28.2"
     clipboard: "npm:^2.0.11"
-    core-js: "npm:^3.49.0"
     dotenv: "npm:^17.4.2"
     eslint: "npm:^10.2.0"
     eslint-config-prettier: "npm:^10.1.8"
@@ -4181,13 +4180,6 @@ __metadata:
   dependencies:
     browserslist: "npm:^4.28.1"
   checksum: 10c0/546e64b7ce45f724825bc13c1347f35c0459a6e71c0dcccff3ec21fbff463f5b0b97fc1220e6d90302153863489301793276fe2bf96f46001ff555ead4140308
-  languageName: node
-  linkType: hard
-
-"core-js@npm:^3.49.0":
-  version: 3.49.0
-  resolution: "core-js@npm:3.49.0"
-  checksum: 10c0/2e42edb47eda38fd5368380131623c8aa5d4a6b42164125b17744bdc08fa5ebbbdd06b4b4aa6ca3663470a560b0f2fba48e18f142dfe264b0039df85bc625694
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- **LCP fix**: Server-side render the first featured banner image + `<link rel="preload">` so the browser discovers it without waiting for JS + API. Reuses `UtilityResponseManager` for URL resolution.
- **Lazy Stimulus controllers**: Added `stimulusFetch: 'lazy'` to 11 page-specific controllers (studio/6, browse/1, own-project-list/1, security/3) — they are now code-split and loaded on demand instead of bundled into every page.
- **Remove core-js**: With `browserslist: "> 5%"`, all target browsers natively support the polyfilled APIs. Saves ~13KB.
- **CSS content-hash**: Changed CSS filename pattern from `[name].css` to `[name]-[contenthash].css`, enabling `Cache-Control: immutable`.

## Test plan

- [ ] Homepage loads and shows featured banner immediately (no flash/skeleton)
- [ ] Banner carousel rotates after JS hydration
- [ ] Studio pages still work (lazy-loaded controllers connect properly)
- [ ] Registration, login, password reset pages work (lazy security controllers)
- [ ] Browse projects page works (lazy browse controller)
- [ ] Profile page "my projects" section works (lazy own-project-list controller)
- [ ] `yarn run dev` and `yarn run build` succeed
- [ ] No regressions in existing Behat tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)