### PR TITLE
fix: webview modal header safe-area fallback

### DIFF
--- a/assets/Components/FullscreenListModal.scss
+++ b/assets/Components/FullscreenListModal.scss
@@ -21,7 +21,9 @@
   border: none;
 
   .is-webview & {
-    padding-top: env(safe-area-inset-top);
+    // Android WebView may not report env(safe-area-inset-top) inside
+    // position:fixed modals. Use a 24px fallback (standard status bar height).
+    padding-top: max(env(safe-area-inset-top, 0px), 24px);
   }
 }
 


### PR DESCRIPTION
## Summary
- `env(safe-area-inset-top)` returns 0 inside `position: fixed` Bootstrap modals on Android WebView, causing the modal header to sit behind the status bar
- Use `max(env(safe-area-inset-top, 0px), 24px)` as fallback — 24px matches the standard Android status bar height

## Screenshot
Modal header ("Edit profile") was crammed against the status bar icons. With 24px min padding, the header content clears the status bar.

## Test plan
- [ ] Webview: open user settings → profile settings — header clears status bar
- [ ] Webview: open security/account/verify settings — same
- [ ] Desktop browser: modals still look correct (24px top padding is minimal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)