### PR TITLE
feat: switch email provider from Brevo to Amazon SES

### DIFF
--- a/.env
+++ b/.env
@@ -107,10 +107,9 @@ GOOGLE_CLOUD_PROJECT=''
 MAILER_DSN='null://null'
 ###< symfony/mailer ###
 
-###> symfony/brevo-mailer ###
-# MAILER_DSN=brevo+api://KEY@default
-# MAILER_DSN=brevo+smtp://USERNAME:PASSWORD@default
-###< symfony/brevo-mailer ###
+###> symfony/amazon-mailer ###
+# MAILER_DSN=ses+smtp://ACCESS_KEY:SECRET_KEY@default?region=eu-central-1
+###< symfony/amazon-mailer ###
 
 ###> bugsnag/bugsnag-symfony ###
 BUGSNAG_API_KEY=''

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "sonata-project/exporter": "3.4.*",
     "sonata-project/twig-extensions": "2.6.*",
     "symfony/asset": "7.4.*",
-    "symfony/brevo-mailer": "7.4.*",
+    "symfony/amazon-mailer": "7.4.*",
     "symfony/cache": "7.4.*",
     "symfony/config": "7.4.*",
     "symfony/console": "7.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,141 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc659d8045d12437f5948afb3987c198",
+    "content-hash": "357fba43de72a6eef12bb2b472d85d5e",
     "packages": [
+        {
+            "name": "async-aws/core",
+            "version": "1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/async-aws/core.git",
+                "reference": "70899695fcc7b23a9247926ff8b581668583b993"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/async-aws/core/zipball/70899695fcc7b23a9247926ff8b581668583b993",
+                "reference": "70899695fcc7b23a9247926ff8b581668583b993",
+                "shasum": ""
+            },
+            "require": {
+                "ext-hash": "*",
+                "ext-simplexml": "*",
+                "php": "^8.2",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0",
+                "symfony/http-client": "^4.4.16 || ^5.1.7 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/http-client-contracts": "^1.1.8 || ^2.0 || ^3.0",
+                "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
+            },
+            "conflict": {
+                "async-aws/s3": "<1.1",
+                "symfony/http-client": "5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.42",
+                "symfony/error-handler": "^7.3.2 || ^8.0",
+                "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.29-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "AsyncAws\\Core\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Core package to integrate with AWS. This is a lightweight AWS SDK provider by AsyncAws.",
+            "keywords": [
+                "amazon",
+                "async-aws",
+                "aws",
+                "sdk",
+                "sts"
+            ],
+            "support": {
+                "source": "https://github.com/async-aws/core/tree/1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jderusse",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-18T17:06:10+00:00"
+        },
+        {
+            "name": "async-aws/ses",
+            "version": "1.14.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/async-aws/ses.git",
+                "reference": "ab3bceb3380e971a5619fbd27d921a5352e644f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/async-aws/ses/zipball/ab3bceb3380e971a5619fbd27d921a5352e644f4",
+                "reference": "ab3bceb3380e971a5619fbd27d921a5352e644f4",
+                "shasum": ""
+            },
+            "require": {
+                "async-aws/core": "^1.9",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.42",
+                "symfony/error-handler": "^7.3.2 || ^8.0",
+                "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.14-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "AsyncAws\\Ses\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "SES client, part of the AWS SDK provided by AsyncAws.",
+            "keywords": [
+                "amazon",
+                "async-aws",
+                "aws",
+                "sdk",
+                "ses"
+            ],
+            "support": {
+                "source": "https://github.com/async-aws/ses/tree/1.14.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jderusse",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-18T17:06:10+00:00"
+        },
         {
             "name": "beberlei/doctrineextensions",
             "version": "v1.5.0",
@@ -7023,6 +7156,76 @@
             "time": "2025-11-23T16:41:45+00:00"
         },
         {
+            "name": "symfony/amazon-mailer",
+            "version": "v7.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/amazon-mailer.git",
+                "reference": "6fedfa970a1b5b2c93fd32c598df7db7d03070b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/amazon-mailer/zipball/6fedfa970a1b5b2c93fd32c598df7db7d03070b4",
+                "reference": "6fedfa970a1b5b2c93fd32c598df7db7d03070b4",
+                "shasum": ""
+            },
+            "require": {
+                "async-aws/ses": "^1.8",
+                "php": ">=8.2",
+                "symfony/mailer": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "symfony/http-client": "^6.4|^7.0|^8.0"
+            },
+            "type": "symfony-mailer-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\Bridge\\Amazon\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Amazon Mailer Bridge",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/amazon-mailer/tree/v7.4.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-11T15:05:50+00:00"
+        },
+        {
             "name": "symfony/asset",
             "version": "v7.4.6",
             "source": {
@@ -7094,79 +7297,6 @@
                 }
             ],
             "time": "2026-02-09T09:33:46+00:00"
-        },
-        {
-            "name": "symfony/brevo-mailer",
-            "version": "v7.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/brevo-mailer.git",
-                "reference": "f1ef26ffe147e9185531030fc1503ed7b63fa0ef"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/brevo-mailer/zipball/f1ef26ffe147e9185531030fc1503ed7b63fa0ef",
-                "reference": "f1ef26ffe147e9185531030fc1503ed7b63fa0ef",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/mailer": "^7.2|^8.0"
-            },
-            "conflict": {
-                "symfony/mime": "<6.2"
-            },
-            "require-dev": {
-                "symfony/http-client": "^6.3|^7.0|^8.0",
-                "symfony/webhook": "^6.3|^7.0|^8.0"
-            },
-            "type": "symfony-mailer-bridge",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Mailer\\Bridge\\Brevo\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Pierre Tanguy",
-                    "homepage": "https://github.com/petanguy"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Brevo Mailer Bridge",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/brevo-mailer/tree/v7.4.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-04T08:00:56+00:00"
         },
         {
             "name": "symfony/cache",
@@ -8729,16 +8859,16 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v7.4.7",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "1010624285470eb60e88ed10035102c75b4ea6af"
+                "reference": "01933e626c3de76bea1e22641e205e78f6a34342"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/1010624285470eb60e88ed10035102c75b4ea6af",
-                "reference": "1010624285470eb60e88ed10035102c75b4ea6af",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/01933e626c3de76bea1e22641e205e78f6a34342",
+                "reference": "01933e626c3de76bea1e22641e205e78f6a34342",
                 "shasum": ""
             },
             "require": {
@@ -8806,7 +8936,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v7.4.7"
+                "source": "https://github.com/symfony/http-client/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -8826,7 +8956,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-05T11:16:58+00:00"
+            "time": "2026-03-30T12:55:43+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -9199,16 +9329,16 @@
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.6",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "b02726f39a20bc65e30364f5c750c4ddbf1f58e9"
+                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/b02726f39a20bc65e30364f5c750c4ddbf1f58e9",
-                "reference": "b02726f39a20bc65e30364f5c750c4ddbf1f58e9",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/f6ea532250b476bfc1b56699b388a1bdbf168f62",
+                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62",
                 "shasum": ""
             },
             "require": {
@@ -9259,7 +9389,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.6"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -9279,20 +9409,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.7",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "da5ab4fde3f6c88ab06e96185b9922f48b677cd1"
+                "reference": "6df02f99998081032da3407a8d6c4e1dcb5d4379"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/da5ab4fde3f6c88ab06e96185b9922f48b677cd1",
-                "reference": "da5ab4fde3f6c88ab06e96185b9922f48b677cd1",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/6df02f99998081032da3407a8d6c4e1dcb5d4379",
+                "reference": "6df02f99998081032da3407a8d6c4e1dcb5d4379",
                 "shasum": ""
             },
             "require": {
@@ -9348,7 +9478,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.7"
+                "source": "https://github.com/symfony/mime/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -9368,7 +9498,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-05T15:24:09+00:00"
+            "time": "2026-03-30T14:11:46+00:00"
         },
         {
             "name": "symfony/monolog-bridge",
@@ -10018,7 +10148,7 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
@@ -10081,7 +10211,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -10105,7 +10235,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.34.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -10166,7 +10296,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.34.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -10190,7 +10320,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.34.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -10251,7 +10381,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.34.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -10275,7 +10405,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.34.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -10335,7 +10465,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.34.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -10439,16 +10569,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149",
                 "shasum": ""
             },
             "require": {
@@ -10495,7 +10625,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -10515,7 +10645,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-08T02:45:35+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php84",

--- a/config/services.php
+++ b/config/services.php
@@ -141,7 +141,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
   $parameters->set('catrobat.translations.project_cache_threshold', 15);
   $parameters->set('catrobat.upload.temp.dir', '%catrobat.pubdir%resources/tmp/uploads/');
   $parameters->set('catrobat.upload.temp.path', 'resources/tmp/uploads/');
-  $parameters->set('dkim.private.key', '%kernel.project_dir%/.dkim/private.key');
+
   $parameters->set('.container.dumper.inline_class_loader', true);
   $parameters->set('reset_password.throttle_limit', 86400);
 

--- a/deploy.php
+++ b/deploy.php
@@ -44,7 +44,6 @@ set('shared_dirs', [
 add('shared_files', [
   '.env.prod.local',      // keep only production .env
   'google_cloud_key.json',
-  '.dkim/private.key',
 ]);
 
 // Writable directories

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -475,11 +475,7 @@
       <code><![CDATA[getUser]]></code>
     </PossiblyNullReference>
   </file>
-  <file src="src/System/Mail/MailerAdapter.php">
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$_ENV['APP_ENV']]]></code>
-    </PossiblyUndefinedArrayOffset>
-  </file>
+
   <file src="src/System/Testing/Behat/Context/ApiContext.php">
     <PossiblyFalseArgument>
       <code><![CDATA[$response->getContent()]]></code>

--- a/src/System/Mail/EmailBudgetManager.php
+++ b/src/System/Mail/EmailBudgetManager.php
@@ -11,14 +11,14 @@ use Psr\Log\LoggerInterface;
 
 class EmailBudgetManager
 {
-  public const int DAILY_LIMIT = 300;
+  public const int DAILY_LIMIT = 5000;
 
   public const array TYPE_RESERVES = [
-    'verification' => 150,
-    'reset' => 30,
-    'consent' => 30,
-    'admin' => 50,
-    'management' => 40,
+    'verification' => 2500,
+    'reset' => 500,
+    'consent' => 500,
+    'admin' => 750,
+    'management' => 750,
   ];
 
   public function __construct(

--- a/src/System/Mail/MailerAdapter.php
+++ b/src/System/Mail/MailerAdapter.php
@@ -6,12 +6,9 @@ namespace App\System\Mail;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
-use Symfony\Component\Mime\Crypto\DkimSigner;
-use Symfony\Component\Mime\Exception\InvalidArgumentException;
 use Symfony\Component\Mime\Message;
 use Twig\Environment;
 
@@ -21,8 +18,6 @@ class MailerAdapter
     protected MailerInterface $mailer,
     protected LoggerInterface $logger,
     protected Environment $templateWrapper,
-    #[Autowire('%dkim.private.key%')]
-    protected string $dkim_private_key_path,
     protected EmailBudgetManager $budgetManager,
   ) {
   }
@@ -36,7 +31,6 @@ class MailerAdapter
     }
 
     $email = $this->buildEmail($to, $subject, $template, $context);
-    // $email = $this->signEmail($email); // Signing is currently disabled due to breveo
     $this->sendEmail($email, $to);
     $this->budgetManager->recordSend($emailType);
 
@@ -60,19 +54,6 @@ class MailerAdapter
       ->context($context)
       ->html($html)
     ;
-  }
-
-  protected function signEmail(Message $email): Message
-  {
-    try {
-      return new DkimSigner('file://'.$this->dkim_private_key_path, 'share.catrob.at', 'sf')->sign($email);
-    } catch (InvalidArgumentException $invalidArgumentException) {
-      if ('prod' === $_ENV['APP_ENV']) {
-        $this->logger->error(sprintf('Private dkim key is missing (%s): ', $this->dkim_private_key_path).$invalidArgumentException->getMessage());
-      }
-
-      return $email;
-    }
   }
 
   protected function sendEmail(Message $email, string $to): void

--- a/symfony.lock
+++ b/symfony.lock
@@ -597,17 +597,17 @@
     "stella-maris/clock": {
         "version": "0.1.4"
     },
-    "symfony/asset": {
-        "version": "v4.4.5"
-    },
-    "symfony/brevo-mailer": {
-        "version": "6.4",
+    "symfony/amazon-mailer": {
+        "version": "7.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
-            "version": "6.4",
-            "ref": "7c1038ceb733175f610a913a885a7c8b552b703a"
+            "version": "4.4",
+            "ref": "9648db3ecae5c8a6b1a5f74715d3907124348815"
         }
+    },
+    "symfony/asset": {
+        "version": "v4.4.5"
     },
     "symfony/browser-kit": {
         "version": "v5.0.5"

--- a/tests/PhpUnit/Admin/System/Maintenance/SystemHealthServiceTest.php
+++ b/tests/PhpUnit/Admin/System/Maintenance/SystemHealthServiceTest.php
@@ -69,9 +69,9 @@ class SystemHealthServiceTest extends TestCase
   {
     $email = $this->service->getEmailBudget();
 
-    self::assertSame(300, $email['daily_limit']);
+    self::assertSame(EmailBudgetManager::DAILY_LIMIT, $email['daily_limit']);
     self::assertSame(25, $email['sent_today']);
-    self::assertSame(275, $email['remaining']);
+    self::assertSame(EmailBudgetManager::DAILY_LIMIT - 25, $email['remaining']);
     self::assertArrayHasKey('breakdown', $email);
     self::assertArrayHasKey('verification', $email['breakdown']);
     self::assertArrayHasKey('reset', $email['breakdown']);

--- a/tests/PhpUnit/Admin/System/Maintenance/SystemHealthServiceTest.php
+++ b/tests/PhpUnit/Admin/System/Maintenance/SystemHealthServiceTest.php
@@ -76,8 +76,8 @@ class SystemHealthServiceTest extends TestCase
     self::assertArrayHasKey('verification', $email['breakdown']);
     self::assertArrayHasKey('reset', $email['breakdown']);
     self::assertSame(10, $email['breakdown']['verification']['sent']);
-    self::assertSame(150, $email['breakdown']['verification']['reserve']);
-    self::assertSame(140, $email['breakdown']['verification']['remaining']);
+    self::assertSame(EmailBudgetManager::TYPE_RESERVES['verification'], $email['breakdown']['verification']['reserve']);
+    self::assertSame(EmailBudgetManager::TYPE_RESERVES['verification'] - 10, $email['breakdown']['verification']['remaining']);
   }
 
   public function testGetProjectCountsReturnsAllCategories(): void

--- a/tests/PhpUnit/System/Mail/EmailBudgetManagerTest.php
+++ b/tests/PhpUnit/System/Mail/EmailBudgetManagerTest.php
@@ -53,12 +53,11 @@ class EmailBudgetManagerTest extends TestCase
 
   public function testCanSendRespectsTypeReserve(): void
   {
-    // Fill up verification reserve (150)
-    $this->budget->setVerificationSent(150);
-    $this->budget->setTotalSent(150);
+    // Fill up verification reserve (2500)
+    $this->budget->setVerificationSent(2500);
+    $this->budget->setTotalSent(2500);
 
-    // Verification can still send from shared pool (300 - 300 reserves = 0 shared)
-    // Total reserved = 150 + 30 + 30 + 50 + 40 = 300, shared pool = 0
+    // Total reserved = 2500 + 500 + 500 + 750 + 750 = 5000, shared pool = 0
     self::assertFalse($this->manager->canSend('verification'));
 
     // Other types are still within their reserves
@@ -67,10 +66,10 @@ class EmailBudgetManagerTest extends TestCase
 
   public function testCanSendAllowsOverflowIntoSharedPool(): void
   {
-    // With total reserves = 300 and daily limit = 300, shared pool = 0
+    // With total reserves = 5000 and daily limit = 5000, shared pool = 0
     // So overflowing a reserve is NOT possible when reserves sum to daily limit
-    $this->budget->setVerificationSent(150);
-    $this->budget->setTotalSent(150);
+    $this->budget->setVerificationSent(2500);
+    $this->budget->setTotalSent(2500);
 
     self::assertFalse($this->manager->canSend('verification'));
   }
@@ -107,23 +106,23 @@ class EmailBudgetManagerTest extends TestCase
 
     $remaining = $this->manager->getRemainingBudget();
 
-    self::assertSame(148, $remaining['verification']);
-    self::assertSame(29, $remaining['reset']);
-    self::assertSame(30, $remaining['consent']);
-    self::assertSame(50, $remaining['admin']);
-    self::assertSame(40, $remaining['management']);
-    self::assertSame(297, $remaining['total']);
+    self::assertSame(2498, $remaining['verification']);
+    self::assertSame(499, $remaining['reset']);
+    self::assertSame(500, $remaining['consent']);
+    self::assertSame(750, $remaining['admin']);
+    self::assertSame(750, $remaining['management']);
+    self::assertSame(4997, $remaining['total']);
   }
 
   public function testGetRemainingBudgetNeverNegative(): void
   {
-    $this->budget->setResetSent(100);
-    $this->budget->setTotalSent(100);
+    $this->budget->setResetSent(1000);
+    $this->budget->setTotalSent(1000);
 
     $remaining = $this->manager->getRemainingBudget();
 
     self::assertSame(0, $remaining['reset']);
-    self::assertSame(200, $remaining['total']);
+    self::assertSame(4000, $remaining['total']);
   }
 
   public function testCanSendThrowsOnInvalidType(): void
@@ -143,12 +142,12 @@ class EmailBudgetManagerTest extends TestCase
   public function testBudgetExhaustionByType(): void
   {
     // Fill reset reserve completely
-    for ($i = 0; $i < 30; ++$i) {
+    for ($i = 0; $i < 500; ++$i) {
       self::assertTrue($this->manager->canSend('reset'));
       $this->manager->recordSend('reset');
     }
 
-    // Reset reserve exhausted, shared pool = 0 (reserves sum to 300 = daily limit)
+    // Reset reserve exhausted, shared pool = 0 (reserves sum to 5000 = daily limit)
     self::assertFalse($this->manager->canSend('reset'));
 
     // Other types still have budget within their reserves
@@ -158,7 +157,7 @@ class EmailBudgetManagerTest extends TestCase
 
   public function testTotalLimitPreventsAllSending(): void
   {
-    $this->budget->setTotalSent(300);
+    $this->budget->setTotalSent(5000);
     $this->budget->setVerificationSent(0);
 
     self::assertFalse($this->manager->canSend('verification'));


### PR DESCRIPTION
## Summary

Closes #6719

- Replace `symfony/brevo-mailer` with `symfony/amazon-mailer` — supports `ses+smtp://` transport DSN
- Raise `EmailBudgetManager::DAILY_LIMIT` from 300 → 5,000 with proportional type reserves (verification: 2500, reset: 500, consent: 500, admin: 750, management: 750)
- Remove local DKIM signing code from `MailerAdapter` — SES handles DKIM natively via DNS CNAME records
- Remove `dkim.private.key` parameter from `config/services.php` and `.dkim/private.key` from `deploy.php` shared files
- Clean up stale Psalm baseline entry for removed DKIM code

### Before deploying (manual steps)

1. **AWS Setup**: Create IAM user with SES-only permissions, verify `catrob.at` domain, request production access
2. **DNS**: Add SES DKIM CNAME records (3), update SPF to include SES, verify DMARC
3. **Prod secrets**: Set `MAILER_DSN=ses+smtp://ACCESS_KEY:SECRET_KEY@default?region=eu-central-1` in `.env.prod.local`
4. **AWS Budget**: Set alert at $15/month, SES sending quota at 5,000/day

## Test plan

- [ ] `bin/phpunit --filter EmailBudgetManagerTest` — all 12 tests pass with updated limits
- [ ] Psalm passes (stale baseline entry removed)
- [ ] CI static analysis + unit tests green
- [ ] After deploy: send test emails from staging, verify deliverability to Gmail/Outlook/Yahoo
- [ ] Monitor SES bounce/complaint rates in AWS console

🤖 Generated with [Claude Code](https://claude.com/claude-code)