### PR TITLE
style(readme): realign services table to fix Prettier check

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Public production services that make up the Catroweb platform:
 | ---------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------ |
 | Sharing platform | [share.catrobat.org](https://share.catrobat.org)                            | Main app — browse, upload and remix projects                       |
 | API docs         | [developer.catrobat.org/Catroweb](https://developer.catrobat.org/Catroweb/) | OpenAPI reference for the public HTTP API                          |
-| CAPTCHA          | [cap.catrobat.org](https://cap.catrobat.org)                                      | Self-hosted CAPTCHA challenge endpoint used by forms               |
+| CAPTCHA          | [cap.catrobat.org](https://cap.catrobat.org)                                | Self-hosted CAPTCHA challenge endpoint used by forms               |
 | Dependency Track | [deptrack.catrobat.org](https://deptrack.catrobat.org)                      | OWASP Dependency-Track — SBOMs from CI land here for vuln tracking |
 
 Live service health is on the [Better Stack status page](https://uptime.betterstack.com/?utm_source=status_badge) (also linked via the badge at the top).


### PR DESCRIPTION
## Problem

The `MD,YAML formatting [Prettier]` check is failing on `main` and therefore on **every open PR branched from it** (e.g. #7059).

Commit `0d7180306` changed the CAPTCHA URL in the services table but did not re-run Prettier, so the table column is now misaligned by a few spaces.

## Fix

Re-ran `prettier --write README.md` — single-line whitespace realignment of the CAPTCHA row, no content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)