### PR TITLE
fix: admin dashboard counts capped at 1000

### DIFF
--- a/config/packages/sonata_admin.php
+++ b/config/packages/sonata_admin.php
@@ -28,6 +28,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
           ],
         ],
         'sonata.block.service.text' => null,
+        'admin.block.service.count' => [
+          'contexts' => [
+            'admin',
+          ],
+        ],
       ],
     ]
   );
@@ -53,7 +58,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
           [
             'class' => 'col-lg-3 col-xs-6',
             'position' => 'bottom',
-            'type' => 'sonata.admin.block.stats',
+            'type' => 'admin.block.service.count',
             'settings' => [
               'code' => 'admin.block.projects.overview',
               'icon' => 'fas fa-cubes',
@@ -64,7 +69,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
           [
             'class' => 'col-lg-3 col-xs-6',
             'position' => 'bottom',
-            'type' => 'sonata.admin.block.stats',
+            'type' => 'admin.block.service.count',
             'settings' => [
               'code' => 'admin.block.users.overview',
               'icon' => 'fas fa-users',
@@ -75,7 +80,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
           [
             'class' => 'col-lg-3 col-xs-6',
             'position' => 'bottom',
-            'type' => 'sonata.admin.block.stats',
+            'type' => 'admin.block.service.count',
             'settings' => [
               'code' => 'admin.block.studios.overview',
               'icon' => 'fas fa-object-group',

--- a/config/services.php
+++ b/config/services.php
@@ -221,6 +221,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
   $services->set(OverwriteController::class);
   $services->alias(SerializerInterface::class, 'open_api_server.service.serializer');
 
+  $services->set('admin.block.service.count', App\Admin\Block\AdminCountBlockService::class)
+    ->tag('sonata.block')
+  ;
+
   // -------------------------------------------------------------------------------------------------------------------
   // Sonata admin service definitions:
   //   - used by config/packages/sonata_admin.php to build the navigation tree

--- a/src/Admin/Block/AdminCountBlockService.php
+++ b/src/Admin/Block/AdminCountBlockService.php
@@ -26,6 +26,7 @@ final class AdminCountBlockService extends AbstractBlockService
     parent::__construct($twig);
   }
 
+  #[\Override]
   public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response
   {
     $admin = $this->pool->getAdminByAdminCode($blockContext->getSetting('code'));
@@ -46,6 +47,7 @@ final class AdminCountBlockService extends AbstractBlockService
     ], $response);
   }
 
+  #[\Override]
   public function configureSettings(OptionsResolver $resolver): void
   {
     $resolver->setDefaults([

--- a/src/Admin/Block/AdminCountBlockService.php
+++ b/src/Admin/Block/AdminCountBlockService.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Admin\Block;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Twig\Environment;
+
+/**
+ * Dashboard stats block that uses a real COUNT(*) query instead of
+ * SimplePager's capped estimate (which tops out at limit+1).
+ */
+final class AdminCountBlockService extends AbstractBlockService
+{
+  public function __construct(
+    Environment $twig,
+    private readonly Pool $pool,
+    private readonly EntityManagerInterface $entity_manager,
+  ) {
+    parent::__construct($twig);
+  }
+
+  public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response
+  {
+    $admin = $this->pool->getAdminByAdminCode($blockContext->getSetting('code'));
+    $class = $admin->getClass();
+
+    $count = (int) $this->entity_manager->createQueryBuilder()
+      ->select('COUNT(e.id)')
+      ->from($class, 'e')
+      ->getQuery()
+      ->getSingleScalarResult()
+    ;
+
+    return $this->renderResponse($blockContext->getTemplate(), [
+      'block' => $blockContext->getBlock(),
+      'settings' => $blockContext->getSettings(),
+      'admin' => $admin,
+      'count' => $count,
+    ], $response);
+  }
+
+  public function configureSettings(OptionsResolver $resolver): void
+  {
+    $resolver->setDefaults([
+      'icon' => 'fas fa-chart-line',
+      'text' => 'Statistics',
+      'translation_domain' => null,
+      'color' => 'bg-aqua',
+      'code' => false,
+      'template' => 'Admin/Block/block_count.html.twig',
+    ]);
+  }
+}

--- a/templates/Admin/Block/block_count.html.twig
+++ b/templates/Admin/Block/block_count.html.twig
@@ -1,0 +1,25 @@
+{% extends sonata_block.templates.block_base %}
+
+{% set translation_domain = settings.translation_domain ?? admin.translationDomain %}
+
+{% block block %}
+    <!-- small box -->
+    <div class="small-box {{ settings.color }}">
+        <div class="inner">
+            <h3>{{ count|number_format }}</h3>
+            <p>
+                {% if translation_domain %}
+                    {{ settings.text|trans({'%count%': count}, translation_domain) }}
+                {% else %}
+                    {{ settings.text }}
+                {% endif %}
+            </p>
+        </div>
+        <div class="icon">
+            {{ settings.icon|parse_icon }}
+        </div>
+        <a href="{{ admin.generateUrl('list') }}" class="small-box-footer">
+            {{ 'stats_view_more'|trans({}, 'SonataAdminBundle') }} <i class="fas fa-arrow-circle-right" aria-hidden="true"></i>
+        </a>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Dashboard stat blocks (projects, users, studios) showed max 1000/1001 because Sonata's `AdminStatsBlockService` uses `SimplePager` which fetches `limit+1` rows to estimate the count (default limit: 1000)
- Created custom `AdminCountBlockService` that runs a real `SELECT COUNT(*)` query via the admin's entity class
- Switched all three dashboard stat blocks to use the new block type

## Changes
- `src/Admin/Block/AdminCountBlockService.php` — custom block service with real COUNT query
- `templates/Admin/Block/block_count.html.twig` — template with `number_format` for readability
- `config/packages/sonata_admin.php` — registered block, switched dashboard blocks to new type
- `config/services.php` — registered block as tagged sonata.block service

## Test plan
- [ ] Visit `/admin/dashboard` — verify project/user/studio counts are accurate (not capped at 1000)
- [ ] Verify "View more" links still navigate to correct admin list pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)