### PR TITLE
fix: profile page horizontal scroll overflow

### DIFF
--- a/assets/Project/ProjectList.scss
+++ b/assets/Project/ProjectList.scss
@@ -172,15 +172,15 @@ $container-padding: 1rem;
 
     // When using action list items, override grid card sizing
     .projects-list-item-wrapper.project-list__project {
-      width: calc(100% + 3rem);
-      margin: 0 -1.5rem !important;
-      margin-bottom: 0 !important;
+      width: 100%;
+      margin: 0 !important;
     }
 
     .projects-container:has(.projects-list-item-wrapper) {
       justify-content: flex-start;
       flex-direction: column;
       padding: 0;
+      margin: 0;
       overflow: visible;
     }
   }

--- a/templates/User/Profile/ProfilePage.html.twig
+++ b/templates/User/Profile/ProfilePage.html.twig
@@ -28,7 +28,7 @@
 {% block body %}
 
   {# Profile header — server renders avatar + username, JS fills verification badge + follow buttons #}
-  <div class="row no-gutters profile">
+  <div class="row g-0 profile">
     {% import 'Components/ResponsiveImage.html.twig' as responsive_image %}
     {% set body_avatar_variants = user_avatar_variants(profile) %}
     <div class="col-4 col-md-2 avatar-container mt-2 pe-3">


### PR DESCRIPTION
## Summary
- Profile pages had ~24px horizontal overflow causing a horizontal scrollbar
- Root cause: `.projects-list-item-wrapper` used a bleed pattern (`width: calc(100% + 3rem)` + `margin: 0 -1.5rem`) to extend past parent padding, but the parent's padding was simultaneously overridden to 0 — so the bleed had nothing to compensate for and overflowed the viewport
- Also fixed BS4 `no-gutters` class (no-op in BS5) to proper BS5 `g-0` on profile header row

## Changes
- `assets/Project/ProjectList.scss`: removed bleed pattern on `.projects-list-item-wrapper` in `project-list--full`, zeroed container margin
- `templates/User/Profile/ProfilePage.html.twig`: `no-gutters` → `g-0`

## Test plan
- [ ] Visit any user profile page — no horizontal scrollbar
- [ ] Check own profile page (MyProfilePage) — no horizontal scrollbar
- [ ] Project list items still render full-width in the tab content
- [ ] Test on mobile viewport widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)