### PR TITLE
fix(registration): theme captcha widget for dark mode

### DIFF
--- a/assets/Security/login.css
+++ b/assets/Security/login.css
@@ -63,3 +63,17 @@
   font-size: 3rem;
   color: var(--primary);
 }
+
+/* The Cap captcha (<cap-widget>) is a third-party web component whose stock
+   palette is light-only (background #fdfdfd, text #212121), so it renders as a
+   bright box with poor contrast on the dark form card. Theme its exposed
+   --cap-* custom properties with light-dark() so it follows the color scheme. */
+cap-widget {
+  --cap-background: light-dark(#fdfdfd, #38384a);
+  --cap-color: light-dark(#212121, #e2e8f0);
+  --cap-border-color: light-dark(#dddddd8f, rgb(255 255 255 / 24%));
+  --cap-checkbox-background: light-dark(#fafafa91, rgb(255 255 255 / 8%));
+  --cap-checkbox-border: 1px solid light-dark(#aaaaaad1, rgb(255 255 255 / 40%));
+  --cap-spinner-background-color: light-dark(#eee, #555);
+  --cap-spinner-color: light-dark(#000, #e2e8f0);
+}


### PR DESCRIPTION
## Problem

In dark mode, parts of the registration form render light with poor contrast (reported from a mobile build of the signup page). The culprit is the Cap captcha (`<cap-widget>`), a third-party web component with a light-only palette (background `#fdfdfd`, text `#212121`). It has no dark handling, so it shows as a bright box with hard-to-read text on the dark form card.

The Material text fields were already dark-aware (`Variables.css`); the captcha was the remaining unthemed piece.

## Fix

Theme the widget's exposed `--cap-*` custom properties with `light-dark()` in `assets/Security/login.css`, matching the surrounding dark form card. Rides the same LightningCSS `light-dark()` polyfill / `color-scheme` toggle-var mechanism already used for the MD text fields.

Applies to the registration and password-reset pages (both share `login.css` and mount the captcha).

## Notes

- CSS-only; no behavior change.
- Not addressed here (not code bugs): Google OAuth is still on hold pending config; the cumbersome native date-of-birth picker is the platform's `<input type="date">` control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)