### PR TITLE
feat: WebView improvements — safe-area, exit route, studios, downloads

### DIFF
--- a/templates/Index/IndexPage.html.twig
+++ b/templates/Index/IndexPage.html.twig
@@ -78,6 +78,8 @@
     {% if isWebview() %}
       {% set categories = [
         ['trending', 'trending', 'author'],
+        ['random', 'random', 'uploaded'],
+        ['_studios_', null, null],
         ['popular', 'popular', 'author'],
         ['example', 'example', 'author'],
       ] %}


### PR DESCRIPTION
## Summary
- Add safe-area-inset-top padding to topbar so it clears the Android status bar in fullscreen WebViews
- Add `/app/exit` route returning empty 200 — app can intercept this URL to close the WebView
- Update "Back to App" sidebar link to use `/app/exit` route
- Show studios and random projects on WebView homepage (were excluded)
- Remove legacy WebView download workaround (`fname` query param + `window.location`)

## Test plan
- [ ] Open share page in Catroid app → topbar not hidden behind status bar
- [ ] Tap "Back to App" in sidebar → navigates to `/app/exit` (app should intercept)
- [ ] Studios and random projects visible on WebView homepage
- [ ] Project download works in WebView (uses fetch+progress, not window.location)
- [ ] Open share page in regular browser → no visual change

🤖 Generated with [Claude Code](https://claude.com/claude-code)