### PR TITLE
chore(nsfw-scanner): bump deps + harden container, add pip Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -58,3 +58,11 @@ updates:
       time: '04:00'
       timezone: 'Europe/Vienna'
     open-pull-requests-limit: 99
+
+  - package-ecosystem: 'pip'
+    directory: '/docker/nsfw-scanner'
+    schedule:
+      interval: daily
+      time: '04:00'
+      timezone: 'Europe/Vienna'
+    open-pull-requests-limit: 99

--- a/docker/nsfw-scanner/Dockerfile
+++ b/docker/nsfw-scanner/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:3.12-slim
 
+ENV HF_HOME=/home/app/.cache/huggingface
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PIP_NO_CACHE_DIR=1
+
+RUN useradd --create-home --shell /usr/sbin/nologin app
+
 WORKDIR /app
 
 COPY requirements.txt .
@@ -7,8 +13,12 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app.py .
 
-# Download model at build time
-RUN python -c "from transformers import pipeline; pipeline('image-classification', model='Falconsai/nsfw_image_detection')"
+# Download model at build time into the non-root user's HF cache
+RUN mkdir -p "$HF_HOME" \
+  && python -c "from transformers import pipeline; pipeline('image-classification', model='Falconsai/nsfw_image_detection')" \
+  && chown -R app:app /home/app
+
+USER app
 
 EXPOSE 5000
 

--- a/docker/nsfw-scanner/app.py
+++ b/docker/nsfw-scanner/app.py
@@ -4,6 +4,7 @@ from PIL import Image
 from transformers import pipeline
 
 app = Flask(__name__)
+app.config["MAX_CONTENT_LENGTH"] = 10 * 1024 * 1024  # 10 MB
 classifier = pipeline("image-classification", model="Falconsai/nsfw_image_detection")
 
 

--- a/docker/nsfw-scanner/requirements.txt
+++ b/docker/nsfw-scanner/requirements.txt
@@ -1,5 +1,5 @@
-flask==3.1.*
-gunicorn==23.*
-transformers==4.48.*
-torch==2.6.*
-Pillow==11.*
+flask>=3.1,<4
+gunicorn>=23,<24
+transformers>=4.57,<5
+torch>=2.8,<3
+Pillow>=12.2,<13


### PR DESCRIPTION
## Summary

- Bumps `Pillow`, `transformers`, and `torch` in `docker/nsfw-scanner/requirements.txt` to versions patching the **18 open Dependabot alerts** on that manifest (3 high, 13 medium, 2 low). Most CVEs target code paths the scanner does not exercise (PSD/FITS/PDF parsers, tokenizer ReDoS, `Trainer` class) but bumping is cheap and clears the backlog.
- Adds a missing `pip` ecosystem to `.github/dependabot.yaml` for `/docker/nsfw-scanner` — root cause nothing was auto-fixing this manifest until now.
- Hardens the container: runs as non-root `app` user, caps Flask request body to 10 MB.

### Version moves

| pkg | before | after |
| --- | --- | --- |
| flask | `==3.1.*` | `>=3.1,<4` |
| gunicorn | `==23.*` | `>=23,<24` |
| transformers | `==4.48.*` | `>=4.57,<5` |
| torch | `==2.6.*` | `>=2.8,<3` |
| Pillow | `==11.*` | `>=12.2,<13` |

One alert (`GHSA-69w3-r845-3855`, `Trainer` class arbitrary code exec, only fixed in `transformers 5.0.0rc3`) will remain — we don't use `Trainer`, only `pipeline("image-classification", ...)`. I'll dismiss it manually post-merge as "vulnerable code not used" unless we want to jump to `transformers 5.x` in a follow-up.

### Deployment note

The repo's `deploy.php` does **not** rebuild the nsfw-scanner container — production runs it via a compose file outside this repo (path TBD). So this PR alone bumps the *image recipe* but not the *running container*. Follow-up work: wire a `restart:nsfw-scanner` Deployer task (or GHCR-pull + Watchtower). Tracking that separately.

## Test plan

- [ ] `docker compose -f docker/docker-compose.dev.yaml build --no-cache nsfw-scanner` succeeds
- [ ] `docker compose -f docker/docker-compose.dev.yaml up -d nsfw-scanner` brings it up healthy
- [ ] `curl -s http://localhost:5050/health` returns `{"status":"ok"}`
- [ ] `curl -s --data-binary @sample.jpg -H 'Content-Type: application/octet-stream' http://localhost:5050/scan` returns the same `{safe, nsfw_score, safe_score, label}` shape as before
- [ ] Posting a >10 MB body returns `413`
- [ ] `bin/phpunit --filter ContentSafetyScannerTest` still green
- [ ] After merge: Security tab alert count for `docker/nsfw-scanner/requirements.txt` drops from 18 to ≤1

🤖 Generated with [Claude Code](https://claude.com/claude-code)