### PR TITLE
fix: skip redundant version query on hashed assets

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -163,11 +163,7 @@
       <code><![CDATA[$user->getId()]]></code>
     </PossiblyNullArgument>
   </file>
-  <file src="src/Application/Framework/VersionStrategy.php">
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$_ENV['APP_ENV']]]></code>
-    </PossiblyUndefinedArrayOffset>
-  </file>
+
   <file src="src/Application/Twig/TwigExtension.php">
     <PossiblyNullReference>
       <code><![CDATA[get]]></code>

--- a/src/Application/Framework/VersionStrategy.php
+++ b/src/Application/Framework/VersionStrategy.php
@@ -15,31 +15,37 @@ class VersionStrategy implements VersionStrategyInterface
   ) {
   }
 
-  /**
-   * @throws \Exception
-   */
   #[\Override]
   public function getVersion(string $path): string
   {
-    $hash = '';
-    $app_env = $_ENV['APP_ENV'];
-    if ('dev' === $app_env) {
-      $hash = '--'.md5(strval(random_int(0, 999999)));
+    if ($this->hasContentHash($path)) {
+      return '';
     }
 
-    if (preg_match('/\?/', $path)) {
-      return '&v='.$this->app_version.$hash;
+    $suffix = '';
+    if ('dev' === ($_ENV['APP_ENV'] ?? '')) {
+      $suffix = '--'.md5(strval(random_int(0, 999_999)));
     }
 
-    return '?v='.$this->app_version.$hash;
+    $separator = str_contains($path, '?') ? '&' : '?';
+
+    return $separator.'v='.$this->app_version.$suffix;
   }
 
-  /**
-   * @throws \Exception
-   */
   #[\Override]
   public function applyVersion(string $path): string
   {
     return $path.$this->getVersion($path);
+  }
+
+  /**
+   * Webpack Encore outputs filenames with content/chunk hashes (e.g. runtime-537e323c06d3e.js).
+   * Appending ?v=APP_VERSION to these is redundant and causes unnecessary cache busts on deploy.
+   */
+  private function hasContentHash(string $path): bool
+  {
+    $file = basename(parse_url($path, PHP_URL_PATH) ?: $path);
+
+    return (bool) preg_match('/[-\.][0-9a-f]{8,}\./', $file);
   }
 }

--- a/tests/PhpUnit/Application/Framework/VersionStrategyTest.php
+++ b/tests/PhpUnit/Application/Framework/VersionStrategyTest.php
@@ -16,12 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(VersionStrategy::class)]
 class VersionStrategyTest extends TestCase
 {
-  /**
-   * @group unit
-   *
-   * @throws \Exception
-   */
   #[DataProvider('provideVersionData')]
+  #[Group('unit')]
   public function testGetVersion(string $path, string $expected): void
   {
     $version_strategy = new VersionStrategy('1.2.3');
@@ -39,16 +35,41 @@ class VersionStrategyTest extends TestCase
         'path' => '/app?color="blue"',
         'expected' => '&v=1.2.3',
       ],
+      'hashed JS asset skips version' => [
+        'path' => '/build/js/8189-3f826f4c1a2b3d4e.js',
+        'expected' => '',
+      ],
+      'hashed CSS asset skips version' => [
+        'path' => '/build/css/base_layout-0ade1f1b2c3d4e5f.css',
+        'expected' => '',
+      ],
+      'hashed font asset skips version' => [
+        'path' => '/build/fonts/material-icons.0c35d18b.woff2',
+        'expected' => '',
+      ],
+      'non-hashed image keeps version' => [
+        'path' => '/resources/featured/featured_9cce88be.avif',
+        'expected' => '?v=1.2.3',
+      ],
+      'non-hashed SVG keeps version' => [
+        'path' => '/build/social/download-on-app-store.svg',
+        'expected' => '?v=1.2.3',
+      ],
     ];
   }
 
-  /**
-   * @throws \Exception
-   */
   #[Group('unit')]
   public function testApplyVersion(): void
   {
     $version_strategy = new VersionStrategy('1.2.3');
     $this->assertEquals('/app?v=1.2.3', $version_strategy->applyVersion('/app'));
+  }
+
+  #[Group('unit')]
+  public function testApplyVersionSkipsHashedAsset(): void
+  {
+    $version_strategy = new VersionStrategy('1.2.3');
+    $path = '/build/js/runtime-537e323c06d3e83a.js';
+    $this->assertEquals($path, $version_strategy->applyVersion($path));
   }
 }


### PR DESCRIPTION
## Summary
- Webpack Encore already includes content/chunk hashes in filenames (`runtime-537e323c.js`, `base_layout-0ade1f1b.css`)
- `VersionStrategy` was appending `?v=26.4.24` to these — redundant and causes ~369 KiB unnecessary cache busts on every deploy
- Now detects hashed filenames and skips the `?v=` suffix
- Non-hashed assets (SVGs, logos, uploaded images) still get versioned normally
- Uploaded images (`?t=` timestamp from `filemtime()`) are unaffected — they already cache-bust on content change, not deploy

## Test plan
- [ ] `bin/phpunit --filter VersionStrategyTest` — 9 tests pass
- [ ] Verify hashed build assets (`/build/js/*.js`, `/build/css/*.css`) no longer have `?v=` in page source
- [ ] Verify non-hashed assets (`download-on-app-store.svg`, `logo_catrobat_text.svg`) still have `?v=`
- [ ] Lighthouse "Use efficient cache lifetimes" audit improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)