### PR TITLE
build(deps): pin nsfw-scanner Python deps to exact versions

### DIFF
--- a/docker/nsfw-scanner/requirements.txt
+++ b/docker/nsfw-scanner/requirements.txt
@@ -1,5 +1,5 @@
-flask>=3.1.3,<4
-gunicorn>=26.0.0,<27
-transformers>=5.10.2,<6
-torch>=2.12.0,<3
-Pillow>=12.2,<13
+flask==3.1.3
+gunicorn==26.0.0
+transformers==5.13.0
+torch==2.12.1
+Pillow==12.3.0


### PR DESCRIPTION
## Why

Dependabot PRs #6984 (torch), #7022 (Pillow) and #7030 (transformers) are blocked by SafeDep vet — but the failures are false positives, not real risk.

vet's pip manifest parser cannot resolve range specs like `torch>=2.12.1,<3`: it treats `2.12.1,<3` as the literal version (the scan report shows `torch@2.12.1,<3`, `LATEST: Not Available`, provenance missing), version resolution fails, and vulnerability matching falls back to package-level matching across **all** releases. The flagged finding GHSA-47fc-vmwq-366v was fixed in torch **1.13.1**.

## What

Pin all five nsfw-scanner deps to exact versions (the same versions Dependabot proposed):

| Package | Before | After |
| --- | --- | --- |
| flask | `>=3.1.3,<4` | `==3.1.3` |
| gunicorn | `>=26.0.0,<27` | `==26.0.0` |
| transformers | `>=5.10.2,<6` | `==5.13.0` |
| torch | `>=2.12.0,<3` | `==2.12.1` |
| Pillow | `>=12.2,<13` | `==12.3.0` |

All five pinned versions are clean per OSV. torch 2.12.1 additionally fixes GHSA-rrmf-rvhw-rf47 (`torch.jit.script` memory corruption), which affects the current 2.12.0 floor.

Exact pins also mean vet resolves the real version going forward (no more range-spec false positives) and Docker image builds are reproducible. Dependabot continues to bump the pins under the existing cooldown config, and its three open PRs become obsolete once this merges.

Closes #6984, closes #7022, closes #7030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)