### PR TITLE
feat: rank media assets by active flavor overlap

### DIFF
--- a/src/Api/MediaLibraryApi.php
+++ b/src/Api/MediaLibraryApi.php
@@ -280,6 +280,7 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
     ?string $search,
     string $sort_by,
     string $sort_order,
+    ?string $flavors,
     int &$responseCode,
     array &$responseHeaders,
   ): ?MediaAssetsListResponse {
@@ -294,6 +295,31 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
     $this->addRateLimitHeaders($responseHeaders, $rate_limit);
 
     $db_file_type = $file_type ? $this->convertToDbFileType($file_type) : null;
+
+    $flavor_list = null !== $flavors && '' !== trim($flavors)
+      ? array_values(array_filter(array_map('trim', explode(',', $flavors))))
+      : [];
+
+    if ([] !== $flavor_list) {
+      $offset = $this->decodeCursorToOffset($cursor);
+      $assets = $this->facade->getLoader()->getAssetsRankedByFlavors(
+        $limit,
+        $offset,
+        $category_id,
+        $db_file_type,
+        $flavor,
+        $search,
+        $sort_by,
+        $sort_order,
+        $flavor_list,
+      );
+      $responseCode = Response::HTTP_OK;
+      $response = $this->facade->getResponseManager()->createAssetsResponse($assets, $limit, $offset);
+      $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
+      $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
+
+      return $response;
+    }
 
     $cursor_data = $this->decodeKeysetCursor($cursor);
     if (null === $cursor_data && null !== $cursor && '' !== $cursor) {

--- a/src/Api/MediaLibraryApi.php
+++ b/src/Api/MediaLibraryApi.php
@@ -313,35 +313,30 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
         $sort_order,
         $flavor_list,
       );
-      $responseCode = Response::HTTP_OK;
       $response = $this->facade->getResponseManager()->createAssetsResponse($assets, $limit, $offset);
-      $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
-      $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
+    } else {
+      $cursor_data = $this->decodeKeysetCursor($cursor);
+      if (null === $cursor_data && null !== $cursor && '' !== $cursor) {
+        $responseCode = Response::HTTP_BAD_REQUEST;
 
-      return $response;
+        return null;
+      }
+
+      $assets = $this->facade->getLoader()->getAssetsPaginatedKeyset(
+        $limit,
+        $category_id,
+        $db_file_type,
+        $flavor,
+        $search,
+        $sort_by,
+        $sort_order,
+        $cursor_data['value'] ?? null,
+        $cursor_data['id'] ?? null
+      );
+      $response = $this->facade->getResponseManager()->createAssetsKeysetResponse($assets, $limit, $sort_by);
     }
-
-    $cursor_data = $this->decodeKeysetCursor($cursor);
-    if (null === $cursor_data && null !== $cursor && '' !== $cursor) {
-      $responseCode = Response::HTTP_BAD_REQUEST;
-
-      return null;
-    }
-
-    $assets = $this->facade->getLoader()->getAssetsPaginatedKeyset(
-      $limit,
-      $category_id,
-      $db_file_type,
-      $flavor,
-      $search,
-      $sort_by,
-      $sort_order,
-      $cursor_data['value'] ?? null,
-      $cursor_data['id'] ?? null
-    );
 
     $responseCode = Response::HTTP_OK;
-    $response = $this->facade->getResponseManager()->createAssetsKeysetResponse($assets, $limit, $sort_by);
     $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
     $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
 

--- a/src/Api/OpenAPI/Server/Api/MediaLibraryApiInterface.php
+++ b/src/Api/OpenAPI/Server/Api/MediaLibraryApiInterface.php
@@ -66,6 +66,7 @@ interface MediaLibraryApiInterface
    * @param string|null $search          Search in name and description (optional)
    * @param string      $sort_by         (optional, default to 'created_at')
    * @param string      $sort_order      (optional, default to 'DESC')
+   * @param string|null $flavors         Comma-separated flavor names to rank results by. Matching assets appear first (ranked by overlap count), then flavorless assets, then non-matching flavored assets. (optional)
    * @param int         &$responseCode   The HTTP Response Code
    * @param array       $responseHeaders Additional HTTP headers to return with the response ()
    */
@@ -79,6 +80,7 @@ interface MediaLibraryApiInterface
     ?string $search,
     string $sort_by,
     string $sort_order,
+    ?string $flavors,
     int &$responseCode,
     array &$responseHeaders,
   ): array|object|null;

--- a/src/Api/OpenAPI/Server/Controller/MediaLibraryController.php
+++ b/src/Api/OpenAPI/Server/Controller/MediaLibraryController.php
@@ -78,6 +78,7 @@ class MediaLibraryController extends Controller
     $search = $request->query->get('search');
     $sort_by = $request->query->get('sort_by', 'created_at');
     $sort_order = $request->query->get('sort_order', 'DESC');
+    $flavors = $request->query->get('flavors');
     $accept_language = $request->headers->get('Accept-Language', 'en');
 
     // Use the default value if no value was provided
@@ -93,6 +94,7 @@ class MediaLibraryController extends Controller
       $search = $this->deserialize($search, 'string', 'string');
       $sort_by = $this->deserialize($sort_by, 'string', 'string');
       $sort_order = $this->deserialize($sort_order, 'string', 'string');
+      $flavors = $this->deserialize($flavors, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -156,6 +158,12 @@ class MediaLibraryController extends Controller
     if ($response instanceof Response) {
       return $response;
     }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
+    $response = $this->validate($flavors, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
 
     try {
       $handler = $this->getApiHandler();
@@ -164,7 +172,7 @@ class MediaLibraryController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->mediaAssetsGet($accept_language, $limit, $cursor, $category_id, $file_type, $flavor, $search, $sort_by, $sort_order, $responseCode, $responseHeaders);
+      $result = $handler->mediaAssetsGet($accept_language, $limit, $cursor, $category_id, $file_type, $flavor, $search, $sort_by, $sort_order, $flavors, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         200 => 'OK',
@@ -394,7 +402,7 @@ class MediaLibraryController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $media_asset_update_request = $this->deserialize($media_asset_update_request, 'OpenAPI\Server\Model\MediaAssetUpdateRequest', $inputFormat);
+      $media_asset_update_request = $this->deserialize($media_asset_update_request, \OpenAPI\Server\Model\MediaAssetUpdateRequest::class, $inputFormat);
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -411,7 +419,7 @@ class MediaLibraryController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type('OpenAPI\Server\Model\MediaAssetUpdateRequest');
+    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\MediaAssetUpdateRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($media_asset_update_request, $asserts);
     if ($response instanceof Response) {
@@ -916,7 +924,7 @@ class MediaLibraryController extends Controller
     try {
       $id = $this->deserialize($id, 'string', 'string');
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $media_category_request = $this->deserialize($media_category_request, 'OpenAPI\Server\Model\MediaCategoryRequest', $inputFormat);
+      $media_category_request = $this->deserialize($media_category_request, \OpenAPI\Server\Model\MediaCategoryRequest::class, $inputFormat);
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -933,7 +941,7 @@ class MediaLibraryController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type('OpenAPI\Server\Model\MediaCategoryRequest');
+    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\MediaCategoryRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($media_category_request, $asserts);
     if ($response instanceof Response) {
@@ -1027,7 +1035,7 @@ class MediaLibraryController extends Controller
     // Deserialize the input values that needs it
     try {
       $inputFormat = $request->getMimeType($request->getContentTypeFormat());
-      $media_category_request = $this->deserialize($media_category_request, 'OpenAPI\Server\Model\MediaCategoryRequest', $inputFormat);
+      $media_category_request = $this->deserialize($media_category_request, \OpenAPI\Server\Model\MediaCategoryRequest::class, $inputFormat);
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
@@ -1036,7 +1044,7 @@ class MediaLibraryController extends Controller
     // Validate the input values
     $asserts = [];
     $asserts[] = new Assert\NotNull();
-    $asserts[] = new Assert\Type('OpenAPI\Server\Model\MediaCategoryRequest');
+    $asserts[] = new Assert\Type(\OpenAPI\Server\Model\MediaCategoryRequest::class);
     $asserts[] = new Assert\Valid();
     $response = $this->validate($media_category_request, $asserts);
     if ($response instanceof Response) {

--- a/src/Api/OpenAPI/specification.yaml
+++ b/src/Api/OpenAPI/specification.yaml
@@ -1943,6 +1943,12 @@ paths:
             type: string
             enum: [ASC, DESC]
             default: DESC
+        - name: flavors
+          in: query
+          required: false
+          schema:
+            type: string
+          description: 'Comma-separated flavor names to rank results by. Matching assets appear first (ranked by overlap count), then flavorless assets, then non-matching flavored assets.'
       responses:
         '200':
           description: 'OK'

--- a/src/Api/Services/MediaLibrary/MediaLibraryApiLoader.php
+++ b/src/Api/Services/MediaLibrary/MediaLibraryApiLoader.php
@@ -13,6 +13,8 @@ use App\DB\EntityRepository\MediaLibrary\MediaCategoryRepository;
 
 class MediaLibraryApiLoader extends AbstractApiLoader
 {
+  private const RANKING_FETCH_LIMIT = 1000;
+
   public function __construct(
     private readonly MediaCategoryRepository $category_repository,
     private readonly MediaAssetRepository $asset_repository,
@@ -165,6 +167,50 @@ class MediaLibraryApiLoader extends AbstractApiLoader
       $flavor,
       $search
     );
+  }
+
+  /**
+   * @param array<string> $flavors
+   *
+   * @return array<MediaAsset>
+   */
+  public function getAssetsRankedByFlavors(
+    int $limit,
+    int $offset,
+    ?string $category_id,
+    ?MediaFileType $file_type,
+    ?string $flavor,
+    ?string $search,
+    string $sort_by,
+    string $sort_order,
+    array $flavors,
+  ): array {
+    $category = $category_id ? $this->category_repository->find($category_id) : null;
+
+    $all = $this->asset_repository->findPaginated(self::RANKING_FETCH_LIMIT, 0, $category, $file_type, $flavor, $search, $sort_by, $sort_order);
+
+    $scoreCache = [];
+    foreach ($all as $asset) {
+      $scoreCache[$asset->getId()] = $this->flavorScore($asset->getFlavorNames(), $flavors);
+    }
+
+    usort($all, static function (MediaAsset $a, MediaAsset $b) use ($scoreCache): int {
+      return $scoreCache[$b->getId()] <=> $scoreCache[$a->getId()];
+    });
+
+    return array_slice($all, $offset, $limit + 1);
+  }
+
+  // overlap_count >= 1 for matches, -1 for neutral (no flavors), -2 for non-matching
+  private function flavorScore(array $assetFlavors, array $activeFlavors): int
+  {
+    if ([] === $assetFlavors) {
+      return -1;
+    }
+
+    $overlap = count(array_intersect($assetFlavors, $activeFlavors));
+
+    return $overlap > 0 ? $overlap : -2;
   }
 
   private function decodeCursorToOffset(?string $cursor): int

--- a/src/System/Testing/Behat/Context/ApiContext.php
+++ b/src/System/Testing/Behat/Context/ApiContext.php
@@ -845,6 +845,21 @@ class ApiContext implements Context
   }
 
   /**
+   * @Then /^the client response should contain "([^"]*)" before "([^"]*)"$/
+   *
+   * @throws \Exception
+   */
+  public function theResponseShouldContainBefore(string $first, string $second): void
+  {
+    $content = $this->getResponseContent();
+    $pos_first = strpos($content, $first);
+    $pos_second = strpos($content, $second);
+    Assert::assertNotFalse($pos_first, sprintf('"%s" not found in response', $first));
+    Assert::assertNotFalse($pos_second, sprintf('"%s" not found in response', $second));
+    Assert::assertLessThan($pos_second, $pos_first, sprintf('Expected "%s" before "%s" in response', $first, $second));
+  }
+
+  /**
    * @When /^I update this project$/
    *
    * @throws \Exception

--- a/tests/BehatFeatures/api/media-library/GET_media_assets.feature
+++ b/tests/BehatFeatures/api/media-library/GET_media_assets.feature
@@ -10,15 +10,20 @@ Feature: Get media assets from the API
       | id | name       |
       | 1  | pocketcode |
       | 2  | luna       |
+      | 3  | embroidery |
+      | 4  | arduino    |
     And there are media categories:
       | id                                   | name                          | priority |
       | 550e8400-e29b-41d4-a716-446655440001 | media_library.category.animals| 10       |
       | 550e8400-e29b-41d4-a716-446655440002 | media_library.category.sounds | 20       |
     And there are media assets:
-      | id                                   | name       | extension | file_type | category                             | flavors    | downloads | author      |
-      | 650e8400-e29b-41d4-a716-446655440001 | Dog Image  | png       | IMAGE     | 550e8400-e29b-41d4-a716-446655440001 | pocketcode | 100       | Bob Schmidt |
-      | 650e8400-e29b-41d4-a716-446655440002 | Cat Image  | png       | IMAGE     | 550e8400-e29b-41d4-a716-446655440001 | luna       | 50        |             |
-      | 650e8400-e29b-41d4-a716-446655440003 | Meow Sound | mp3       | SOUND     | 550e8400-e29b-41d4-a716-446655440002 | pocketcode | 25        |             |
+      | id                                   | name              | extension | file_type | category                             | flavors              | downloads | author      |
+      | 650e8400-e29b-41d4-a716-446655440001 | Dog Image         | png       | IMAGE     | 550e8400-e29b-41d4-a716-446655440001 | pocketcode           | 100       | Bob Schmidt |
+      | 650e8400-e29b-41d4-a716-446655440002 | Cat Image         | png       | IMAGE     | 550e8400-e29b-41d4-a716-446655440001 | luna                 | 50        |             |
+      | 650e8400-e29b-41d4-a716-446655440003 | Meow Sound        | mp3       | SOUND     | 550e8400-e29b-41d4-a716-446655440002 | pocketcode           | 25        |             |
+      | 650e8400-e29b-41d4-a716-446655440004 | Neutral Asset     | png       | IMAGE     | 550e8400-e29b-41d4-a716-446655440001 |                      | 10        |             |
+      | 650e8400-e29b-41d4-a716-446655440005 | Embroidery Only   | png       | IMAGE     | 550e8400-e29b-41d4-a716-446655440001 | embroidery           | 5         |             |
+      | 650e8400-e29b-41d4-a716-446655440006 | Embroidery Arduino| png       | IMAGE     | 550e8400-e29b-41d4-a716-446655440001 | embroidery,arduino   | 3         |             |
 
   Scenario: Get all media assets
     And I have a request header "HTTP_ACCEPT" with value "application/json"
@@ -69,3 +74,38 @@ Feature: Get media assets from the API
     Given I have a request header "HTTP_ACCEPT" with value "invalid"
     And I request "GET" "/api/media/assets"
     Then the response status code should be "406"
+
+  Scenario: Ranking by single active flavor - matching asset appears before neutral and non-matching
+    And I have a request header "HTTP_ACCEPT" with value "application/json"
+    And I request "GET" "/api/media/assets?flavors=embroidery"
+    Then the response status code should be "200"
+    And the client response should contain "Embroidery Only"
+    And the client response should contain "Embroidery Arduino"
+    And the client response should contain "Neutral Asset"
+    And the client response should contain "Dog Image"
+    And the client response should contain "Embroidery Only" before "Neutral Asset"
+    And the client response should contain "Embroidery Arduino" before "Neutral Asset"
+    And the client response should contain "Neutral Asset" before "Dog Image"
+
+  Scenario: Ranking by multiple active flavors - higher overlap ranks first
+    And I have a request header "HTTP_ACCEPT" with value "application/json"
+    And I request "GET" "/api/media/assets?flavors=embroidery,arduino"
+    Then the response status code should be "200"
+    And the client response should contain "Embroidery Arduino" before "Embroidery Only"
+    And the client response should contain "Embroidery Only" before "Neutral Asset"
+    And the client response should contain "Neutral Asset" before "Dog Image"
+
+  Scenario: Ranking combined with category filter
+    And I have a request header "HTTP_ACCEPT" with value "application/json"
+    And I request "GET" "/api/media/assets?flavors=embroidery&category_id=550e8400-e29b-41d4-a716-446655440001"
+    Then the response status code should be "200"
+    And the client response should contain "Embroidery Only"
+    And the client response should not contain "Meow Sound"
+    And the client response should contain "Embroidery Only" before "Neutral Asset"
+
+  Scenario: No active flavors - falls back to default ordering
+    And I have a request header "HTTP_ACCEPT" with value "application/json"
+    And I request "GET" "/api/media/assets?flavors="
+    Then the response status code should be "200"
+    And the client response should contain "Dog Image"
+    And the client response should contain "Cat Image"

--- a/tests/PhpUnit/Api/MediaLibraryApiTest.php
+++ b/tests/PhpUnit/Api/MediaLibraryApiTest.php
@@ -343,15 +343,15 @@ final class MediaLibraryApiTest extends TestCase
     $response_headers = [];
 
     $loader = $this->createStub(MediaLibraryApiLoader::class);
-    $loader->method('getAssetsPaginated')->willReturn([]);
+    $loader->method('getAssetsPaginatedKeyset')->willReturn([]);
     $this->facade->method('getLoader')->willReturn($loader);
 
     $response_manager = $this->createStub(MediaLibraryResponseManager::class);
     $assets_response = $this->createStub(MediaAssetsListResponse::class);
-    $response_manager->method('createAssetsResponse')->willReturn($assets_response);
+    $response_manager->method('createAssetsKeysetResponse')->willReturn($assets_response);
     $this->facade->method('getResponseManager')->willReturn($response_manager);
 
-    $response = $this->api->mediaAssetsGet('en', 20, null, null, null, null, null, 'name', 'asc', $response_code, $response_headers);
+    $response = $this->api->mediaAssetsGet('en', 20, null, null, null, null, null, 'name', 'asc', null, $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_OK, $response_code);
     $this->assertInstanceOf(MediaAssetsListResponse::class, $response);


### PR DESCRIPTION
## Summary

Closes #6695

- Adds `?flavors=embroidery,arduino` query param to `GET /api/media/assets`
- Assets ranked into 3 buckets: **matching** (by overlap count desc) → **neutral** (no flavors) → **non-matching**
- Falls back to existing keyset pagination when `flavors` is omitted or empty
- Flavor names pre-cached before sort to avoid redundant Doctrine collection iteration

## Implementation

- `specification.yaml` — new optional `flavors` string param
- `MediaLibraryApiLoader::getAssetsRankedByFlavors()` — fetch up to `RANKING_FETCH_LIMIT=1000`, score and sort in PHP, return offset-paginated slice
- `MediaLibraryApi::mediaAssetsGet()` — parse comma-separated flavors, route to ranked path when non-empty
- `ApiContext` — new Behat step: `the client response should contain "X" before "Y"`
- `GET_media_assets.feature` — 4 new scenarios covering single match, multi-overlap, combined filter, and empty fallback

## Test plan

- [ ] `docker exec app.catroweb bin/behat -f pretty -s api-media-library` — all scenarios pass
- [ ] `GET /api/media/assets?flavors=embroidery` returns embroidery assets before untagged assets
- [ ] `GET /api/media/assets?flavors=embroidery,arduino` returns 2-overlap asset before 1-overlap asset
- [ ] `GET /api/media/assets` (no param) — unchanged ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)