### PR TITLE
fix(csp): allow Cap captcha widget sources so it can solve

### DIFF
--- a/src/Security/SecurityHeadersSubscriber.php
+++ b/src/Security/SecurityHeadersSubscriber.php
@@ -15,6 +15,10 @@ class SecurityHeadersSubscriber
   public function __construct(
     #[Autowire('%kernel.environment%')]
     private readonly string $kernelEnvironment,
+    #[Autowire('%env(bool:CAPTCHA_ENABLED)%')]
+    private readonly bool $captchaEnabled = false,
+    #[Autowire('%env(CAPTCHA_PUBLIC_URL)%')]
+    private readonly string $captchaPublicUrl = '',
   ) {
   }
 
@@ -41,10 +45,66 @@ class SecurityHeadersSubscriber
     // same-site (not same-origin) so resources can be loaded by sibling Catrobat subdomains.
     $headers->set('Cross-Origin-Resource-Policy', 'same-site');
 
-    $headers->set('Content-Security-Policy', "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.bugsnag.com https://*.google-analytics.com https://*.googletagmanager.com https://appleid.apple.com https://cap.catrobat.org; frame-ancestors 'self'");
+    $headers->set('Content-Security-Policy', $this->buildContentSecurityPolicy());
 
     if ('prod' === $this->kernelEnvironment) {
       $headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
     }
+  }
+
+  private function buildContentSecurityPolicy(): string
+  {
+    $connect_src = [
+      "'self'",
+      'https://*.bugsnag.com',
+      'https://*.google-analytics.com',
+      'https://*.googletagmanager.com',
+      'https://appleid.apple.com',
+    ];
+    $worker_src = ["'self'"];
+
+    // The Cap captcha (<cap-widget>) talks to its self-hosted backend, fetches
+    // its proof-of-work WASM solver from the jsDelivr CDN, and runs the solver
+    // in a Web Worker spawned from a blob: URL. Whitelist exactly those when
+    // the captcha is enabled; the backend host is derived from the configured
+    // public URL so the CSP can never drift from the widget's endpoint.
+    if ($this->captchaEnabled) {
+      $captcha_origin = $this->originFromUrl($this->captchaPublicUrl);
+      if (null !== $captcha_origin) {
+        $connect_src[] = $captcha_origin;
+      }
+      $connect_src[] = 'https://cdn.jsdelivr.net';
+      $worker_src[] = 'blob:';
+    }
+
+    return implode('; ', [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com",
+      "style-src 'self' 'unsafe-inline'",
+      'img-src '."'self'".' data: https:',
+      'font-src '."'self'".' data:',
+      'connect-src '.implode(' ', $connect_src),
+      'worker-src '.implode(' ', $worker_src),
+      "frame-ancestors 'self'",
+    ]);
+  }
+
+  /**
+   * Reduces a URL to its CSP source origin (scheme://host[:port]), or null when
+   * the URL is empty or unparseable.
+   */
+  private function originFromUrl(string $url): ?string
+  {
+    $parts = parse_url($url);
+    if (false === $parts || empty($parts['scheme']) || empty($parts['host'])) {
+      return null;
+    }
+
+    $origin = $parts['scheme'].'://'.$parts['host'];
+    if (isset($parts['port'])) {
+      $origin .= ':'.$parts['port'];
+    }
+
+    return $origin;
   }
 }

--- a/tests/PhpUnit/Security/SecurityHeadersSubscriberTest.php
+++ b/tests/PhpUnit/Security/SecurityHeadersSubscriberTest.php
@@ -38,6 +38,48 @@ class SecurityHeadersSubscriberTest extends TestCase
     $this->assertNotNull($response->headers->get('Content-Security-Policy'));
   }
 
+  public function testCaptchaCspOmittedWhenDisabled(): void
+  {
+    $subscriber = new SecurityHeadersSubscriber('prod', false, 'https://cap.example.org');
+    $event = $this->createResponseEvent(HttpKernelInterface::MAIN_REQUEST);
+
+    $subscriber->onKernelResponse($event);
+
+    $csp = (string) $event->getResponse()->headers->get('Content-Security-Policy');
+    $this->assertStringNotContainsString('cap.example.org', $csp);
+    $this->assertStringNotContainsString('cdn.jsdelivr.net', $csp);
+    $this->assertStringNotContainsString('blob:', $csp);
+    $this->assertStringContainsString("worker-src 'self'", $csp);
+  }
+
+  public function testCaptchaCspWhitelistsWidgetSourcesWhenEnabled(): void
+  {
+    $subscriber = new SecurityHeadersSubscriber('prod', true, 'https://cap.catrob.at');
+    $event = $this->createResponseEvent(HttpKernelInterface::MAIN_REQUEST);
+
+    $subscriber->onKernelResponse($event);
+
+    $csp = (string) $event->getResponse()->headers->get('Content-Security-Policy');
+    // Backend origin is derived from the configured public URL, so connect-src
+    // always matches the widget's actual endpoint.
+    $this->assertStringContainsString('connect-src ', $csp);
+    $this->assertStringContainsString('https://cap.catrob.at', $csp);
+    // WASM solver CDN and the blob: worker the widget spawns.
+    $this->assertStringContainsString('https://cdn.jsdelivr.net', $csp);
+    $this->assertStringContainsString("worker-src 'self' blob:", $csp);
+  }
+
+  public function testCaptchaOriginPreservesPort(): void
+  {
+    $subscriber = new SecurityHeadersSubscriber('dev', true, 'http://localhost:3000');
+    $event = $this->createResponseEvent(HttpKernelInterface::MAIN_REQUEST);
+
+    $subscriber->onKernelResponse($event);
+
+    $csp = (string) $event->getResponse()->headers->get('Content-Security-Policy');
+    $this->assertStringContainsString('http://localhost:3000', $csp);
+  }
+
   public function testSkipsSubRequests(): void
   {
     $subscriber = new SecurityHeadersSubscriber('prod');


### PR DESCRIPTION
## Problem

The registration / password-reset captcha (`<cap-widget>`) is fully blocked by our Content-Security-Policy in production — it can never solve a challenge. Console on `/register`:

- `connect-src` whitelisted the **hardcoded** host `cap.catrobat.org`, but the widget actually calls the host configured via `CAPTCHA_PUBLIC_URL` — the two had drifted, so the challenge request is refused.
- The widget fetches its proof-of-work **WASM solver from `cdn.jsdelivr.net`** → blocked by `connect-src`.
- The solver runs in a **Web Worker spawned from a `blob:` URL** → no `worker-src` was set, so it fell back to `script-src` (no `blob:`) and was blocked.

Result: `Unable to solve challenge, self-hosted instance likely down` — but the instance is up; CSP was the wall.

## Fix

Build the CSP programmatically in `SecurityHeadersSubscriber`:

- Derive the captcha backend origin from `CAPTCHA_PUBLIC_URL` (single source of truth → `connect-src` can no longer drift from the widget's endpoint).
- Whitelist the jsDelivr WASM CDN in `connect-src`.
- Add `worker-src 'self' blob:`.

Captcha sources are only added when `CAPTCHA_ENABLED` is true, so the policy stays tight on every page where the widget is absent.

## Tests

`SecurityHeadersSubscriberTest`: added cases for captcha-enabled (host derived from URL, jsDelivr, blob worker), captcha-disabled (none of those present), and port preservation. 7 tests / 20 assertions green; phpstan + psalm clean.

## Follow-up (not in this PR)

The WASM solver is pulled from a third-party CDN at solve time, so the captcha now has a runtime dependency on jsDelivr. Self-hosting `@cap.js/wasm` would drop `cdn.jsdelivr.net` from the policy — worth considering separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)