### PR TITLE
fix(ci): stop loading external help URL + bump Chrome to 124

### DIFF
--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -109,7 +109,7 @@ services:
   # --- Tests:
 
   chrome.catroweb:
-    image: zenika/alpine-chrome:100
+    image: zenika/alpine-chrome:124
     container_name: chrome.catroweb
     restart: on-failure
     shm_size: '512mb'

--- a/docker/docker-compose.test.yaml
+++ b/docker/docker-compose.test.yaml
@@ -24,7 +24,7 @@ services:
     # --- Tests:
 
   chrome.catroweb:
-    image: zenika/alpine-chrome:100
+    image: zenika/alpine-chrome:124
     container_name: chrome.catroweb
     shm_size: '512mb'
     restart: on-failure

--- a/src/System/Testing/Behat/Context/ApiContext.php
+++ b/src/System/Testing/Behat/Context/ApiContext.php
@@ -444,6 +444,17 @@ class ApiContext implements Context
   }
 
   /**
+   * @Then /^the response Location header should be "([^"]*)"$/
+   *
+   * @throws \Exception
+   */
+  public function theResponseLocationHeaderShouldBe(string $expected_url): void
+  {
+    $location_header = $this->getKernelBrowser()->getResponse()->headers->get('Location');
+    Assert::assertSame($expected_url, $location_header);
+  }
+
+  /**
    * @Then /^the response should be in json format$/
    *
    * @throws \Exception

--- a/src/System/Testing/Behat/Context/ApiContext.php
+++ b/src/System/Testing/Behat/Context/ApiContext.php
@@ -455,6 +455,16 @@ class ApiContext implements Context
   }
 
   /**
+   * @Given /^I do not follow redirects$/
+   *
+   * @throws \Exception
+   */
+  public function iDoNotFollowRedirects(): void
+  {
+    $this->getKernelBrowser()->followRedirects(false);
+  }
+
+  /**
    * @Then /^the response should be in json format$/
    *
    * @throws \Exception

--- a/tests/BehatFeatures/web/general/help.feature
+++ b/tests/BehatFeatures/web/general/help.feature
@@ -6,12 +6,14 @@ Feature: Help page redirect
   # external catrobat.org/docs/ page in CI.
 
   Scenario: Navigating to "/app/help" should redirect to the wiki
+    Given I do not follow redirects
     When I set request language to "English"
     And I GET "/app/help"
     Then the response status code should be "302"
     And the response Location header should be "https://catrobat.org/docs/"
 
   Scenario: Navigating to "/app/help" should redirect to a german page
+    Given I do not follow redirects
     When I set request language to "Deutsch"
     And I GET "/app/help"
     Then the response status code should be "302"

--- a/tests/BehatFeatures/web/general/help.feature
+++ b/tests/BehatFeatures/web/general/help.feature
@@ -1,14 +1,18 @@
 @web @help
 Feature: Help page redirect
 
+  # Note: assert via HTTP redirect (Location header), not browser navigation.
+  # Browser navigation triggered Chrome OOM crashes when loading the heavy
+  # external catrobat.org/docs/ page in CI.
+
   Scenario: Navigating to "/app/help" should redirect to the wiki
-    When I switch the language to "English"
-    And I go to "/app/help"
-    And I wait for the page to be loaded
-    Then I should be on "https://catrobat.org/docs/"
+    When I set request language to "English"
+    And I GET "/app/help"
+    Then the response status code should be "302"
+    And the response Location header should be "https://catrobat.org/docs/"
 
   Scenario: Navigating to "/app/help" should redirect to a german page
-    When I switch the language to "Deutsch"
-    And I go to "/app/help"
-    And I wait for the page to be loaded
-    Then I should be on "https://catrobat.org/de/dokumentation/"
+    When I set request language to "Deutsch"
+    And I GET "/app/help"
+    Then the response status code should be "302"
+    And the response Location header should be "https://catrobat.org/de/dokumentation/"


### PR DESCRIPTION
## Summary

- **Root cause:** Both \"Development Container\" and \"Behat (web-general web-notifications)\" pipelines have been failing on every PR (e.g. #6819) since 2026-05-05. Same SHA passed 2026-05-04 → not a code regression. The shared scenario `help.feature` makes the browser navigate to `https://catrobat.org/docs/`; that page apparently got heavier and Chromium 100 (`zenika/alpine-chrome:100`, Apr 2022, frozen) OOMs loading it. Symptom: `Browser crashed`, `Couldn't find window`, `<--- Last few GCs --->  Mark-sweep ... allocation failure`.
- **Option A — fix the test:** rewrite `help.feature` to assert the 302 + `Location` header via `KernelBrowser` (no real browser, no external page load). We test our own redirect, not catrobat.org's page weight. Adds a reusable `the response Location header should be ":url"` step in `ApiContext`.
- **Option B — bump the engine:** `zenika/alpine-chrome:100` → `:124` in both `docker-compose.dev.yaml` and `docker-compose.test.yaml`. Future browser-loaded tests get a current engine instead of one stuck at 2022.

## Test plan

- [ ] `Behat (web-general web-notifications)` passes
- [ ] `Development Container` passes (runs `bin/behat -s web-general` as smoke)
- [ ] All other Behat suites still green on bumped Chrome 124
- [ ] PHPUnit + static analysis green

🤖 Generated with [Claude Code](https://claude.com/claude-code)