### PR TITLE
Restrict machine translation trim action to privileged admins

### DIFF
--- a/src/Admin/Statistics/Translation/Controller/AbstractMachineTranslationAdminController.php
+++ b/src/Admin/Statistics/Translation/Controller/AbstractMachineTranslationAdminController.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * @phpstan-extends CRUDController<ProjectMachineTranslation|CommentMachineTranslation>
@@ -98,7 +99,9 @@ abstract class AbstractMachineTranslationAdminController extends CRUDController
 
   public function trimAction(Request $request): Response
   {
-    $this->admin->checkAccess('list');
+    if (!$this->admin->isGranted('MASTER')) {
+      throw new AccessDeniedException();
+    }
 
     $days = (string) $request->query->get('days');
 

--- a/templates/Admin/Statistics/MachineTranslation.html.twig
+++ b/templates/Admin/Statistics/MachineTranslation.html.twig
@@ -11,19 +11,20 @@
 
         {{ include('@SonataTwig/FlashMessage/render.html.twig') }}
 
-{# TODO wrap in permission #}
-        <form action="{{ trimUrl }}">
-            <h3>Delete old entries based on last modified date</h3><br/>
-            <label for="days">Older than (days):</label>
-            <input type="number" id="days" name="days" value="30" min="1" max="999"><br>
+        {% if admin.isGranted('MASTER') %}
+            <form action="{{ trimUrl }}">
+                <h3>Delete old entries based on last modified date</h3><br/>
+                <label for="days">Older than (days):</label>
+                <input type="number" id="days" name="days" value="30" min="1" max="999"><br>
 
-            <button id="delete-button" class="btn btn-danger">Delete </button>
+                <button id="delete-button" class="btn btn-danger">Delete </button>
 
-            <div id='confirmation' style="display: none">
-                <label>Are you sure? This cannot be undone.</label>
-                <input class="btn btn-danger" type="submit" value="YES">
-            </div>
-        </form>
+                <div id='confirmation' style="display: none">
+                    <label>Are you sure? This cannot be undone.</label>
+                    <input class="btn btn-danger" type="submit" value="YES">
+                </div>
+            </form>
+        {% endif %}
     </div>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- gate the machine translation trim form in Twig behind `admin.isGranted('MASTER')`
- enforce the same permission check server-side in `trimAction`
- remove the unresolved TODO in the template

## Context
Addresses the missing permission-check item raised in #6521.
