### PR TITLE
ci(sbom): upload SBOM to Dependency-Track on push to main

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -10,7 +10,7 @@
 #   - This workflow    -> CVE gate + auditable SBOM artifact per commit
 #
 #  The SBOM is uploaded as a workflow artifact and can later be attached to GitHub Releases or
-#  fed into a Dependency-Track instance if the org adopts one.
+#  fed into the Dependency-Track instance at https://deptrack.catrobat.org for CVE tracking.
 #
 #  Trivy docs: https://aquasecurity.github.io/trivy/
 #
@@ -50,6 +50,14 @@ jobs:
           name: sbom-${{ github.sha }}
           path: sbom.cdx.json
           retention-days: 90
+
+      - name: Upload SBOM to Dependency-Track
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          curl -sSf -X POST https://deptrack.catrobat.org/api/v1/bom \
+            -H "X-API-Key: ${{ secrets.DEPTRACK_API_KEY }}" \
+            -F "project=${{ vars.DEPTRACK_CATROWEB_UUID }}" \
+            -F "bom=@sbom.cdx.json"
 
       - name: Scan dependencies for CVEs
         uses: aquasecurity/trivy-action@v0.36.0


### PR DESCRIPTION
## Summary
- Existing Trivy step already generates `sbom.cdx.json`.
- New step posts the BOM to `https://deptrack.catrobat.org/api/v1/bom` on push to main only.
- PRs intentionally skipped to keep Dep-Track project history clean.

## Required repo config (one-time)
- Secret `DEPTRACK_API_KEY` — Dep-Track team API key with `BOM_UPLOAD`, `VIEW_PORTFOLIO`, `PROJECT_CREATION_UPLOAD`.
- Variable `DEPTRACK_CATROWEB_UUID` — Catroweb project UUID in Dep-Track.

## Test plan
- [ ] Merge → SBOM workflow runs on the merge commit
- [ ] Dep-Track shows new components / metrics for Catroweb after run
- [ ] No new step on PR runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)