### PR TITLE
fix: webview layout and interaction improvements

### DIFF
--- a/assets/Layout/ColorScheme.js
+++ b/assets/Layout/ColorScheme.js
@@ -5,6 +5,7 @@
  * Adapted by the Catroweb Project
  */
 
+import Swal from 'sweetalert2'
 import { showSnackbar, SnackbarDuration } from './Snackbar'
 import { escapeAttr, escapeHtml } from '../Components/HtmlEscape'
 
@@ -68,7 +69,6 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () 
 })
 
 async function showThemePicker(menuItem) {
-  const { default: Swal } = await import('sweetalert2')
   const themeOptions = [
     {
       value: 'light',

--- a/assets/Layout/TopBar.scss
+++ b/assets/Layout/TopBar.scss
@@ -142,8 +142,9 @@
 
 // In Catroid WebView the page may render behind the Android status bar.
 // Push the topbar down by the safe-area inset and adjust page-content.
+// Use direct child selector so nested .mdc-top-app-bar (e.g. search bar) don't get double padding.
 .is-webview {
-  .mdc-top-app-bar {
+  > .mdc-top-app-bar {
     padding-top: env(safe-area-inset-top);
   }
 

--- a/assets/Project/ProjectList.scss
+++ b/assets/Project/ProjectList.scss
@@ -203,6 +203,17 @@ $container-padding: 1rem;
       height: calc(100vh - 56px);
     }
 
+    // In webview the topbar is taller due to safe-area inset
+    .is-webview & {
+      top: calc(64px + env(safe-area-inset-top));
+      height: calc(100vh - 64px - env(safe-area-inset-top));
+
+      @media (width <= 599px) {
+        top: calc(56px + env(safe-area-inset-top));
+        height: calc(100vh - 56px - env(safe-area-inset-top));
+      }
+    }
+
     .project-list__title {
       padding-bottom: 1rem;
     }

--- a/assets/Project/ProjectPage.scss
+++ b/assets/Project/ProjectPage.scss
@@ -1064,6 +1064,11 @@ input[type='number'] {
   padding: 1rem math.div($grid-gutter-width, 2) 1.5rem;
   overflow-y: auto;
   background: var(--theme-background);
+
+  .is-webview & {
+    top: calc(50px + env(safe-area-inset-top));
+    height: calc(100vh - 50px - env(safe-area-inset-top));
+  }
 }
 
 .translation-list {

--- a/assets/Project/ProjectPage.scss
+++ b/assets/Project/ProjectPage.scss
@@ -325,7 +325,7 @@
       height: $like-detail-triangle-height;
       content: '';
       // stylelint-disable-next-line scss/operator-no-unspaced
-      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 33.17 23.98"><defs><style>.a{fill:white}.b{fill:none;stroke:rgb(178,178,178);stroke-linecap:square;stroke-linejoin:round;stroke-width:2px;}</style></defs><polygon class="a" points="10.19 0 1 22.98 33.17 0 10.19 0"/><polyline class="b" points="9.28 2.27 1 22.98 30 2.27"/></svg>');
+      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 33.17 23.98"><defs>\3c style>.a{fill:white}.b{fill:none;stroke:rgb(178,178,178);stroke-linecap:square;stroke-linejoin:round;stroke-width:2px;}\3c /style></defs><polygon class="a" points="10.19 0 1 22.98 33.17 0 10.19 0"/><polyline class="b" points="9.28 2.27 1 22.98 30 2.27"/></svg>');
       background-repeat: no-repeat;
     }
   }

--- a/assets/User/UserList.scss
+++ b/assets/User/UserList.scss
@@ -185,6 +185,16 @@ $container-padding: 1rem;
       height: calc(100vh - 56px);
     }
 
+    .is-webview & {
+      top: calc(64px + env(safe-area-inset-top));
+      height: calc(100vh - 64px - env(safe-area-inset-top));
+
+      @media (width <= 599px) {
+        top: calc(56px + env(safe-area-inset-top));
+        height: calc(100vh - 56px - env(safe-area-inset-top));
+      }
+    }
+
     .user-list__title {
       padding-bottom: 1rem;
     }

--- a/config/packages/feature_flags.php
+++ b/config/packages/feature_flags.php
@@ -11,6 +11,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     [
       'Test-Flag' => false,
       'GET_projects_elastica' => false,
+      'force_webview' => false,
     ]
   );
 };

--- a/src/Application/Twig/TwigExtension.php
+++ b/src/Application/Twig/TwigExtension.php
@@ -216,7 +216,8 @@ class TwigExtension extends AbstractExtension
   public function isWebview(): bool
   {
     // Example Webview: $user_agent = "Catrobat/0.93 PocketCode/0.9.14 Platform/Android";
-    return boolval(preg_match('/Catrobat/', $this->getUserAgent()));
+    return boolval(preg_match('/Catrobat/', $this->getUserAgent()))
+      || $this->feature_flag_manager->isEnabled('force_webview');
   }
 
   public function isAndroid(): bool

--- a/templates/Layout/Sidebar.html.twig
+++ b/templates/Layout/Sidebar.html.twig
@@ -153,7 +153,7 @@
       </li>
     {% endif %}
 
-    {% if not isWebview() and app.user %}
+    {% if app.user %}
       {# logout #}
       <li class="nav-item" id="logout-nav-item">
         <a class="nav-link" href="#" id="btn-logout" data-logout-path="{{ url('logout') }}">

--- a/tests/BehatFeatures/web/authentication/webview_jwt_authentication.feature
+++ b/tests/BehatFeatures/web/authentication/webview_jwt_authentication.feature
@@ -48,13 +48,13 @@ Feature: Users should be logged in automatically when they are logged in in the 
     And I should be on "/app/login"
     And I should see 1 "#password__input"
 
-  Scenario: Logout button should be hidden in webview
+  Scenario: Logout button should be visible in webview
     Given I use a valid JWT token for "WebViewUser"
     And I use a release build of the Catroid app
     And I am on the homepage
     And I wait for the page to be loaded
     And I open the menu
-    Then I should see 0 "#btn-logout"
+    Then I should see 1 "#btn-logout"
     Then I should see 0 "#btn-login"
     Then I should see 1 "#btn-profile"
 


### PR DESCRIPTION
## Summary
- **Search bar**: fixed double `env(safe-area-inset-top)` padding in webview — nested `.mdc-top-app-bar` (search row) no longer inherits the outer header's webview padding
- **Vertical overview**: "show more" fullscreen overlay now accounts for safe-area inset in webview so content isn't hidden behind the topbar
- **Theme picker**: changed SweetAlert2 from dynamic `await import()` to static import — Android WebView loses user-gesture context during async import after MDC menu closes, blocking the popup
- **Logout**: removed `not isWebview()` guard from sidebar logout button
- **Feature flag**: added `force_webview` flag (admin panel or `X-Feature-Flag-force_webview: 1` header) for testing webview mode in a regular browser

## Test plan
- [ ] Enable `force_webview` flag in admin → verify `is-webview` class on body
- [ ] Open search bar in webview mode → should align flush with topbar, no double padding
- [ ] Click "show more" on a project slider → vertical overlay should not be hidden behind topbar
- [ ] Open three-dot menu → click Theme → Swal picker should appear
- [ ] Open sidebar → logout button should be visible in webview
- [ ] Test on actual Android WebView (Catroid app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)