### PR TITLE
fix: debug project retention display and Content-Disposition for downloads

### DIFF
--- a/config/packages/security.php
+++ b/config/packages/security.php
@@ -292,6 +292,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
           'requires_channel' => '%env(SECURE_SCHEME)%',
         ],
         [
+          'path' => '^/api/media/assets/[a-zA-Z0-9_-]+/download/?$',
+          'roles' => 'PUBLIC_ACCESS',
+          'methods' => ['GET'],
+          'requires_channel' => '%env(SECURE_SCHEME)%',
+        ],
+        [
           'path' => '^/api/health/?$',
           'roles' => 'PUBLIC_ACCESS',
           'methods' => ['GET'],

--- a/config/routes.php
+++ b/config/routes.php
@@ -29,6 +29,12 @@ return static function (RoutingConfigurator $routingConfigurator): void {
     ->requirements(['id' => '^[a-zA-Z0-9\\\-]+$'])
   ;
 
+  $routingConfigurator->add('open_api_server_mediaLibrary_mediaassetsiddownloadget', '/api/media/assets/{id}/download')
+    ->controller([OverwriteController::class, 'mediaAssetsIdDownloadGet'])
+    ->methods(['GET'])
+    ->requirements(['id' => '^[a-zA-Z0-9\\\-]+$'])
+  ;
+
   $routingConfigurator->add('legacy_hour_of_code_route', '/hourOfCode')
     ->controller([RedirectController::class, 'hourOfCode'])
     ->methods(['GET'])

--- a/src/Api/MediaLibraryApi.php
+++ b/src/Api/MediaLibraryApi.php
@@ -20,9 +20,11 @@ use OpenAPI\Server\Model\MediaCategoriesListResponse;
 use OpenAPI\Server\Model\MediaCategoryDetailResponse;
 use OpenAPI\Server\Model\MediaCategoryRequest;
 use OpenAPI\Server\Model\MediaCategoryResponse;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 
 class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiInterface
@@ -420,6 +422,36 @@ class MediaLibraryApi extends AbstractApiController implements MediaLibraryApiIn
     $response = $this->facade->getResponseManager()->createAssetResponse($asset, $user);
     $this->facade->getResponseManager()->addResponseHashToHeaders($responseHeaders, $response);
     $this->facade->getResponseManager()->addContentLanguageToHeaders($responseHeaders);
+
+    return $response;
+  }
+
+  #[\Override]
+  public function mediaAssetsIdDownloadGet(
+    string $id,
+    int &$responseCode,
+    array &$responseHeaders,
+  ): array|object|null {
+    $asset = $this->facade->getLoader()->getAssetById($id);
+    if (!$asset instanceof \App\DB\Entity\MediaLibrary\MediaAsset) {
+      $responseCode = Response::HTTP_NOT_FOUND;
+
+      return null;
+    }
+
+    $file = $this->facade->getResponseManager()->getAssetFile($asset);
+    if (null === $file) {
+      $responseCode = Response::HTTP_NOT_FOUND;
+
+      return null;
+    }
+
+    $this->facade->getProcessor()->incrementDownloads($asset);
+
+    $filename = $asset->getName().'.'.$asset->getExtension();
+    $fallback = $asset->getId().'.'.$asset->getExtension();
+    $response = new BinaryFileResponse($file);
+    $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename, $fallback);
 
     return $response;
   }

--- a/src/Api/OpenAPI/Server/Api/MediaLibraryApiInterface.php
+++ b/src/Api/OpenAPI/Server/Api/MediaLibraryApiInterface.php
@@ -103,6 +103,21 @@ interface MediaLibraryApiInterface
   ): void;
 
   /**
+   * Operation mediaAssetsIdDownloadGet.
+   *
+   * Download a media asset file
+   *
+   * @param string $id              Asset UUID (required)
+   * @param int    &$responseCode   The HTTP Response Code
+   * @param array  $responseHeaders Additional HTTP headers to return with the response ()
+   */
+  public function mediaAssetsIdDownloadGet(
+    string $id,
+    int &$responseCode,
+    array &$responseHeaders,
+  ): array|object|null;
+
+  /**
    * Operation mediaAssetsIdGet.
    *
    * Get details of a specific media asset

--- a/src/Api/OpenAPI/Server/Controller/MediaLibraryController.php
+++ b/src/Api/OpenAPI/Server/Controller/MediaLibraryController.php
@@ -278,6 +278,80 @@ class MediaLibraryController extends Controller
   }
 
   /**
+   * Operation mediaAssetsIdDownloadGet.
+   *
+   * Download a media asset file
+   *
+   * @param Request $request the Symfony request to handle
+   *
+   * @return Response the Symfony response
+   */
+  public function mediaAssetsIdDownloadGetAction(Request $request, $id): Response
+  {
+    // Figure out what data format to return to the client
+    $produces = ['application/octet-stream', 'application/json'];
+    // Figure out what the client accepts
+    $clientAccepts = $request->headers->has('Accept') ? $request->headers->get('Accept') : '*/*';
+    $responseFormat = $this->getOutputFormat($clientAccepts, $produces);
+    if (null === $responseFormat) {
+      return new Response('', 406);
+    }
+
+    // Handle authentication
+
+    // Read out all input parameter values into variables
+
+    // Use the default value if no value was provided
+
+    // Deserialize the input values that needs it
+    try {
+      $id = $this->deserialize($id, 'string', 'string');
+    } catch (SerializerRuntimeException $exception) {
+      return $this->createBadRequestResponse($exception->getMessage());
+    }
+
+    // Validate the input values
+    $asserts = [];
+    $asserts[] = new Assert\NotNull();
+    $asserts[] = new Assert\Type('string');
+    $asserts[] = new Assert\Regex('/^[a-zA-Z0-9\-]+$/');
+    $response = $this->validate($id, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
+
+    try {
+      $handler = $this->getApiHandler();
+
+      // Make the call to the business logic
+      $responseCode = 200;
+      $responseHeaders = [];
+
+      $result = $handler->mediaAssetsIdDownloadGet($id, $responseCode, $responseHeaders);
+
+      $message = match ($responseCode) {
+        200 => 'Media asset file successfully downloaded',
+        404 => 'Not found',
+        default => '',
+      };
+
+      return new Response(
+        null !== $result ? $this->serialize($result, $responseFormat) : '',
+        $responseCode,
+        array_merge(
+          $responseHeaders,
+          [
+            'Content-Type' => $responseFormat,
+            'X-OpenAPI-Message' => $message,
+          ]
+        )
+      );
+    } catch (\Throwable $fallthrough) {
+      return $this->createErrorResponse(new HttpException(500, 'An unsuspected error occurred.', $fallthrough));
+    }
+  }
+
+  /**
    * Operation mediaAssetsIdGet.
    *
    * Get details of a specific media asset

--- a/src/Api/OpenAPI/Server/Resources/config/routing.yaml
+++ b/src/Api/OpenAPI/Server/Resources/config/routing.yaml
@@ -149,6 +149,14 @@ open_api_server_mediaLibrary_mediaassetsiddelete:
   requirements:
     id: '^[a-zA-Z0-9\-]+$'
 
+open_api_server_mediaLibrary_mediaassetsiddownloadget:
+  path: /media/assets/{id}/download
+  methods: [GET]
+  defaults:
+    _controller: open_api_server.controller.mediaLibrary::mediaAssetsIdDownloadGetAction
+  requirements:
+    id: '^[a-zA-Z0-9\-]+$'
+
 open_api_server_mediaLibrary_mediaassetsidget:
   path: /media/assets/{id}
   methods: [GET]

--- a/src/Api/OpenAPI/specification.yaml
+++ b/src/Api/OpenAPI/specification.yaml
@@ -2087,6 +2087,39 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  '/media/assets/{id}/download':
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          pattern: '^[a-zA-Z0-9\-]+$'
+        description: 'Asset UUID'
+
+    get:
+      tags:
+        - 'Media Library'
+      summary: 'Download a media asset file'
+      description: 'Returns the media asset file with a Content-Disposition header containing the human-readable asset name. Increments the download counter.'
+      responses:
+        '200':
+          description: 'Media asset file successfully downloaded'
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+                description: Used only with `application/octet-stream` responses
+                example: attachment; filename="Cat.png"
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   ######################################################
   # Search
   ###

--- a/src/Api/ProjectsApi.php
+++ b/src/Api/ProjectsApi.php
@@ -619,7 +619,7 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
 
       return null;
     }
-    $response = $this->facade->getResponseManager()->createProjectCatrobatFileResponse($project_id, $zipFile);
+    $response = $this->facade->getResponseManager()->createProjectCatrobatFileResponse($project_id, $zipFile, $project->getName());
     $responseCode = Response::HTTP_OK;
 
     $user = $this->facade->getAuthenticationManager()->getAuthenticatedUser();

--- a/src/Api/Services/MediaLibrary/MediaLibraryApiProcessor.php
+++ b/src/Api/Services/MediaLibrary/MediaLibraryApiProcessor.php
@@ -123,6 +123,18 @@ class MediaLibraryApiProcessor extends AbstractApiProcessor
     $this->entity_manager->flush();
   }
 
+  public function incrementDownloads(MediaAsset $asset): void
+  {
+    $this->entity_manager->createQueryBuilder()
+      ->update(MediaAsset::class, 'a')
+      ->set('a.downloads', 'a.downloads + 1')
+      ->where('a.id = :id')
+      ->setParameter('id', $asset->getId())
+      ->getQuery()
+      ->execute()
+    ;
+  }
+
   public function deleteAsset(MediaAsset $asset): void
   {
     $this->asset_repository->removeFile($asset->getId(), $asset->getExtension());

--- a/src/Api/Services/MediaLibrary/MediaLibraryResponseManager.php
+++ b/src/Api/Services/MediaLibrary/MediaLibraryResponseManager.php
@@ -18,7 +18,8 @@ use OpenAPI\Server\Model\MediaCategoriesListResponse;
 use OpenAPI\Server\Model\MediaCategoryDetailResponse;
 use OpenAPI\Server\Model\MediaCategoryResponse;
 use OpenAPI\Server\Service\SerializerInterface;
-use Symfony\Component\HttpFoundation\UrlHelper;
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class MediaLibraryResponseManager extends AbstractResponseManager
@@ -32,8 +33,8 @@ class MediaLibraryResponseManager extends AbstractResponseManager
     \Psr\Cache\CacheItemPoolInterface $cache,
     private readonly MediaLibraryApiLoader $loader,
     private readonly MediaAssetRepository $asset_repository,
-    private readonly ?UrlHelper $url_helper,
     private readonly ImageVariantUrlBuilder $image_variant_url_builder,
+    private readonly UrlGeneratorInterface $url_generator,
   ) {
     parent::__construct($translator, $serializer, $cache);
   }
@@ -223,9 +224,11 @@ class MediaLibraryResponseManager extends AbstractResponseManager
 
   public function createAssetResponse(MediaAsset $asset, ?User $user = null): MediaAssetResponse
   {
-    $base_url = $this->url_helper?->getAbsoluteUrl('/') ?? '';
-    $download_path = $this->asset_repository->getWebPath($asset->getId(), $asset->getExtension());
-    $download_url = $base_url.$download_path;
+    $download_url = $this->url_generator->generate(
+      'open_api_server_mediaLibrary_mediaassetsiddownloadget',
+      ['id' => $asset->getId()],
+      UrlGeneratorInterface::ABSOLUTE_URL
+    );
 
     $thumbnail = null;
     if ($asset->isImage()) {
@@ -265,6 +268,16 @@ class MediaLibraryResponseManager extends AbstractResponseManager
       'created_at' => $asset->getCreatedAt(),
       'updated_at' => $asset->getUpdatedAt(),
     ]);
+  }
+
+  public function getAssetFile(MediaAsset $asset): ?File
+  {
+    $path = $this->asset_repository->getFilePath($asset->getId(), $asset->getExtension());
+    if (!is_file($path)) {
+      return null;
+    }
+
+    return new File($path);
   }
 
   /**

--- a/src/Api/Services/OverwriteController.php
+++ b/src/Api/Services/OverwriteController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Api\Services;
 
+use App\Api\MediaLibraryApi;
 use App\Api\ProjectsApi;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -11,8 +12,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class OverwriteController extends AbstractController
 {
-  public function __construct(protected ProjectsApi $projectsApi)
-  {
+  public function __construct(
+    protected ProjectsApi $projectsApi,
+    protected MediaLibraryApi $mediaLibraryApi,
+  ) {
   }
 
   public function projectsIdCatrobatGet(string $id): ?Response
@@ -20,6 +23,19 @@ class OverwriteController extends AbstractController
     $responseCode = 200;
     $responseHeaders = [];
     $result = $this->projectsApi->customProjectsIdCatrobatGet($id, $responseCode, $responseHeaders);
+
+    if (!$result instanceof BinaryFileResponse) {
+      return new Response(null, $responseCode, $responseHeaders);
+    }
+
+    return $result;
+  }
+
+  public function mediaAssetsIdDownloadGet(string $id): Response
+  {
+    $responseCode = 200;
+    $responseHeaders = [];
+    $result = $this->mediaLibraryApi->mediaAssetsIdDownloadGet($id, $responseCode, $responseHeaders);
 
     if (!$result instanceof BinaryFileResponse) {
       return new Response(null, $responseCode, $responseHeaders);

--- a/src/Api/Services/Projects/ProjectsResponseManager.php
+++ b/src/Api/Services/Projects/ProjectsResponseManager.php
@@ -12,7 +12,6 @@ use App\Api\Traits\KeysetCursorTrait;
 use App\DB\Entity\Project\Extension;
 use App\DB\Entity\Project\Project;
 use App\DB\Entity\Project\ProjectCodeStatistics;
-use App\DB\Entity\Project\Special\ExampleProject;
 use App\DB\Entity\Project\Special\FeaturedProject;
 use App\DB\Entity\Project\Special\SpecialProject;
 use App\DB\Entity\Project\Tag;
@@ -20,7 +19,6 @@ use App\Project\ProjectManager;
 use App\Storage\ImageRepository;
 use App\Storage\StorageLifecycleService;
 use App\Utils\ElapsedTimeStringFormatter;
-use Doctrine\ORM\EntityManagerInterface;
 use OpenAPI\Server\Model\CodeStatisticsResponse;
 use OpenAPI\Server\Model\ErrorResponse;
 use OpenAPI\Server\Model\ExtensionResponse;
@@ -34,6 +32,7 @@ use OpenAPI\Server\Service\SerializerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -51,8 +50,8 @@ class ProjectsResponseManager extends AbstractResponseManager
     SerializerInterface $serializer,
     private readonly ProjectManager $project_manager,
     \Psr\Cache\CacheItemPoolInterface $cache,
-    private readonly EntityManagerInterface $entity_manager,
     private readonly ImageRepository $image_repository,
+    private readonly StorageLifecycleService $storage_lifecycle,
   ) {
     parent::__construct($translator, $serializer, $cache);
   }
@@ -317,54 +316,7 @@ class ProjectsResponseManager extends AbstractResponseManager
 
   private function computeRetentionDays(Project $project): int
   {
-    if ($project->isStorageProtected()) {
-      return StorageLifecycleService::PROTECTED_DAYS;
-    }
-
-    $projectId = $project->getId();
-    if (null !== $projectId) {
-      $featured = (int) $this->entity_manager->createQueryBuilder()
-        ->select('COUNT(f.id)')
-        ->from(FeaturedProject::class, 'f')
-        ->where('f.project = :project')
-        ->setParameter('project', $project)
-        ->getQuery()
-        ->getSingleScalarResult()
-      ;
-      if ($featured > 0) {
-        return StorageLifecycleService::PROTECTED_DAYS;
-      }
-
-      $example = (int) $this->entity_manager->createQueryBuilder()
-        ->select('COUNT(e.id)')
-        ->from(ExampleProject::class, 'e')
-        ->where('e.project = :project')
-        ->setParameter('project', $project)
-        ->getQuery()
-        ->getSingleScalarResult()
-      ;
-      if ($example > 0) {
-        return StorageLifecycleService::PROTECTED_DAYS;
-      }
-    }
-
-    if ($project->getDownloads() >= 10) {
-      return StorageLifecycleService::ACTIVE_DAYS;
-    }
-
-    $user = $project->getUser();
-    if (null !== $user) {
-      $lastLogin = $user->getLastLogin();
-      if (null !== $lastLogin && $lastLogin > new \DateTime('-180 days')) {
-        return StorageLifecycleService::ACTIVE_DAYS;
-      }
-    }
-
-    if ($project->isVisible() && !$project->getAutoHidden() && null !== $user && $user->isVerified()) {
-      return StorageLifecycleService::STANDARD_DAYS;
-    }
-
-    return StorageLifecycleService::SHORT_DAYS;
+    return $this->storage_lifecycle->getRetentionDays($project);
   }
 
   public function createFeaturedProjectResponse(FeaturedProject $featured_project, ?string $attributes = null): FeaturedProjectResponse
@@ -519,13 +471,11 @@ class ProjectsResponseManager extends AbstractResponseManager
     ]);
   }
 
-  public function createProjectCatrobatFileResponse(string $id, File $file): BinaryFileResponse
+  public function createProjectCatrobatFileResponse(string $id, File $file, ?string $name = null): BinaryFileResponse
   {
     $response = new BinaryFileResponse($file);
-    $response->headers->set(
-      'Content-Disposition',
-      'attachment; filename="'.$id.'.catrobat"'
-    );
+    $filename = null !== $name ? $name.'.catrobat' : $id.'.catrobat';
+    $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename, $id.'.catrobat');
     $response->headers->set('Content-Type', 'application/zip');
 
     return $response;


### PR DESCRIPTION
## Summary
- **Bug fix**: Debug projects showed 365-day retention in API responses because `ProjectsResponseManager` duplicated retention logic but missed the `isDebugBuild()` check. Replaced with delegation to `StorageLifecycleService::getRetentionDays()`, eliminating the duplication.
- **New endpoint**: `GET /api/media/assets/{id}/download` — serves media files with `Content-Disposition: attachment; filename="AssetName.ext"` so Catroid downloads get human-readable filenames instead of UUIDs.
- **Project downloads**: `.catrobat` file downloads now include the project name in `Content-Disposition` with ASCII fallback for unicode names.

## Changes
- `ProjectsResponseManager`: removed 50-line duplicated retention logic, delegates to `StorageLifecycleService`; removed unused `EntityManagerInterface` dependency
- `MediaLibraryApi`: new `mediaAssetsIdDownloadGet()` endpoint with `BinaryFileResponse`
- `MediaLibraryResponseManager`: `download_url` now points to API endpoint (uses Symfony router); added `getAssetFile()` helper
- `MediaLibraryApiProcessor`: `incrementDownloads()` uses DQL UPDATE (no flush side effects)
- `OverwriteController`: handles `BinaryFileResponse` for media download (same pattern as project download)
- OpenAPI spec, routing, security config updated for new endpoint

## Test plan
- [ ] Verify debug projects show 7-day retention (not 365) in API responses
- [ ] Download media asset via `/api/media/assets/{id}/download` — check `Content-Disposition` header has asset name
- [ ] Download `.catrobat` project file — check `Content-Disposition` header has project name
- [ ] Verify download counter increments for media assets
- [ ] Test unicode asset/project names produce valid headers with ASCII fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)