### PR TITLE
fix: update FAB selector and re-create test upload input

### DIFF
--- a/assets/MediaLibrary/CategoryDetailPage.scss
+++ b/assets/MediaLibrary/CategoryDetailPage.scss
@@ -7,7 +7,7 @@ $tile-size-sm: 92px;
 $tile-size-md: 104px;
 $tile-size-lg: 128px;
 $tile-padding-y: 8px;
-$tile-padding-overflow-x: 1.5rem;
+$tile-padding-overflow-x: 0.75rem;
 $img-border-strength: 2px;
 
 @keyframes skeleton-pulse {

--- a/assets/Project/ProjectPage.js
+++ b/assets/Project/ProjectPage.js
@@ -661,9 +661,23 @@ function initComponents(data, earlyInits) {
 }
 
 function initProjectScreenshotUpload() {
+  const createTestFileInput = function (parent) {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = 'image/*'
+    input.name = 'project-screenshot-upload-field'
+    input.className = 'd-none'
+    addChangeListenerToFileInput(input)
+    parent.appendChild(input)
+  }
+
   const addChangeListenerToFileInput = function (input) {
     input.onchange = async () => {
+      const parentElement = input.parentElement
       input.remove()
+      if (globalConfiguration.environment === 'test' && parentElement) {
+        createTestFileInput(parentElement)
+      }
       const spinner = document.getElementById('upload-image-spinner')
       spinner.classList.remove('d-none')
 
@@ -732,13 +746,7 @@ function initProjectScreenshotUpload() {
     })
 
     if (globalConfiguration.environment === 'test') {
-      const input = document.createElement('input')
-      input.type = 'file'
-      input.accept = 'image/*'
-      addChangeListenerToFileInput(input)
-      input.name = 'project-screenshot-upload-field'
-      input.className = 'd-none'
-      changeButton.parentElement.appendChild(input)
+      createTestFileInput(changeButton.parentElement)
     }
   }
 }

--- a/assets/Search/SearchPage.js
+++ b/assets/Search/SearchPage.js
@@ -3,6 +3,8 @@ import { escapeHtml, escapeAttr } from '../Components/HtmlEscape'
 import { createPictureElement } from '../Layout/ImageVariants'
 import './Search.scss'
 
+const RESULTS_PER_PAGE = 30
+
 document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('search-results')
   if (!container) return
@@ -73,7 +75,11 @@ function renderPage(container, query, theme, baseUrl, trans) {
   }
 
   const apiUrl =
-    baseUrl + '/api/search?query=' + encodeURIComponent(query) + '&type=all&limit=30&offset=0'
+    baseUrl +
+    '/api/search?query=' +
+    encodeURIComponent(query) +
+    '&type=all&limit=' +
+    RESULTS_PER_PAGE
 
   fetch(apiUrl)
     .then((response) => {
@@ -84,6 +90,10 @@ function renderPage(container, query, theme, baseUrl, trans) {
       renderProjects(projectsSection, data.projects || [], theme, trans)
       renderUsers(usersSection, data.users || [], baseUrl, trans)
       renderStudios(studiosSection, data.studios || [], baseUrl, trans)
+
+      wireShowMore(projectsSection, 'projects', query, baseUrl, theme, trans)
+      wireShowMore(usersSection, 'users', query, baseUrl, theme, trans)
+      wireShowMore(studiosSection, 'studios', query, baseUrl, theme, trans)
     })
     .catch((error) => {
       console.error('Search API error:', error)
@@ -91,6 +101,103 @@ function renderPage(container, query, theme, baseUrl, trans) {
       showEmpty(usersSection, trans.noUsers)
       showEmpty(studiosSection, trans.noStudios)
     })
+}
+
+function wireShowMore(section, type, query, baseUrl, theme, trans) {
+  const btn = section.querySelector('.search-section__title__show-more')
+  if (!btn || btn.classList.contains('d-none')) return
+
+  let nextOffset = RESULTS_PER_PAGE
+  let loading = false
+
+  btn.addEventListener('click', (e) => {
+    e.preventDefault()
+    if (loading) return
+    loading = true
+    btn.style.opacity = '0.5'
+
+    const cursor = btoa(String(nextOffset))
+    const apiUrl =
+      baseUrl +
+      '/api/search?query=' +
+      encodeURIComponent(query) +
+      '&type=' +
+      type +
+      '&limit=' +
+      RESULTS_PER_PAGE +
+      '&cursor=' +
+      encodeURIComponent(cursor)
+
+    fetch(apiUrl)
+      .then((response) => {
+        if (!response.ok) throw new Error('HTTP ' + response.status)
+        return response.json()
+      })
+      .then((data) => {
+        const items = data[type] || []
+        const container = section.querySelector('.search-section__items')
+
+        if (type === 'projects') {
+          items.forEach((project) => {
+            const url = (project.project_url || '').replace('/app/', '/' + theme + '/')
+            container.appendChild(
+              createCard(
+                url,
+                project.screenshot,
+                'card',
+                '/images/default/screenshot-card@1x.webp',
+                project.name || '',
+                'calendar_today',
+                project.uploaded_string || '',
+              ),
+            )
+          })
+        } else if (type === 'users') {
+          items.forEach((user) => {
+            const url = baseUrl + '/app/user/' + escapeAttr(String(user.id))
+            container.appendChild(
+              createCard(
+                url,
+                user.avatar,
+                'thumb',
+                '/images/default/avatar_default-thumb@1x.webp',
+                user.username || '',
+                'code',
+                (user.projects || 0) + ' ' + trans.projects,
+              ),
+            )
+          })
+        } else if (type === 'studios') {
+          items.forEach((studio) => {
+            const url = baseUrl + '/app/studio/' + escapeAttr(String(studio.id))
+            container.appendChild(
+              createCard(
+                url,
+                studio.cover,
+                'card',
+                '/images/default/screenshot-card@1x.webp',
+                studio.name || '',
+                'group',
+                (studio.members_count || 0) + ' ' + trans.members,
+              ),
+            )
+          })
+        }
+
+        nextOffset += RESULTS_PER_PAGE
+
+        if (items.length < RESULTS_PER_PAGE) {
+          btn.classList.add('d-none')
+        }
+      })
+      .catch((error) => {
+        console.error('Search load more error:', error)
+      })
+      .finally(() => {
+        loading = false
+        btn.style.opacity = ''
+      })
+  })
 }
 
 function createSection(id, variant, title, showMoreText) {
@@ -129,7 +236,7 @@ function renderProjects(section, projects, theme, trans) {
     return
   }
 
-  if (projects.length >= 30) {
+  if (projects.length >= RESULTS_PER_PAGE) {
     section.querySelector('.search-section__title__show-more').classList.remove('d-none')
   }
 
@@ -157,7 +264,7 @@ function renderUsers(section, users, baseUrl, trans) {
     return
   }
 
-  if (users.length >= 30) {
+  if (users.length >= RESULTS_PER_PAGE) {
     section.querySelector('.search-section__title__show-more').classList.remove('d-none')
   }
 
@@ -185,7 +292,7 @@ function renderStudios(section, studios, baseUrl, trans) {
     return
   }
 
-  if (studios.length >= 30) {
+  if (studios.length >= RESULTS_PER_PAGE) {
     section.querySelector('.search-section__title__show-more').classList.remove('d-none')
   }
 

--- a/templates/MediaLibrary/CategoryDetail.html.twig
+++ b/templates/MediaLibrary/CategoryDetail.html.twig
@@ -62,8 +62,8 @@
 
   {% if isWebview() %}
     <a href="{{ path('exit-webview') }}" id="media-library-done-fab" class="floating-action-button" style="display: none;">
-      <span class="material-icons">check</span>
-      <span>{{ 'done'|trans({}, 'catroweb') }}</span>
+      <span class="material-icons">arrow_back</span>
+      <span>{{ 'media_library.back_to_app'|trans({}, 'catroweb') }}</span>
     </a>
   {% endif %}
 

--- a/templates/MediaLibrary/Overview.html.twig
+++ b/templates/MediaLibrary/Overview.html.twig
@@ -74,8 +74,8 @@
 
   {% if isWebview() %}
     <a href="{{ path('exit-webview') }}" id="media-library-done-fab" class="floating-action-button" style="display: none;">
-      <span class="material-icons">check</span>
-      <span>{{ 'done'|trans({}, 'catroweb') }}</span>
+      <span class="material-icons">arrow_back</span>
+      <span>{{ 'media_library.back_to_app'|trans({}, 'catroweb') }}</span>
     </a>
   {% endif %}
 

--- a/tests/BehatFeatures/web/project-list/projects_browse.feature
+++ b/tests/BehatFeatures/web/project-list/projects_browse.feature
@@ -29,19 +29,19 @@ Feature: Projects browse page shows user's projects and explore sections
   Scenario: Upload FAB button is visible
     Given I am on "/app/projects"
     And I wait for the page to be loaded
-    Then the element ".projects-fab" should be visible
+    Then the element ".floating-action-button" should be visible
 
   Scenario: Upload FAB redirects logged-in user to upload page
     Given I log in as "Catrobat"
     And I am on "/app/projects"
     And I wait for the page to be loaded
-    When I click ".projects-fab"
+    When I click ".floating-action-button"
     And I wait for the page to be loaded
     Then I should be on "/app/project/upload"
 
   Scenario: Upload FAB redirects not-logged-in user to login
     Given I am on "/app/projects"
     And I wait for the page to be loaded
-    When I click ".projects-fab"
+    When I click ".floating-action-button"
     And I wait for the page to be loaded
     Then I should be on "/app/login"

--- a/translations/catroweb.en.yaml
+++ b/translations/catroweb.en.yaml
@@ -1333,6 +1333,7 @@ media_library:
   assets_count: 'assets'
   view_all: 'View all'
   view_all_category: 'View all %category%'
+  back_to_app: 'Back to app'
 
 snackbar:
   project_not_found: 'The requested project is not available'


### PR DESCRIPTION
## Summary
- **Behat FAB selector**: `.projects-fab` renamed to `.floating-action-button` in dabd4930e but test not updated — 3 scenario failures
- **Behat upload input**: `project-screenshot-upload-field` removed from DOM after first use but never re-created in test env — second upload failed
- **Media library horizontal scroll**: `$tile-padding-overflow-x` was 1.5rem but `.page-content` padding is 0.75rem — items overflowed 12px on mobile
- **Search "Show more" broken**: Button was `<a href="#">` with no handler. Now loads next page via cursor-based API pagination, appends cards inline, hides when exhausted
- **Media library "Done" FAB**: Renamed to "Back to app" with `arrow_back` icon for clearer webview UX

## Test plan
- [ ] `web-project-list` suite passes (FAB selector scenarios)
- [ ] `web-project-details` suite passes (project image double-upload scenario)
- [ ] No horizontal scroll on media library category pages (mobile)
- [ ] Search "Show more" loads additional results on share.catrobat.org
- [ ] Media library FAB shows "Back to app" in webview

🤖 Generated with [Claude Code](https://claude.com/claude-code)