### PR TITLE
fix(profile): rename placeholder tab id "test" to "tab-followers"

### DIFF
--- a/templates/User/Profile/MyProfilePage.html.twig
+++ b/templates/User/Profile/MyProfilePage.html.twig
@@ -109,7 +109,7 @@
             </button>
 
             {% if not app.user.isMinor() %}
-              <button class="mdc-tab mdc-tab--stacked" id="test" role="tab" aria-selected="false" tabindex="0">
+              <button class="mdc-tab mdc-tab--stacked" id="tab-followers" role="tab" aria-selected="false" tabindex="0">
               <span class="mdc-tab__content">
                 <span class="mdc-tab__icon" id="followers-count">-</span>
                 <span class="mdc-tab__icon-text">{{ 'follower.followers'|trans({}, 'catroweb') }}</span>


### PR DESCRIPTION
## Summary
- Tab button in MyProfilePage had `id="test"` (placeholder/debug name).
- Renamed to `id="tab-followers"` to match sibling tab naming and describe purpose.

## Test plan
- [ ] Profile page renders, followers tab is reachable
- [ ] No JS regressions (grep shows no code depending on `#test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)