### PR TITLE
ci: add CycloneDX SBOM + Trivy CVE scan

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Generate CycloneDX SBOM
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -52,7 +52,7 @@ jobs:
           retention-days: 90
 
       - name: Scan dependencies for CVEs
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Generate CycloneDX SBOM
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -52,7 +52,7 @@ jobs:
           retention-days: 90
 
       - name: Scan dependencies for CVEs
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -1,0 +1,63 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ** SBOM + vulnerability scan **
+#
+#  Generates a CycloneDX Software Bill of Materials (SBOM) covering both PHP (composer.lock) and
+#  JavaScript (yarn.lock) dependencies, then scans them for known CVEs using Trivy.
+#
+#  Complements:
+#   - Dependabot       -> continuous CVE alerts via GitHub dependency graph
+#   - SafeDep vet      -> supply-chain risk (malicious / unmaintained / typosquatted packages)
+#   - This workflow    -> CVE gate + auditable SBOM artifact per commit
+#
+#  The SBOM is uploaded as a workflow artifact and can later be attached to GitHub Releases or
+#  fed into a Dependency-Track instance if the org adopts one.
+#
+#  Trivy docs: https://aquasecurity.github.io/trivy/
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+name: SBOM
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    name: Generate SBOM + scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate CycloneDX SBOM
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: cyclonedx
+          output: sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ github.sha }}
+          path: sbom.cdx.json
+          retention-days: 90
+
+      - name: Scan dependencies for CVEs
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+          ignore-unfixed: true
+          # Skip noisy categories — focus on dependency CVEs only.
+          scanners: vuln


### PR DESCRIPTION
## Summary
- New `SBOM` workflow generates a CycloneDX SBOM from `composer.lock` + `yarn.lock` on every PR and push to `main`, uploads it as a 90-day artifact (`sbom-<sha>.cdx.json`), then runs Trivy to gate on `CRITICAL`/`HIGH` CVEs with available fixes (`ignore-unfixed: true`).
- Trivy reads lock files directly, so no `composer install` / `yarn install` step — fast (~30s) and minimal surface area.
- Complements existing supply-chain tooling: Dependabot (continuous CVE alerts), SafeDep vet (malicious / unmaintained packages). Trivy adds a hard CVE gate plus an auditable per-commit SBOM artifact.

## Where results show up
- **PR check fails** with red ✗ if a fixable HIGH/CRITICAL CVE is found (can be marked required in branch protection).
- **Actions tab** shows the Trivy table with CVE ID, affected package, and fixed version.
- **Artifacts** on each workflow run contain `sbom.cdx.json`, ready to attach to a future GitHub Release or feed into Dependency-Track if the org adopts one later.

## Test plan
- [ ] PR triggers the `SBOM` workflow and it completes green on a clean dependency graph.
- [ ] SBOM artifact `sbom-<sha>.cdx.json` is downloadable from the workflow run.
- [ ] Trivy table is visible in the workflow logs.
- [ ] (Optional) Mark `SBOM` as a required check in branch protection once green on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)