### PR TITLE
build(deps-dev): bump phpstan/phpstan to 2.2.8

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -16442,11 +16442,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.7",
+            "version": "2.2.8",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/692db47b9dddb0487934e5236e77d48594aef921",
-                "reference": "692db47b9dddb0487934e5236e77d48594aef921",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e285254e60f33c21902efef4a926ca0987c06804",
+                "reference": "e285254e60f33c21902efef4a926ca0987c06804",
                 "shasum": ""
             },
             "require": {
@@ -16502,7 +16502,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-29T17:39:32+00:00"
+            "time": "2026-08-04T22:21:45+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",

--- a/src/Project/CatrobatCode/Parser/CodeStatistic.php
+++ b/src/Project/CatrobatCode/Parser/CodeStatistic.php
@@ -218,30 +218,25 @@ class CodeStatistic
     ++$this->total_num_bricks;
     switch ($brick->getImgFile()) {
       // Normal Bricks
+      // The extension constants (RASPI_*, PHIRO_*, AR_DRONE_*, JUMPING_SUMO_*) alias the
+      // plain ones by value, so they are covered by the cases below and must not be
+      // listed separately — a second case label with the same value is dead code.
       case Constants::EVENT_SCRIPT_IMG:
       case Constants::EVENT_BRICK_IMG:
-      case Constants::RASPI_EVENT_SCRIPT_IMG:
         $this->updateBrickTypeStatistic($brick->getType(), 'eventBricks');
         break;
       case Constants::CONTROL_SCRIPT_IMG:
       case Constants::CONTROL_BRICK_IMG:
-      case Constants::RASPI_CONTROL_BRICK_IMG:
-      case Constants::PHIRO_CONTROL_BRICK_IMG:
         $this->updateBrickTypeStatistic($brick->getType(), 'controlBricks');
         break;
       case Constants::MOTION_SCRIPT_IMG:
       case Constants::MOTION_BRICK_IMG:
-      case Constants::JUMPING_SUMO_BRICK_IMG:
-      case Constants::AR_DRONE_MOTION_BRICK_IMG:
         $this->updateBrickTypeStatistic($brick->getType(), 'motionBricks');
         break;
       case Constants::SOUND_BRICK_IMG:
-      case Constants::PHIRO_SOUND_BRICK_IMG:
         $this->updateBrickTypeStatistic($brick->getType(), 'soundBricks');
         break;
       case Constants::LOOKS_BRICK_IMG:
-      case Constants::AR_DRONE_LOOKS_BRICK_IMG:
-      case Constants::PHIRO_LOOK_BRICK_IMG:
         $this->updateBrickTypeStatistic($brick->getType(), 'looksBricks');
         break;
       case Constants::PEN_BRICK_IMG:
@@ -253,19 +248,13 @@ class CodeStatistic
       case Constants::DEVICE_BRICK_IMG:
         $this->updateBrickTypeStatistic($brick->getType(), 'deviceBricks');
         break;
+      // DEPRECATED_* share the grey images, LEGO_NXT the yellow one, and RASPI/PHIRO/
+      // TESTING/YOUR the light blue one — all already matched by the cases listed here.
       case Constants::UNKNOWN_BRICK_IMG:
-      case Constants::DEPRECATED_BRICK_IMG:
       case Constants::UNKNOWN_SCRIPT_IMG:
-      case Constants::DEPRECATED_SCRIPT_IMG:
       case Constants::LEGO_EV3_BRICK_IMG:
-      case Constants::LEGO_NXT_BRICK_IMG:
       case Constants::ARDUINO_BRICK_IMG:
       case Constants::EMBROIDERY_BRICK_IMG:
-      case Constants::RASPI_BRICK_IMG:
-      case Constants::PHIRO_BRICK_IMG:
-      case Constants::TESTING_BRICK_IMG:
-      case Constants::YOUR_BRICK_IMG:
-      case Constants::YOUR_SCRIPT_IMG:
         $this->updateBrickTypeStatistic($brick->getType(), 'specialBricks');
         break;
     }

--- a/src/Project/CatrobatCode/Parser/CodeStatistic.php
+++ b/src/Project/CatrobatCode/Parser/CodeStatistic.php
@@ -248,8 +248,8 @@ class CodeStatistic
       case Constants::DEVICE_BRICK_IMG:
         $this->updateBrickTypeStatistic($brick->getType(), 'deviceBricks');
         break;
-      // DEPRECATED_* share the grey images, LEGO_NXT the yellow one, and RASPI/PHIRO/
-      // TESTING/YOUR the light blue one — all already matched by the cases listed here.
+        // DEPRECATED_* share the grey images, LEGO_NXT the yellow one, and RASPI/PHIRO/
+        // TESTING/YOUR the light blue one — all already matched by the cases listed here.
       case Constants::UNKNOWN_BRICK_IMG:
       case Constants::UNKNOWN_SCRIPT_IMG:
       case Constants::LEGO_EV3_BRICK_IMG:


### PR DESCRIPTION
Supersedes #7098, which fails Php-Stan with 16 errors.

## Why it was red

2.2.8 enables the `switch.duplicateCase` rule, and it is right: 16 `case` labels in `CodeStatistic::updateBrickStatistic()` are dead code. The extension constants alias the plain image names *by value* —

```php
final public const string RASPI_CONTROL_BRICK_IMG = self::CONTROL_BRICK_IMG;
final public const string DEPRECATED_BRICK_IMG    = '1h_brick_grey.png'; // == UNKNOWN_BRICK_IMG
final public const string PHIRO_BRICK_IMG         = '1h_brick_light_blue.png'; // == ARDUINO_BRICK_IMG
```

— so the first label in each group already matches and the later ones can never be reached.

## The fix

Drop the 16 unreachable labels; keep the aliasing documented in a comment so the intent (which robot family counts as which brick category) is not lost.

## Verified

- phpstan 2.2.8 on `CodeStatistic.php`: 16 errors before, 0 after.
- `CodeStatisticTest`, `CodeStatisticsParserTest`, `ParsedSceneProgramTest`, `ParsedSimpleProgramTest` — OK (33 tests, 129 assertions). Runtime behaviour is unchanged by construction: every removed label had a duplicate value in the same case group.