### PR TITLE
docs: link to private Catrobat/infrastructure repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Core project docs are maintained in-repo:
 - [docs/setup/Developer-Quickstart.md](./docs/setup/Developer-Quickstart.md)
 - [docs/architecture/Architecture-Overview.md](./docs/architecture/Architecture-Overview.md)
 
+## Operations & Infrastructure
+
+Production deployment configuration for the Catrobat ecosystem (web platform infra, monitoring stacks, reverse proxy, CI/CD) is maintained in the private companion repo [`Catrobat/infrastructure`](https://github.com/Catrobat/infrastructure).
+
+Open-source-friendly operations docs live in [`docs/operations/`](./docs/operations/README.md).
+
 ## Issues
 
 Found a bug?

--- a/docs/operations/How-To-Deploy.md
+++ b/docs/operations/How-To-Deploy.md
@@ -1,5 +1,7 @@
 # Deployer
 
+> Note: This document covers Catroweb app deployment via Deployer-PHP. Production infrastructure (compose stacks, nginx vhosts, fail2ban, Cockpit, monitoring) is deployed separately from the private [`Catrobat/infrastructure`](https://github.com/Catrobat/infrastructure) repo on push to its `main` branch.
+
 We use Deployer to deploy to development and production servers.
 
 - You may need to modify the file deploy.php. Ask our coordinator if specific settings are unclear.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,17 @@
+# Operations
+
+Public operations docs for Catroweb maintainers.
+
+- [Cron-Jobs.md](./Cron-Jobs.md) — How the `catrobat:cronjob` dispatcher schedules and tracks all periodic tasks.
+- [Domain-Change.md](./Domain-Change.md) — Procedure for changing the production domain behind Cloudflare + nginx origin.
+- [How-To-Deploy.md](./How-To-Deploy.md) — Deploying the Catroweb app to dev/prod servers via Deployer-PHP.
+- [Malware-Scanning.md](./Malware-Scanning.md) — ClamAV-based scanning of uploaded `.catrobat` files before extraction.
+- [NSFW-Content-Scanning.md](./NSFW-Content-Scanning.md) — Self-hosted AI image moderation for user-uploaded media.
+- [Redis-Cache.md](./Redis-Cache.md) — Redis as the production application cache backend (Symfony, Doctrine, trust scores).
+- [Secret-Management.md](./Secret-Management.md) — Symfony `.env` hierarchy and how production overrides committed dev defaults.
+- [Server-Setup.md](./Server-Setup.md) — Historical manual server setup notes (see banner; superseded by the private infra repo).
+- [Storage-Architecture.md](./Storage-Architecture.md) — Symlink chain under `public/resources/` for user-generated content storage.
+
+## Production infrastructure
+
+Production deployment configuration — docker-compose stacks for self-hosted services, nginx vhost configs, host-level configs, the CI deploy workflow, and Dependabot for Docker image bumps — lives in the private companion repo [`Catrobat/infrastructure`](https://github.com/Catrobat/infrastructure). The repo is private; only Catrobat org maintainers have access.

--- a/docs/operations/Server-Setup.md
+++ b/docs/operations/Server-Setup.md
@@ -1,3 +1,7 @@
+> [!WARNING]
+> **This document is historical / outdated.**
+> Current production server configuration is maintained in the private repo [`Catrobat/infrastructure`](https://github.com/Catrobat/infrastructure). The steps below describe an older PHP 8.4 / manual setup and should not be followed verbatim.
+
 ## Warning: Outdated!
 
 1. **Connect** (via SSH) to the server.


### PR DESCRIPTION
## Summary
- Public docs now point readers to the new private companion repo `Catrobat/infrastructure` for production deployment configuration.
- New `docs/operations/README.md` indexes the existing operations docs and references the private infra repo at the bottom.
- `Server-Setup.md` and `How-To-Deploy.md` gain banners so readers don't follow stale manual-setup steps.
- No hostnames, IPs, or other operational details added to public files.

## Test plan
- [ ] Links resolve (README and operations index)
- [ ] No leaked private details (grep for IPs / hostnames in diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)