### PR TITLE
fix: search bar color mismatch with topbar in dark mode

### DIFF
--- a/assets/Layout/TopBar.scss
+++ b/assets/Layout/TopBar.scss
@@ -50,7 +50,7 @@
     width: 100%;
     height: 100%;
     color: #fff;
-    background-color: color-mix(in srgb, var(--primary), black 26%);
+    background-color: color-mix(in srgb, var(--primary-bg, var(--primary)), black 26%);
     border: none;
     outline: none;
   }


### PR DESCRIPTION
## Summary
- Search input background used `color-mix(var(--primary), black 26%)` — in dark mode `--primary` is `#4dd0e1`, creating a cyan tint that doesn't match the topbar
- Topbar uses `--primary-bg` (`#007f8f`) which stays constant across light/dark mode
- Changed search input to use `--primary-bg` with `--primary` fallback, so it always matches the topbar

## Test plan
- [ ] Toggle dark mode and verify search bar blends with topbar (no color mismatch)
- [ ] Verify light mode still looks correct
- [ ] Check non-default themes (if any override `--primary-bg`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)