### PR TITLE
ci: auto-approve and auto-merge Dependabot PRs behind a CI gate

### DIFF
--- a/.github/workflows/code_quality.yaml
+++ b/.github/workflows/code_quality.yaml
@@ -237,3 +237,58 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
       - run: bin/check-default-secrets
+
+  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  # CI gate:
+  #
+  #   - Aggregates every job of this workflow into a single status check, so branch protection can require one stable
+  #     context instead of eleven that have to be kept in sync whenever a tool is added or removed here.
+  #
+  #   - `skipped` counts as passing on purpose: when an upstream job fails, its dependents report `skipped`, and the
+  #     failure is already caught by checking that upstream job itself.
+  #
+  ci_gate:
+    name: 'CI gate: static analysis'
+    needs:
+      - biome
+      - prettier
+      - php-cs-fixer
+      - phpstan
+      - psalm
+      - phpcpd
+      - php-loc
+      - lint-twig
+      - lint-yaml
+      - lint-container
+      - check-secrets
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results of all jobs
+        env:
+          RESULTS: |
+            biome ${{ needs.biome.result }}
+            prettier ${{ needs.prettier.result }}
+            php-cs-fixer ${{ needs.php-cs-fixer.result }}
+            phpstan ${{ needs.phpstan.result }}
+            psalm ${{ needs.psalm.result }}
+            phpcpd ${{ needs.phpcpd.result }}
+            php-loc ${{ needs.php-loc.result }}
+            lint-twig ${{ needs.lint-twig.result }}
+            lint-yaml ${{ needs.lint-yaml.result }}
+            lint-container ${{ needs.lint-container.result }}
+            check-secrets ${{ needs.check-secrets.result }}
+        run: |
+          echo "$RESULTS"
+          failed=0
+          while read -r job result; do
+            [ -z "$job" ] && continue
+            case "$result" in
+              success | skipped) ;;
+              *)
+                echo "::error::job '$job' ended with '$result'"
+                failed=1
+                ;;
+            esac
+          done <<< "$RESULTS"
+          exit "$failed"

--- a/.github/workflows/dependabot_auto_merge.yaml
+++ b/.github/workflows/dependabot_auto_merge.yaml
@@ -1,0 +1,55 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ** Dependabot auto-merge **
+#
+#  `main` requires one approving review, so dependency bumps sat blocked on a human even with all checks green. Since
+#  they are only ever a lock file change, and since the pipeline is what actually decides whether a bump is safe, they
+#  are approved and queued for auto-merge here instead.
+#
+#  - Green is still enforced, by GitHub, not by this workflow:
+#
+#      `--auto` merges only once every *required* status check on the branch has succeeded. The required contexts are
+#      the two `CI gate: ...` jobs plus `Development Container`, which together cover every job of every workflow. If a
+#      check goes red the pull request simply stays open. Removing the required contexts from the branch protection
+#      would turn this into an unconditional merge — so do not do that without removing this workflow too.
+#
+#  - Only Dependabot's own pull requests are touched. Everything else, including human dependency bumps, keeps the
+#    normal review requirement.
+#
+#  - `pull_request_target` is deliberate:
+#
+#      On a `pull_request` run triggered by Dependabot the GITHUB_TOKEN is read-only, so it could neither approve nor
+#      enable auto-merge. `pull_request_target` runs with the base branch's token instead. This workflow never checks
+#      out the pull request, so no code from it is ever executed here — the steps only talk to the GitHub API.
+#
+name: 'Dependabot auto-merge'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  pull_request_target:
+    branches:
+      - '**' # all branches
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  auto_merge:
+    name: Approve and enable auto-merge
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -454,3 +454,43 @@ jobs:
           docker logs db.catroweb.test
           echo "--- Chrome Logs ---"
           docker logs chrome.catroweb
+
+  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  # CI gate:
+  #
+  #   - Aggregates every job of this workflow into a single status check, so that branch protection has one stable
+  #     context to require instead of a list that has to be kept in sync by hand.
+  #
+  #   - This matters most for Behat: those jobs are a matrix, so their check names ("Behat (web-studio)", ...) change
+  #     whenever a test suite is added, renamed or split. Requiring them individually means every such change silently
+  #     blocks all merges until someone edits the branch protection to match.
+  #
+  #   - `skipped` counts as passing on purpose: when an upstream job fails, its dependents report `skipped`, and the
+  #     failure is already caught by checking that upstream job itself.
+  #
+  ci_gate:
+    name: 'CI gate: dynamic analysis'
+    needs: [build, tests_phpunit, tests_behat]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results of all jobs
+        env:
+          RESULTS: |
+            build ${{ needs.build.result }}
+            tests_phpunit ${{ needs.tests_phpunit.result }}
+            tests_behat ${{ needs.tests_behat.result }}
+        run: |
+          echo "$RESULTS"
+          failed=0
+          while read -r job result; do
+            [ -z "$job" ] && continue
+            case "$result" in
+              success | skipped) ;;
+              *)
+                echo "::error::job '$job' ended with '$result'"
+                failed=1
+                ;;
+            esac
+          done <<< "$RESULTS"
+          exit "$failed"


### PR DESCRIPTION
`main` requires one approving review, so dependency bumps sit blocked on a human even when all 42 checks are green — #7096, #7097 and #7100 are all in that state right now. This approves Dependabot's own pull requests and enables auto-merge on them.

## The part that is easy to get wrong

`--auto` releases a pull request once every **required** status check has succeeded. `main` has *no* required status checks today (`required_status_checks.contexts` is empty) — the review requirement was the only gate. So enabling auto-merge on its own would merge bumps within seconds of the bot's approval, roughly 40 minutes before Behat finishes. That is the opposite of merging on green.

Two aggregate jobs give branch protection something stable to require:

| job | needs |
|---|---|
| `CI gate: dynamic analysis` | `build`, `tests_phpunit`, `tests_behat` |
| `CI gate: static analysis` | all eleven `code_quality` jobs |

Together with the existing `Development Container` check, three contexts cover every job of every workflow.

Requiring the jobs individually would not hold: the Behat jobs are a matrix, so their check names (`Behat (web-studio)`, …) change whenever a suite is added, renamed or split — and every such change would silently block all merges until someone edited the branch protection to match. `skipped` counts as passing in the gates on purpose, because a failed upstream job makes its dependents report `skipped` and the failure is already caught on the upstream job itself.

## After merging this — in this order

The gate jobs have to exist before they can be required, otherwise every open pull request blocks on a context that will never report:

```sh
gh api -X PATCH repos/Catrobat/Catroweb/branches/main/protection/required_status_checks \
  -F strict=false \
  -f 'contexts[]=CI gate: dynamic analysis' \
  -f 'contexts[]=CI gate: static analysis' \
  -f 'contexts[]=Development Container'
```

`strict=false` on purpose: `strict=true` additionally requires the branch to be up to date with `main`, which makes Dependabot rebase after every unrelated merge and can turn into a rebase loop when several bumps are open.

**This applies to human pull requests too** — they will need those three contexts green to merge. That is the intended effect, but it is a policy change for everyone working on the repo, not just for the bot.

Note the coupling in the other direction: if the required contexts are ever removed from `main`, this workflow becomes an unconditional merge. Remove the workflow at the same time.

## Notes

- Repo settings needed no changes: `allow_auto_merge` is already true, Actions may already approve pull requests, and the default workflow token is already `write`.
- `pull_request_target` is deliberate: on a `pull_request` run triggered by Dependabot the GITHUB_TOKEN is read-only, so it could neither approve nor merge. The workflow never checks out the pull request, so no code from it executes here — the steps only call the GitHub API.
- Scoped to `dependabot[bot]` only. ImgBot pull requests still need a human; easy to add later if wanted.

## Verified

- All three workflow files parse, and `prettier` (the `MD,YAML formatting` job) reports no changes.
- The gate script was exercised under `bash -e`: all-success → exit 0, one `failure` → exit 1 with an `::error::` annotation, all-`skipped` → exit 0, `cancelled` → exit 1.