### PR TITLE
ci: retry transient docker registry and huggingface failures

### DIFF
--- a/.github/workflows/container_tests.yaml
+++ b/.github/workflows/container_tests.yaml
@@ -64,10 +64,23 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Same registry flakiness as in the dynamic analysis workflow: pulls from
+      # registry-1.docker.io time out and take the whole job down. Retry with backoff.
       - name: Build and start all containers (Docker Compose)
         run: |
           cd docker
-          docker compose -f docker-compose.dev.yaml up -d
+          attempt=1
+          max_attempts=3
+          until docker compose -f docker-compose.dev.yaml up -d; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "docker compose up failed after $max_attempts attempts"
+              exit 1
+            fi
+            echo "docker compose up failed (attempt $attempt/$max_attempts), retrying..."
+            docker compose -f docker-compose.dev.yaml down -v || true
+            sleep "$((attempt * 15))"
+            attempt="$((attempt + 1))"
+          done
 
       - name: Check Symfony application (info)
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -85,8 +85,24 @@ jobs:
           TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.pull_request.head.sha || github.sha }}"
           echo "tags=${TAG}" >> "$GITHUB_OUTPUT"
 
+      # ghcr.io occasionally rejects the blob upload PUT with a 5xx. The build itself is
+      # cached (type=gha), so a second attempt only re-pushes and costs a few seconds.
       - name: Build and push Catroweb App Image (internal)
+        id: push-internal
         if: steps.fork-check.outputs.is_fork == 'false'
+        continue-on-error: true
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: APP_ENVIRONMENT=test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Retry push of Catroweb App Image (internal)
+        if: steps.fork-check.outputs.is_fork == 'false' && steps.push-internal.outcome == 'failure'
         uses: docker/build-push-action@v7.3.0
         with:
           context: .
@@ -164,10 +180,23 @@ jobs:
       - name: Tag image for docker-compose
         run: docker tag ${{ needs.build.outputs.image-tag }} app.catroweb
 
+      # Pulls of the chrome/db images from registry-1.docker.io time out often enough to
+      # be the single biggest source of red CI on otherwise fine PRs. Retry with backoff.
       - name: Build and Start Docker Containers
         run: |
           cd docker
-          docker compose -f docker-compose.test.yaml up -d
+          attempt=1
+          max_attempts=3
+          until docker compose -f docker-compose.test.yaml up -d; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "docker compose up failed after $max_attempts attempts"
+              exit 1
+            fi
+            echo "docker compose up failed (attempt $attempt/$max_attempts), retrying..."
+            docker compose -f docker-compose.test.yaml down -v || true
+            sleep "$((attempt * 15))"
+            attempt="$((attempt + 1))"
+          done
 
       - name: Run PHPUnit Tests
         run: |
@@ -275,10 +304,23 @@ jobs:
       - name: Tag image for docker-compose
         run: docker tag ${{ needs.build.outputs.image-tag }} app.catroweb
 
+      # Pulls of the chrome/db images from registry-1.docker.io time out often enough to
+      # be the single biggest source of red CI on otherwise fine PRs. Retry with backoff.
       - name: Build and Start Docker Containers
         run: |
           cd docker
-          docker compose -f docker-compose.test.yaml up -d
+          attempt=1
+          max_attempts=3
+          until docker compose -f docker-compose.test.yaml up -d; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "docker compose up failed after $max_attempts attempts"
+              exit 1
+            fi
+            echo "docker compose up failed (attempt $attempt/$max_attempts), retrying..."
+            docker compose -f docker-compose.test.yaml down -v || true
+            sleep "$((attempt * 15))"
+            attempt="$((attempt + 1))"
+          done
 
       - name: Warmup the cache
         run: |

--- a/docker/nsfw-scanner/Dockerfile
+++ b/docker/nsfw-scanner/Dockerfile
@@ -13,8 +13,16 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app.py .
 
-# Download model at build time into the non-root user's HF cache
+# Download model at build time into the non-root user's HF cache.
+# Anonymous huggingface.co requests get rate limited (HTTP 429) on shared CI runners,
+# which fails the build for reasons that have nothing to do with the change under test.
+# Retry with a growing backoff; the final call verifies the model really is cached.
 RUN mkdir -p "$HF_HOME" \
+  && for attempt in 1 2 3 4 5; do \
+       python -c "from transformers import pipeline; pipeline('image-classification', model='Falconsai/nsfw_image_detection')" && break; \
+       echo "Model download failed (attempt $attempt/5), retrying in $((attempt * 20))s"; \
+       sleep "$((attempt * 20))"; \
+     done \
   && python -c "from transformers import pipeline; pipeline('image-classification', model='Falconsai/nsfw_image_detection')" \
   && chown -R app:app /home/app
 

--- a/docker/nsfw-scanner/Dockerfile
+++ b/docker/nsfw-scanner/Dockerfile
@@ -20,6 +20,7 @@ COPY app.py .
 RUN mkdir -p "$HF_HOME" \
   && for attempt in 1 2 3 4 5; do \
        python -c "from transformers import pipeline; pipeline('image-classification', model='Falconsai/nsfw_image_detection')" && break; \
+       if [ "$attempt" -eq 5 ]; then break; fi; \
        echo "Model download failed (attempt $attempt/5), retrying in $((attempt * 20))s"; \
        sleep "$((attempt * 20))"; \
      done \


### PR DESCRIPTION
Four dependabot PRs were red this week without a single one of them actually breaking
anything. All four failed on transient external infrastructure:

| PR | Job | Failure |
|---|---|---|
| #7089 | Development Container | `429 Too Many Requests` from huggingface.co while prefetching `Falconsai/nsfw_image_detection` |
| #7088 | Behat (api-moderation) | `registry-1.docker.io` timeout pulling `chrome.catroweb` |
| #7085 | Behat (web-code …) | same docker.io timeout, `db.catroweb.test` |
| #7071 | Build Catroweb Image | `failed to push ghcr.io/catrobat/catroweb-test:…` — bad status on the blob upload PUT |

All four went green on a plain re-run, no code change. This makes red CI cheap to ignore,
which is the actual cost.

## What this does

- **`docker compose up` retry** (`tests.yaml` PHPUnit + Behat jobs, `container_tests.yaml` dev
  container): up to 3 attempts, 15s/30s backoff, `down -v` between tries so a half-started
  stack does not poison the retry. A real compose failure still fails the job, just three
  times slower.
- **ghcr push retry** (`tests.yaml` build job): the push step becomes `continue-on-error`
  with a second attempt gated on its outcome. The layers are already in the `type=gha`
  cache, so the retry is a re-push, not a rebuild.
- **Hugging Face download retry** (`docker/nsfw-scanner/Dockerfile`): up to 5 attempts with
  20s/40s/60s/80s backoff. The unconditional call after the loop is the verification step —
  if the model never landed in the cache the build still fails.

## What this deliberately does not do

- No `HF_TOKEN`. An authenticated token would raise the rate limit properly, but that needs a
  repo secret and would break fork builds. Retrying fixes the observed failure without either.
- No Docker Hub mirror or registry proxy. Bigger change, worth discussing separately if the
  timeouts keep up.
- No retry around the Behat runs themselves — those already have a `--rerun` path, and
  masking genuine test flakiness is not the goal here.
