### PR TITLE
fix: restore the password reset form on Symfony 8

### DIFF
--- a/src/Application/Controller/Security/RegistrationController.php
+++ b/src/Application/Controller/Security/RegistrationController.php
@@ -51,7 +51,7 @@ class RegistrationController extends AbstractController
     try {
       $this->verify_email_helper->validateEmailConfirmation($request->getUri(), $user->getId(), $user->getEmail());
     } catch (VerifyEmailExceptionInterface $verifyEmailException) {
-      $this->logger->critical('Email verification failed for '.$user->getId().$user->getEmail());
+      $this->logger->critical(sprintf('Email verification failed for user %s: %s', (string) $user->getId(), $verifyEmailException->getReason()));
       $this->addFlash('verify_email_error', $verifyEmailException->getReason());
 
       return $this->redirectToRoute('register');

--- a/src/Application/Form/ChangePasswordFormType.php
+++ b/src/Application/Form/ChangePasswordFormType.php
@@ -23,9 +23,7 @@ class ChangePasswordFormType extends AbstractType
         'first_options' => [
           'attr' => ['autocomplete' => 'new-password'],
           'constraints' => [
-            new NotBlank([
-              'message' => 'Please enter a password',
-            ]),
+            new NotBlank(message: 'Please enter a password'),
             new Length(min: 6, max: 4096, minMessage: 'Your password should be at least {{ limit }} characters'),
           ],
           'label' => 'New password',

--- a/src/System/Testing/Behat/Context/CatrowebBrowserContext.php
+++ b/src/System/Testing/Behat/Context/CatrowebBrowserContext.php
@@ -18,6 +18,7 @@ use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTEncodeFailureException;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\KernelInterface;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
 
 /**
  * Class CatrowebBrowserContext.
@@ -54,6 +55,23 @@ class CatrowebBrowserContext extends BrowserContext
   // --------------------------------------------------------------------------------------------------------------------
   //  Authentication
   // --------------------------------------------------------------------------------------------------------------------
+  /**
+   * Opens the reset link a user would receive by e-mail, without going through the mailer.
+   *
+   * @When /^I open the password reset link for "([^"]*)"$/
+   */
+  public function iOpenThePasswordResetLinkFor(string $username): void
+  {
+    $user = $this->getUserManager()->findUserByUsername($username);
+    Assert::assertNotNull($user, 'Unknown user: '.$username);
+
+    $helper = $this->getSymfonyService(ResetPasswordHelperInterface::class);
+    Assert::assertInstanceOf(ResetPasswordHelperInterface::class, $helper);
+    $token = $helper->generateResetToken($user)->getToken();
+
+    $this->visit('/app/reset-password/reset/'.$token);
+  }
+
   /**
    * @Given /^I( [^"]*)? log in as "([^"]*)" with the password "([^"]*)"$/
    * @Given /^I( [^"]*)? log in as "([^"]*)"$/

--- a/tests/BehatFeatures/web/authentication/reset_password.feature
+++ b/tests/BehatFeatures/web/authentication/reset_password.feature
@@ -18,3 +18,16 @@ Feature:
     And I press "Send reset email"
     Then I wait for the page to be loaded
     And I should see "If an account matching your email exists"
+
+  Scenario: Reset link should show the new password form and change the password
+    When I open the password reset link for "Catrobat"
+    And I wait for the page to be loaded
+    Then I should be on "/app/reset-password/reset"
+    And I should see "Reset your password"
+    When I fill in "change_password_form[plainPassword][first]" with "MyNewPassword123"
+    And I fill in "change_password_form[plainPassword][second]" with "MyNewPassword123"
+    And I press "Reset password"
+    And I wait for the page to be loaded
+    Then I should be on "/app/"
+    When I log in as "Catrobat" with the password "MyNewPassword123"
+    Then I should be logged in


### PR DESCRIPTION
## Summary

Opening the password reset link from the reset e-mail returns a 500 in production. The form builds its `NotBlank` constraint with an options array, which `symfony/validator` 8 no longer supports:

```
Symfony\Component\Validator\Exception\InvalidArgumentException:
"Passing an array of options to configure the "Symfony\Component\Validator\Constraints\NotBlank" constraint is no longer supported." at NotBlank.php line 44
```

The exception is thrown while building the form, so the page never renders and nobody can complete a password reset. Fixed by using named arguments.

While looking at the surrounding controller: a rejected e-mail verification link logged the user id and e-mail address concatenated into one string and dropped the actual reason. It now logs the reason, which is what you need to tell an expired link from a tampered one.

## Test plan

The reset flow had no coverage past the "check your emails" page, which is why this reached production. Added a scenario that opens the reset link, submits a new password and logs in with it.

New Behat step `I open the password reset link for :username` generates a real reset token through `ResetPasswordHelperInterface`, so the test exercises the same route the e-mail points at without going through the mailer.

- [x] `bin/behat -s web-authentication tests/BehatFeatures/web/authentication/reset_password.feature` — 2 scenarios, 23 steps, all passing
- [x] PHP-CS-Fixer, PHPStan, Psalm clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)