### PR TITLE
test(behat): fix flaky custom translation delete scenario

### DIFF
--- a/tests/BehatFeatures/web/translation/custom_translation.feature
+++ b/tests/BehatFeatures/web/translation/custom_translation.feature
@@ -143,6 +143,7 @@ Feature: Projects should have an editor a custom translation can be defined
     When I click "#edit-delete-button"
     Then should see "Are you sure you want to delete the translation?"
     When I click ".swal2-deny"
+    And I wait for the element "#edit-text-ui" to appear and if so to disappear again
     And I wait for AJAX to finish
     Then there should be project custom translations:
       | project_id | language | name | description | credit |


### PR DESCRIPTION
## Summary
- The `Delete a custom translation with the delete button` scenario relies on `I wait for AJAX to finish` (a fixed 1s sleep) after clicking `.swal2-deny` to confirm the deletion.
- `deleteTranslationResult` issues a `Promise.all` of three parallel DELETE fetches (name, description, credit) and only closes the editor — hiding `#edit-text-ui` via `d-none` — once all three resolve. Under CI load the 1s budget elapses before the requests complete, so the DB still has the row when the `there should be project custom translations:` assertion runs (`Failed asserting that 0 matches expected 1`).
- Layer a wait for `#edit-text-ui` to disappear in front of the AJAX wait — that's the visual signal that `Promise.all` resolved and all three DELETEs hit the DB. Aligns with the flaky-test guidance in `.claude/CLAUDE.md` (wait for content changes, not fixed delays).

## Test plan
- [ ] CI green on `web-translation` suite
- [ ] Re-run the scenario locally a few times to confirm it no longer races