### PR TITLE
fix: studios dropdown styles, hide broken OAuth buttons

### DIFF
--- a/assets/Studio/StudiosPage.js
+++ b/assets/Studio/StudiosPage.js
@@ -1,2 +1,3 @@
 // Studios overview page entrypoint — UI logic handled by Stimulus controller (studio--overview)
 require('./Studios.scss')
+require('../Project/ProjectList.scss')

--- a/templates/Security/OauthRegistration.html.twig
+++ b/templates/Security/OauthRegistration.html.twig
@@ -14,11 +14,6 @@
     <a class="btn social-login-btn me-2" id="btn-login-google" href="{{ path('hwi_oauth_service_redirect', {service: 'google'}) }}">
       <img class="social-login-btn__img" alt="Google Login" src="{{ asset('images/social/btn_google_custom.png') }}"/>
     </a>
-    <a class="btn social-login-btn social-login-btn--facebook me-2" id="btn-login-facebook" href="{{ path('hwi_oauth_service_redirect', {service: 'facebook'}) }}">
-      <img class="social-login-btn__img social-login-btn__img--facebook" alt="Facebook Login" src="{{ asset('images/social/fb_logo.svg') }}"/>
-    </a>
-    <a class="btn social-login-btn me-2" id="btn-login-apple" href="{{ path('hwi_oauth_service_redirect', {service: 'apple'}) }}">
-      <img class="social-login-btn__img" alt="Apple Login" src="{{ asset('images/social/apple_logo__black.svg') }}"/>
-    </a>
+    {# Facebook and Apple OAuth disabled — see GitHub issues #6679 and #6680 #}
   </div>
 </div>


### PR DESCRIPTION
## Summary

- Import `ProjectList.scss` in `StudiosPage.js` so the action menu dropdown (Open/Share) on the studios overview page renders with proper styles — border, padding, hover states
- Hide Facebook and Apple OAuth login buttons until fixed (see #6679, #6680)

## Test plan

- [ ] Visit `/app/studios`, click three-dot menu — Open/Share styled correctly
- [ ] Visit `/app/login` — only Google OAuth button visible
- [ ] Projects overview action menus still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)