### PR TITLE
fix: webview improvements — menu clicks, file upload, modal safe-area, media lib Done FAB

### DIFF
--- a/assets/Admin/SystemManagement/Logs.js
+++ b/assets/Admin/SystemManagement/Logs.js
@@ -54,7 +54,6 @@ if (document.readyState === 'loading') {
 
 function applyFilters() {
   const logEntries = document.querySelectorAll('.log-entry')
-  let visibleCount = 0
 
   logEntries.forEach(function (entry) {
     let visible = true
@@ -77,7 +76,6 @@ function applyFilters() {
 
     if (visible) {
       entry.style.display = ''
-      visibleCount++
     } else {
       entry.style.display = 'none'
     }

--- a/assets/Admin/SystemManagement/Logs.js
+++ b/assets/Admin/SystemManagement/Logs.js
@@ -82,9 +82,6 @@ function applyFilters() {
       entry.style.display = 'none'
     }
   })
-
-  // Show count of visible logs
-  console.log(`Showing ${visibleCount} of ${logEntries.length} log entries`)
 }
 
 function loadFileContent(file) {
@@ -123,6 +120,6 @@ function loadFileContent(file) {
     })
     .catch(() => {
       document.getElementById('loading-spinner').style.display = 'none'
-      alert('something went terribly wrong')
+      alert('Failed to load log file. Please try again.')
     })
 }

--- a/assets/Components/FullscreenListModal.scss
+++ b/assets/Components/FullscreenListModal.scss
@@ -18,6 +18,10 @@
   color: #fff;
   background-color: var(--mdc-theme-primary, #00acc1);
   border: none;
+
+  .is-webview & {
+    padding-top: env(safe-area-inset-top);
+  }
 }
 
 @media only screen and (width >= 768px) {

--- a/assets/Layout/ColorScheme.js
+++ b/assets/Layout/ColorScheme.js
@@ -176,24 +176,8 @@ const initializeColorScheme = () => {
     })
   }
 
-  // Use MDCMenu:selected event — direct click handlers on <li> elements
-  // may not fire in Android WebView due to MDC's touch event handling.
-  let handledByMdc = false
-  const optionsMenu = document.getElementById('top-app-bar__options-menu')
-  if (optionsMenu) {
-    optionsMenu.addEventListener('MDCMenu:selected', (event) => {
-      if (event.detail?.item === menuItem) {
-        handledByMdc = true
-        openThemePicker()
-      }
-    })
-  }
-
   menuItem.addEventListener('click', () => {
-    if (!handledByMdc) {
-      openThemePicker()
-    }
-    handledByMdc = false
+    openThemePicker()
   })
 }
 

--- a/assets/User/MyProfilePage.js
+++ b/assets/User/MyProfilePage.js
@@ -109,6 +109,8 @@ class OwnProfile {
         const input = document.createElement('input')
         input.type = 'file'
         input.accept = 'image/*'
+        input.style.display = 'none'
+        document.body.appendChild(input)
         self.addProfilePictureChangeListenerToInput(input)
         input.click()
       })


### PR DESCRIPTION
## Summary

Fixes multiple webview issues caused by commits pushed directly to main without PR.

### Menu click reliability (TopBar.js)
- Android WebView MDC touch/ripple handling swallows native click events on `<li>` menu items
- Listen for `MDCMenu:selected` and re-dispatch synthetic click if no native click detected within 300ms
- Fixes theme picker, share button, and any future menu items in webview
- WeakSet dedup prevents double-fire on desktop

### File upload support (Catroid WebViewActivity.java)
- Added `WebChromeClient` with `onShowFileChooser` override — without this, `<input type="file">` is silently ignored by Android WebView
- Uses `ActivityResultLauncher` for modern activity result handling
- Enabled `setDomStorageEnabled(true)` for localStorage/sessionStorage support
- Also fixed Content-Disposition filename parsing for media library downloads

### Fullscreen modal safe-area (FullscreenListModal.scss)
- Added `padding-top: env(safe-area-inset-top)` to `.modal-header-full` in webview
- Added `border-radius: 0` to `.full-modal-content` to prevent Bootstrap rounding from clipping safe-area background
- Fixes: UserSettings, ProfileSettings, SecuritySettings, AccountSettings, VerifySettings modals

### Media library Done FAB
- Floating "Done" button appears after first asset download on media library pages in webview
- Links to `/exit` route which triggers `onBackPressed()` in Catroid, returning all downloaded file paths
- Extracted `.floating-action-button` to shared `Components/Fab.scss` (was `.projects-fab`)

### Cleanup
- Removed debug `console.log` and unused `visibleCount` from admin Logs.js (was breaking CI)
- Improved error message in admin log viewer

## Test plan
- [ ] Webview: tap options menu → theme picker popup opens
- [ ] Webview: tap options menu → share button works
- [ ] Webview: tap options menu → report button still works
- [ ] Desktop browser: all menu items still work (no double-fire)
- [ ] Webview: profile avatar tap → file picker opens (requires Catroid update)
- [ ] Webview: project screenshot change → file picker opens (requires Catroid update)
- [ ] Webview: open user settings modal → header not behind status bar
- [ ] Webview: media library → download asset → Done FAB appears
- [ ] Webview: tap Done FAB → returns to app
- [ ] Desktop: media library pages — no Done FAB visible
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)