### PR TITLE
[codex] Fix Crowdin workflow token permissions

### DIFF
--- a/.github/workflows/sync_crowdin.yaml
+++ b/.github/workflows/sync_crowdin.yaml
@@ -15,7 +15,7 @@
 name: Synchronize Crowdin
 
 permissions:
-  contents: read
+  contents: write
 
 #
 # New base strings could be uploaded on the merge of a new feature.


### PR DESCRIPTION
## What changed
- Updated the Crowdin sync workflow permission from `contents: read` to `contents: write` in `.github/workflows/sync_crowdin.yaml`.

## Why
- The scheduled Crowdin job successfully generated translation updates but failed to push branch `l10n_crowdin_action` with `403 Permission denied to github-actions[bot]`.
- Root cause: the workflow-level permission explicitly restricted `GITHUB_TOKEN` to read-only contents.

## Impact
- Allows the Crowdin GitHub Action to push the translation branch and keep the automated translation PR flow working.

## Validation
- Inspected failing job logs from run `24437719473`, job `71395579315`.
- Confirmed failure occurred at git push with HTTP 403.
- Confirmed this PR contains only the permission fix needed for push access.