### PR TITLE
Show system icon for project expiring/deleted notifications

### DIFF
--- a/assets/User/NotificationsPage.js
+++ b/assets/User/NotificationsPage.js
@@ -274,6 +274,9 @@ class UserNotifications {
     if (fetched.type === 'moderation') {
       return '<span class="material-icons notification-broadcast-icon">flag</span>'
     }
+    if (fetched.type === 'project' && !fetched.from) {
+      return '<span class="material-icons notification-broadcast-icon">auto_delete</span>'
+    }
     if (fetched.type !== 'other') {
       const safeFrom = encodeURIComponent(fetched.from)
       const safeName = escapeAttr(fetched.from_name || '')


### PR DESCRIPTION
## Summary
- Project system notifications (expiring/deleted) rendered a default avatar because they have no sender (`from` field)
- Now shows `auto_delete` Material Icon instead, consistent with how moderation notifications show a `flag` icon
- No backend changes — the "projects" filter chip already includes these notification types

## Test plan
- [ ] Verify project deleted/expiring notifications show `auto_delete` icon
- [ ] Verify comment notifications (type=project with sender) still show user avatar
- [ ] Verify moderation notifications still show flag icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)