### PR TITLE
docs(nsfw): swap inverted threshold tuning examples

### DIFF
--- a/docs/operations/NSFW-Content-Scanning.md
+++ b/docs/operations/NSFW-Content-Scanning.md
@@ -214,13 +214,13 @@ docker restart nsfw-scanner
 If you get false positives (safe images being rejected), lower the threshold:
 
 ```env
-CONTENT_SAFETY_THRESHOLD=0.8
+CONTENT_SAFETY_THRESHOLD=0.6
 ```
 
 If you get false negatives (NSFW images getting through), raise it:
 
 ```env
-CONTENT_SAFETY_THRESHOLD=0.6
+CONTENT_SAFETY_THRESHOLD=0.8
 ```
 
 The default (0.7) is conservative and should work well for most cases.


### PR DESCRIPTION
## Summary
- Lower-threshold example was 0.8 (higher than 0.7 default).
- Raise-threshold example was 0.6 (lower than default).
- Swapped both to match the surrounding prose.

## Test plan
- [ ] Doc reads consistently: lower → 0.6, raise → 0.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)