### PR TITLE
ci(dependabot): add cooldown canary delay for supply chain safety

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,7 +23,7 @@ updates:
     open-pull-requests-limit: 99
     cooldown:
       default-days: 5
-      semver-major-days: 7
+      semver-major-days: 5
       semver-minor-days: 5
       semver-patch-days: 3
 
@@ -40,7 +40,7 @@ updates:
           - '@material/*'
     cooldown:
       default-days: 7
-      semver-major-days: 14
+      semver-major-days: 7
       semver-minor-days: 7
       semver-patch-days: 3
 
@@ -67,7 +67,7 @@ updates:
           - 'doctrine/*'
     cooldown:
       default-days: 7
-      semver-major-days: 14
+      semver-major-days: 7
       semver-minor-days: 7
       semver-patch-days: 3
 
@@ -80,7 +80,7 @@ updates:
     open-pull-requests-limit: 99
     cooldown:
       default-days: 5
-      semver-major-days: 7
+      semver-major-days: 5
       semver-minor-days: 5
       semver-patch-days: 3
 
@@ -93,6 +93,6 @@ updates:
     open-pull-requests-limit: 99
     cooldown:
       default-days: 7
-      semver-major-days: 14
+      semver-major-days: 7
       semver-minor-days: 7
       semver-patch-days: 3

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,9 +23,6 @@ updates:
     open-pull-requests-limit: 99
     cooldown:
       default-days: 5
-      semver-major-days: 5
-      semver-minor-days: 5
-      semver-patch-days: 3
 
   - package-ecosystem: 'npm'
     directory: '/'
@@ -80,9 +77,6 @@ updates:
     open-pull-requests-limit: 99
     cooldown:
       default-days: 5
-      semver-major-days: 5
-      semver-minor-days: 5
-      semver-patch-days: 3
 
   - package-ecosystem: 'pip'
     directory: '/docker/nsfw-scanner'

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,11 @@
 #
 #   - use this file to configure which dependencies (package-ecosystem) should be updated and on what schedule_
 #
+# Cooldown: delays PRs for freshly published releases as a canary buffer against
+# supply chain attacks (compromised packages are often pulled within days of
+# publication). Patches roll faster than minors/majors so security fixes still
+# land quickly.
+#
 version: 2
 updates:
   - package-ecosystem: 'docker'
@@ -16,6 +21,11 @@ updates:
       time: '04:00'
       timezone: 'Europe/Vienna'
     open-pull-requests-limit: 99
+    cooldown:
+      default-days: 5
+      semver-major-days: 7
+      semver-minor-days: 5
+      semver-patch-days: 3
 
   - package-ecosystem: 'npm'
     directory: '/'
@@ -28,6 +38,11 @@ updates:
       material:
         patterns:
           - '@material/*'
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
 
   - package-ecosystem: 'composer'
     directory: '/'
@@ -50,6 +65,11 @@ updates:
       doctrine:
         patterns:
           - 'doctrine/*'
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
 
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -58,6 +78,11 @@ updates:
       time: '04:00'
       timezone: 'Europe/Vienna'
     open-pull-requests-limit: 99
+    cooldown:
+      default-days: 5
+      semver-major-days: 7
+      semver-minor-days: 5
+      semver-patch-days: 3
 
   - package-ecosystem: 'pip'
     directory: '/docker/nsfw-scanner'
@@ -66,3 +91,8 @@ updates:
       time: '04:00'
       timezone: 'Europe/Vienna'
     open-pull-requests-limit: 99
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3


### PR DESCRIPTION
## Summary
- Adds a `cooldown` block to every ecosystem in `.github/dependabot.yaml` (docker, npm, composer, github-actions, pip).
- Freshly published releases are held back before Dependabot opens a PR — gives the ecosystem time to detect and pull compromised packages (the classic supply chain attack window is hours-to-days post publish).
- Patches roll faster than minors/majors so security fixes still land quickly.

## Cooldown matrix
| Ecosystem        | patch | minor | major | default |
|------------------|------:|------:|------:|--------:|
| npm              | 3d    | 7d    | 7d    | 7d      |
| composer         | 3d    | 7d    | 7d    | 7d      |
| pip              | 3d    | 7d    | 7d    | 7d      |
| docker           | —     | —     | —     | 5d      |
| github-actions   | —     | —     | —     | 5d      |

Docker and GitHub Actions don't follow semver, so Dependabot only supports `default-days` for those ecosystems (semver-* keys are rejected at validation).

Tighter window for docker/github-actions since those are pinned by digest/tag and the blast radius is more contained.

## Refs
- GitHub docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--

## Test plan
- [ ] CI green (config is YAML — GitHub validates on next Dependabot run)
- [ ] After merge, confirm next Dependabot run respects the cooldown (no PR for releases <3 days old)

🤖 Generated with [Claude Code](https://claude.com/claude-code)