### PR TITLE
Fix featured banner pause button toggle behavior

### DIFF
--- a/assets/Index/FeaturedBanner.js
+++ b/assets/Index/FeaturedBanner.js
@@ -137,6 +137,9 @@ export class FeaturedBanner {
     const carouselInstance = new Carousel(carouselDiv, {
       interval: prefersReducedMotion ? false : 5000,
       ride: prefersReducedMotion ? false : 'carousel',
+      // Keep manual pause/play deterministic: Bootstrap's default `pause: 'hover'`
+      // can restart cycling on mouseleave/touchend via `_maybeEnableCycle()`.
+      pause: false,
     })
 
     // Pause/play toggle button for auto-playing carousel (a11y)


### PR DESCRIPTION
## Summary
- disable Bootstrap carousel hover/touch auto-resume for the featured banner
- keep the pause/play button state deterministic so manual pause stays paused
- add inline comment explaining the Bootstrap maybeEnableCycle interaction

## Testing
- yarn run test-js