### PR TITLE
fix(templates): remove stray quote in data-app-env attribute

### DIFF
--- a/templates/Layout/Base.html.twig
+++ b/templates/Layout/Base.html.twig
@@ -112,7 +112,7 @@
 <div id="gtm-container-id" data-gtm-container-id="{{ gtm_container_id }}" style="display: none;"></div>
 <div id="app-version" data-app-version="{{ app_version }}" style="display: none;">{{ app_version }}</div>
 <div id="app-language" data-app-language="{{ app.request.locale }}"></div>
-<div class="js-app-env" data-app-env="'{{ app_env }}"></div>
+<div class="js-app-env" data-app-env="{{ app_env }}"></div>
 <div class="js-user-state" data-is-user-logged-in="{% if app.user != null %}true{% else %}false{% endif %}"></div>
 <div id="cookie-consent-config" style="display: none;"
      data-trans-message="{{ 'cookie-consent.message'|trans({}, 'catroweb')|escape('html_attr') }}"


### PR DESCRIPTION
## Summary
- `data-app-env` had a stray leading `'` inside the attribute value.
- DOM exposed `'prod` instead of `prod`; any JS reading `dataset.appEnv` got the malformed value.

## Test plan
- [ ] Inspect rendered page: `data-app-env` equals raw env string
- [ ] JS env-gated code paths behave correctly in dev/prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)