### PR TITLE
fix: prevent DQL injection in UserDataReportController

### DIFF
--- a/src/Admin/Users/UserDataReport/UserDataReportController.php
+++ b/src/Admin/Users/UserDataReport/UserDataReportController.php
@@ -52,7 +52,8 @@ class UserDataReportController extends CRUDController
   protected function getReportedProjects(string $user_id): mixed
   {
     return $this->entity_manager
-      ->createQuery(sprintf('SELECT cr FROM App\DB\Entity\Moderation\ContentReport cr WHERE cr.reporter=\'%s\'', $user_id))
+      ->createQuery('SELECT cr FROM App\DB\Entity\Moderation\ContentReport cr WHERE cr.reporter = :user_id')
+      ->setParameter('user_id', $user_id)
       ->getResult()
     ;
   }
@@ -60,7 +61,8 @@ class UserDataReportController extends CRUDController
   protected function getUserComments(string $user_id): mixed
   {
     return $this->entity_manager
-      ->createQuery(sprintf('SELECT uc FROM App\DB\Entity\User\Comment\UserComment uc WHERE uc.user=\'%s\'', $user_id))
+      ->createQuery('SELECT uc FROM App\DB\Entity\User\Comment\UserComment uc WHERE uc.user = :user_id')
+      ->setParameter('user_id', $user_id)
       ->getResult()
     ;
   }
@@ -68,7 +70,8 @@ class UserDataReportController extends CRUDController
   protected function getUserProjects(string $user_id): mixed
   {
     return $this->entity_manager
-      ->createQuery(sprintf('SELECT up FROM App\DB\Entity\Project\Project up WHERE up.user=\'%s\'', $user_id))
+      ->createQuery('SELECT up FROM App\DB\Entity\Project\Project up WHERE up.user = :user_id')
+      ->setParameter('user_id', $user_id)
       ->getResult()
     ;
   }


### PR DESCRIPTION
## What

The three queries in `UserDataReportController` (reported projects, user comments, user projects) built DQL by interpolating the route-supplied user id directly via `sprintf('... = \'%s\'', $user_id)`. This is a DQL injection sink.

Replaced with parameterized queries using bound parameters.

## Why

A crafted id value could alter the query (e.g. `x' OR '1'='1`). The endpoint is behind the `^/admin/` firewall (`ROLE_ADMIN`), so exploitation requires an admin session — severity is moderate rather than critical — but parameterization is the correct, trivial fix and removes the injection entirely.

## Changes

- `getReportedProjects()`, `getUserComments()`, `getUserProjects()` now use `:user_id` bound parameters instead of `sprintf()` interpolation.

## Verification

- `php-cs-fixer` — clean
- `phpstan` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)