### PR TITLE
fix: add missing category.trending translation

### DIFF
--- a/translations/catroweb.en.yaml
+++ b/translations/catroweb.en.yaml
@@ -1090,6 +1090,7 @@ category:
   scratch: Scratch remixes
   recommended: Recommended projects
   popular: Most popular
+  trending: Trending projects
 
 achievements:
   sidebar:

--- a/translations/catroweb.en_AU.yaml
+++ b/translations/catroweb.en_AU.yaml
@@ -1028,6 +1028,7 @@ category:
   scratch: Scratch remixes
   recommended: Recommended projects
   popular: Most popular
+  trending: Trending projects
 achievements:
   sidebar:
     title: 'Achievements'

--- a/translations/catroweb.en_CA.yaml
+++ b/translations/catroweb.en_CA.yaml
@@ -1028,6 +1028,7 @@ category:
   scratch: Scratch remixes
   recommended: Recommended projects
   popular: Most popular
+  trending: Trending projects
 achievements:
   sidebar:
     title: 'Achievements'

--- a/translations/catroweb.en_GB.yaml
+++ b/translations/catroweb.en_GB.yaml
@@ -1029,6 +1029,7 @@ category:
   scratch: Scratch remixes
   recommended: Recommended projects
   popular: Most popular
+  trending: Trending projects
 achievements:
   sidebar:
     title: 'Achievements'


### PR DESCRIPTION
## Summary
- The `/api/projects/categories` endpoint translates category names using `category.{name}` keys
- `category.trending` was missing from all English translation files, causing the API to return the raw key `"category.trending"` instead of `"Trending projects"`
- Added the missing key to `catroweb.en.yaml`, `catroweb.en_AU.yaml`, `catroweb.en_CA.yaml`, `catroweb.en_GB.yaml`

## Test plan
- [ ] Call `GET /api/projects/categories` with `Accept-Language: en` and verify "trending" category shows "Trending projects" instead of "category.trending"

🤖 Generated with [Claude Code](https://claude.com/claude-code)