### PR TITLE
chore: drop removed rector strictBooleans set

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -20,6 +20,5 @@ return RectorConfig::configure()
     codeQuality: true,
     typeDeclarations: true,
     earlyReturn: true,
-    strictBooleans: true,
   )
 ;


### PR DESCRIPTION
## What broke

PHPStan fails on #7107 (rector/rector 2.5.9 → 2.6.1):

```
rector.php:23  Unknown parameter $strictBooleans in call to method
               Rector\Configuration\RectorConfigBuilder::withPreparedSets().
```

rector 2.6 removed the `$strictBooleans` parameter from `withPreparedSets()`.

## Why this fix

The parameter was already a deprecated **no-op** in 2.5.x — it was excluded from the set map and only printed a warning telling users to rely on `codeQuality` / `codingStyle` instead. So removing the argument changes nothing about which rules run, both before and after the bump.

`codeQuality: true` is already enabled in `rector.php`.

## Verified locally

- `bin/phpstan analyse rector.php` — reproduced the error with rector 2.6.1, clean after the fix
- Same file also clean under the currently locked 2.5.9, so this can land ahead of the bump
- `bin/rector process --dry-run` runs fine with 2.6.1
- `bin/php-cs-fixer` clean

Unblocks #7107, which auto-merges once it rebases onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)