### PR TITLE
fix(deploy): rsync nsfw-scanner without owner/group preservation

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -97,7 +97,8 @@ task('restart:php-fpm', function () {
 // when the source files actually changed (model download is multi-minute). On
 // first run after switching from raw `docker run` to compose, the legacy
 // container is force-removed so compose can take over the `nsfw-scanner` name.
-// Requires the deploy user to be in the `docker` group on the prod host.
+// Requires the deploy user to be in the `docker` group on the prod host and
+// to own /opt/nsfw-scanner (e.g. chown -R deploy:deploy /opt/nsfw-scanner).
 task('restart:nsfw-scanner', function () {
   $dst = '/opt/nsfw-scanner';
   if (!test("[ -d {$dst} ]")) {
@@ -118,7 +119,8 @@ task('restart:nsfw-scanner', function () {
   }
 
   info('nsfw-scanner sources changed, rebuilding');
-  run("rsync -a --delete {$src}/ {$dst}/");
+  // -rlt (not -a): skip owner/group preservation since the deploy user is not root
+  run("rsync -rlt --delete {$src}/ {$dst}/");
 
   $composeProject = trim(run("docker inspect nsfw-scanner --format '{{index .Config.Labels \"com.docker.compose.project\"}}' 2>/dev/null || true"));
   if ('' === $composeProject) {

--- a/docs/operations/NSFW-Content-Scanning.md
+++ b/docs/operations/NSFW-Content-Scanning.md
@@ -84,8 +84,9 @@ The NSFW scanner runs as a standalone Docker container on the production server.
 One-time prerequisites on the production server (run as `root`):
 
 ```bash
-# Create the scanner directory
+# Create the scanner directory and hand it to the deploy user
 mkdir -p /opt/nsfw-scanner
+chown -R deploy:deploy /opt/nsfw-scanner
 
 # Allow the deploy user to manage the container without sudo
 usermod -aG docker deploy


### PR DESCRIPTION
## Summary

Fix-forward for the failed deploy run [25683832620](https://github.com/Catrobat/Catroweb/actions/runs/25683832620) after #6833 merged.

The `restart:nsfw-scanner` task in `deploy.php` ran for the first time and failed at rsync:

```
rsync: [generator] chgrp "/opt/nsfw-scanner/." failed: Operation not permitted (1)
rsync: [receiver] mkstemp "/opt/nsfw-scanner/.Dockerfile.OClsSc" failed: Permission denied (13)
...
exit code 23 (Unknown error)
```

Two root causes:

1. **`/opt/nsfw-scanner/` is owned by `root:root`** — leftover from the manual bootstrap that originally seeded the directory. The `deploy` user cannot write into it.
2. **`rsync -a` implies `-o -g`** (preserve owner/group), which fails for any user without `CAP_CHOWN` — exactly the situation under SSH-as-`deploy`.

## Fix

- Switch the rsync flag set from `-a --delete` to `-rlt --delete --no-owner --no-group`-equivalent (`-rlt`). The only attributes worth carrying across releases are recursion, symlinks, and mtimes; ownership is managed by the bootstrap state of the destination directory, not by rsync.
- Add the missing `chown -R deploy:deploy /opt/nsfw-scanner` step to the one-time prerequisites in `docs/operations/NSFW-Content-Scanning.md` and the task's leading comment in `deploy.php`.

## Required action on prod before the next deploy

```bash
ssh root@95.216.224.116 'chown -R deploy:deploy /opt/nsfw-scanner'
```

After that, the next deploy will rsync the new sources in, force-remove the legacy `docker run` container (first-run migration code path), and run `docker compose up -d --build` for the first time. Expect ~5 min extra deploy time for the model download.

## Current prod state (no user-visible breakage)

The failed deploy still completed `deploy:symlink`, `restart:nginx`, and `restart:php-fpm` before erroring, so Catroweb itself is serving the new release. The old nsfw-scanner container is untouched (rsync errored before it wrote anything, and the rm/compose-up steps never ran). Image uploads continue to hit the existing scanner on `127.0.0.1:5000` exactly as before.

## Test plan

- [ ] Apply the `chown` on prod
- [ ] Trigger a manual deploy via `Deployment` workflow → `workflow_dispatch`
- [ ] Watch `restart:nsfw-scanner` task succeed: expect rsync OK → "Migrating nsfw-scanner from raw docker-run to docker compose" log → `docker compose up -d --build` runs
- [ ] Post-deploy: `ssh root@95.216.224.116 'docker inspect nsfw-scanner --format "{{index .Config.Labels \"com.docker.compose.project\"}}"'` returns `nsfw-scanner` (proof migration completed)
- [ ] `curl -sf http://127.0.0.1:5000/health` on prod returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)