### PR TITLE
fix: add pull-requests write permission to Crowdin workflow

### DIFF
--- a/.github/workflows/sync_crowdin.yaml
+++ b/.github/workflows/sync_crowdin.yaml
@@ -16,6 +16,7 @@ name: Synchronize Crowdin
 
 permissions:
   contents: write
+  pull-requests: write
 
 #
 # New base strings could be uploaded on the merge of a new feature.


### PR DESCRIPTION
## Summary
- Adds `pull-requests: write` permission to `sync_crowdin.yaml`
- Without it the Crowdin action fails with `403 Resource not accessible by integration` when creating the translations PR

## Test plan
- [ ] Re-run the Crowdin sync workflow and verify it creates/updates the translations PR without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)