### PR TITLE
feat: add optional project_id to upload API

### DIFF
--- a/src/Api/OpenAPI/Server/Api/ProjectsApiInterface.php
+++ b/src/Api/OpenAPI/Server/Api/ProjectsApiInterface.php
@@ -364,6 +364,7 @@ interface ProjectsApiInterface
    * @param string       $accept_language (optional, default to 'en')
    * @param string       $flavor          The flavor of this project (optional, default to 'pocketcode')
    * @param bool         $private         Indicates whether a project should be private (optional, default to false)
+   * @param string|null  $project_id      Optional UUID of an existing project to update (optional)
    * @param int          &$responseCode   The HTTP Response Code
    * @param array        $responseHeaders Additional HTTP headers to return with the response ()
    */
@@ -373,6 +374,7 @@ interface ProjectsApiInterface
     string $accept_language,
     string $flavor,
     bool $private,
+    ?string $project_id,
     int &$responseCode,
     array &$responseHeaders,
   ): array|object|null;

--- a/src/Api/OpenAPI/Server/Controller/ProjectsController.php
+++ b/src/Api/OpenAPI/Server/Controller/ProjectsController.php
@@ -1574,6 +1574,7 @@ class ProjectsController extends Controller
     $file = $request->files->get('file');
     $flavor = $request->request->get('flavor', 'pocketcode');
     $private = $request->request->get('private', false);
+    $project_id = $request->request->get('project_id');
 
     // Use the default value if no value was provided
 
@@ -1583,6 +1584,7 @@ class ProjectsController extends Controller
       $accept_language = $this->deserialize($accept_language, 'string', 'string');
       $flavor = $this->deserialize($flavor, 'string', 'string');
       $private = $this->deserialize($private, 'bool', 'string');
+      $project_id = $this->deserialize($project_id, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -1620,6 +1622,12 @@ class ProjectsController extends Controller
     if ($response instanceof Response) {
       return $response;
     }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
+    $response = $this->validate($project_id, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
 
     try {
       $handler = $this->getApiHandler();
@@ -1631,7 +1639,7 @@ class ProjectsController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->projectsPost($checksum, $file, $accept_language, $flavor, $private, $responseCode, $responseHeaders);
+      $result = $handler->projectsPost($checksum, $file, $accept_language, $flavor, $private, $project_id, $responseCode, $responseHeaders);
 
       $message = match ($responseCode) {
         201 => 'Project successfully uploaded',

--- a/src/Api/OpenAPI/Server/Controller/ProjectsController.php
+++ b/src/Api/OpenAPI/Server/Controller/ProjectsController.php
@@ -1624,6 +1624,7 @@ class ProjectsController extends Controller
     }
     $asserts = [];
     $asserts[] = new Assert\Type('string');
+    $asserts[] = new Assert\Uuid();
     $response = $this->validate($project_id, $asserts);
     if ($response instanceof Response) {
       return $response;

--- a/src/Api/OpenAPI/specification.yaml
+++ b/src/Api/OpenAPI/specification.yaml
@@ -4164,6 +4164,11 @@ components:
           description: 'Indicates whether a project should be private'
           default: false
           example: false
+        project_id:
+          type: string
+          format: uuid
+          description: 'Optional UUID of an existing project to update. When provided, the server matches by ID instead of by name, allowing project renames without creating duplicates.'
+          example: '63768cf1-5f07-11ea-a2ae-000c292a0f49'
       required:
         - checksum
         - file

--- a/src/Api/ProjectsApi.php
+++ b/src/Api/ProjectsApi.php
@@ -302,7 +302,7 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
   }
 
   #[\Override]
-  public function projectsPost(string $checksum, UploadedFile $file, string $accept_language, string $flavor, bool $private, int &$responseCode, array &$responseHeaders): array|object|null
+  public function projectsPost(string $checksum, UploadedFile $file, string $accept_language, string $flavor, bool $private, ?string $project_id, int &$responseCode, array &$responseHeaders): array|object|null
   {
     // Getting the user who uploaded
     $user = $this->facade->getAuthenticationManager()->getAuthenticatedUser();
@@ -341,7 +341,8 @@ class ProjectsApi extends AbstractApiController implements ProjectsApiInterface
           $file,
           $this->facade->getLoader()->getClientIp(),
           $accept_language,
-          $flavor
+          $flavor,
+          $project_id,
         )
       );
     } catch (InvalidCatrobatFileException $e) {

--- a/src/Project/AddProjectRequest.php
+++ b/src/Project/AddProjectRequest.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\File\File;
 
 class AddProjectRequest
 {
-  public function __construct(private User $user, private File $project_file, private readonly ?string $ip = '127.0.0.1', private ?string $language = null, private readonly ?string $flavor = Flavor::POCKETCODE)
+  public function __construct(private User $user, private File $project_file, private readonly ?string $ip = '127.0.0.1', private ?string $language = null, private readonly ?string $flavor = Flavor::POCKETCODE, private readonly ?string $project_id = null)
   {
   }
 
@@ -52,5 +52,10 @@ class AddProjectRequest
   public function getFlavor(): ?string
   {
     return $this->flavor;
+  }
+
+  public function getProjectId(): ?string
+  {
+    return $this->project_id;
   }
 }

--- a/src/Project/ProjectManager.php
+++ b/src/Project/ProjectManager.php
@@ -165,7 +165,16 @@ class ProjectManager
     }
 
     /** @var Project|null $old_project */
-    $old_project = $this->findOneByNameAndUser($extracted_file->getName(), $request->getUser());
+    $old_project = null;
+    $request_project_id = $request->getProjectId();
+    if (null !== $request_project_id) {
+      $old_project = $this->find($request_project_id);
+      if (null !== $old_project && $old_project->getUser()->getId() !== $request->getUser()->getId()) {
+        $old_project = null; // ignore project_id if it belongs to a different user
+      }
+    }
+
+    $old_project ??= $this->findOneByNameAndUser($extracted_file->getName(), $request->getUser());
     if (null !== $old_project) {
       $project = $old_project;
       $this->removeAllTags($project);

--- a/src/Project/ProjectManager.php
+++ b/src/Project/ProjectManager.php
@@ -169,8 +169,8 @@ class ProjectManager
     $request_project_id = $request->getProjectId();
     if (null !== $request_project_id) {
       $old_project = $this->find($request_project_id);
-      if (null !== $old_project && $old_project->getUser()->getId() !== $request->getUser()->getId()) {
-        $old_project = null; // ignore project_id if it belongs to a different user
+      if (null !== $old_project && $old_project->getUser()?->getId() !== $request->getUser()->getId()) {
+        $old_project = null;
       }
     }
 

--- a/src/System/Testing/Behat/Context/ApiContext.php
+++ b/src/System/Testing/Behat/Context/ApiContext.php
@@ -323,6 +323,16 @@ class ApiContext implements Context
   }
 
   /**
+   * @When I upload a valid Catrobat project, setting the project_id parameter to the id of the last uploaded project
+   */
+  public function iUploadAValidCatrobatProjectWithProjectId(): void
+  {
+    $project_id = $this->getIDOfLastUploadedProject();
+    $this->request_parameters['project_id'] = $project_id;
+    $this->uploadProject($this->FIXTURES_DIR.'test.catrobat');
+  }
+
+  /**
    * @When user :username uploads a valid Catrobat project
    *
    * @param string $username The name of the user who initiates the upload

--- a/src/System/Testing/Behat/Context/ApiContext.php
+++ b/src/System/Testing/Behat/Context/ApiContext.php
@@ -72,6 +72,8 @@ class ApiContext implements Context
 
   private ?string $saved_cursor = null;
 
+  private ?string $stored_project_id = null;
+
   // to df ->function
   private array $checked_catrobat_remix_forward_ancestor_relations;
 
@@ -328,8 +330,18 @@ class ApiContext implements Context
   public function iUploadAValidCatrobatProjectWithProjectId(): void
   {
     $project_id = $this->getIDOfLastUploadedProject();
+    $this->stored_project_id = $project_id;
     $this->request_parameters['project_id'] = $project_id;
     $this->uploadProject($this->FIXTURES_DIR.'test.catrobat');
+  }
+
+  /**
+   * @Then the response should have the same project id as the first upload
+   */
+  public function theResponseShouldHaveSameProjectId(): void
+  {
+    $current_id = $this->getIDOfLastUploadedProject();
+    Assert::assertSame($this->stored_project_id, $current_id);
   }
 
   /**

--- a/tests/BehatFeatures/api/projects/POST_projects/projects_post.feature
+++ b/tests/BehatFeatures/api/projects/POST_projects/projects_post.feature
@@ -134,4 +134,4 @@ Feature: Uploading a project
     And the uploaded project should exist in the database
     When I upload a valid Catrobat project, setting the project_id parameter to the id of the last uploaded project
     Then the response status code should be "201"
-    And it should be updated
+    And the response should have the same project id as the first upload

--- a/tests/BehatFeatures/api/projects/POST_projects/projects_post.feature
+++ b/tests/BehatFeatures/api/projects/POST_projects/projects_post.feature
@@ -126,3 +126,12 @@ Feature: Uploading a project
     And I upload a valid Catrobat project with the same name
     Then the uploaded project should exist in the database
     And it should be updated
+
+  Scenario: uploading with project_id should update the existing project even with a different name
+    Given I am "Catrobat"
+    When I upload a valid Catrobat project
+    Then the response status code should be "201"
+    And the uploaded project should exist in the database
+    When I upload a valid Catrobat project, setting the project_id parameter to the id of the last uploaded project
+    Then the response status code should be "201"
+    And it should be updated

--- a/tests/BehatFeatures/web/general/homepage.feature
+++ b/tests/BehatFeatures/web/general/homepage.feature
@@ -86,7 +86,7 @@ Feature: Pocketcode homepage
     And I wait for the page to be loaded
     And I wait for AJAX to finish
     Then the element "#home-projects__my_projects" should exist
-    And one of the ".project-list__title" elements should contain "My projects"
+    And one of the ".project-list__title" elements should contain "My shared projects"
 
   Scenario: My Projects section appears before other categories on the landing page
     Given I log in as "Catrobat"

--- a/tests/PhpUnit/Api/ProjectsApiTest.php
+++ b/tests/PhpUnit/Api/ProjectsApiTest.php
@@ -609,7 +609,7 @@ final class ProjectsApiTest extends KernelTestCase
     $this->facade->method('getProcessor')->willReturn($processor);
 
     $file = $this->createStub(UploadedFile::class);
-    $response = $this->object->projectsPost('checksum', $file, 'en', '', false, $response_code, $response_headers);
+    $response = $this->object->projectsPost('checksum', $file, 'en', '', false, null, $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_CREATED, $response_code);
     $this->assertArrayHasKey('Location', $response_headers);
@@ -642,7 +642,7 @@ final class ProjectsApiTest extends KernelTestCase
     $this->facade->method('getRequestValidator')->willReturn($validator);
 
     $file = $this->createStub(UploadedFile::class);
-    $response = $this->object->projectsPost('checksum', $file, 'en', '', false, $response_code, $response_headers);
+    $response = $this->object->projectsPost('checksum', $file, 'en', '', false, null, $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response_code);
     $this->assertInstanceOf(ErrorResponse::class, $response);
@@ -669,7 +669,7 @@ final class ProjectsApiTest extends KernelTestCase
     $this->facade->method('getProcessor')->willReturn($processor);
 
     $file = $this->createStub(UploadedFile::class);
-    $response = $this->object->projectsPost('checksum', $file, 'en', '', false, $response_code, $response_headers);
+    $response = $this->object->projectsPost('checksum', $file, 'en', '', false, null, $response_code, $response_headers);
 
     $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response_code);
     $this->assertInstanceOf(ErrorResponse::class, $response);

--- a/translations/catroweb.en.yaml
+++ b/translations/catroweb.en.yaml
@@ -199,7 +199,7 @@ project:
   tooLongName: The project name is too long!
   tooLongDescription: The project description is too long!
   tooLongCredits: The project notes and credits are too long!
-  my_projects: My projects
+  my_projects: My shared projects
   trending: Trending projects
   popular: Popular projects
   most:


### PR DESCRIPTION
## Summary
- Adds optional `project_id` (UUID) parameter to `POST /api/projects` upload endpoint
- When provided, server matches by UUID instead of by name, allowing project renames without creating duplicates
- Falls back to name-based matching when `project_id` is not provided (backward compatible)
- Validates that `project_id` belongs to the authenticated user before matching
- Renames "My projects" to "My shared projects" on index page

## Context
When the Catroid app downloads a project, modifies it, and re-uploads with a different name, the server currently creates a duplicate instead of updating the existing project. This is because duplicate detection only uses name + user matching.

This change enables the app to send the original project UUID during re-upload, so the server can correctly identify the project to update even after a rename.

Companion PR in Catroid: the `restore-share` branch will send `project_id` during upload and set the remix URL on download.

## Test plan
- [ ] Existing upload tests pass (PHPUnit ProjectsApiTest - verified locally)
- [ ] New Behat scenario: upload with `project_id` updates existing project
- [ ] Upload without `project_id` still works (backward compatible)
- [ ] `project_id` belonging to different user is ignored (falls back to name matching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)