### PR TITLE
test(behat): replace fixed delays with element waits in achievement popup

### DIFF
--- a/tests/BehatFeatures/web/achievements/achievements_sidebar_badge.feature
+++ b/tests/BehatFeatures/web/achievements/achievements_sidebar_badge.feature
@@ -49,9 +49,10 @@ Feature: Sidebar should show an indication of unseen achievements in form of a b
     When I am on "/app/achievements"
     And I wait for the page to be loaded
     And I wait for AJAX to finish
+    And I wait for the element ".swal2-confirm" to be visible
     And I click ".swal2-confirm"
     And I wait for AJAX to finish
-    And I wait for the page to be loaded
+    And the element ".swal2-popup" should not exist
     Then the element "#sidebar_badge--unseen-achievements" should not be visible
     When I am on "/app"
     And I open the menu

--- a/tests/BehatFeatures/web/achievements/new_achievement_animation.feature
+++ b/tests/BehatFeatures/web/achievements/new_achievement_animation.feature
@@ -31,9 +31,10 @@ Feature: Sidebar should show an indication of unseen achievements in form of a b
     When I am on "/app/achievements"
     And I wait for the page to be loaded
     And I wait for AJAX to finish
-    And I wait 1000 milliseconds
+    And I wait for the element ".swal2-popup" to be visible
+    And I wait for the element ".swal2-popup" to contain "Congratulations"
     Then I should see "Congratulations"
     When I click ".swal2-confirm"
     And I wait for AJAX to finish
-    And I wait 500 milliseconds
-    Then I should not see "Congratulations"
+    Then the element ".swal2-popup" should not exist
+    And I should not see "Congratulations"


### PR DESCRIPTION
## Summary
- web-achievements suite has been flaky on `Then I should see "Congratulations"` (e.g. PR #6823 CI run [74941865353](https://github.com/Catrobat/Catroweb/actions/runs/25532490435/job/74941865353)).
- Root cause: the SweetAlert popup is rendered after `await import('sweetalert2')` (dynamic ES chunk) + async SVG load via `external-svg-loader`. Neither is tracked by `wait for AJAX to finish`, and the fixed `wait 1000 milliseconds` raced on slow CI.
- Fix: replace fixed delays with element-state waits (`element to be visible` / `element to contain :text`) and assert `.swal2-popup should not exist` after close (Swal removes the node, per CLAUDE.md flaky-test rule).

No JS / app changes — feature files only.

## Test plan
- [ ] CI: `Behat (web-achievements)` passes
- [ ] No regression in other Behat suites