### PR TITLE
fix(nsfw-scanner): narrow image-decode except + block dev-server entrypoint

### DIFF
--- a/docker/nsfw-scanner/app.py
+++ b/docker/nsfw-scanner/app.py
@@ -1,6 +1,6 @@
 import io
 from flask import Flask, request, jsonify
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 from transformers import pipeline
 
 app = Flask(__name__)
@@ -20,7 +20,7 @@ def scan():
 
     try:
         image = Image.open(io.BytesIO(request.data)).convert("RGB")
-    except Exception:
+    except (UnidentifiedImageError, OSError, ValueError):
         return jsonify({"error": "Invalid image data"}), 400
 
     results = classifier(image)
@@ -41,4 +41,7 @@ def scan():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000)
+    raise RuntimeError(
+        "Do not run with Flask's built-in server in production. "
+        "Start this app with gunicorn instead."
+    )


### PR DESCRIPTION
## Summary
- Catch `UnidentifiedImageError`/`OSError`/`ValueError` instead of bare `Exception` — unrelated bugs no longer get masked as "Invalid image data".
- `__main__` now raises `RuntimeError` directing to gunicorn (per Dockerfile), preventing accidental use of Flask's dev server.

## Test plan
- [ ] POST a non-image payload → 400 "Invalid image data"
- [ ] Container starts via gunicorn (existing entrypoint) and serves /
- [ ] `python docker/nsfw-scanner/app.py` raises RuntimeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)