### PR TITLE
Fix wasted preconnect hints and duplicate image preloads

### DIFF
--- a/templates/Index/IndexPage.html.twig
+++ b/templates/Index/IndexPage.html.twig
@@ -12,8 +12,7 @@
             imagesizes="(min-width: 1200px) 960px, 100vw"
             type="image/avif"
             fetchpriority="high">
-    {% endif %}
-    {% if _variants.webp1x is defined %}
+    {% elseif _variants.webp1x is defined %}
       <link rel="preload" as="image"
             href="{{ _variants.webp1x }}"
             imagesrcset="{{ _variants.webp1x }} 1x{% if _variants.webp2x is defined %}, {{ _variants.webp2x }} 2x{% endif %}"

--- a/templates/Layout/Base.html.twig
+++ b/templates/Layout/Base.html.twig
@@ -14,8 +14,6 @@
   {% if bugsnag_api_key %}
     <link rel="dns-prefetch" href="https://sessions.bugsnag.com">
     <link rel="dns-prefetch" href="https://notify.bugsnag.com">
-    <link rel="preconnect" href="https://sessions.bugsnag.com" crossorigin>
-    <link rel="preconnect" href="https://notify.bugsnag.com" crossorigin>
   {% endif %}
 
   {% block stylesheets %}


### PR DESCRIPTION
## Summary
- **Remove Bugsnag `preconnect` hints** — ad blockers kill Bugsnag requests (`ERR_BLOCKED_BY_CLIENT`), wasting full TCP+TLS handshakes. `dns-prefetch` kept (near-zero cost, fails silently). Fixes Lighthouse "Unused preconnect" warning.
- **Only preload AVIF for featured banner** — was preloading both AVIF and WebP; browser picks AVIF → WebP preload unused → "preloaded but not used within a few seconds" console warning. Now: AVIF if available, else WebP, else default.

## Test plan
- [ ] Verify no "unused preconnect" warning in Lighthouse
- [ ] Verify no "preloaded but not used" console warning on index page
- [ ] Verify featured banner still loads correctly (AVIF in modern browsers, WebP fallback)
- [ ] Verify Bugsnag error reporting still works (dns-prefetch sufficient)

🤖 Generated with [Claude Code](https://claude.com/claude-code)