### PR TITLE
ops(nsfw-scanner): automate prod rebuild via Deployer

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -93,6 +93,42 @@ task('restart:php-fpm', function () {
   run('sudo /usr/sbin/service php{{php_fpm_version}}-fpm restart');
 });
 
+// Sync nsfw-scanner sources to /opt/nsfw-scanner and rebuild the container only
+// when the source files actually changed (model download is multi-minute). On
+// first run after switching from raw `docker run` to compose, the legacy
+// container is force-removed so compose can take over the `nsfw-scanner` name.
+// Requires the deploy user to be in the `docker` group on the prod host.
+task('restart:nsfw-scanner', function () {
+  $dst = '/opt/nsfw-scanner';
+  if (!test("[ -d {$dst} ]")) {
+    info('nsfw-scanner not installed on this host, skipping');
+
+    return;
+  }
+
+  $src = '{{release_path}}/docker/nsfw-scanner';
+  $hashCmd = "find %s -type f -exec sha256sum {} + | sort | sha256sum | cut -d' ' -f1";
+  $srcHash = trim(run(sprintf($hashCmd, $src)));
+  $dstHash = trim(run(sprintf($hashCmd, $dst)));
+
+  if ($srcHash === $dstHash) {
+    info('nsfw-scanner sources unchanged, skipping rebuild');
+
+    return;
+  }
+
+  info('nsfw-scanner sources changed, rebuilding');
+  run("rsync -a --delete {$src}/ {$dst}/");
+
+  $composeProject = trim(run("docker inspect nsfw-scanner --format '{{index .Config.Labels \"com.docker.compose.project\"}}' 2>/dev/null || true"));
+  if ('' === $composeProject) {
+    info('Migrating nsfw-scanner from raw docker-run to docker compose');
+    run('docker rm -f nsfw-scanner 2>/dev/null || true');
+  }
+
+  run("cd {$dst} && docker compose -f docker-compose.prod.yaml up -d --build");
+});
+
 task('install:yarn', function () {
   cd('{{release_path}}');
   run('mkdir -p .corepack-bin && corepack enable --install-directory=.corepack-bin');
@@ -183,6 +219,7 @@ task('deploy', [
   'deploy:symlink',
   'restart:nginx',
   'restart:php-fpm',
+  'restart:nsfw-scanner',
   'update:flavors',
   'update:achievements',
   'update:tags',

--- a/docker/nsfw-scanner/docker-compose.prod.yaml
+++ b/docker/nsfw-scanner/docker-compose.prod.yaml
@@ -1,0 +1,20 @@
+services:
+  nsfw-scanner:
+    container_name: nsfw-scanner
+    build: .
+    image: nsfw-scanner:latest
+    ports:
+      - '127.0.0.1:5000:5000'
+    restart: always
+    mem_limit: 4g
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'python',
+          '-c',
+          "import urllib.request; urllib.request.urlopen('http://localhost:5000/health')",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3

--- a/docs/operations/NSFW-Content-Scanning.md
+++ b/docs/operations/NSFW-Content-Scanning.md
@@ -81,27 +81,24 @@ The NSFW scanner runs as a standalone Docker container on the production server.
 
 ### Installation
 
+One-time prerequisites on the production server (run as `root`):
+
 ```bash
 # Create the scanner directory
 mkdir -p /opt/nsfw-scanner
 
-# Copy the three files from the repo
-cp docker/nsfw-scanner/app.py /opt/nsfw-scanner/
-cp docker/nsfw-scanner/requirements.txt /opt/nsfw-scanner/
-cp docker/nsfw-scanner/Dockerfile /opt/nsfw-scanner/
-
-# Build the image (takes ~5 minutes first time)
-cd /opt/nsfw-scanner
-docker build -t nsfw-scanner:latest .
-
-# Run with auto-restart (survives reboots)
-docker run -d \
-  --name nsfw-scanner \
-  --restart always \
-  -p 127.0.0.1:5000:5000 \
-  --memory=4g \
-  nsfw-scanner:latest
+# Allow the deploy user to manage the container without sudo
+usermod -aG docker deploy
 ```
+
+After the next deploy, the `restart:nsfw-scanner` task in `deploy.php` will:
+
+1. `rsync` `docker/nsfw-scanner/` from the release directory into `/opt/nsfw-scanner/`.
+2. Compare a sha256 of the source vs. the deployed tree and skip rebuild when unchanged (the model download is multi-minute).
+3. On the very first run after switching from raw `docker run` to compose, force-remove the legacy container so compose can adopt the `nsfw-scanner` name.
+4. Run `docker compose -f docker-compose.prod.yaml up -d --build` to rebuild and (re)start the container.
+
+Subsequent deploys auto-update the container whenever any file under `docker/nsfw-scanner/` changes.
 
 ### Verify
 
@@ -132,17 +129,11 @@ CONTENT_SAFETY_THRESHOLD=0.7
 
 ### Updating
 
+Merging a change to any file under `docker/nsfw-scanner/` and triggering a deploy is sufficient — the `restart:nsfw-scanner` task picks it up automatically. Manual intervention is only needed if you have to roll back outside the Deployer workflow:
+
 ```bash
 cd /opt/nsfw-scanner
-docker stop nsfw-scanner
-docker rm nsfw-scanner
-docker build -t nsfw-scanner:latest .
-docker run -d \
-  --name nsfw-scanner \
-  --restart always \
-  -p 127.0.0.1:5000:5000 \
-  --memory=4g \
-  nsfw-scanner:latest
+docker compose -f docker-compose.prod.yaml up -d --build
 ```
 
 ## Monitoring


### PR DESCRIPTION
## Summary

Until now the `nsfw-scanner` container on the `share.catrobat.org` host was managed entirely by hand: someone had to ssh in, copy the three source files from the repo into `/opt/nsfw-scanner/`, `docker build`, and `docker run`. As a result the running image drifted weeks behind the repo — the 18 open Dependabot alerts on `requirements.txt` were only being addressed at the repo level (#6832), never on the actual server.

This PR closes the gap.

### Changes

- **`docker/nsfw-scanner/docker-compose.prod.yaml`** — same port binding (`127.0.0.1:5000`), restart policy, and memory cap the hand-rolled `docker run` used, but expressed as compose so deploys can adopt the standard `docker compose up -d --build` flow.
- **`deploy.php` → `restart:nsfw-scanner` task** wired in right after `restart:php-fpm`. It:
  1. Bails out if `/opt/nsfw-scanner/` does not exist (e.g. running against a host without the scanner installed).
  2. Compares a `sha256sum` of the release-tree's `docker/nsfw-scanner/` against the currently deployed `/opt/nsfw-scanner/` and **skips the rebuild entirely** when unchanged — the HuggingFace model download is multi-minute, so deploys must not pay that cost every time.
  3. `rsync -a --delete`s the new sources into place.
  4. On the very first run after switching from raw `docker run` to compose, detects the missing `com.docker.compose.project` label on the current container and force-removes it so compose can adopt the `nsfw-scanner` name.
  5. Runs `docker compose -f docker-compose.prod.yaml up -d --build`.
- **`docs/operations/NSFW-Content-Scanning.md`** updated: bootstrap section now reflects the one-time prereq, manual "Updating" runbook replaced with a one-liner pointing at the Deployer task.

### One-time prereq on the prod host before merging

```bash
sudo usermod -aG docker deploy
# deploy user must re-login (or wait for a deploy session refresh) for the group to take effect
```

The `deploy` user is currently in groups `deploy users` only — without `docker` group membership the new task would fail at `docker inspect`/`docker compose`.

### Why two PRs

This is the *deploy automation* half; the *dependency bumps themselves* (Pillow 12.2+, transformers 4.57+, torch 2.8+, non-root user, 10 MB request cap) ship in #6832. Either PR is valuable on its own:

- #6832 alone silences the 18 Dependabot alerts in the repo, but the running image stays stale until someone manually rebuilds.
- This PR alone wires automation, but until #6832 lands the next deploy will rebuild the existing vulnerable recipe.

Recommended landing order: #6832 first, then this PR. After both merge, the very next deploy will rebuild the container with the patched dependencies.

## Test plan

- [ ] `php -l deploy.php` (already passes locally)
- [ ] One-time prereq applied on prod: `usermod -aG docker deploy`
- [ ] Trigger a deploy with no changes under `docker/nsfw-scanner/` → expect `"nsfw-scanner sources unchanged, skipping rebuild"` log line, container untouched
- [ ] Trigger a deploy after merging #6832 → expect rebuild log + container restarts with new image
- [ ] After the rebuilt container is up, `curl http://127.0.0.1:5000/health` on prod returns `{"status":"ok"}`
- [ ] `docker inspect nsfw-scanner` now shows `com.docker.compose.project: nsfw-scanner` labels (proof the migration completed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)