### PR TITLE
[codex] Resolve remaining issue #6521 remix concurrency TODO

### DIFF
--- a/src/Project/Remix/RemixUpdaterEventListener.php
+++ b/src/Project/Remix/RemixUpdaterEventListener.php
@@ -71,14 +71,42 @@ class RemixUpdaterEventListener
     }
 
     if (!file_exists($this->migration_lock_file_path)) {
-      // TODO: make sure no inconsistencies (due to concurrency issues) can happen here!!
-      $this->remix_manager->addScratchProjects($scratch_info_data);
-      $this->remix_manager->addRemixes($project, $remixes_data);
+      $this->withRemixUpdateLock(function () use ($scratch_info_data, $project, $remixes_data): void {
+        if (file_exists($this->migration_lock_file_path)) {
+          return;
+        }
+
+        $this->remix_manager->addScratchProjects($scratch_info_data);
+        $this->remix_manager->addRemixes($project, $remixes_data);
+      });
     }
 
     $project_xml_properties->header->remixOf = $remix_url_string;
     $project_xml_properties->header->url = $this->router->generate('project', ['id' => $project->getId(), 'theme' => Flavor::POCKETCODE]);
     $project_xml_properties->header->userHandle = $project->getUser()->getUsername();
     $file->saveProjectXmlProperties();
+  }
+
+  /**
+   * Serializes remix writes to avoid races when multiple uploads are processed in parallel.
+   */
+  private function withRemixUpdateLock(callable $update_callback): void
+  {
+    $lock_file_path = sys_get_temp_dir().'/catrobat-remix-updater-'.md5($this->migration_lock_file_path).'.lock';
+    $lock_file = fopen($lock_file_path, 'c+');
+    if (false === $lock_file) {
+      throw new \RuntimeException('Could not open lock file: '.$lock_file_path);
+    }
+
+    try {
+      if (!flock($lock_file, LOCK_EX)) {
+        throw new \RuntimeException('Could not acquire lock file: '.$lock_file_path);
+      }
+
+      $update_callback();
+    } finally {
+      flock($lock_file, LOCK_UN);
+      fclose($lock_file);
+    }
   }
 }

--- a/tests/PhpUnit/Project/Remix/RemixUpdaterEventListenerTest.php
+++ b/tests/PhpUnit/Project/Remix/RemixUpdaterEventListenerTest.php
@@ -497,6 +497,43 @@ class RemixUpdaterEventListenerTest extends TestCase
   /**
    * @throws \Exception
    */
+  public function testSkipsRemixDatabaseUpdatesDuringMigration(): void
+  {
+    $migration_lock_file_path = tempnam(sys_get_temp_dir(), 'catrobat-remix-migration-');
+    $this->assertIsString($migration_lock_file_path);
+
+    $router = $this->createStub(RouterInterface::class);
+    $logger = $this->createStub(LoggerInterface::class);
+    $router->method('generate')->willReturnMap([
+      ['project', ['id' => '3571', 'theme' => Flavor::POCKETCODE], UrlGeneratorInterface::ABSOLUTE_PATH, 'http://share.catrob.at/details/3571'],
+      ['project', ['id' => '3572', 'theme' => Flavor::POCKETCODE], UrlGeneratorInterface::ABSOLUTE_PATH, 'http://share.catrob.at/details/3572'],
+    ]);
+
+    $remix_updater = new RemixUpdaterEventListener(
+      $this->remix_manager,
+      $this->async_http_client,
+      $router,
+      $logger,
+      $migration_lock_file_path
+    );
+
+    $file = new ExtractedCatrobatFile(BootstrapExtension::$CACHE_DIR.'base/', '/webpath', 'hash');
+    $this->program_entity->expects($this->atLeastOnce())->method('getId')->willReturn('3571');
+    $this->program_entity->expects($this->atLeastOnce())->method('isInitialVersion')->willReturn(true);
+    $this->async_http_client->expects($this->atLeastOnce())->method('fetchScratchProjectDetails')->with($this->isArray())->willReturn([]);
+    $this->remix_manager->expects($this->atLeastOnce())->method('getProjectRepository');
+    $this->remix_manager->expects($this->atLeastOnce())->method('filterExistingScratchProjectIds')->with(['117697631'])->willReturn([]);
+    $this->remix_manager->expects($this->never())->method('addScratchProjects');
+    $this->remix_manager->expects($this->never())->method('addRemixes');
+
+    $remix_updater->update($file, $this->program_entity);
+
+    @unlink($migration_lock_file_path);
+  }
+
+  /**
+   * @throws \Exception
+   */
   #[AllowMockObjectsWithoutExpectations]
   public function testUpdateTheRemixOfOfTheEntity(): void
   {


### PR DESCRIPTION
## Summary
- add a file-lock protected critical section around remix DB writes in `RemixUpdaterEventListener`
- keep migration compatibility by re-checking the migration lock inside the critical section before persisting remix data
- add a PHPUnit test that verifies remix DB writes are skipped while migration lock is present

## Why
Issue #6521 still had one unresolved TODO in `RemixUpdaterEventListener` about possible inconsistencies under concurrent uploads. The listener performed write operations without synchronization, which could race when multiple uploads are processed in parallel.

## Impact
- serializes `addScratchProjects` + `addRemixes` writes per deployment environment
- preserves existing XML/header update behavior for uploaded projects
- adds regression coverage for migration-lock behavior

## Validation
- `bin/phpunit tests/PhpUnit/Project/Remix/RemixUpdaterEventListenerTest.php`

Fixes #6521