### PR TITLE
test(behat): harden flaky search-by-owner scenarios

### DIFF
--- a/src/System/Testing/Behat/Context/DataFixturesContext.php
+++ b/src/System/Testing/Behat/Context/DataFixturesContext.php
@@ -1678,6 +1678,23 @@ class DataFixturesContext implements Context
   }
 
   /**
+   * Synchronously populates and refreshes the FOS Elastica indices so search
+   * queries see fixture data immediately. Use after fixtures are persisted
+   * and before any search assertions to avoid races with the default 1s ES
+   * refresh interval.
+   *
+   * @Given the search index is up-to-date
+   */
+  public function theSearchIndexIsUpToDate(): void
+  {
+    CommandHelper::executeShellCommand(
+      ['bin/console', 'fos:elastica:populate', '-q'],
+      ['timeout' => 60],
+      'Populating Elasticsearch index'
+    );
+  }
+
+  /**
    * @Given there are project machine translations:
    */
   public function thereAreProjectMachineTranslations(TableNode $table): void

--- a/tests/BehatFeatures/web/search/search_projects_via_projectowner.feature
+++ b/tests/BehatFeatures/web/search/search_projects_via_projectowner.feature
@@ -13,12 +13,13 @@ Feature: Searching for projects with ownername
       | 1  | project 1 | Catrobat |
       | 2  | project 2 | User2    |
       | 3  | project 3 | User3    |
-    And I wait 500 milliseconds
+    And the search index is up-to-date
 
   Scenario: search for projects with full name should work
     When I am on "/app/search/User3"
     And I wait for the page to be loaded
     And I wait for AJAX to finish
+    And I wait for the element "#search-projects" to contain "project 3"
     Then I should see "Results for"
     And I should not see "project 1"
     And I should not see "project 2"
@@ -28,6 +29,7 @@ Feature: Searching for projects with ownername
     When I am on "/app/search/User"
     And I wait for the page to be loaded
     And I wait for AJAX to finish
+    And I wait for the element "#search-projects" to contain "project 3"
     Then I should see "Results for"
     And I should not see "project 1"
     And I should see "project 2"


### PR DESCRIPTION
## Summary
Stabilizes `tests/BehatFeatures/web/search/search_projects_via_projectowner.feature` which intermittently fails with:

> The text \"project 3\" was not found anywhere in the text of the current page.

## Root causes
1. **ES indexing race.** `Background` persists projects then `I wait 500 milliseconds`. Elasticsearch's default refresh interval is 1s, so the 500 ms hope-wait races the search query — sometimes the doc is searchable, sometimes not.
2. **`wait for AJAX` is a lie here.** `SearchPage.js` uses native `fetch()` (see `assets/Search/SearchPage.js:84`). The `wait for AJAX to finish` step only tracks jQuery XHRs, so it returns immediately while the fetch is still in flight. The positive assertions then run against an empty result list.

## Fix
- New Behat step **`the search index is up-to-date`** in `DataFixturesContext` runs `bin/console fos:elastica:populate -q` synchronously after fixtures — deterministic, replaces the fragile 500 ms wait.
- Add **`I wait for the element \"#search-projects\" to contain \"project 3\"`** before the assertions. Uses the existing 10 s polling step (`BrowserContext::iWaitForTheElementToContain`) so we wait on actual rendered content rather than the un-tracked fetch.

## Scope
Only the affected feature is touched. The same anti-patterns exist in the other `web/search` features — leaving them alone for now per \"don't broaden scope\" rule; happy to do a follow-up if these turn out flaky too.

## Test plan
- [ ] `web-general` Behat suite green (this feature is under @search)
- [ ] Re-run the flaky scenario a few times in CI — should be deterministic now

🤖 Generated with [Claude Code](https://claude.com/claude-code)