### PR TITLE
fix: prevent horizontal scroll on mobile

### DIFF
--- a/assets/Layout/Footer.scss
+++ b/assets/Layout/Footer.scss
@@ -11,6 +11,7 @@ body {
 .page-content {
   padding: 0.75rem;
   margin-bottom: 1.25rem;
+  overflow-x: clip;
 }
 
 .footer {


### PR DESCRIPTION
## Summary
- Add `overflow-x: clip` to `.page-content` to prevent horizontal scrolling on mobile
- Fixes studios listing page (`/app/studios`) and index page where negative-margin patterns (`.home-section`, `.studios-list-item-wrapper`, `.featured-slider`) extend past the viewport
- Uses `clip` instead of `hidden` to avoid creating a scroll container (preserves sticky positioning, dropdowns, etc.)

## Test plan
- [ ] Open `/app/studios` on mobile (or narrow viewport) — no horizontal scroll
- [ ] Open index/home page on mobile — no horizontal scroll
- [ ] Verify dropdowns, sticky elements, and modals still work correctly
- [ ] Check desktop layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)