### PR TITLE
fix(index): avoid null-deref in DefaultProjectLists missing-element warn

### DIFF
--- a/assets/Index/DefaultProjectLists.js
+++ b/assets/Index/DefaultProjectLists.js
@@ -3,12 +3,13 @@ import '../Project/ProjectList.scss'
 
 export class DefaultProjectLists {
   constructor(elementId) {
+    this.elementId = elementId
     this.containerElement = document.getElementById(elementId)
   }
 
   init() {
     if (!this.containerElement) {
-      console.warn(`#${this.containerElement.id} can't be found in the DOM.`)
+      console.warn(`#${this.elementId} can't be found in the DOM.`)
       return
     }
 


### PR DESCRIPTION
## Summary
- `console.warn` read `this.containerElement.id` after a `!this.containerElement` guard, so the warn path threw `TypeError`.
- Store the constructor arg as `this.elementId` and reference it in the warning.

## Test plan
- [ ] Construct `DefaultProjectLists('non-existent-id')` then `init()` — logs the expected warning, no throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)