### PR TITLE
fix: sanitize slashes in project name for catrobat download

### DIFF
--- a/src/Api/Services/Projects/ProjectsResponseManager.php
+++ b/src/Api/Services/Projects/ProjectsResponseManager.php
@@ -474,7 +474,8 @@ class ProjectsResponseManager extends AbstractResponseManager
   public function createProjectCatrobatFileResponse(string $id, File $file, ?string $name = null): BinaryFileResponse
   {
     $response = new BinaryFileResponse($file);
-    $filename = null !== $name ? $name.'.catrobat' : $id.'.catrobat';
+    $sanitized = null !== $name ? str_replace(['/', '\\'], '_', $name) : $id;
+    $filename = $sanitized.'.catrobat';
     $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename, $id.'.catrobat');
     $response->headers->set('Content-Type', 'application/zip');
 

--- a/tests/PhpUnit/Api/ProjectsApiTest.php
+++ b/tests/PhpUnit/Api/ProjectsApiTest.php
@@ -719,4 +719,19 @@ final class ProjectsApiTest extends KernelTestCase
 
     $this->assertSame(Response::HTTP_OK, $response_code);
   }
+
+  public function testCreateProjectCatrobatFileResponseSanitizesSlashesInName(): void
+  {
+    $tmp = tempnam(sys_get_temp_dir(), 'catrobat_test_');
+    file_put_contents($tmp, 'dummy');
+    $file = new \Symfony\Component\HttpFoundation\File\File($tmp);
+
+    $response = $this->full_response_manager->createProjectCatrobatFileResponse('abc', $file, 'path/to\project');
+
+    $disposition = $response->headers->get('Content-Disposition');
+    $this->assertStringContainsString('path_to_project.catrobat', $disposition);
+    $this->assertStringNotContainsString('/', $disposition);
+
+    unlink($tmp);
+  }
 }

--- a/tests/PhpUnit/Api/ProjectsApiTest.php
+++ b/tests/PhpUnit/Api/ProjectsApiTest.php
@@ -723,6 +723,7 @@ final class ProjectsApiTest extends KernelTestCase
   public function testCreateProjectCatrobatFileResponseSanitizesSlashesInName(): void
   {
     $tmp = tempnam(sys_get_temp_dir(), 'catrobat_test_');
+    $this->assertIsString($tmp);
     file_put_contents($tmp, 'dummy');
     $file = new \Symfony\Component\HttpFoundation\File\File($tmp);
 


### PR DESCRIPTION
## Summary
- Project names containing `/` or `\` caused API 500 when downloading `.catrobat` files (`GET /api/projects/{id}/catrobat`)
- Symfony's `HeaderUtils::makeDisposition()` rejects those characters in `Content-Disposition` filenames
- Fix: replace `/` and `\` with `_` in the download filename

## Test plan
- [x] Added PHPUnit test for filename sanitization with slashes
- [ ] Verify downloading a project whose name contains `/` or `\` returns 200 instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)