### PR TITLE
fix: restore light-dark() colors broken by Vite 8 LightningCSS polyfill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -137,7 +137,8 @@ Catroweb/
 
 ### Dark Mode
 
-- Use `light-dark(lightValue, darkValue)` for automatic dark mode color adaptation — works because Bootstrap sets `color-scheme: light dark`.
+- Use `light-dark(lightValue, darkValue)` for automatic dark mode color adaptation. Our `:root { color-scheme: light; }` (BootstrapOverwrite.scss) + Bootstrap's `[data-bs-theme=dark] { color-scheme: dark; }` drive it — `ColorScheme.js` always sets an explicit `data-bs-theme`.
+- The `:root` color-scheme rule is **required** for Vite 8's LightningCSS `light-dark()` downlevel polyfill: toggle vars are only injected into rules declaring `color-scheme`; without a light-mode declaration, every `light-dark()` value computes to garbage in light mode (footer lost its colors after the Vite 8 bump).
 - `--primary` is `light-dark(#007f8f, #4dd0e1)` — auto-adapts in dark mode for text/borders/links.
 - `--primary-bg: #007f8f` — always dark, for filled backgrounds (topbar, btn-primary, FABs, pills) where `#fff` on-primary text sits on top.
 - `--on-primary: #fff` — text on filled primary surfaces.

--- a/assets/Layout/BootstrapOverwrite.scss
+++ b/assets/Layout/BootstrapOverwrite.scss
@@ -1,3 +1,15 @@
+// Vite 8's LightningCSS downlevels light-dark() into the
+// --lightningcss-light/dark var-toggle polyfill and only injects the toggle
+// definitions into rules that declare color-scheme. Bootstrap declares it
+// solely under [data-bs-theme=dark], so without this rule the light-mode
+// toggles stay undefined and every light-dark() value computes to garbage
+// (e.g. the footer lost its colors). "light" (not "light dark") is correct:
+// ColorScheme.js always sets an explicit data-bs-theme, so dark comes from
+// Bootstrap's override, never from the OS preference.
+:root {
+  color-scheme: light;
+}
+
 .container {
   max-width: 1400px !important;
 }


### PR DESCRIPTION
## Symptom

Since the Vite 7→8 bump (#6894), all `light-dark()` colors are broken in light mode on production — e.g. the footer lost its gray background ([share.catrobat.org/app](https://share.catrobat.org/app/)).

## Cause

Vite 8 minifies CSS with LightningCSS, which downlevels `light-dark()` into the `--lightningcss-light`/`--lightningcss-dark` var-toggle polyfill for our browserslist targets. The toggle definitions are only injected into rules that declare `color-scheme` — and the only such rule was Bootstrap's `[data-bs-theme=dark]`. In light mode both toggles were undefined, so

```css
background-color: var(--lightningcss-light, #e1e2e1) var(--lightningcss-dark, #1e1d1e);
```

resolved both fallbacks to `#e1e2e1 #1e1d1e` — invalid, declaration dropped.

## Fix

`:root { color-scheme: light; }` in BootstrapOverwrite.scss. LightningCSS now emits `:root { --lightningcss-light: initial; --lightningcss-dark: ; }`, making light mode resolve correctly; dark mode keeps working via Bootstrap's `[data-bs-theme=dark]` override.

`light` rather than `light dark` is deliberate: `ColorScheme.js` always sets an explicit `data-bs-theme` (auto is resolved in JS), so dark must come only from the attribute override — `light dark` would let the OS preference flip colors even when the user picked the light theme.

Verified in the built output: light toggle rule present, `.footer` resolves to `#e1e2e1` (light) / `#1e1d1e` (dark). Also corrects the CLAUDE.md dark-mode note that wrongly claimed Bootstrap sets `color-scheme: light dark`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)