### PR TITLE
docs(readme): add BetterStack status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ If you haven’t heard about Catrobat, what we do, or how you can contribute, st
 
 # Catroweb
 
+[![Better Stack Badge](https://uptime.betterstack.com/status-badges/v1/monitor/2n8pf.svg)](https://uptime.betterstack.com/?utm_source=status_badge)
+
 Catroweb is the name of the **Pocket Code sharing platform**, where our community uploads and shares projects.  
 If you uploaded your game in a previous step, it should already be visible to other users.
 


### PR DESCRIPTION
## Summary
- Adds a live BetterStack status badge near the top of the README pointing at https://status.catrobat.org.
- Single-line addition, no other content changed.

## Test plan
- [ ] Badge renders on the rendered README page on GitHub.
- [ ] Badge image URL responds (`curl -I https://uptime.betterstack.com/status-badges/v1/monitor/2n8pf.svg`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)